### PR TITLE
[FIX] [STUDIO-99] Reduced new instance name max character count from 15 to 14 characters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harperdb-studio",
-  "version": "4.5.9",
+  "version": "4.6.1",
   "description": "A UI for HarperDB",
   "deploymentUrl": "studio.harperdb.io",
   "private": true,
@@ -84,5 +84,6 @@
     "stylelint-order": "^6.0.1",
     "stylelint-scss": "^6.0.0",
     "typescript": "^5.6.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/instances/new/MetaLocal.js
+++ b/src/components/instances/new/MetaLocal.js
@@ -98,7 +98,7 @@ function MetaLocal() {
     <>
       <Card>
         <CardBody>
-          <ContentContainer header="Instance Name" subheader="letters, numbers, and hyphens only. 16 char max.">
+          <ContentContainer header="Instance Name" subheader="letters, numbers, and hyphens only. 14 char max.">
             <Row>
               <Col sm="4" className="pt-2 text-nowrap text-grey">
                 Example: &quot;local-1&quot;
@@ -113,10 +113,11 @@ function MetaLocal() {
                         .replace(/^0+/, '')
                         .replace(/^-+/, '')
                         .replace(/[^a-z\d-]+/gi, '')
-                        .substring(0, 15)
+                        .substring(0, 14)
                         .toLowerCase(),
                     })
                   }
+                  max={14}
                   type="text"
                   title="instance_name"
                   value={formData.instance_name}


### PR DESCRIPTION
## Ticket: 
[STUDIO-99](https://harperdb.atlassian.net/browse/STUDIO-99)

## Overview:
- Reduces "Instance Name" character count from 15 characters to 14 characters.
- Version bump 4.6.0 -> 4.6.1

## Manual Testing:
1. Login using your credentials
2. Navigate to your "org"
3. Click "Create New HarperDB Cloud Instance" Card Button
4. Create an instance with an "Instance Name" character count to the max allowed(14) in the input

**Expected Result:**
You should be able to create an instance with 14 characters or less.

## Additional Context:
AWS expects 14 characters as the max and will throw an error if it's above it. Reducing the input to have a max of 14 characters fixes it.


