### PR TITLE
Rename cluster tag to abbreviated name

### DIFF
--- a/src/features/clusters/hooks/useCreateNewCluster.ts
+++ b/src/features/clusters/hooks/useCreateNewCluster.ts
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 export type NewClusterInfo = {
 	clusterName: string;
 	organizationId: string;
-	clusterTag: string;
+	abbreviatedName: string;
 };
 
 type NewClusterInfoResponse = {
@@ -17,11 +17,11 @@ type NewClusterInfoResponse = {
 export const onNewClusterSubmit = async ({
 	clusterName,
 	organizationId,
-	clusterTag,
+	abbreviatedName,
 }: NewClusterInfo): Promise<NewClusterInfoResponse> => {
 	const { data } = await apiClient.post('/Cluster', {
 		name: clusterName,
-		tag: clusterTag,
+		abbreviatedName,
 		organizationId,
 	});
 	if (data) {

--- a/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
+++ b/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
@@ -14,7 +14,7 @@ function InfoForm() {
 					<FormItem className="">
 						<FormLabel className="pb-1">Cluster Name</FormLabel>
 						<FormControl>
-							<Input type="text" placeholder="User Cluster" maxLength={25} {...field} className="max-w-64" />
+							<Input type="text" placeholder="User Cluster" maxLength={255} {...field} className="max-w-64" />
 						</FormControl>
 						<FormMessage />
 					</FormItem>
@@ -27,7 +27,7 @@ function InfoForm() {
 					<FormItem className="">
 						<FormLabel className="pb-1">Abbreviated Name</FormLabel>
 						<FormControl>
-							<Input type="text" placeholder="ex. cluster-1" maxLength={10} {...field} className="max-w-64" />
+							<Input type="text" placeholder="ex. cluster-1" maxLength={20} {...field} className="max-w-64" />
 						</FormControl>
 						<FormMessage />
 					</FormItem>

--- a/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
+++ b/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
@@ -14,7 +14,7 @@ function InfoForm() {
 					<FormItem className="">
 						<FormLabel className="pb-1">Cluster Name</FormLabel>
 						<FormControl>
-							<Input type="text" placeholder="User Cluster" {...field} className="max-w-64" />
+							<Input type="text" placeholder="User Cluster" maxLength={25} {...field} className="max-w-64" />
 						</FormControl>
 						<FormMessage />
 					</FormItem>
@@ -22,12 +22,12 @@ function InfoForm() {
 			/>
 			<FormField
 				control={form.control}
-				name="clusterTag"
+				name="abbreviatedName"
 				render={({ field }) => (
 					<FormItem className="">
-						<FormLabel className="pb-1">Cluster Tag</FormLabel>
+						<FormLabel className="pb-1">Abbreviated Name</FormLabel>
 						<FormControl>
-							<Input type="text" placeholder="ex. user-cluster-1" {...field} className="max-w-64" />
+							<Input type="text" placeholder="ex. cluster-1" maxLength={10} {...field} className="max-w-64" />
 						</FormControl>
 						<FormMessage />
 					</FormItem>

--- a/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
+++ b/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
@@ -16,7 +16,7 @@ import { Control } from 'react-hook-form';
 type RegionFormInputsProps = {
 	control: Control<{
 		clusterName: string;
-		clusterTag: string;
+		abbreviatedName: string;
 		instanceTypes: string;
 		storage: string;
 		regions?: { region: string; count: number; cloudProvider: string }[] | undefined;

--- a/src/features/clusters/modals/NewClusterModal/index.tsx
+++ b/src/features/clusters/modals/NewClusterModal/index.tsx
@@ -52,7 +52,7 @@ const storageSizeOptions = [
 
 const NewClusterSchema = z.object({
 	clusterName: z.string().min(4, 'Must be at least 4 characters long.').max(25, 'Must be at most 25 characters long.'),
-	clusterTag: z.string().min(4, 'Must be at least 4 characters long.').max(10, 'Must be at most 10 characters long.'),
+	abbreviatedName: z.string().min(4, 'Must be at least 4 characters long.').max(10, 'Must be at most 10 characters long.'),
 	instanceTypes: z.string({
 		required_error: 'Please select an instance type.',
 	}),
@@ -77,7 +77,7 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 		resolver: zodResolver(NewClusterSchema),
 		defaultValues: {
 			clusterName: '',
-			clusterTag: '',
+			abbreviatedName: '',
 			regions: [], // Initialize regions as an empty array
 		},
 	});
@@ -92,7 +92,7 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 
 	const selectedRegions = form.watch('regions');
 
-	const submitForm = async (formData: { clusterName: string; clusterTag: string }) => {
+	const submitForm = async (formData: { clusterName: string; abbreviatedName: string }) => {
 		const updatedFormData = {
 			organizationId: orgId,
 			...formData,
@@ -126,7 +126,7 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 								<FormItem className="md:col-span-3">
 									<FormLabel className="pb-1">Cluster Name</FormLabel>
 									<FormControl>
-										<Input type="text" placeholder="User Cluster" {...field} className="" />
+										<Input type="text" placeholder="User Cluster" maxLength={25} {...field} className="" />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -134,12 +134,12 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 						/>
 						<FormField
 							control={form.control}
-							name="clusterTag"
+							name="abbreviatedName"
 							render={({ field }) => (
 								<FormItem className="md:col-span-3">
-									<FormLabel className="pb-1">Cluster Tag</FormLabel>
+									<FormLabel className="pb-1">Abbreviated Name</FormLabel>
 									<FormControl>
-										<Input type="text" placeholder="ex. user-cluster-1" {...field} className="" />
+										<Input type="text" placeholder="ex. cluster-1" maxLength={10} {...field} className="" />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/src/features/clusters/modals/NewClusterModal/index.tsx
+++ b/src/features/clusters/modals/NewClusterModal/index.tsx
@@ -51,8 +51,11 @@ const storageSizeOptions = [
 ];
 
 const NewClusterSchema = z.object({
-	clusterName: z.string().min(4, 'Must be at least 4 characters long.').max(25, 'Must be at most 25 characters long.'),
-	abbreviatedName: z.string().min(4, 'Must be at least 4 characters long.').max(10, 'Must be at most 10 characters long.'),
+	clusterName: z.string().min(1, 'Must be at least 1 character long.').max(255, 'Must be at most 255 characters long.'),
+	abbreviatedName: z.string()
+		.min(1, 'Must be at least 1 character long.')
+		.max(20, 'Must be at most 20 characters long.')
+		.regex(/^[a-zA-Z0-9-]+$/, 'Can only contain letters, numbers and dashes'),
 	instanceTypes: z.string({
 		required_error: 'Please select an instance type.',
 	}),
@@ -126,7 +129,7 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 								<FormItem className="md:col-span-3">
 									<FormLabel className="pb-1">Cluster Name</FormLabel>
 									<FormControl>
-										<Input type="text" placeholder="User Cluster" maxLength={25} {...field} className="" />
+										<Input type="text" placeholder="User Cluster" maxLength={255} {...field} className="" />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -139,7 +142,7 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 								<FormItem className="md:col-span-3">
 									<FormLabel className="pb-1">Abbreviated Name</FormLabel>
 									<FormControl>
-										<Input type="text" placeholder="ex. cluster-1" maxLength={10} {...field} className="" />
+										<Input type="text" placeholder="ex. cluster-1" maxLength={20} {...field} className="" />
 									</FormControl>
 									<FormMessage />
 								</FormItem>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f6db4ff2-7fbd-4c7c-b48c-397f0328d510)


Instead of cluster tags, we're shifting to abbreviated names! This will let us create clusters again under the new central manager. I also bubbled the current length restrictions out to the HTML `<input />` elements for the cluster name and abbreviated names so that we don't bait-and-switch the user on the length of the name as they type. That may be a controversial change, you never know, and I don't feel particularly strong either way. 😉 

https://harperdb.atlassian.net/browse/FAB-125