### PR TITLE
All exports are now named

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,10 @@ import { ClusterProvider } from '@/features/cluster/context/ClusterAuthContext';
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 // import { toast } from 'sonner';
 import { Toaster } from '@/components/ui/sonner';
-import ErrorComponent from '@/components/ErrorComponent';
-import NotFoundComponent from '@/components/NotFoundComponent';
+import { ErrorComponent } from '@/components/ErrorComponent';
+import { NotFoundComponent } from '@/components/NotFoundComponent';
 
-function App() {
+export function App() {
 	// const isLocalStudio = import.meta.env.VITE_LOCAL_STUDIO == 'true';
 	const hashHistory = createHashHistory();
 	// const loadedRouter = isLocalStudio ? localRouteTree : cloudRouteTree;
@@ -69,5 +69,3 @@ function App() {
 		</>
 	);
 }
-
-export default App;

--- a/src/StudioCloud.tsx
+++ b/src/StudioCloud.tsx
@@ -1,7 +1,5 @@
 import { Outlet } from '@tanstack/react-router';
 
-function StudioCloud() {
+export function StudioCloud() {
 	return <Outlet />;
 }
-
-export default StudioCloud;

--- a/src/StudioLocal.tsx
+++ b/src/StudioLocal.tsx
@@ -1,11 +1,9 @@
 import { Outlet } from '@tanstack/react-router';
 
-function FabricLocal() {
+export function StudioLocal() {
 	return (
 		<>
 			<Outlet />
 		</>
 	);
 }
-
-export default FabricLocal;

--- a/src/components/ErrorComponent/index.tsx
+++ b/src/components/ErrorComponent/index.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ArrowLeft } from 'lucide-react';
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser';
 
-const ErrorComponent = ({ error }: { error: Error }) => {
+export function ErrorComponent({ error }: { error: Error }) {
 	const { data: user, isLoading: isUserLoading } = useGetCurrentUser();
 
 	return (
@@ -34,6 +34,4 @@ const ErrorComponent = ({ error }: { error: Error }) => {
 			</CardContent>
 		</Card>
 	);
-};
-
-export default ErrorComponent;
+}

--- a/src/components/InstanceTypeSelectInput/index.tsx
+++ b/src/components/InstanceTypeSelectInput/index.tsx
@@ -4,7 +4,7 @@
 // import { useQuery } from '@tanstack/react-query';
 // import { Controller } from 'react-hook-form';
 
-// function InstanceTypeSelectInput({ defaultValue, name, control, rules }) {
+// export function InstanceTypeSelectInput({ defaultValue, name, control, rules }) {
 // 	const { data: instanceTypes } = useQuery(getInstanceTypeOptions());
 // 	return (
 // 		<Controller
@@ -31,5 +31,3 @@
 // 		/>
 // 	);
 // }
-
-// export default InstanceTypeSelectInput;

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -2,13 +2,11 @@ interface LoadingProps extends React.ComponentProps<'div'> {
 	text?: string;
 }
 
-const Loading = ({ className, text, ...props }: LoadingProps) => {
+export function Loading({ className, text, ...props }: LoadingProps) {
 	return (
 		<div className={`text-white h-full w-full ${className}`} {...props}>
 			<img src="/HDBDogOnly.svg" width="100px" height="100px" alt="HDB Dog Logo Loading" />
 			<p className="pt-4">{!text ? 'Loading...' : text}</p>
 		</div>
 	);
-};
-
-export default Loading;
+}

--- a/src/components/NotFoundComponent/index.tsx
+++ b/src/components/NotFoundComponent/index.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft } from 'lucide-react';
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser';
 
-const NotFoundComponent = () => {
+export function NotFoundComponent() {
 	const { data: user, isLoading: isUserLoading } = useGetCurrentUser();
 	return (
 		<div className="flex items-center justify-center h-screen px-3">
@@ -34,6 +34,4 @@ const NotFoundComponent = () => {
 			</Card>
 		</div>
 	);
-};
-
-export default NotFoundComponent;
+}

--- a/src/config/apiClient.ts
+++ b/src/config/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { TypedAxios } from './typed-axios';
 
-const apiClient = axios.create({
+export const apiClient = axios.create({
 	withCredentials: true,
 	baseURL: import.meta.env.VITE_CENTRAL_MANAGER_API_URL,
 	timeout: 15000,
@@ -9,5 +9,3 @@ const apiClient = axios.create({
 		'Content-Type': 'application/json',
 	},
 }) as TypedAxios;
-
-export default apiClient;

--- a/src/config/instanceClient.ts
+++ b/src/config/instanceClient.ts
@@ -1,11 +1,10 @@
 import axios from 'axios';
 
-const instanceClient = axios.create({
+export const instanceClient = axios.create({
 	withCredentials: true,
 	timeout: 15000,
 	headers: {
 		'Content-Type': 'application/json',
 	},
 });
-// TODO: }) as TypedAxios?
-export default instanceClient;
+// TODO: as TypedAxios?

--- a/src/features/auth/AuthLayout.tsx
+++ b/src/features/auth/AuthLayout.tsx
@@ -9,7 +9,7 @@ function ListItem({ title, children }: { title: string; children: React.ReactNod
 	);
 }
 
-function AuthLayout() {
+export function AuthLayout() {
 	return (
 		<div className="grid h-screen grid-cols-1 md:grid-cols-2">
 			<section className="items-center justify-center hidden text-white md:flex bg-linear-(--blue-pink-gradient) px-6">
@@ -78,4 +78,4 @@ function AuthLayout() {
 	);
 }
 
-export default AuthLayout;
+

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -17,7 +17,7 @@ const ForgotPasswordSchema = z.object({
 		.email({ message: 'Please enter a valid email address' }),
 });
 
-function ForgotPassword() {
+export function ForgotPassword() {
 	const navigate = useNavigate();
 	const form = useForm<z.infer<typeof ForgotPasswordSchema>>({
 		resolver: zodResolver(ForgotPasswordSchema),
@@ -85,4 +85,4 @@ function ForgotPassword() {
 	);
 }
 
-export default ForgotPassword;
+

--- a/src/features/auth/LocalSignIn.tsx
+++ b/src/features/auth/LocalSignIn.tsx
@@ -21,7 +21,7 @@ const LocalSignInSchema = z.object({
 		.max(50, { message: 'Password must be less than 50 characters' }),
 });
 
-function LocalSignIn() {
+export function LocalSignIn() {
 	const navigate = useNavigate();
 	const router = useRouter();
 	const form = useForm<z.infer<typeof LocalSignInSchema>>({
@@ -94,5 +94,3 @@ function LocalSignIn() {
 		</div>
 	);
 }
-
-export default LocalSignIn;

--- a/src/features/auth/ResetPassword.tsx
+++ b/src/features/auth/ResetPassword.tsx
@@ -19,7 +19,7 @@ const ResetPasswordSchema = z
 		path: ['confirmPassword'],
 	});
 
-function RestPassword() {
+export function RestPassword() {
 	const { token } = useSearch({ strict: false });
 	const navigate = useNavigate();
 
@@ -110,4 +110,4 @@ function RestPassword() {
 	);
 }
 
-export default RestPassword;
+

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -22,7 +22,7 @@ const SignInSchema = z.object({
 		.max(50, { message: 'Password must be less than 50 characters' }),
 });
 
-function SignIn() {
+export function SignIn() {
 	const navigate = useNavigate();
 	const router = useRouter();
 	const form = useForm<z.infer<typeof SignInSchema>>({
@@ -102,4 +102,4 @@ function SignIn() {
 	);
 }
 
-export default SignIn;
+

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -35,7 +35,7 @@ const SignInSchema = z.object({
 		.max(50, { message: 'Password must be less than 50 characters.' }),
 });
 
-function SignUp() {
+export function SignUp() {
 	const navigate = useNavigate();
 	const form = useForm<z.infer<typeof SignInSchema>>({
 		resolver: zodResolver(SignInSchema),
@@ -156,4 +156,4 @@ function SignUp() {
 	);
 }
 
-export default SignUp;
+

--- a/src/features/auth/VerifyEmail.tsx
+++ b/src/features/auth/VerifyEmail.tsx
@@ -75,7 +75,7 @@ function SendEmailVerification() {
 	);
 }
 
-function VerifyEmail() {
+export function VerifyEmail() {
 	const { token } = useSearch({ strict: false });
 	const navigate = useNavigate();
 
@@ -114,4 +114,4 @@ function VerifyEmail() {
 	);
 }
 
-export default VerifyEmail;
+

--- a/src/features/auth/hooks/useForgotPassword.ts
+++ b/src/features/auth/hooks/useForgotPassword.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
@@ -10,7 +10,7 @@ type ForgotPasswordResponse = {
 	email: string;
 };
 
-export const onResetPasswordSubmit = async ({ email }: ForgotPasswordCredential): Promise<ForgotPasswordResponse> => {
+export async function onResetPasswordSubmit({ email }: ForgotPasswordCredential): Promise<ForgotPasswordResponse> {
 	const { data } = await apiClient.post('/ForgotPassword/', {
 		email,
 	});
@@ -20,7 +20,7 @@ export const onResetPasswordSubmit = async ({ email }: ForgotPasswordCredential)
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useForgotPasswordMutation() {
 	return useMutation<ForgotPasswordResponse, Error, ForgotPasswordCredential>({

--- a/src/features/auth/hooks/useLocalSignIn.ts
+++ b/src/features/auth/hooks/useLocalSignIn.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
@@ -11,10 +11,10 @@ type RegistrationInfoResponse = {
 	message: string;
 };
 
-export const onInstanceLoginSubmit = async ({
+export async function onInstanceLoginSubmit({
 	username,
 	password,
-}: InstanceLoginCredentials): Promise<RegistrationInfoResponse> => {
+}: InstanceLoginCredentials): Promise<RegistrationInfoResponse> {
 	// TODO: The OpenAPI specs don't describe this route.
 	const { data } = await apiClient.post('/' as never, {
 		operation: 'login',
@@ -26,7 +26,7 @@ export const onInstanceLoginSubmit = async ({
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useLocalSignIn() {
 	return useMutation<RegistrationInfoResponse, Error, InstanceLoginCredentials>({

--- a/src/features/auth/hooks/useResendEmailVerification.ts
+++ b/src/features/auth/hooks/useResendEmailVerification.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation

--- a/src/features/auth/hooks/useResetPassword.ts
+++ b/src/features/auth/hooks/useResetPassword.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 type ResetPasswordRequest = {

--- a/src/features/auth/hooks/useSignIn.ts
+++ b/src/features/auth/hooks/useSignIn.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
@@ -14,7 +14,7 @@ type SignInResponse = {
 	lastname: string;
 };
 
-export const onLoginSubmit = async ({ email, password }: SignInCredentials): Promise<SignInResponse> => {
+export async function onLoginSubmit({ email, password }: SignInCredentials): Promise<SignInResponse> {
 	// TODO: The OpenAPI request body for this endpoint isn't defined.
 	const { data } = await apiClient.post('/Login/', {
 		email,
@@ -26,7 +26,7 @@ export const onLoginSubmit = async ({ email, password }: SignInCredentials): Pro
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useLoginMutation() {
 	return useMutation<SignInResponse, Error, SignInCredentials>({

--- a/src/features/auth/hooks/useSignOut.ts
+++ b/src/features/auth/hooks/useSignOut.ts
@@ -1,15 +1,15 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
 
-export const onSignOutSubmit = async () => {
+export async function onSignOutSubmit() {
 	// TODO: OpenAPI only describes a 200, not a 204.
 	const { status } = await apiClient.post('/Logout/');
 	if (status === 204) {
 		return;
 	}
-};
+}
 
 export function useSignOutMutation() {
 	return useMutation({

--- a/src/features/auth/hooks/useSignUp.ts
+++ b/src/features/auth/hooks/useSignUp.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 import { SchemaUser } from '@/lib/api.gen';
 
@@ -16,7 +16,8 @@ type SignUpResponse = {
 	firstname: string;
 	lastname: string;
 };
-export const onSignUpSubmit = async (signUpCredentials: SignUpCredentials): Promise<SignUpResponse> => {
+
+export async function onSignUpSubmit(signUpCredentials: SignUpCredentials): Promise<SignUpResponse> {
 	// TODO: The types in our OpenAPI for this endpoint aren't defined.
 	const { data } = await apiClient.post<SignUpCredentials>('/User/', signUpCredentials);
 	if (data) {
@@ -24,7 +25,7 @@ export const onSignUpSubmit = async (signUpCredentials: SignUpCredentials): Prom
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useSignUpMutation() {
 	return useMutation<SignUpResponse, Error, SignUpCredentials>({

--- a/src/features/auth/hooks/useVerifyEmail.ts
+++ b/src/features/auth/hooks/useVerifyEmail.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation

--- a/src/features/cluster/ClusterLayout.tsx
+++ b/src/features/cluster/ClusterLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from '@tanstack/react-router';
 
-function ClusterLayout() {
+export function ClusterLayout() {
 	return <Outlet />;
 }
 
-export default ClusterLayout;
+

--- a/src/features/cluster/CreateInstance.tsx
+++ b/src/features/cluster/CreateInstance.tsx
@@ -1,9 +1,7 @@
-function NewInstance() {
+export function NewInstance() {
   return (
     <div>
       <h1>New Instance Modal</h1>
     </div>
   );
 }
-
-export default NewInstance;

--- a/src/features/cluster/hooks/useCluster.ts
+++ b/src/features/cluster/hooks/useCluster.ts
@@ -1,8 +1,6 @@
 import { useContext } from 'react';
 import { ClusterAuthContext, ClusterContextValue } from '@/features/cluster/context/ClusterAuthContext';
 
-const useCluster = () => {
+export function useCluster() {
 	return useContext(ClusterAuthContext) as ClusterContextValue;
-};
-
-export default useCluster;
+}

--- a/src/features/cluster/hooks/useCreateNewInstance.ts
+++ b/src/features/cluster/hooks/useCreateNewInstance.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
@@ -26,7 +26,7 @@ type NewInstanceInfoResponse = {
 	tempPassword: string;
 };
 
-export const onNewInstanceSubmit = async ({
+export async function onNewInstanceSubmit({
 	name,
 	instanceTypeId,
 	url,
@@ -34,7 +34,7 @@ export const onNewInstanceSubmit = async ({
 	storage,
 	operationsApiPort,
 	operationsApiSecure,
-}: NewInstanceInfo): Promise<NewInstanceInfoResponse> => {
+}: NewInstanceInfo): Promise<NewInstanceInfoResponse> {
 	const { data } = await apiClient.post('/HDBInstance/', {
 		name,
 		instanceTypeId,
@@ -52,7 +52,7 @@ export const onNewInstanceSubmit = async ({
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useCreateNewInstanceMutation() {
 	return useMutation<NewInstanceInfoResponse, Error, NewInstanceInfo>({

--- a/src/features/cluster/hooks/useDeleteInstance.ts
+++ b/src/features/cluster/hooks/useDeleteInstance.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 type DeleteInstanceResponse = {

--- a/src/features/cluster/index.tsx
+++ b/src/features/cluster/index.tsx
@@ -1,16 +1,16 @@
 import { getRouteApi, Link } from '@tanstack/react-router';
 import { Card, CardContent } from '@/components/ui/card';
-import NewInstanceModal from './modals/NewInstanceModal';
+import { NewInstanceModal } from './modals/NewInstanceModal';
 import { DataTable } from '@/components/DataTable';
 import { useEffect, useMemo } from 'react';
 import { ColumnDef } from '@tanstack/react-table';
 import { Badge } from '@/components/ui/badge';
-import EditInstanceModal from './modals/EditInstanceModal';
+import { EditInstanceModal } from './modals/EditInstanceModal';
 import { BadgeStatus, renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 // import { useRegistrationInfo } from '@/hooks/instance/useRegistrationInfo';
-import InstanceLogInModal from './modals/InstanceLoginInModal';
+import { InstanceLogInModal } from './modals/InstanceLoginInModal';
 import { renderInstanceTypeOption, InstanceTypes } from '@/shared/functions/InstanceType';
-import useCluster from '@/features/cluster/hooks/useCluster';
+import { useCluster } from '@/features/cluster/hooks/useCluster';
 
 // 1. Once successfully logging into one instance, we should be able to use the same credentials(cookie) for all instances in the cluster.
 // Essentially looping through and do a query to logging into all the other instances.
@@ -42,7 +42,7 @@ function EmptyCluster({ clusterId }: { clusterId: string }) {
 	);
 }
 
-function ClusterIndex() {
+export function ClusterIndex() {
 	const { organizationId, clusterId } = route.useParams();
 	const { currentCluster, isAuthenticated, loadCluster, isLoading } = useCluster(); // Assuming currentCluster is the one we need
 	// const { mutate: submitRegistrationData, data: registrationInfo } = useRegistrationInfo();
@@ -164,4 +164,4 @@ function ClusterIndex() {
 	);
 }
 
-export default ClusterIndex;
+

--- a/src/features/cluster/modals/EditInstanceModal.tsx
+++ b/src/features/cluster/modals/EditInstanceModal.tsx
@@ -112,7 +112,7 @@ function UpdateInstanceContent({
 	);
 }
 
-function EditInstanceModal({ instanceId, instanceName }: { instanceId: string; instanceName: string }) {
+export function EditInstanceModal({ instanceId, instanceName }: { instanceId: string; instanceName: string }) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isDeleteContentDisplayed, setIsDeleteContentDisplayed] = useState(false);
 
@@ -153,5 +153,3 @@ function EditInstanceModal({ instanceId, instanceName }: { instanceId: string; i
 		</Dialog>
 	);
 }
-
-export default EditInstanceModal;

--- a/src/features/cluster/modals/InstanceLoginInModal.tsx
+++ b/src/features/cluster/modals/InstanceLoginInModal.tsx
@@ -19,7 +19,7 @@ import { useState } from 'react';
 // import { useQueryClient } from '@tanstack/react-query';
 // import { queryKeys } from '@/react-query/constants';
 import { InstanceLoginCredentials } from '@/features/instance/operations/mutations/readInstanceLogin';
-import useCluster from '../hooks/useCluster';
+import { useCluster } from '../hooks/useCluster';
 
 const NewClusterSchema = z.object({
 	username: z.string({
@@ -30,7 +30,7 @@ const NewClusterSchema = z.object({
 	}),
 });
 
-function InstanceLogInModal({
+export function InstanceLogInModal({
 	instanceUrl,
 	instanceName,
 }: {
@@ -126,5 +126,3 @@ function InstanceLogInModal({
 		</Dialog>
 	);
 }
-
-export default InstanceLogInModal;

--- a/src/features/cluster/modals/NewInstanceModal.tsx
+++ b/src/features/cluster/modals/NewInstanceModal.tsx
@@ -64,7 +64,7 @@ const NewInstanceSchema = z.object({
 	}),
 });
 
-function NewInstanceModal({ clusterId }: { clusterId: string }) {
+export function NewInstanceModal({ clusterId }: { clusterId: string }) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const { data: instanceTypes } = useQuery(getInstanceTypeOptions());
 	const form = useForm({
@@ -220,5 +220,3 @@ function NewInstanceModal({ clusterId }: { clusterId: string }) {
 		</Dialog>
 	);
 }
-
-export default NewInstanceModal;

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -1,5 +1,5 @@
 import { BadgeStatus } from '@/components/ui/utils/badgeStatus';
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { queryOptions } from '@tanstack/react-query';
 import { SchemaCluster, SchemaHdbInstance } from '@/lib/api.gen';

--- a/src/features/cluster/queries/getInstanceTypeQuery.ts
+++ b/src/features/cluster/queries/getInstanceTypeQuery.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/clusters/ClustersLayout.tsx
+++ b/src/features/clusters/ClustersLayout.tsx
@@ -1,7 +1,5 @@
 import { Outlet } from '@tanstack/react-router';
 
-function ClustersLayout() {
+export function ClustersLayout() {
 	return <Outlet />;
 }
-
-export default ClustersLayout;

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -1,15 +1,15 @@
 import { getRouteApi } from '@tanstack/react-router';
-import ClusterCard from '@/features/organization/components/ClusterCard';
+import { ClusterCard } from '@/features/organization/components/ClusterCard';
 import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
-import NewClusterModal from '@/features/clusters/modals/NewClusterModal';
+import { NewClusterModal } from '@/features/clusters/modals/NewClusterModal';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 const route = getRouteApi('');
 
-function ClustersList() {
+export function ClustersList() {
 	const { organizationId } = route.useParams();
 	const { data: orgInfo, isSuccess } = useSuspenseQuery(getOrganizationQueryOptions(organizationId));
 
@@ -58,4 +58,4 @@ function ClustersList() {
 	);
 }
 
-export default ClustersList;
+

--- a/src/features/clusters/EditCluster.tsx
+++ b/src/features/clusters/EditCluster.tsx
@@ -1,9 +1,7 @@
-function EditCluster() {
+export function EditCluster() {
   return (
     <div>
       <h1>Edit Cluster Modal</h1>
     </div>
   )
 }
-
-export default EditCluster;

--- a/src/features/clusters/hooks/useCreateNewCluster.ts
+++ b/src/features/clusters/hooks/useCreateNewCluster.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 export type NewClusterInfo = {
@@ -14,11 +14,11 @@ type NewClusterInfoResponse = {
 	tag: string;
 };
 
-export const onNewClusterSubmit = async ({
+export async function onNewClusterSubmit({
 	clusterName,
 	organizationId,
 	abbreviatedName,
-}: NewClusterInfo): Promise<NewClusterInfoResponse> => {
+}: NewClusterInfo): Promise<NewClusterInfoResponse> {
 	// TODO: Work through any disagreements between the SchemaCluster and our local types here.
 	const { data } = await apiClient.post('/Cluster/', {
 		name: clusterName,
@@ -30,7 +30,7 @@ export const onNewClusterSubmit = async ({
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useCreateNewClusterMutation() {
 	return useMutation<NewClusterInfoResponse, Error, NewClusterInfo>({

--- a/src/features/clusters/index.tsx
+++ b/src/features/clusters/index.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from '@tanstack/react-router';
 
-function ClustersLayoutComponent() {
+export function ClustersLayoutComponent() {
 	return <Outlet />;
 }
 
-export default ClustersLayoutComponent;
+

--- a/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
+++ b/src/features/clusters/modals/NewClusterModal/InfoForm.tsx
@@ -2,7 +2,7 @@ import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/comp
 import { Input } from '@/components/ui/input';
 import { useFormContext } from 'react-hook-form';
 
-function InfoForm() {
+export function InfoForm() {
 	const form = useFormContext();
 
 	return (
@@ -36,5 +36,3 @@ function InfoForm() {
 		</>
 	);
 }
-
-export default InfoForm;

--- a/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
+++ b/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
@@ -27,7 +27,7 @@ type RegionFormInputsProps = {
 	selectedRegions: { region: string; count: number; cloudProvider: string }[] | undefined;
 };
 
-const RegionFormInputs = ({ control, index, remove, regionLocations, selectedRegions }: RegionFormInputsProps) => {
+export function RegionFormInputs({ control, index, remove, regionLocations, selectedRegions }: RegionFormInputsProps) {
 	const selectedRegionValues = new Set(selectedRegions?.filter((_, idx) => idx !== index).map((x) => x.region) ?? []);
 
 	return (
@@ -116,6 +116,4 @@ const RegionFormInputs = ({ control, index, remove, regionLocations, selectedReg
 			</Button>
 		</div>
 	);
-};
-
-export default RegionFormInputs;
+}

--- a/src/features/clusters/modals/NewClusterModal/index.tsx
+++ b/src/features/clusters/modals/NewClusterModal/index.tsx
@@ -29,7 +29,9 @@ import {
 import { getInstanceTypeOptions } from '@/features/cluster/queries/getInstanceTypeQuery';
 import { getRegionLocationsOptions } from '@/features/clusters/queries/getRegionLocationsQuery';
 import { Input } from '@/components/ui/input';
-import RegionFormInputs from '@/features/clusters/modals/NewClusterModal/components/RegionFormInputs';
+import {
+	RegionFormInputs,
+} from '@/features/clusters/modals/NewClusterModal/components/RegionFormInputs';
 import { InstanceTypes, renderInstanceTypeOption } from '@/shared/functions/InstanceType';
 
 // TODO: consolidate this with the storage size options in the NewInstanceModal
@@ -73,7 +75,7 @@ const NewClusterSchema = z.object({
 		.optional(),
 });
 
-function NewClusterModal({ orgId }: { orgId: string }) {
+export function NewClusterModal({ orgId }: { orgId: string }) {
 	const queryClient = useQueryClient();
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const form = useForm({
@@ -244,5 +246,3 @@ function NewClusterModal({ orgId }: { orgId: string }) {
 		</Dialog>
 	);
 }
-
-export default NewClusterModal;

--- a/src/features/clusters/queries/getRegionLocationsQuery.ts
+++ b/src/features/clusters/queries/getRegionLocationsQuery.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { SchemaLocation } from '@/lib/api.gen';
 

--- a/src/features/instance/InstanceLayout.tsx
+++ b/src/features/instance/InstanceLayout.tsx
@@ -1,12 +1,12 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getInstanceInfoQueryOptions } from '@/features/instance/queries/getInstanceInfoQuery';
 import { Outlet, getRouteApi } from '@tanstack/react-router';
-import InstanceNavBar from '@/features/instance/InstanceNavBar';
+import { InstanceNavBar } from '@/features/instance/InstanceNavBar';
 
 const route = getRouteApi('');
 
-function InstanceLayout() {
+export function InstanceLayout() {
 	const { instanceId } = route.useParams();
 	const { data: instanceInfo, isSuccess } = useSuspenseQuery(getInstanceInfoQueryOptions(instanceId));
 
@@ -28,4 +28,4 @@ function InstanceLayout() {
 	);
 }
 
-export default InstanceLayout;
+

--- a/src/features/instance/InstanceNavBar.tsx
+++ b/src/features/instance/InstanceNavBar.tsx
@@ -22,8 +22,8 @@ function DesktopInstanceNavBar() {
 				<Link to={`/orgs/${organizationId}/clusters/${clusterId}/instance/${instanceId}/applications`}>
 					<Package className="inline-block" /> Applications
 				</Link>
-				<Link to={'#contact'}>
-					<ChartBarBig className="inline-block" /> Status & Config
+				<Link to={`/orgs/${organizationId}/clusters/${clusterId}/instance/${instanceId}/config`}>
+					<ChartBarBig className="inline-block" /> Config
 				</Link>
 				<Link to={`/orgs/${organizationId}/clusters/${clusterId}/instance/${instanceId}/logs`}>
 					<NotepadText className="inline-block" /> Logs
@@ -69,7 +69,7 @@ function MobileInstanceNavBar() {
 	);
 }
 
-function InstanceNavBar() {
+export function InstanceNavBar() {
 	return (
 		<>
 			<MobileInstanceNavBar />
@@ -77,5 +77,3 @@ function InstanceNavBar() {
 		</>
 	);
 }
-
-export default InstanceNavBar;

--- a/src/features/instance/applications/editor/components/ApplicationsSidebar/EmptyApplicationsView.tsx
+++ b/src/features/instance/applications/editor/components/ApplicationsSidebar/EmptyApplicationsView.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { FolderOpen, Plus } from 'lucide-react';
 
-function EmptyApplicationsView() {
+export function EmptyApplicationsView() {
 	return (
 		<div className="flex flex-col items-center justify-center h-full px-4 text-center">
 			<FolderOpen className="w-10 h-10 mt-16 mb-4 text-gray-400" />
@@ -13,4 +13,3 @@ function EmptyApplicationsView() {
 		</div>
 	);
 }
-export default EmptyApplicationsView;

--- a/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/FileMenu.tsx
+++ b/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/FileMenu.tsx
@@ -51,7 +51,7 @@ export function DeleteFileButton({ onClick, disabled, text = '', extraClasses = 
 	);
 }
 
-function FileMenu({ children }: { children: React.ReactNode[] }) {
+export function FileMenu({ children }: { children: React.ReactNode[] }) {
 	return (
 		<ul className="file-menu text-nowrap">
 			{children.map(
@@ -65,5 +65,3 @@ function FileMenu({ children }: { children: React.ReactNode[] }) {
 		</ul>
 	);
 }
-
-export default FileMenu;

--- a/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
+++ b/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
@@ -289,7 +289,7 @@ function Folder({
 }
 
 // A recursive directory tree representation
-function FileTreeExplorer({
+export function FileTreeExplorer({
 	files,
 }: // userOnSelect,
 // onFileSelect,
@@ -324,5 +324,3 @@ function FileTreeExplorer({
 		</div>
 	);
 }
-
-export default FileTreeExplorer;

--- a/src/features/instance/applications/editor/components/ApplicationsSidebar/index.tsx
+++ b/src/features/instance/applications/editor/components/ApplicationsSidebar/index.tsx
@@ -1,12 +1,15 @@
-import EmptyApplicationsView from '@/features/instance/applications/editor/components/ApplicationsSidebar/EmptyApplicationsView';
-import FileTreeExplorer from '@/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer';
+import {
+	EmptyApplicationsView,
+} from '@/features/instance/applications/editor/components/ApplicationsSidebar/EmptyApplicationsView';
+import {
+	FileTreeExplorer,
+} from '@/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer';
 import { GetComponentsResponse } from '@/features/instance/operations/queries/getComponents';
 
-function ApplicationsSidebar({ fileTreeQueryData }: { fileTreeQueryData?: GetComponentsResponse }) {
+export function ApplicationsSidebar({ fileTreeQueryData }: { fileTreeQueryData?: GetComponentsResponse }) {
 	if (!fileTreeQueryData || !fileTreeQueryData.entries.length) {
 		return <EmptyApplicationsView />;
 	}
 
 	return <FileTreeExplorer files={fileTreeQueryData} />;
 }
-export default ApplicationsSidebar;

--- a/src/features/instance/applications/editor/index.tsx
+++ b/src/features/instance/applications/editor/index.tsx
@@ -1,12 +1,14 @@
 import { Editor } from '@monaco-editor/react';
-import ApplicationsSidebar from '@/features/instance/applications/editor/components/ApplicationsSidebar';
+import {
+	ApplicationsSidebar,
+} from '@/features/instance/applications/editor/components/ApplicationsSidebar';
 import { getComponentsQueryOptions } from '@/features/instance/operations/queries/getComponents';
 import { getRouteApi } from '@tanstack/react-router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 const route = getRouteApi('');
 
-function EditApplications() {
+export function EditApplications() {
 	const { instanceId } = route.useParams();
 	const { data: getComponentsQueryData } = useSuspenseQuery(getComponentsQueryOptions(instanceId));
 
@@ -22,4 +24,4 @@ function EditApplications() {
 	);
 }
 
-export default EditApplications;
+

--- a/src/features/instance/applications/index.tsx
+++ b/src/features/instance/applications/index.tsx
@@ -4,7 +4,7 @@ import { Edit, FolderPlus } from 'lucide-react';
 
 const route = getRouteApi('');
 
-function ApplicationsIndex() {
+export function ApplicationsIndex() {
 	const { organizationId, clusterId, instanceId } = route.useParams();
 
 	return (
@@ -34,4 +34,4 @@ function ApplicationsIndex() {
 	);
 }
 
-export default ApplicationsIndex;
+

--- a/src/features/instance/applications/new/CreateNewProjectFrom.tsx
+++ b/src/features/instance/applications/new/CreateNewProjectFrom.tsx
@@ -22,7 +22,7 @@ const NewProjectSchema = z.object({
 
 const route = getRouteApi('');
 
-function CreateNewProjectFrom() {
+export function CreateNewProjectFrom() {
 	const navigate = useNavigate();
 	const { organizationId, clusterId, instanceId } = route.useParams();
 	const form = useForm<z.infer<typeof NewProjectSchema>>({
@@ -68,4 +68,3 @@ function CreateNewProjectFrom() {
 		</div>
 	);
 }
-export default CreateNewProjectFrom;

--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -12,8 +12,8 @@ import {
 import { toast } from 'sonner';
 import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import { FormEvent } from 'react';
-import { getGitHubRepo } from '@/features/instance/applications/new/functions/getGitHubRepo';
-import isValidTarballUrl from './functions/isValidTarballUrl';
+import { getGitHubRepo } from '@/features/instance/applications/new/functions/getGithubRepo';
+import { isValidTarballUrl } from './functions/isValidTarballUrl';
 
 const ImportProjectSchema = z.object({
 	newApplicationName: z
@@ -26,7 +26,7 @@ const ImportProjectSchema = z.object({
 
 const route = getRouteApi('');
 
-function ImportProjectForm() {
+export function ImportProjectForm() {
 	const navigate = useNavigate();
 	const { organizationId, clusterId, instanceId } = route.useParams();
 	const form = useForm<z.infer<typeof ImportProjectSchema>>({
@@ -124,4 +124,3 @@ function ImportProjectForm() {
 		</div>
 	);
 }
-export default ImportProjectForm;

--- a/src/features/instance/applications/new/functions/isValidTarballUrl.ts
+++ b/src/features/instance/applications/new/functions/isValidTarballUrl.ts
@@ -1,11 +1,9 @@
 import { isValidUrl } from '@/shared/functions/isValidUrl';
 
-function isValidTarballUrl(url: string) {
+export function isValidTarballUrl(url: string) {
 	// npm restrictions on the tarball url install here: https://docs.npmjs.com/cli/v9/commands/npm-install
 	// updated to indexOf to allow signed URLs (with tokens appended)
 	return isValidUrl(url) && (url.includes('.tar') || url.includes('.tar.gz') || url.includes('.tgz'));
 }
 
 // function getCustomApplicationRepo() {}
-
-export default isValidTarballUrl;

--- a/src/features/instance/applications/new/functions/parsePackageType.ts
+++ b/src/features/instance/applications/new/functions/parsePackageType.ts
@@ -7,7 +7,7 @@ type PackageMetaType = {
 	tag: string | null;
 };
 
-function parsePackageType(pkg: { url: string }) {
+export function parsePackageType(pkg: { url: string }) {
 	if (!pkg) {
 		return null;
 	}
@@ -59,5 +59,3 @@ function parsePackageType(pkg: { url: string }) {
 
 	return meta;
 }
-
-export default parsePackageType;

--- a/src/features/instance/applications/new/index.tsx
+++ b/src/features/instance/applications/new/index.tsx
@@ -1,14 +1,14 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft, FolderPlus, Import } from 'lucide-react';
-import CreateNewProjectFrom from './CreateNewProjectFrom';
+import { CreateNewProjectFrom } from './CreateNewProjectFrom';
 import { useState } from 'react';
-import ImportProjectForm from './ImportProjectForm';
+import { ImportProjectForm } from './ImportProjectForm';
 import { getRouteApi, Link } from '@tanstack/react-router';
 
 const route = getRouteApi('');
 
-function NewApplications() {
+export function NewApplications() {
 	const [appType, setAppType] = useState('');
 	const { organizationId, clusterId, instanceId } = route.useParams();
 	return (
@@ -57,4 +57,4 @@ function NewApplications() {
 	);
 }
 
-export default NewApplications;
+

--- a/src/features/instance/browse/BrowseDataTableView.tsx
+++ b/src/features/instance/browse/BrowseDataTableView.tsx
@@ -4,14 +4,14 @@ import { getRouteApi } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { getDescribeTableQueryOptions } from '@/features/instance/operations/queries/getDescribeTable';
 import { getSearchByValueOptions } from '@/features/instance/operations/queries/getSearchByValue';
-import BrowseDataTable from '@/features/instance/browse/components/BrowseDataTable';
-import EditTableRowModal from '@/features/instance/modals/EditTableRowModal';
+import { BrowseDataTable } from '@/features/instance/browse/components/BrowseDataTable';
+import { EditTableRowModal } from '@/features/instance/modals/EditTableRowModal';
 import { getSearchByHashOptions } from '@/features/instance/operations/queries/getSearchByHash';
 import { formatBrowseDataTableHeader } from '@/features/instance/browse/functions/formatBrowseDataTableHeader';
 import { PaginationState } from '@tanstack/react-table';
 import { useUpdateTableRecords } from '@/features/instance/operations/mutations/updateTableRecords';
 import { useDeleteTableRecords } from '@/features/instance/operations/mutations/deleteTableRecords';
-import UploadCSVModal from '@/features/instance/modals/UploadCSVModal';
+import { UploadCSVModal } from '@/features/instance/modals/UploadCSVModal';
 
 // TODO: Define on describe table data call
 // type AttributesTypes = {
@@ -34,7 +34,7 @@ import UploadCSVModal from '@/features/instance/modals/UploadCSVModal';
 
 const route = getRouteApi('');
 
-function BrowseDataTableView() {
+export function BrowseDataTableView() {
 	const { instanceId, schemaName, tableName } = route.useParams();
 
 	const { data: describeTableData, refetch: refetchDescribeTableQueryOptions } = useSuspenseQuery(
@@ -178,5 +178,3 @@ function BrowseDataTableView() {
 		</>
 	);
 }
-
-export default BrowseDataTableView;

--- a/src/features/instance/browse/components/BrowseDataTable/index.tsx
+++ b/src/features/instance/browse/components/BrowseDataTable/index.tsx
@@ -30,7 +30,7 @@ interface BrowseDataTableProps<TData, TValue> {
 	setPagination: Dispatch<SetStateAction<PaginationState>>;
 }
 
-function BrowseDataTable<TData, TValue>({
+export function BrowseDataTable<TData, TValue>({
 	columns,
 	data,
 	totalPages,
@@ -150,5 +150,3 @@ function BrowseDataTable<TData, TValue>({
 		</div>
 	);
 }
-
-export default BrowseDataTable;

--- a/src/features/instance/browse/components/BrowseSideBar/index.tsx
+++ b/src/features/instance/browse/components/BrowseSideBar/index.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import CreateNewTableModal from '@/features/instance/modals/CreateNewTableModal';
+import { CreateNewTableModal } from '@/features/instance/modals/CreateNewTableModal';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -37,7 +37,7 @@ const NewDatabaseSchema = z.object({
 		.regex(/^[a-zA-Z0-9_]+$/, { message: 'Database name can only contain letters, numbers, and underscores' }),
 });
 
-function BrowseSidebar({ databases, onSelectDatabase, selectedDatabase, tables, onSelectTable }: BrowseSidebarProps) {
+export function BrowseSidebar({ databases, onSelectDatabase, selectedDatabase, tables, onSelectTable }: BrowseSidebarProps) {
 	const queryClient = useQueryClient();
 	const { organizationId, clusterId, instanceId, schemaName } = route.useParams();
 	const navigate = useNavigate();
@@ -226,5 +226,3 @@ function BrowseSidebar({ databases, onSelectDatabase, selectedDatabase, tables, 
 		</div>
 	);
 }
-
-export default BrowseSidebar;

--- a/src/features/instance/browse/functions/buildInstanceDataStructure.ts
+++ b/src/features/instance/browse/functions/buildInstanceDataStructure.ts
@@ -12,7 +12,7 @@ type Structure = {
 	};
 };
 
-const buildInstanceDataStructure = (dbResponse: DescribeAllResponse): Structure => {
+export function buildInstanceDataStructure(dbResponse: DescribeAllResponse): Structure {
 	const structure: Structure = {};
 
 	if (!dbResponse.error) {
@@ -32,6 +32,4 @@ const buildInstanceDataStructure = (dbResponse: DescribeAllResponse): Structure 
 	}
 
 	return structure;
-};
-
-export default buildInstanceDataStructure;
+}

--- a/src/features/instance/browse/index.tsx
+++ b/src/features/instance/browse/index.tsx
@@ -2,9 +2,11 @@ import { Suspense, useState } from 'react';
 import { getRouteApi, Outlet, useNavigate } from '@tanstack/react-router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getDescribeAllQueryOptions } from '@/features/instance/operations/queries/getDescribeAll';
-import buildInstanceDataStructure from '@/features/instance/browse/functions/buildInstanceDataStructure';
-import Loading from '@/components/Loading';
-import BrowseSideBar from '@/features/instance/browse/components/BrowseSideBar';
+import {
+	buildInstanceDataStructure,
+} from '@/features/instance/browse/functions/buildInstanceDataStructure';
+import { Loading } from '@/components/Loading';
+import { BrowseSidebar as BrowseSideBar } from '@/features/instance/browse/components/BrowseSideBar';
 
 const route = getRouteApi('');
 
@@ -12,7 +14,7 @@ const getTableList = (structure: Record<string, unknown>, selectedDatabase: stri
 	return Object.keys(structure?.[selectedDatabase] || []);
 };
 
-function Browse() {
+export function Browse() {
 	const navigate = useNavigate();
 	const { organizationId, clusterId, instanceId, schemaName, tableName } = route.useParams();
 	const { data: describeAllQueryData } = useSuspenseQuery(getDescribeAllQueryOptions(instanceId));
@@ -75,5 +77,3 @@ function Browse() {
 		</main>
 	);
 }
-
-export default Browse;

--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -1,0 +1,27 @@
+import { Outlet } from '@tanstack/react-router';
+import { Suspense } from 'react';
+import { Loading } from '@/components/Loading';
+
+export function ConfigIndex() {
+	return (
+		<main className="grid grid-cols-1 gap-4 md:grid-cols-12">
+			<section className="col-span-1 text-white md:col-span-4 lg:col-span-3">
+				<h2>Config</h2>
+				<ul>
+					<li>User Management</li>
+					<li>Role Management</li>
+					<li>Components</li>
+				</ul>
+			</section>
+			<section className="col-span-1 text-white md:col-span-8 lg:col-span-9">
+				<Suspense
+					fallback={
+						<Loading className="flex flex-col items-center justify-center h-full" text="Loading..." />
+					}
+				>
+					<Outlet />
+				</Suspense>
+			</section>
+		</main>
+	);
+}

--- a/src/features/instance/log/index.tsx
+++ b/src/features/instance/log/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/features/instance/operations/queries/getReadLog';
 import { getRouteApi } from '@tanstack/react-router';
 import { LogsDataTable } from '@/features/instance/log/LogsDataTable';
-import ViewLogModal from '@/features/instance/modals/ViewLogModal';
+import { ViewLogModal } from '@/features/instance/modals/ViewLogModal';
 import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { renderBadgeLogLevelText, renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
@@ -82,7 +82,7 @@ const isValidDateRange = (startDate?: Date, endDate?: Date) => {
 
 const route = getRouteApi('');
 
-function Logs() {
+export function Logs() {
 	const { instanceId } = route.useParams();
 	const [logFilters, setLogFilters] = useState<z.infer<typeof LogFiltersSchema>>({
 		limit: 1000,
@@ -303,4 +303,4 @@ function Logs() {
 	);
 }
 
-export default Logs;
+

--- a/src/features/instance/modals/BrowseSettingsModal.tsx
+++ b/src/features/instance/modals/BrowseSettingsModal.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogT
 import { Save, Settings, Trash } from 'lucide-react';
 import { useState } from 'react';
 
-function BrowseSettingsModal() {
+export function BrowseSettingsModal() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
@@ -35,4 +35,3 @@ function BrowseSettingsModal() {
 		</Dialog>
 	);
 }
-export default BrowseSettingsModal;

--- a/src/features/instance/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/modals/CreateNewTableModal.tsx
@@ -44,7 +44,7 @@ const CreateTableSchema = z.object({
 		}),
 });
 
-function CreateNewTableModal({ databaseName, instanceId }: { databaseName: string; instanceId: string }) {
+export function CreateNewTableModal({ databaseName, instanceId }: { databaseName: string; instanceId: string }) {
 	const queryClient = useQueryClient();
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const form = useForm({
@@ -126,5 +126,3 @@ function CreateNewTableModal({ databaseName, instanceId }: { databaseName: strin
 		</Dialog>
 	);
 }
-
-export default CreateNewTableModal;

--- a/src/features/instance/modals/EditTableRowModal.tsx
+++ b/src/features/instance/modals/EditTableRowModal.tsx
@@ -1,11 +1,11 @@
-import Loading from '@/components/Loading';
+import { Loading } from '@/components/Loading';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import Editor from '@monaco-editor/react';
 import { Save, Trash } from 'lucide-react';
 import { useState } from 'react';
 
-function EditTableRowModal({
+export function EditTableRowModal({
 	setIsModalOpen,
 	isModalOpen,
 	data,
@@ -78,5 +78,3 @@ function EditTableRowModal({
 		</Dialog>
 	);
 }
-
-export default EditTableRowModal;

--- a/src/features/instance/modals/UploadCSVModal.tsx
+++ b/src/features/instance/modals/UploadCSVModal.tsx
@@ -4,7 +4,7 @@ import { Input } from '@/components/ui/input';
 import { FileSpreadsheet, UploadCloud } from 'lucide-react';
 import { useState } from 'react';
 
-function UploadCSVModal() {
+export function UploadCSVModal() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
@@ -28,4 +28,3 @@ function UploadCSVModal() {
 		</Dialog>
 	);
 }
-export default UploadCSVModal;

--- a/src/features/instance/modals/ViewLogModal.tsx
+++ b/src/features/instance/modals/ViewLogModal.tsx
@@ -1,4 +1,4 @@
-import Loading from '@/components/Loading';
+import { Loading } from '@/components/Loading';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -16,7 +16,7 @@ function isJsonString(str: string) {
 	return true;
 }
 
-function ViewLogModal({
+export function ViewLogModal({
 	setIsModalOpen,
 	isModalOpen,
 	data,
@@ -89,5 +89,3 @@ function ViewLogModal({
 		</Dialog>
 	);
 }
-
-export default ViewLogModal;

--- a/src/features/instance/operations/mutations/createComponent.ts
+++ b/src/features/instance/operations/mutations/createComponent.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type CreateComponentFormData = {
 	newApplicationName: string;

--- a/src/features/instance/operations/mutations/createDatabase.ts
+++ b/src/features/instance/operations/mutations/createDatabase.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type CreateDatabaseFormData = {
 	newDatabaseName: string;

--- a/src/features/instance/operations/mutations/createTable.ts
+++ b/src/features/instance/operations/mutations/createTable.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type CreateDatabaseFormData = {
 	databaseName: string;

--- a/src/features/instance/operations/mutations/deleteDatabase.ts
+++ b/src/features/instance/operations/mutations/deleteDatabase.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 const onDeleteDatabase = async (databaseName: string) => {
 	const { data } = await instanceClient.post('/', {

--- a/src/features/instance/operations/mutations/deleteTable.ts
+++ b/src/features/instance/operations/mutations/deleteTable.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type DeleteTableData = {
 	databaseName: string;

--- a/src/features/instance/operations/mutations/deleteTableRecords.ts
+++ b/src/features/instance/operations/mutations/deleteTableRecords.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type DeleteTableRecordsData = {
 	databaseName: string;

--- a/src/features/instance/operations/mutations/deployComponent.ts
+++ b/src/features/instance/operations/mutations/deployComponent.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type DeployComponentFormData = {
 	newApplicationName: string;

--- a/src/features/instance/operations/mutations/readInstanceLogin.ts
+++ b/src/features/instance/operations/mutations/readInstanceLogin.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation

--- a/src/features/instance/operations/mutations/updateTableRecords.ts
+++ b/src/features/instance/operations/mutations/updateTableRecords.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 type UpdateTableRecordsData = {
 	databaseName: string;

--- a/src/features/instance/operations/queries/getComponents.ts
+++ b/src/features/instance/operations/queries/getComponents.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/operations/queries/getDescribeAll.ts
+++ b/src/features/instance/operations/queries/getDescribeAll.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/operations/queries/getDescribeTable.ts
+++ b/src/features/instance/operations/queries/getDescribeTable.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/operations/queries/getReadLog.ts
+++ b/src/features/instance/operations/queries/getReadLog.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 import { z } from 'zod';

--- a/src/features/instance/operations/queries/getRegistrationInfo.ts
+++ b/src/features/instance/operations/queries/getRegistrationInfo.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/operations/queries/getSearchByHash.ts
+++ b/src/features/instance/operations/queries/getSearchByHash.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 import { queryOptions } from '@tanstack/react-query';
 
 // type SearchConditions = {

--- a/src/features/instance/operations/queries/getSearchByValue.ts
+++ b/src/features/instance/operations/queries/getSearchByValue.ts
@@ -1,4 +1,4 @@
-import instanceClient from '@/config/instanceClient';
+import { instanceClient } from '@/config/instanceClient';
 
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/queries/getInstanceInfoQuery.ts
+++ b/src/features/instance/queries/getInstanceInfoQuery.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { queryOptions } from '@tanstack/react-query';
 

--- a/src/features/instance/status/index.tsx
+++ b/src/features/instance/status/index.tsx
@@ -1,5 +1,5 @@
-function Status() {
+export function Status() {
 	return <div>Status</div>;
 }
 
-export default Status;
+

--- a/src/features/layouts/Dashboard.tsx
+++ b/src/features/layouts/Dashboard.tsx
@@ -1,13 +1,13 @@
 import { Outlet, Navigate } from '@tanstack/react-router';
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser';
 import { NavBar } from '@/components/Navbar';
-import Loading from '@/components/Loading';
+import { Loading } from '@/components/Loading';
 // import { useUserInfoMutation } from '@/hooks/instance/useUserInfo';
 // import { useEffect } from 'react';
 
 // const isLocalStudio = import.meta.env.VITE_LOCAL_STUDIO === 'true';
 
-function Dashboard() {
+export function Dashboard() {
 	const { data: user, isLoading: isUserLoading } = useGetCurrentUser();
 	// const { mutate: submitUserInfoData, data: userInfo, isPending: isUserInfoLoading } = useUserInfoMutation();
 
@@ -36,5 +36,3 @@ function Dashboard() {
 		</div>
 	);
 }
-
-export default Dashboard;

--- a/src/features/organization/Billing.tsx
+++ b/src/features/organization/Billing.tsx
@@ -1,9 +1,7 @@
-function Billing() {
+export function Billing() {
   return (
     <div>
       <h1>Billing Info</h1>
     </div>
   )
 }
-
-export default Billing;

--- a/src/features/organization/OrganizationLayout.tsx
+++ b/src/features/organization/OrganizationLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from '@tanstack/react-router';
 
-function OrganizationLayout() {
+export function OrganizationLayout() {
 	return <Outlet />;
 }
 
-export default OrganizationLayout;
+

--- a/src/features/organization/components/ClusterCard.tsx
+++ b/src/features/organization/components/ClusterCard.tsx
@@ -12,7 +12,7 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-function ClusterCard({
+export function ClusterCard({
 	clusterId,
 	clusterName,
 	organizationId,
@@ -60,5 +60,3 @@ function ClusterCard({
 		</Card>
 	);
 }
-
-export default ClusterCard;

--- a/src/features/organization/index.tsx
+++ b/src/features/organization/index.tsx
@@ -2,7 +2,7 @@ import { getRouteApi, Navigate, Outlet, useMatchRoute } from '@tanstack/react-ro
 
 const route = getRouteApi('');
 
-function OrganizationIndex() {
+export function OrganizationIndex() {
 	const { organizationId } = route.useParams();
 	const matchRoute = useMatchRoute();
 	const match = matchRoute({ to: '/orgs/$organizationId' });
@@ -13,4 +13,4 @@ function OrganizationIndex() {
 	}
 }
 
-export default OrganizationIndex;
+

--- a/src/features/organization/members/AddMember.tsx
+++ b/src/features/organization/members/AddMember.tsx
@@ -1,9 +1,7 @@
-function AddMember() {
+export function AddMember() {
   return (
     <div>
       <h1>Add Member Modal</h1>
     </div>
   );
 }
-
-export default AddMember;

--- a/src/features/organization/members/EditMember.tsx
+++ b/src/features/organization/members/EditMember.tsx
@@ -1,9 +1,7 @@
-function EditMember() {
+export function EditMember() {
   return (
     <div>
       <h1>Edit Member Modal</h1>
     </div>
   );
 }
-
-export default EditMember;

--- a/src/features/organization/members/index.tsx
+++ b/src/features/organization/members/index.tsx
@@ -1,9 +1,7 @@
-function Members() {
+export function Members() {
   return (
     <div>
       <h1>Members List</h1>
     </div>
   )
 }
-
-export default Members;

--- a/src/features/organization/queries/getOrganizationQuery.ts
+++ b/src/features/organization/queries/getOrganizationQuery.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { queryOptions } from '@tanstack/react-query';
 import { SchemaCluster, SchemaOrganization } from '@/lib/api.gen';

--- a/src/features/organization/roles/AddRole.tsx
+++ b/src/features/organization/roles/AddRole.tsx
@@ -1,9 +1,7 @@
-function AddRole() {
+export function AddRole() {
   return (
     <div>
       <h1>Add Role Modal</h1>
     </div>
   )
 }
-
-export default AddRole;

--- a/src/features/organization/roles/EditRole.tsx
+++ b/src/features/organization/roles/EditRole.tsx
@@ -1,9 +1,7 @@
-function EditRole() {
+export function EditRole() {
   return (
     <div>
       <h1>Edit Role Modal</h1>
     </div>
   );
 }
-
-export default EditRole;

--- a/src/features/organization/roles/index.tsx
+++ b/src/features/organization/roles/index.tsx
@@ -1,9 +1,7 @@
-function Roles() {
+export function Roles() {
   return (
     <div>
       <h1>Roles List (Can edit roles here too)</h1>
     </div>
   )
 }
-
-export default Roles;

--- a/src/features/organizations/NewOrg.tsx
+++ b/src/features/organizations/NewOrg.tsx
@@ -1,9 +1,7 @@
-function NewOrg() {
+export function NewOrg() {
   return (
     <div>
       <h1>New Org</h1>
     </div>
   )
 }
-
-export default NewOrg;

--- a/src/features/organizations/OrganizationsLayout.tsx
+++ b/src/features/organizations/OrganizationsLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from '@tanstack/react-router';
 
-function OrganizationsLayout() {
+export function OrganizationsLayout() {
 	return <Outlet />;
 }
 
-export default OrganizationsLayout;
+

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -10,7 +10,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-function OrgCard({
+export function OrgCard({
 	organizationId,
 	organizationName,
 	roleName,
@@ -56,5 +56,3 @@ function OrgCard({
 		</Card>
 	);
 }
-
-export default OrgCard;

--- a/src/features/organizations/hooks/useCreateNewOrganization.ts
+++ b/src/features/organizations/hooks/useCreateNewOrganization.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 export type NewOrganizationInfo = {
@@ -13,10 +13,10 @@ type NewClusterInfoResponse = {
 	subdomain: string;
 };
 
-export const onNewOrganizationSubmit = async ({
+export async function onNewOrganizationSubmit({
 	orgName,
 	orgSubdomain,
-}: NewOrganizationInfo): Promise<NewClusterInfoResponse> => {
+}: NewOrganizationInfo): Promise<NewClusterInfoResponse> {
 	const { data } = await apiClient.post('/Organization/', {
 		name: orgName,
 		subdomain: orgSubdomain,
@@ -27,7 +27,7 @@ export const onNewOrganizationSubmit = async ({
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useCreateNewOrganizationMutation() {
 	return useMutation<NewClusterInfoResponse, Error, NewOrganizationInfo>({

--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -1,10 +1,10 @@
 import { ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import OrgCard from '@/features/organizations/components/OrgCard';
+import { OrgCard } from '@/features/organizations/components/OrgCard';
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser';
-import NewOrganizationModal from '@/features/organizations/modals/NewOrganizationModal';
-function OrganizationsIndex() {
+import { NewOrganizationModal } from '@/features/organizations/modals/NewOrganizationModal';
+export function OrganizationsIndex() {
 	const { data: user } = useGetCurrentUser();
 	return (
 		<div>
@@ -35,4 +35,4 @@ function OrganizationsIndex() {
 	);
 }
 
-export default OrganizationsIndex;
+

--- a/src/features/organizations/modals/NewOrganizationModal.tsx
+++ b/src/features/organizations/modals/NewOrganizationModal.tsx
@@ -39,7 +39,7 @@ const NewOrganizationSchema = z.object({
 		}),
 });
 
-function NewOrganizationModal() {
+export function NewOrganizationModal() {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const form = useForm({
 		resolver: zodResolver(NewOrganizationSchema),
@@ -112,5 +112,3 @@ function NewOrganizationModal() {
 		</Dialog>
 	);
 }
-
-export default NewOrganizationModal;

--- a/src/features/profile/UpdateProfile.tsx
+++ b/src/features/profile/UpdateProfile.tsx
@@ -1,9 +1,7 @@
-function UpdateProfile() {
+export function UpdateProfile() {
   return (
     <div>
       <h1>Update Profile Modal</h1>
     </div>
   );
 }
-
-export default UpdateProfile;

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -1,4 +1,4 @@
-function ProfileIndex() {
+export function ProfileIndex() {
 	return (
 		<div>
 			<h1>Profile</h1>
@@ -6,4 +6,4 @@ function ProfileIndex() {
 	);
 }
 
-export default ProfileIndex;
+

--- a/src/hooks/instance/useUserInfo.ts
+++ b/src/hooks/instance/useUserInfo.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 // TODO: Consolidate with useOnSignUpSubmitMutation
@@ -14,7 +14,7 @@ type SignInResponse = {
 	lastname: string;
 };
 
-export const onUserInfoSubmit = async (): Promise<SignInResponse> => {
+export async function onUserInfoSubmit(): Promise<SignInResponse> {
 	// TODO: The OpenAPI specs don't describe this endpoint.
 	const { data } = await apiClient.post('/' as never, {
 		operation: 'user_info',
@@ -24,7 +24,7 @@ export const onUserInfoSubmit = async (): Promise<SignInResponse> => {
 	} else {
 		throw new Error('Something went wrong');
 	}
-};
+}
 
 export function useUserInfoMutation() {
 	return useMutation({

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,10 +20,10 @@
 // 	password: string;
 // };
 
-// const useAuth = () => {
+// export function useAuth {
 // 	const queryClient = useQueryClient();
 // 	const queryCache = new QueryCache();
-
+//
 // 	// const {data: user, isLoading: isUserLoading} = useQuery<User | null>({
 // 	// 	queryKey: ['user'],
 // 	// 	queryFn: async () => {
@@ -35,7 +35,7 @@
 // 	// 	},
 // 	// 	retry: false,
 // 	// });
-
+//
 // 	const login = useMutation({
 // 		mutationFn: async ({ email, password }: SignInCredentials) => {
 //      // TODO: The OpenAPI types for /Login/ aren't very comprehensive.
@@ -53,7 +53,7 @@
 // 		// 	queryClient.setQueryData(['user'], data);
 // 		// },
 // 	});
-
+//
 // 	const logout = useQuery<User | null>({
 // 		queryKey: [queryKeys.user],
 // 		queryFn: async () => {
@@ -68,9 +68,7 @@
 // 		},
 // 		retry: false,
 // 	});
-
+//
 // 	return { login, logout };
 // 	// return { user, isPending, isSuccess, login, logout, isAuthenticated };
-// };
-
-// export default useAuth;
+// }

--- a/src/hooks/useGetCurrentUser.ts
+++ b/src/hooks/useGetCurrentUser.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/config/apiClient';
+import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { useQuery } from '@tanstack/react-query';
 import { SchemaOrganizationRole, SchemaUser } from '@/lib/api.gen';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from '@/App';
+import { App } from '@/App';
 
 
 createRoot(document.getElementById('root')!).render(

--- a/src/router/cloudRouter.ts
+++ b/src/router/cloudRouter.ts
@@ -1,33 +1,33 @@
 import { createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { QueryClient } from '@tanstack/react-query';
-import StudioCloud from '@/StudioCloud';
-import Dashboard from '@/features/layouts/Dashboard';
-import ProfileIndex from '@/features/profile';
-import OrganizationsIndex from '@/features/organizations';
-import OrganizationIndex from '@/features/organization';
-import ClusterIndex from '@/features/cluster';
-import ClusterList from '@/features/clusters/ClustersList';
-import AuthLayout from '@/features/auth/AuthLayout';
-import SignIn from '@/features/auth/SignIn';
-import SignUp from '@/features/auth/SignUp';
-import ForgotPassword from '@/features/auth/ForgotPassword';
-import ClustersLayoutComponent from '@/features/clusters';
-import OrganizationsLayout from '@/features/organizations/OrganizationsLayout';
-import OrganizationLayout from '@/features/organization/OrganizationLayout';
-import ClusterLayout from '@/features/cluster/ClusterLayout';
-import VerifyEmail from '@/features/auth/VerifyEmail';
-import ResetPassword from '@/features/auth/ResetPassword';
-
+import { StudioCloud } from '@/StudioCloud';
+import { Dashboard } from '@/features/layouts/Dashboard';
+import { ProfileIndex } from '@/features/profile';
+import { OrganizationsIndex } from '@/features/organizations';
+import { OrganizationIndex } from '@/features/organization';
+import { ClusterIndex } from '@/features/cluster';
+import { ClustersList as ClusterList } from '@/features/clusters/ClustersList';
+import { AuthLayout } from '@/features/auth/AuthLayout';
+import { SignIn } from '@/features/auth/SignIn';
+import { SignUp } from '@/features/auth/SignUp';
+import { ForgotPassword } from '@/features/auth/ForgotPassword';
+import { ClustersLayoutComponent } from '@/features/clusters';
+import { OrganizationsLayout } from '@/features/organizations/OrganizationsLayout';
+import { OrganizationLayout } from '@/features/organization/OrganizationLayout';
+import { ClusterLayout } from '@/features/cluster/ClusterLayout';
+import { VerifyEmail } from '@/features/auth/VerifyEmail';
+import { RestPassword as ResetPassword } from '@/features/auth/ResetPassword';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
-import InstanceLayout from '@/features/instance/InstanceLayout';
-import Browse from '@/features/instance/browse';
+import { InstanceLayout } from '@/features/instance/InstanceLayout';
+import { Browse } from '@/features/instance/browse';
 import { getInstanceInfoQueryOptions } from '@/features/instance/queries/getInstanceInfoQuery';
-import BrowseDataTableView from '@/features/instance/browse/BrowseDataTableView';
-import Logs from '@/features/instance/log';
-import ApplicationsIndex from '@/features/instance/applications';
-import NewApplications from '@/features/instance/applications/new';
-import EditApplications from '@/features/instance/applications/editor';
+import { BrowseDataTableView } from '@/features/instance/browse/BrowseDataTableView';
+import { Logs } from '@/features/instance/log';
+import { ApplicationsIndex } from '@/features/instance/applications';
+import { NewApplications } from '@/features/instance/applications/new';
+import { EditApplications } from '@/features/instance/applications/editor';
+import { ConfigIndex } from '@/features/instance/config';
 
 const rootRoute = createRootRouteWithContext<{
 	queryClient: QueryClient;
@@ -202,6 +202,12 @@ const instanceApplicationsEditorRoute = createRoute({
 	component: EditApplications,
 });
 
+const instanceConfigRoute = createRoute({
+	getParentRoute: () => instanceLayoutRoute,
+	path: 'config',
+	component: ConfigIndex,
+});
+
 export const cloudRouteTree = rootRoute.addChildren([
 	authLayout.addChildren([signInRoute, signUpRoute, forgotPasswordRoute, verifyEmailRoute, resetPasswordRoute]),
 	dashboardLayout.addChildren([
@@ -220,6 +226,7 @@ export const cloudRouteTree = rootRoute.addChildren([
 							instanceApplicationsIndexRoute,
 							instanceApplicationsNewRoute,
 							instanceApplicationsEditorRoute,
+							instanceConfigRoute,
 						]),
 					]),
 				]),

--- a/src/router/localRouter.ts
+++ b/src/router/localRouter.ts
@@ -1,12 +1,12 @@
 import { createRootRoute, createRoute } from '@tanstack/react-router';
-import StudioLocal from '../StudioLocal';
-import LocalSignIn from '../features/auth/LocalSignIn';
-import Dashboard from '../features/layouts/Dashboard';
-import Browse from '@/features/instance/browse';
-import Applications from '@/features/instance/applications';
-import Log from '@/features/instance/log';
-import Status from '@/features/instance/status';
-import InstanceLayout from '@/features/instance/InstanceLayout';
+import { StudioLocal } from '../StudioLocal';
+import { LocalSignIn } from '../features/auth/LocalSignIn';
+import { Dashboard } from '../features/layouts/Dashboard';
+import { Browse } from '@/features/instance/browse';
+import { ApplicationsIndex as Applications } from '@/features/instance/applications';
+import { Logs as Log } from '@/features/instance/log';
+import { Status } from '@/features/instance/status';
+import { InstanceLayout } from '@/features/instance/InstanceLayout';
 
 const rootRoute = createRootRoute({
 	component: StudioLocal,

--- a/src/shared/functions/isValidUrl.ts
+++ b/src/shared/functions/isValidUrl.ts
@@ -1,7 +1,7 @@
-export const isValidUrl = (url: string) => {
+export function isValidUrl(url: string) {
 	try {
 		return Boolean(new URL(url));
 	} catch {
 		return false;
 	}
-};
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e05db017-27de-4c5f-8179-6f580bc5a979)


This is influenced by Angular and Google, I recognize, but personal preference (and it was easy to apply across the board): standardize on named exports instead of default exports.

https://google.github.io/styleguide/jsguide.html#file-goog-module-exports