### PR TITLE
[Enhancement] Added Max Length to necessary Input Fields on Sign Up Page

### DIFF
--- a/src/components/auth/SignUp.js
+++ b/src/components/auth/SignUp.js
@@ -44,6 +44,7 @@ function SignUp() {
               <Input
                 id="firstname"
                 name="fname"
+                maxLength={20}
                 required
                 autoComplete="given-name"
                 type="text"
@@ -59,6 +60,7 @@ function SignUp() {
               <Input
                 id="lastname"
                 name="lname"
+                maxLength={20}
                 required
                 autoComplete="family-name"
                 type="text"
@@ -74,6 +76,7 @@ function SignUp() {
               <Input
                 id="email"
                 autoComplete="email"
+                maxLength={64}
                 name="email"
                 required
                 className="mb-2"


### PR DESCRIPTION
## Ticket: 
N/A

## Overview:
- Added Max Length to necessary Input Fields on Sign Up Page. Prevents people/bots from inputting unnecessarily long strings in our form fields

## Manual Testing:
1. Navigate to the Sign Up Page
2. Fill out form fields
**Expected Result**
Inputs:
- First Name: max length of 20 characters
- Last Name: max length of 20 characters
- Email: max length of 64 characters


## Additional Context