### PR TITLE
Primary key warning fix

### DIFF
--- a/src/components/instance/browse/index.js
+++ b/src/components/instance/browse/index.js
@@ -92,7 +92,7 @@ function BrowseIndex() {
        * FIXME: There is a fair amount of logic scattered throughout this
        * page that could be put in a router-level validation function.
        *
-       * Splitting the browse endpoint into /schema/ and /schema/table heirarchy
+       * Splitting the browse endpoint into /schema/ and /schema/table hierarchy
        * might ease this.
        *
        */
@@ -162,18 +162,16 @@ function BrowseIndex() {
           onError={(error, componentStack) => addError({ error: { message: error.message, componentStack } })}
           FallbackComponent={ErrorFallback}>
           {
-            hasHashAttr ? (
-              schema && table && action === 'csv' && entities.activeTable ? (
-                <CSVUpload />
-              ) : schema && table && action && entities.activeTable ? (
-                <JSONEditor newEntityAttributes={tableState.newEntityAttributes} hashAttribute={tableState.hashAttribute} />
-              ) : schema && table && entities.activeTable ? (
-                <DataTable activeTable={entities.activeTable} tableState={tableState} setTableState={setTableState} />
-              ) : (
-                <EmptyPrompt headline={emptyPromptMessage} icon={<i className="fa fa-exclamation-triangle text-warning" />} />
-              )
+            schema && table && action === 'csv' && entities.activeTable ? (
+              <CSVUpload />
+            ) : schema && table && action && entities.activeTable ? (
+              <JSONEditor newEntityAttributes={tableState.newEntityAttributes} hashAttribute={tableState.hashAttribute} />
+            ) : schema && table && entities.activeTable ? (
+              <DataTable activeTable={entities.activeTable} tableState={tableState} setTableState={setTableState} />
+            ) : schema && table && !hasHashAttr ? (
+              <NoPrimaryKeyMessage />
             ) :
-            <NoPrimaryKeyMessage table={table} />
+            <EmptyPrompt headline={emptyPromptMessage} icon={<i className="fa fa-exclamation-triangle text-warning" />} />
           }
         </ErrorBoundary>
       </Col>


### PR DESCRIPTION
Prior fix for preventing tables w/ no primary key was showing a warning when there were no tables at all.  This occurs when navigating from one instance's browse view to another via the instance nav.  The instance nav seems to assume that the 2nd instance has the same table (that may need to change, tbd). This refines that check so when navigating to instance b, it shows the appropriate view for that instance.