### PR TITLE
Only cached mode

### DIFF
--- a/src/components/instance/browse/BrowseDatatable.js
+++ b/src/components/instance/browse/BrowseDatatable.js
@@ -69,6 +69,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
         filtered: tableState.filtered,
         pageSize: tableState.pageSize,
         sorted: tableState.sorted,
+        onlyCached: tableState.onlyCached,
         page: tableState.page,
         auth,
         url,
@@ -78,7 +79,13 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
 
       if (isMounted) {
         setLoading(false);
-        if (!newData.error) {
+        if (newData.error) {
+          setTableState({
+            ...tableState,
+            tableData: [],
+            error,
+          });
+        } else {
           if (!tableState.filtered.length) {
             setTotalPages(newTotalPages);
             setTotalRecords(newTotalRecords);
@@ -109,7 +116,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
       isMounted = false;
     };
     // eslint-disable-next-line
-  }, [tableState.sorted, tableState.page, tableState.filtered, tableState.pageSize, lastUpdate, activeTable]);
+  }, [tableState.sorted, tableState.page, tableState.filtered, tableState.pageSize, tableState.onlyCached, lastUpdate, activeTable]);
 
   useInterval(() => tableState.autoRefresh && setLastUpdate(Date.now()), config.refresh_content_interval);
 
@@ -120,8 +127,10 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
         loading={loading}
         loadingFilter={loadingFilter}
         autoRefresh={tableState.autoRefresh}
+        onlyCached={tableState.onlyCached}
         refresh={() => setLastUpdate(Date.now())}
         toggleAutoRefresh={() => setTableState({ ...tableState, autoRefresh: !tableState.autoRefresh })}
+        toggleOnlyCached={() => setTableState({ ...tableState, onlyCached: !tableState.onlyCached })}
         toggleFilter={() => setTableState({ ...tableState, showFilter: !tableState.showFilter })}
       />
       <Card className="my-3">
@@ -130,6 +139,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
             manual
             columns={tableState.dataTableColumns || []}
             data={tableState.tableData || []}
+            error={tableState.error}
             currentPage={tableState.page}
             pageSize={tableState.pageSize}
             totalPages={totalPages || 0}

--- a/src/components/instance/browse/BrowseDatatableHeader.js
+++ b/src/components/instance/browse/BrowseDatatableHeader.js
@@ -4,7 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import commaNumbers from '../../../functions/util/commaNumbers';
 
