### PR TITLE
Only add metadata id for tables that are lacking a primary key

### DIFF
--- a/src/functions/instance/getTableData.js
+++ b/src/functions/instance/getTableData.js
@@ -10,6 +10,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
   let newData = [];
   let allAttributes = false;
   let hashAttribute = false;
+  let get_attributes = ['*']
   const offset = page * pageSize;
 
   try {
@@ -22,7 +23,12 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
 
     const { record_count, attributes, hash_attribute } = result;
     allAttributes = attributes.map((a) => a.attribute);
-    hashAttribute = hash_attribute ?? '$id';
+    if (hash_attribute == undefined) {
+      hashAttribute = '$id';
+      get_attributes = ['$id', '*'];
+    } else
+      hashAttribute = hash_attribute;
+
     newTotalRecords = record_count;
     newTotalPages = newTotalRecords && Math.ceil(newTotalRecords / pageSize);
   } catch (e) {
@@ -36,7 +42,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
           schema,
           table,
           operator: 'and',
-          get_attributes: ['$id', '*'],
+          get_attributes,
           limit: pageSize,
           offset,
           sort: sorted.length ? { attribute: sorted[0].id, descending: sorted[0].desc } : undefined,
@@ -52,7 +58,7 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
           table,
           search_attribute: hashAttribute,
           search_value: '*',
-          get_attributes: ['$id', '*'],
+          get_attributes,
           limit: pageSize,
           offset,
           sort: sorted.length ? { attribute: sorted[0].id, descending: sorted[0].desc } : undefined,


### PR DESCRIPTION
Only add the $id metadata attribute for tables without primary keys so we don't mess up older hdb versions with tables that do have a primary key.