### PR TITLE
Select first schema and table automatically

### DIFF
--- a/src/features/instance/browse/components/BrowseSideBar/index.tsx
+++ b/src/features/instance/browse/components/BrowseSideBar/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getRouteApi } from '@tanstack/react-router';
+import { getRouteApi, useRouter } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -37,6 +37,7 @@ const NewDatabaseSchema = z.object({
 });
 
 export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTable }: BrowseSidebarProps) {
+	const router = useRouter();
 	const queryClient = useQueryClient();
 	const { instanceId, schemaName, tableName } = route.useParams();
 
@@ -55,20 +56,22 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 
 	const submitNewDatabase = (formData: z.infer<typeof NewDatabaseSchema>) => {
 		createNewDatabase(formData, {
-			onSuccess: () => {
-				queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'] })
-					.then(() => onSelectDatabase(formData.newDatabaseName));
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'], refetchType: 'all' });
+				await router.invalidate();
 				setIsCreatingDatabase(false);
 				form.reset();
 				toast.success(`Database ${formData.newDatabaseName} created successfully`);
+				onSelectDatabase(formData.newDatabaseName);
 			},
 		});
 	};
 
 	const deleteSelectedDatabase = (databaseName: string) => {
 		deleteDatabase(databaseName, {
-			onSuccess: () => {
-				void queryClient.invalidateQueries({ queryKey: [instanceId] });
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'], refetchType: 'all' });
+				await router.invalidate();
 				toast.success(`Database ${databaseName} deleted successfully`);
 				onSelectDatabase(undefined);
 			},
@@ -77,12 +80,13 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 
 	const deleteSelectedTable = (data: DeleteTableData) => {
 		deleteTable(data, {
-			onSuccess: () => {
-				void queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'] });
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'], refetchType: 'all' });
+				await router.invalidate();
+				toast.success(`Table ${data.tableName} deleted successfully`);
 				if (data.tableName === tableName) {
 					onSelectTable(undefined);
 				}
-				toast.success(`Table ${data.tableName} deleted successfully`);
 			},
 		});
 	};
@@ -174,7 +178,7 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 							<div className="w-full h-full text-center">
 								<p className="py-6">No tables found in this database.</p>
 								<div className="mx-auto max-w-48">
-									<CreateNewTableModal databaseName={schemaName || ''} instanceId={instanceId} />
+									<CreateNewTableModal databaseName={schemaName} instanceId={instanceId} onSelectTable={onSelectTable} />
 								</div>
 							</div>
 						) : (tables ?? []).length === 0 && !schemaName?.length ? (
@@ -211,7 +215,7 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 				</ScrollArea>
 			</Tabs>
 			{schemaName?.length && (
-				<CreateNewTableModal databaseName={schemaName} instanceId={instanceId} />
+				<CreateNewTableModal databaseName={schemaName} instanceId={instanceId} onSelectTable={onSelectTable} />
 			)}
 		</div>
 	);

--- a/src/features/instance/browse/index.tsx
+++ b/src/features/instance/browse/index.tsx
@@ -1,19 +1,16 @@
 import { Suspense, useCallback, useMemo } from 'react';
 import { getRouteApi, Outlet, useNavigate } from '@tanstack/react-router';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { getDescribeAllQueryOptions } from '@/features/instance/operations/queries/getDescribeAll';
-import {
-	buildInstanceDataStructure,
-} from '@/features/instance/browse/functions/buildInstanceDataStructure';
+import { buildInstanceDataStructure } from '@/features/instance/browse/functions/buildInstanceDataStructure';
 import { Loading } from '@/components/Loading';
 import { BrowseSidebar as BrowseSideBar } from '@/features/instance/browse/components/BrowseSideBar';
+import { DescribeAllResponse } from '@/features/instance/operations/queries/getDescribeAll';
 
 const route = getRouteApi('');
 
 export function Browse() {
 	const navigate = useNavigate();
-	const { instanceId, schemaName, tableName } = route.useParams();
-	const { data: describeAllQueryData } = useSuspenseQuery(getDescribeAllQueryOptions(instanceId));
+	const { schemaName, tableName } = route.useParams();
+	const describeAllQueryData = route.useLoaderData() as DescribeAllResponse;
 
 	const structure = useMemo(() => buildInstanceDataStructure(describeAllQueryData), [describeAllQueryData]);
 
@@ -28,12 +25,12 @@ export function Browse() {
 
 	const onSelectDatabase = useCallback((newSchemaName: string | undefined) => {
 		const tables = newSchemaName ? Object.keys(structure[newSchemaName] || []).sort() : [];
-		const parts = [schemaName ? '../' : '', tableName ? '../' : '', newSchemaName, tables[0]].filter(Boolean);
+		const parts = [schemaName ? '..' : '', tableName ? '..' : '', newSchemaName, tables[0]].filter(Boolean);
 		void navigate({ to: parts.join('/') });
 	}, [navigate, structure, schemaName, tableName]);
 
 	const onSelectTable = useCallback((newTableName: string | undefined) => {
-		const parts = [tableName ? '../' : '', newTableName].filter(Boolean);
+		const parts = [tableName ? '..' : '', newTableName].filter(Boolean);
 		void navigate({ to: parts.join('/') });
 	}, [tableName, navigate]);
 

--- a/src/features/instance/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/modals/CreateNewTableModal.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCreateTableMutation } from '@/features/instance/operations/mutations/createTable';
 import { toast } from 'sonner';
+import { useRouter } from '@tanstack/react-router';
 
 const CreateTableSchema = z.object({
 	tableName: z
@@ -44,8 +45,13 @@ const CreateTableSchema = z.object({
 		}),
 });
 
-export function CreateNewTableModal({ databaseName, instanceId }: { databaseName: string; instanceId: string }) {
+export function CreateNewTableModal({ databaseName, instanceId, onSelectTable }: {
+	readonly databaseName: string;
+	readonly instanceId: string;
+	readonly onSelectTable: (tableName: string | undefined) => void;
+}) {
 	const queryClient = useQueryClient();
+	const router = useRouter();
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const form = useForm({
 		resolver: zodResolver(CreateTableSchema),
@@ -64,10 +70,12 @@ export function CreateNewTableModal({ databaseName, instanceId }: { databaseName
 		};
 		submitNewTableData(updatedFormData, {
 			onSuccess: async () => {
-				await queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'] });
+				await queryClient.invalidateQueries({ queryKey: [instanceId, 'describe_all'], refetchType: 'all' });
 				toast.success(`Table ${formData.tableName} created successfully`);
 				setIsModalOpen(false);
 				form.reset();
+				onSelectTable(formData.tableName);
+				await router.invalidate();
 			},
 		});
 	};

--- a/src/features/instance/operations/queries/getDescribeAll.ts
+++ b/src/features/instance/operations/queries/getDescribeAll.ts
@@ -13,7 +13,7 @@ type DescribeAllResponse = {
 		[key: string]: DBTableInfo;
 	};
 };
-function getDescribeAllQueryOptions(instanceId: string) {
+function getDescribeAllQueryOptions(instanceId?: string) {
 	return queryOptions({
 		queryKey: [instanceId, 'describe_all'] as const,
 		queryFn: async () => {

--- a/src/features/instance/routes.ts
+++ b/src/features/instance/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute } from '@tanstack/react-router';
+import { createRoute, redirect } from '@tanstack/react-router';
 import { clusterLayoutRoute } from '@/features/cluster/routes';
 import { InstanceLayout } from '@/features/instance/InstanceLayout';
 import { getInstanceInfoQueryOptions } from '@/features/instance/queries/getInstanceInfoQuery';
@@ -14,23 +14,25 @@ import { ConfigRolesIndex } from '@/features/instance/config/roles';
 import { ConfigUsersIndex } from '@/features/instance/config/users';
 import { dashboardLayout } from '@/router/dashboard-route';
 import { isLocalStudio } from '@/config/constants';
+import { getDescribeAllQueryOptions } from '@/features/instance/operations/queries/getDescribeAll';
+import { QueryClient } from '@tanstack/react-query';
 
 export const instanceLayoutRoute = isLocalStudio
 	? createRoute({
 		getParentRoute: () => dashboardLayout,
 		id: '_instanceLayout',
 		component: InstanceLayout,
-		loader: (() => {
+		loader: () => {
 			// TODO: Load instance information?
-		}),
+		},
 	})
 	: createRoute({
 		getParentRoute: () => clusterLayoutRoute,
 		path: 'instance/$instanceId',
 		component: InstanceLayout,
-		loader: ((opts) => {
-			opts.context.queryClient.ensureQueryData(getInstanceInfoQueryOptions(opts.params.instanceId));
-		}),
+		loader: async (opts) => {
+			return await opts.context.queryClient.ensureQueryData(getInstanceInfoQueryOptions(opts.params.instanceId));
+		},
 	});
 
 const instanceIndexRoute = createRoute({
@@ -43,16 +45,48 @@ const instanceBrowseRoute = createRoute({
 	getParentRoute: () => instanceLayoutRoute,
 	path: '/browse',
 	component: Browse,
+	loader: ({ context, params }) => loadInstanceBrowseData(context.queryClient, params),
 });
 const browseDatabaseRoute = createRoute({
 	getParentRoute: () => instanceBrowseRoute,
 	path: '$schemaName',
+	loader: ({ context, params }) => loadInstanceBrowseData(context.queryClient, params),
 });
 const browseTableRoute = createRoute({
 	getParentRoute: () => instanceBrowseRoute,
 	path: '$schemaName/$tableName',
 	component: BrowseDataTableView,
+	loader: ({ context, params }) => loadInstanceBrowseData(context.queryClient, params),
 });
+
+async function loadInstanceBrowseData(queryClient: QueryClient, params: {
+	instanceId?: string;
+	schemaName?: string;
+	tableName?: string;
+}) {
+	const data = await queryClient.ensureQueryData(getDescribeAllQueryOptions(params.instanceId));
+	let newSchemaName: string | undefined;
+	let newTableName: string | undefined;
+	if (data) {
+		if (!params.schemaName) {
+			newSchemaName = Object.keys(data).sort()[0];
+		}
+		const schemaName = params.schemaName ?? newSchemaName;
+		if (!params.tableName && schemaName && data[schemaName]) {
+			newTableName = Object.keys(data[schemaName]).sort()[0];
+		}
+	}
+	if (newSchemaName || newTableName) {
+		const to = [
+			params.schemaName ? '..' : '',
+			params.tableName ? '..' : '',
+			newSchemaName ?? params.schemaName,
+			newTableName,
+		].filter(Boolean).join('/');
+		throw redirect({ to });
+	}
+	return data;
+}
 
 const instanceLogsRoute = createRoute({
 	getParentRoute: () => instanceLayoutRoute,


### PR DESCRIPTION
This shifts to using the loader to getDescribeAllQueryOptions for the instance browse pages. Based on the provided params, it will then inspect the data, and redirect to the first schema or table.

There are a lot of edge cases for this particular one, which were fun to work through!
1. Create a database for the first time
2. Create a database when another one is selected
3. Create a table in an empty database
4. Create a table when another one is selected
5. Delete a table when there is another one in the database
6. Delete a table when it's the last one in the database
7. Delete a database when there's another one in the instance
8. Delete a database when it's the last one in an instance

In all these circumstances, it should redirect you to the first alphabetical database or table available after your deletion.

https://harperdb.atlassian.net/browse/STUDIO-178