### PR TITLE
Cloud 1178

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 
 .eslintcache
 
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,67 +1,13 @@
 FROM node:current as builder
 
-ARG STRIPE_PUBLIC_KEY="na"
-ARG GOOGLE_ANALYTICS_CODE="na"
-ARG GOOGLE_ANALYTICS_CODE="na"
 ARG ENVIRONMENT="dev"
-ARG URL="https://${ENVIRONMENT}.studio.harperdb.io"
 
 # copy whole repo into docker image to start
 COPY . .
+RUN cp src/config/index.example.js src/config/index.js
 
 # Build stuff, mostly copied from .github/workflows/publish-stage.yaml
 #######################################################################
-
-# write config file
-RUN PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' ./package.json); \
-    cat <<EOF > ./src/config/index.js
-export default {
-  env: '${ENVIRONMENT}',
-  stripe_public_key: '${STRIPE_PUBLIC_KEY}',
-  lms_api_url: 'https://dev.harperdbcloudservices.com/',
-  google_analytics_code: '${GOOGLE_ANALYTICS_CODE}',
-  youtube_api_key: '${YOUTUBE_API_KEY}',
-  postman_collection_url: 'https://www.postman.com/collections/7046690-5a70b340-8fe1-4487-88bd-ffac077c3df8',
-  tc_version: '2020-01-01',
-  check_version_interval: 300000,
-  refresh_content_interval: 15000,
-  total_cloud_instance_limit: 10,
-  free_cloud_instance_limit: 1,
-  total_local_instance_limit: false,
-  free_local_instance_limit: false,
-  max_file_upload_size: 10380902,
-  studio_version:'${PACKAGE_VERSION}',
-  user_guide_id: 16032,
-  alarm_badge_threshold: 86400,
-  maintenance: 0,
-  errortest: 0
-};
-EOF
-
-# write manifest file
-RUN cat <<EOF > ./public/manifest.json
-{
-  "short_name": "HarperDB Studio",
-  "name": "HarperDB Studio",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "images/logo_vertical_white.png",
-      "type": "image/png",
-      "sizes": "536x672"
-    }
-  ],
-  "start_url": "${URL}",
-  "display": "standalone",
-  "theme_color": "#480b8a",
-  "background_color": "#ffffff"
-}
-EOF
-
 RUN yarn; yarn lint; yarn build:${ENVIRONMENT}
 
 FROM node:current-slim
@@ -73,10 +19,17 @@ COPY --chown=node:node --from=builder /package.json /home/node/app/
 COPY --chown=node:node --from=builder src /home/node/app/src
 COPY --chown=node:node --from=builder .eslintrc /home/node/app/
 COPY --chown=node:node --from=builder .eslintignore /home/node/app/
+COPY --chown=node:node docker-scripts/entrypoint.sh /home/node/app/entrypoint.sh
 
 USER node
 WORKDIR /home/node/app
 
+ENV STRIPE_PUBLIC_KEY="na"
+ENV GOOGLE_ANALYTICS_CODE="na"
+ENV YOUTUBE_API_KEY="na"
+ENV ENVIRONMENT=$ENVIRONMENT
+ENV URL="https://$ENVIRONMENT.studio.harperdb.io"
+
 EXPOSE 3000
 
-CMD npm run docker
+ENTRYPOINT ["/home/node/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,82 @@
+FROM node:current as builder
+
+ARG STRIPE_PUBLIC_KEY="na"
+ARG GOOGLE_ANALYTICS_CODE="na"
+ARG GOOGLE_ANALYTICS_CODE="na"
+ARG ENVIRONMENT="dev"
+ARG URL="https://${ENVIRONMENT}.studio.harperdb.io"
+
+# copy whole repo into docker image to start
+COPY . .
+
+# Build stuff, mostly copied from .github/workflows/publish-stage.yaml
+#######################################################################
+
+# write config file
+RUN PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' ./package.json); \
+    cat <<EOF > ./src/config/index.js
+export default {
+  env: '${ENVIRONMENT}',
+  stripe_public_key: '${STRIPE_PUBLIC_KEY}',
+  lms_api_url: 'https://dev.harperdbcloudservices.com/',
+  google_analytics_code: '${GOOGLE_ANALYTICS_CODE}',
+  youtube_api_key: '${YOUTUBE_API_KEY}',
+  postman_collection_url: 'https://www.postman.com/collections/7046690-5a70b340-8fe1-4487-88bd-ffac077c3df8',
+  tc_version: '2020-01-01',
+  check_version_interval: 300000,
+  refresh_content_interval: 15000,
+  total_cloud_instance_limit: 10,
+  free_cloud_instance_limit: 1,
+  total_local_instance_limit: false,
+  free_local_instance_limit: false,
+  max_file_upload_size: 10380902,
+  studio_version:'${PACKAGE_VERSION}',
+  user_guide_id: 16032,
+  alarm_badge_threshold: 86400,
+  maintenance: 0,
+  errortest: 0
+};
+EOF
+
+# write manifest file
+RUN cat <<EOF > ./public/manifest.json
+{
+  "short_name": "HarperDB Studio",
+  "name": "HarperDB Studio",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "images/logo_vertical_white.png",
+      "type": "image/png",
+      "sizes": "536x672"
+    }
+  ],
+  "start_url": "${URL}",
+  "display": "standalone",
+  "theme_color": "#480b8a",
+  "background_color": "#ffffff"
+}
+EOF
+
+RUN yarn; yarn lint; yarn build:${ENVIRONMENT}
+
+FROM node:current-slim
+
+# copy only build files from builder stage
+COPY --chown=node:node --from=builder build /home/node/app/public
+COPY --chown=node:node --from=builder node_modules/ /home/node/app/node_modules
+COPY --chown=node:node --from=builder /package.json /home/node/app/
+COPY --chown=node:node --from=builder src /home/node/app/src
+COPY --chown=node:node --from=builder .eslintrc /home/node/app/
+COPY --chown=node:node --from=builder .eslintignore /home/node/app/
+
+USER node
+WORKDIR /home/node/app
+
+EXPOSE 3000
+
+CMD npm run docker

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+HDBMS_VERSION=$(shell jq -r .version package.json)
+WARNING = "The docker images created with this file are not suitable for publishing, so please don't do that."
+
+all: image run
+
+image:
+	docker buildx build \
+		--build-arg VCS_REF=`git rev-parse HEAD` \
+		--build-arg BUILD_DATE=`date -u +%FT%T` \
+		--progress auto \
+		--output=type=docker \
+		--file Dockerfile \
+		--tag harperdb/hdbms:${HDBMS_VERSION} .
+	@echo $(WARNING)
+
+run: clean
+	docker run -d \
+		-p 3000:3000 \
+		--name hdbms \
+		harperdb/hdbms:${HDBMS_VERSION}
+
+get-version:
+	@echo "HDB_VERSION  = $(HDBMS_VERSION)"
+
+clean:
+	docker rm -f hdbms

