### PR TITLE
[Enhancement] Added Dynamically Defined Keys in Rows as Table Columns 

### DIFF
--- a/src/assets/styles/components/_react-table.scss
+++ b/src/assets/styles/components/_react-table.scss
@@ -18,6 +18,11 @@
         min-width: 100px;
         white-space: nowrap;
 
+        &.disabled-column {
+          background-color: $lighter-grey-overlay !important;
+          cursor: not-allowed;
+        }
+
         &.sorted {
           &.desc {
             box-shadow: inset 0 -2px 0 0 $lighter-grey-overlay;
@@ -26,7 +31,6 @@
           &.asc {
             box-shadow: inset 0 2px 0 0 $lighter-grey-overlay;
           }
-
         }
       }
     }
@@ -128,7 +132,6 @@
         float: right;
       }
     }
-
 
     .paginator {
       align-items: center;

--- a/src/components/instance/browse/BrowseDatatable.js
+++ b/src/components/instance/browse/BrowseDatatable.js
@@ -65,7 +65,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
       }
       controller = new AbortController();
       controller2 = new AbortController();
-      const { newData, newTotalRecords, newTotalPages, newEntityAttributes, hashAttribute, dataTableColumns, error } = await getTableData({
+      const { newData, newTotalRecords, newTotalPages, newEntityAttributes, hashAttribute, dataTableColumns, dynamicAttributesFromDataTable, error } = await getTableData({
         schema,
         table,
         filtered: tableState.filtered,
@@ -103,6 +103,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
             newEntityAttributes,
             hashAttribute,
             dataTableColumns,
+            dynamicAttributesFromDataTable,
             error,
           });
         }
@@ -154,6 +155,7 @@ function BrowseDatatable({ tableState, setTableState, activeTable }) {
             showFilter={tableState.showFilter}
             sorted={tableState.sorted.length ? tableState.sorted : [{ id: tableState.hashAttribute, desc: false }]}
             loading={loading && !tableState.autoRefresh}
+            dynamicAttributesFromDataTable={tableState.dynamicAttributesFromDataTable}
             onFilteredChange={(value) => {
               setTableState({ ...tableState, page: 0, filtered: value });
             }}

--- a/src/components/shared/DataTable.js
+++ b/src/components/shared/DataTable.js
@@ -71,6 +71,7 @@ function DataTable({
   onRowClick,
   sorted,
   loading,
+  dynamicAttributesFromDataTable,
   manual = false,
 }) {
   const { headerGroups, page, rows, prepareRow, state, setAllFilters, canPreviousPage, canNextPage, pageOptions, pageCount, gotoPage, nextPage, previousPage, setPageSize } =
@@ -111,7 +112,7 @@ function DataTable({
   return (
     <ErrorBoundary onError={(err, componentStack) => addError({ error: { message: err.message, componentStack } })} FallbackComponent={ErrorFallback}>
       <div className="react-table-scroller">
-        <DataTableHeader headerGroups={headerGroups} onSortedChange={onSortedChange} sorted={sorted} showFilter={showFilter} />
+        <DataTableHeader headerGroups={headerGroups} onSortedChange={onSortedChange} sorted={sorted} showFilter={showFilter} dynamicAttributesFromDataTable={dynamicAttributesFromDataTable} />
         {loading || localLoading ? (
           <div className="centered text-center">
             <i className="fa fa-spinner fa-spin" />

--- a/src/components/shared/DataTable.js
+++ b/src/components/shared/DataTable.js
@@ -111,7 +111,7 @@ function DataTable({
 
   return (
     <ErrorBoundary onError={(err, componentStack) => addError({ error: { message: err.message, componentStack } })} FallbackComponent={ErrorFallback}>
-      <div className="react-table-scroller">
+      <div role="table" aria-label="Table Data" className="react-table-scroller">
         <DataTableHeader headerGroups={headerGroups} onSortedChange={onSortedChange} sorted={sorted} showFilter={showFilter} dynamicAttributesFromDataTable={dynamicAttributesFromDataTable} />
         {loading || localLoading ? (
           <div className="centered text-center">

--- a/src/components/shared/DataTableHeader.js
+++ b/src/components/shared/DataTableHeader.js
@@ -1,14 +1,6 @@
 import React from 'react';
 import { Row, Col } from 'reactstrap';
 
-// // loop through each column and add ' disableSortBy: true' if column Header string matches string from dynamicAttributesFromDataTable
-// columns.forEach((column) => {
-//   dynamicAttributesFromDataTable.forEach((dynamicAttribute) => {
-//     if (column.Header === dynamicAttribute) {
-//       column.enableSorting = false
-//     }
-//   })
-// })
 const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter, dynamicAttributesFromDataTable }) =>
   headerGroups.map((headerGroup) => {
     const { key, ...rest } = headerGroup.getHeaderGroupProps();

--- a/src/components/shared/DataTableHeader.js
+++ b/src/components/shared/DataTableHeader.js
@@ -19,8 +19,6 @@ const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter, dyn
             <Col
               key={column.id}
               onClick={() => {
-                console.log('dynamicAttributesFromDataTable', dynamicAttributesFromDataTable);
-                console.log('column.id', column.id)
                 if (!dynamicAttributesFromDataTable.includes(column.id)) {
                   onSortedChange([{ id: column.id, desc: sorted[0]?.id === column.id ? !sorted[0]?.desc : false }])
                 }

--- a/src/components/shared/DataTableHeader.js
+++ b/src/components/shared/DataTableHeader.js
@@ -15,7 +15,7 @@ const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter, dyn
                   onSortedChange([{ id: column.id, desc: sorted[0]?.id === column.id ? !sorted[0]?.desc : false }])
                 }
               }}
-              className={`${sorted[0]?.id === column.id ? 'sorted' : ''} ${sorted[0]?.desc ? 'desc' : 'asc'} ${column.id.indexOf('hdb-narrow') !== -1 ? 'action' : ''} px-1`}
+              className={`${sorted[0]?.id === column.id ? 'sorted' : ''} ${sorted[0]?.desc ? 'desc' : 'asc'} ${column.id.indexOf('hdb-narrow') !== -1 ? 'action' : ''} px-1 ${!dynamicAttributesFromDataTable.includes(column.id) ? '' : 'disabled-column'}`}
             >
               <div className="text-renderer">{column.render('Header')}</div>
             </Col>

--- a/src/components/shared/DataTableHeader.js
+++ b/src/components/shared/DataTableHeader.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import { Row, Col } from 'reactstrap';
 
-const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter }) =>
+// // loop through each column and add ' disableSortBy: true' if column Header string matches string from dynamicAttributesFromDataTable
+// columns.forEach((column) => {
+//   dynamicAttributesFromDataTable.forEach((dynamicAttribute) => {
+//     if (column.Header === dynamicAttribute) {
+//       column.enableSorting = false
+//     }
+//   })
+// })
+const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter, dynamicAttributesFromDataTable }) =>
   headerGroups.map((headerGroup) => {
     const { key, ...rest } = headerGroup.getHeaderGroupProps();
     return (
@@ -10,7 +18,13 @@ const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter }) =
           {headerGroup.headers.map((column) => (
             <Col
               key={column.id}
-              onClick={() => onSortedChange([{ id: column.id, desc: sorted[0]?.id === column.id ? !sorted[0]?.desc : false }])}
+              onClick={() => {
+                console.log('dynamicAttributesFromDataTable', dynamicAttributesFromDataTable);
+                console.log('column.id', column.id)
+                if (!dynamicAttributesFromDataTable.includes(column.id)) {
+                  onSortedChange([{ id: column.id, desc: sorted[0]?.id === column.id ? !sorted[0]?.desc : false }])
+                }
+              }}
               className={`${sorted[0]?.id === column.id ? 'sorted' : ''} ${sorted[0]?.desc ? 'desc' : 'asc'} ${column.id.indexOf('hdb-narrow') !== -1 ? 'action' : ''} px-1`}
             >
               <div className="text-renderer">{column.render('Header')}</div>
@@ -29,5 +43,4 @@ const DataTableHeader = ({ headerGroups, onSortedChange, sorted, showFilter }) =
       </div>
     );
   });
-
 export default DataTableHeader;

--- a/src/functions/instance/getTableData.js
+++ b/src/functions/instance/getTableData.js
@@ -3,18 +3,24 @@ import searchByValue from '../api/instance/searchByValue';
 import searchByConditions from '../api/instance/searchByConditions';
 
 const getAttributesFromTableData = (tableData, existingAttributes) => {
-  const existing = new Set(existingAttributes);
-  const extra = new Set();
+  const existing = new Map(existingAttributes.map((value, index) => [value, index]));
+  const extra = new Map();
   for (const dataRow of tableData) {
     for (const key of Object.keys(dataRow)) {
       if (!existing.has(key)) {
-        extra.add(key);
+        const count = extra.get(key) || 0;
+        extra.set(key, count + 1);
       }
     }
   }
-  return Array.from(extra);
+  const result = [];
+  for (const [key, count] of extra) {
+    if (count >= 8) {
+      result.push(key);
+    }
+  }
+  return result;
 }
-
 
 export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, page, auth, url, signal, signal2 }) => {
   let fetchError = false;

--- a/src/functions/instance/getTableData.js
+++ b/src/functions/instance/getTableData.js
@@ -78,6 +78,15 @@ export default async ({ schema, table, filtered, pageSize, onlyCached, sorted, p
 
   // sort columns, but keep primary key / hash attribute first, and created and updated last.
   // NOTE: __created__ and __updated__ might not exist in the schema, only include if they exist.
+  let extraAttributesArray = [];
+  for (const dataRow of newData) {
+    const dataRowAttributes = Object.keys(dataRow);
+    if (dataRowAttributes.length !== allAttributes.length) {
+      extraAttributesArray = dataRowAttributes.filter((dataRowAttribute) => !allAttributes.includes(dataRowAttribute))
+      allAttributes.push(...extraAttributesArray)
+    };
+  }
+
   const orderedColumns = allAttributes.filter((a) => ![hashAttribute, '__createdtime__', '__updatedtime__'].includes(a)).sort();
   const newEntityAttributes = orderedColumns.reduce((ac, a) => ({ ...ac, [a]: null }), {});
 


### PR DESCRIPTION
## Ticket: 
[STUDIO-110](https://harperdb.atlassian.net/browse/STUDIO-110)

## Overview:
- Added functionality for dynamically defined keys in Rows to display as Table Columns. 

## Manual Testing:
1. Login
2. Choose an instance and navigate to the 'browse' sub-menu' tab and navigate to a database
4. Click on a row and add a new key/value pair in the JSON object save
**Expected Result:**
New column should be added to rows and clicking that column to initiate filtering should be disabled.


## Additional Context
When filtering on some columns, the data returned from the server doesn't have the dynamically added key/value pairs. The dynamically added columns disappear as well. Is that okay? @kriszyp 