### PR TITLE
Fix instance drop-down navigation regression

### DIFF
--- a/src/components/instance/Subnav.js
+++ b/src/components/instance/Subnav.js
@@ -57,7 +57,7 @@ function Subnav({ routes = [] }) {
   };
 
   const navigateFn = ({ value, has_auth, is_unavailable }) => {
-    if (!is_unavailable) {
+    if (is_unavailable) {
       return false;
     }
     if (has_auth) {


### PR DESCRIPTION
Fixes broken instance drop-down navigation on instance browse page (introduced by me during react router upgrade from v5 to v6).