-function BrowseDatatableHeader({ totalRecords, loading, loadingFilter, refresh, autoRefresh, toggleAutoRefresh, toggleFilter }) {
+function BrowseDatatableHeader({ totalRecords, loading, loadingFilter, refresh, autoRefresh, onlyCached, toggleAutoRefresh, toggleOnlyCached, toggleFilter }) {
   const navigate = useNavigate();
   const { compute_stack_id, schema, table, customer_id } = useParams();
 
@@ -30,6 +30,10 @@ function BrowseDatatableHeader({ totalRecords, loading, loadingFilter, refresh, 
         <Button id="toggleAutoRefresh" color="link" tabIndex="0" title="Turn on Auto-Refresh" onClick={toggleAutoRefresh}>
           <span className="me-2">auto</span>
           <i className={`fa fa-lg fa-toggle-${autoRefresh ? 'on' : 'off'}`} />
+        </Button>
+        <Button id="toggleOnlyCached" color="link" tabIndex="0" title="Only show cached data" onClick={toggleOnlyCached}>
+          <span className="me-2">only cached</span>
+          <i className={`fa fa-lg fa-toggle-${onlyCached ? 'on' : 'off'}`} />
         </Button>
         <span className="mx-3 text">|</span>
         <Button id="toggleSearch" color="link" tabIndex="0" title={`Filter table ${table}`} className="me-3" onClick={toggleFilter}>

--- a/src/components/instance/browse/JSONEditor.js
+++ b/src/components/instance/browse/JSONEditor.js
@@ -97,7 +97,9 @@ function JSONEditor({ newEntityAttributes, hashAttribute }) {
               schema,
               table,
               hash_values,
-              get_attributes: ['*']
+              get_attributes: ['*'],
+              onlyIfCached: true,
+              noCacheStore: true
           },
           auth,
           url

--- a/src/components/instance/browse/index.js
+++ b/src/components/instance/browse/index.js
@@ -27,6 +27,7 @@ const defaultTableState = {
   page: 0,
   pageSize: 20,
   autoRefresh: false,
+  onlyCached: false,
   showFilter: false,
   newEntityAttributes: false,
   hashAttribute: false,

--- a/src/components/instance/query/Datatable.js
+++ b/src/components/instance/query/Datatable.js
@@ -25,6 +25,7 @@ const defaultTableState = {
   totalPages: 1,
   pageSize: 20,
   autoRefresh: false,
+  onlyCached: false,
   showFilter: false,
   lastUpdate: false,
 };
@@ -103,7 +104,9 @@ function Datatable({ query }) {
         filtered={tableState.filtered}
         toggleFilter={(newValues) => setTableState({ ...tableState, ...newValues })}
         autoRefresh={tableState.autoRefresh}
+        onlyCached={tableState.onlyCached}
         setAutoRefresh={() => setTableState({ ...tableState, autoRefresh: !tableState.autoRefresh })}
+        setOnlyCached={() => setTableState({ ...tableState, onlyCached: !tableState.onlyCached })}
         setLastUpdate={setLastUpdate}
         setShowChartModal={setShowChartModal}
       />

--- a/src/components/shared/DataTable.js
+++ b/src/components/shared/DataTable.js
@@ -59,6 +59,7 @@ const defaultColumn = {
 function DataTable({
   columns,
   data,
+  error,
   currentPage,
   pageSize,
   totalPages,
@@ -120,7 +121,7 @@ function DataTable({
         ) : (
           <div className="centered text-center">
             <i className="fa fa-exclamation-triangle text-danger" />
-            <div className="mt-2 text-darkgrey">no records</div>
+            <div className="mt-2 text-darkgrey">{error ? 'Error loading data: ' + error : 'no records'}</div>
           </div>
         )}
       </div>

--- a/src/config/index.base.js
+++ b/src/config/index.base.js
@@ -1,0 +1,17 @@
+export default {
+  studio_version: 'x.x.xx',
+  env: 'dev',
+  stripe_public_key: 'pk_test_XXXXXXXXXXXXXXXXXXXXXX',
+  lms_api_url: 'https://dev.harperdbcloudservices.com/',
+  google_analytics_code: 'UA-XXXXXXXXXXXXX-3',
+  tc_version: '2020-01-01',
+  check_version_interval: 300000,
+  check_user_interval: 900000,
+  refresh_content_interval: 10000,
+  free_cloud_instance_limit: 1,
+  max_file_upload_size: 10380902,
+  alarm_badge_threshold: 86400,
+  maintenance: 0,
+  is_local_studio: process.env.REACT_APP_LOCALSTUDIO, // this is injected at build-time and loads LocalApp.js instead of App.js
+  local_studio_dev_url: 'http://localhost:9925', // this lets you dev the UI on port 3000 and talk to your local instance on 9925
+};

--- a/src/config/index.example.js
+++ b/src/config/index.example.js
@@ -1,17 +1,5 @@
 export default {
-  studio_version: 'x.x.xx',
-  env: 'dev',
   stripe_public_key: 'pk_test_XXXXXXXXXXXXXXXXXXXXXX',
   lms_api_url: 'XXXXXXXXXXXXXXXXXXXXXXXX',
   google_analytics_code: 'UA-XXXXXXXXXXXXX-3',
-  tc_version: '2020-01-01',
-  check_version_interval: 300000,
-  check_user_interval: 900000,
-  refresh_content_interval: 10000,
-  free_cloud_instance_limit: 1,
-  max_file_upload_size: 10380902,
-  alarm_badge_threshold: 86400,
-  maintenance: 0,
-  is_local_studio: process.env.REACT_APP_LOCALSTUDIO, // this is injected at build-time and loads LocalApp.js instead of App.js
-  local_studio_dev_url: 'http://localhost:9925', // this lets you dev the UI on port 3000 and talk to your local instance on 9925
 };

--- a/src/functions/api/instance/searchByConditions.js
+++ b/src/functions/api/instance/searchByConditions.js
@@ -1,8 +1,8 @@
 import queryInstance from '../queryInstance';
 
-export default async ({ auth, url, schema, table, operator, get_attributes, limit, offset, conditions, signal }) =>
+export default async ({ auth, url, schema, table, operator, get_attributes, limit, offset, onlyCached, conditions, signal }) =>
   queryInstance({
-    operation: { operation: 'search_by_conditions', schema, table, operator, get_attributes, limit, offset, conditions },
+    operation: { operation: 'search_by_conditions', schema, table, operator, get_attributes, limit, offset, conditions, onlyIfCached: onlyCached, noCacheStore: onlyCached },
     auth,
     url,
     signal,

--- a/src/functions/api/instance/searchByValue.js
+++ b/src/functions/api/instance/searchByValue.js
@@ -1,8 +1,8 @@
 import queryInstance from '../queryInstance';
 
-export default async ({ auth, url, schema, table, search_attribute, search_value, get_attributes, limit, offset, signal }) =>
+export default async ({ auth, url, schema, table, search_attribute, search_value, get_attributes, limit, offset, sort, onlyCached, signal }) =>
   queryInstance({
-    operation: { operation: 'search_by_value', schema, table, search_attribute, search_value, get_attributes, limit, offset },
+    operation: { operation: 'search_by_value', schema, table, search_attribute, search_value, get_attributes, limit, offset, sort, onlyIfCached: onlyCached, noCacheStore: onlyCached },
     auth,
     url,
     signal,

--- a/src/functions/instance/getTableData.js
+++ b/src/functions/instance/getTableData.js
@@ -22,7 +22,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
 
     const { record_count, attributes, hash_attribute } = result;
     allAttributes = attributes.map((a) => a.attribute);
-    hashAttribute = hash_attribute;
+    hashAttribute = hash_attribute ?? '$id';
     newTotalRecords = record_count;
     newTotalPages = newTotalRecords && Math.ceil(newTotalRecords / pageSize);
   } catch (e) {
@@ -36,7 +36,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
           schema,
           table,
           operator: 'and',
-          get_attributes: ['*'],
+          get_attributes: ['$id', '*'],
           limit: pageSize,
           offset,
           sort: sorted.length ? { attribute: sorted[0].id, descending: sorted[0].desc } : undefined,
@@ -52,7 +52,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
           table,
           search_attribute: hashAttribute,
           search_value: '*',
-          get_attributes: ['*'],
+          get_attributes: ['$id', '*'],
           limit: pageSize,
           offset,
           sort: sorted.length ? { attribute: sorted[0].id, descending: sorted[0].desc } : undefined,
@@ -79,7 +79,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
   if (allAttributes.includes('__updatedtime__')) orderedColumns.push('__updatedtime__');
 
   const dataTableColumns = (hashAttribute ? [ hashAttribute, ...orderedColumns ] : [ ...orderedColumns ]).map((k) => ({
-    Header: k.toString(),
+    Header: k === '$id' ? 'Primary Key' : k.toString(),
     accessor: (row) => row[k.toString()],
   }));
 


### PR DESCRIPTION
* Adds support for a cache-only mode
* Get rid of that terrible SQL query
* Show errors when they occur instead always saying "no records"
* Fix handling of tables with no primary key attribute
* Define a base config so individual configs aren't over-specified and drift out of sync