### PR TITLE
Studio-81: switch from stripe product name to stripe product id when identifying storage/compute plans

### DIFF
--- a/src/functions/api/lms/getProducts.js
+++ b/src/functions/api/lms/getProducts.js
@@ -36,9 +36,6 @@ export default async () => {
         cloud_compute: buildRadioSelectProductOptions(response.find((p) => p.id === PRODUCT_MAP[config.env].cloud_compute)?.plans.filter((p) => !p.metadata.prepaid) || []),
         wavelength_compute: buildRadioSelectProductOptions(response.find((p) => p.id === PRODUCT_MAP[config.env].wavelength_compute)?.plans.filter((p) => !p.metadata.prepaid) || []),
         local_compute: buildRadioSelectProductOptions(response.find((p) => p.id === PRODUCT_MAP[config.env].local_compute)?.plans.filter((p) => !p.metadata.prepaid) || []),
-
-        // is this still used? no entry in stripe prod/test products
-        lumen_compute: buildRadioSelectProductOptions(response.find((p) => p.name === 'Lumen Edge Compute')?.plans.filter((p) => !p.metadata.prepaid) || []),
       };
     });
   } catch (e) {


### PR DESCRIPTION
this PR prevents an important failure case that could be triggered by updating Stripe products from the Stripe dashboard:
- creates a map from stripe product type to stripe product id for dev and prod environments
- instead of the editable product name, uses the uneditable product id of a given product type as filter key when displaying available products for a given type.