### PR TITLE
Studio 5

### DIFF
--- a/src/assets/styles/pages/_auth.scss
+++ b/src/assets/styles/pages/_auth.scss
@@ -78,11 +78,9 @@
 
   input {
     background: $faint-white-overlay !important;
-    color: $color-white !important;
     text-align: center !important;
 
     &::placeholder {
-      color: $white-overlay !important;
       font-family: $font-family-sans;
       font-weight: $font-weight-light;
       text-align: center !important;


### PR DESCRIPTION
Fixes color for input text and placeholder so that it is legible in the default / 'purple' theme.