--- a/docker-scripts/entrypoint.sh
+++ b/docker-scripts/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# write config file
+PACKAGE_VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)",$/\1/p' ./package.json); \
+cat <<EOF > /home/node/app/src/config/index.js
+export default {
+  env: '${ENVIRONMENT}',
+  stripe_public_key: '${STRIPE_PUBLIC_KEY}',
+  lms_api_url: 'https://dev.harperdbcloudservices.com/',
+  google_analytics_code: '${GOOGLE_ANALYTICS_CODE}',
+  youtube_api_key: '${YOUTUBE_API_KEY}',
+  postman_collection_url: 'https://www.postman.com/collections/7046690-5a70b340-8fe1-4487-88bd-ffac077c3df8',
+  tc_version: '2020-01-01',
+  check_version_interval: 300000,
+  refresh_content_interval: 15000,
+  total_cloud_instance_limit: 10,
+  free_cloud_instance_limit: 1,
+  total_local_instance_limit: false,
+  free_local_instance_limit: false,
+  max_file_upload_size: 10380902,
+  studio_version:'${PACKAGE_VERSION}',
+  user_guide_id: 16032,
+  alarm_badge_threshold: 86400,
+  maintenance: 0,
+  errortest: 0
+};
+EOF
+
+ # write manifest file
+cat <<EOF > /home/node/app/public/manifest.json
+{
+  "short_name": "HarperDB Studio",
+  "name": "HarperDB Studio",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "images/logo_vertical_white.png",
+      "type": "image/png",
+      "sizes": "536x672"
+    }
+  ],
+  "start_url": "${URL}",
+  "display": "standalone",
+  "theme_color": "#480b8a",
+  "background_color": "#ffffff"
+}
+EOF
+
+npm run docker

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "HTTPS=true SSL_CRT_FILE=./.cert/cert.pem SSL_KEY_FILE=./.cert/key.pem react-scripts start",
+    "docker": "HTTPS=false react-scripts start",
     "build:dev": "PUBLIC_URL=https://d2uv4fa0aeja0t.cloudfront.net react-scripts build",
     "build:stage": "GENERATE_SOURCEMAP=false PUBLIC_URL=https://dbjxbnqel2bw9.cloudfront.net react-scripts build",
     "build:prod": "GENERATE_SOURCEMAP=false PUBLIC_URL=https://ds5zz9rfvzuta.cloudfront.net react-scripts build",


### PR DESCRIPTION
### Changes:
 - add `docker` to package.json scripts to start via npm in docker
 - add Makefile to easily create and run docker image on localhost
 
 using `make`
 ```
# creates local docker image using docker-buildx as harperdb/hdbms:[HDBMS_VERSION]
make image

# runs harperdb/hdbms:[HDBMS_VERSION] with the name 'hdbms' 
make run

# displays the version derived from package.json
make get-version

# stops and removes hdbms container
make clean

# builds, then runs image
make all

# clean up old image, then build an run new one, fuctionally the same as 'make clean image run'
make clean all
```

`[HDBMS_VERSION]` is pulled from `package.json`
to view logs of the running container, use `docker logs hdbms`. Add `-f` to follow logs, `ctrl+c` to stop following.

### Outstanding Issues

We are generating `src/config/index.js` and `public/manifest.json` in the `entrypoint.sh` script, which is run on container execution. This is causing the instance view to be stuck in a loop. If we generate these files in the docker build process, everything works correctly, however, the image is then restricted to running in that environment. 

In all reality, the issue is more likely to be with `src/config/index.js`. Regardless, changes still need to be made to the code base to support handling these files at runtime.