### PR TITLE
Fix account activation messaging

### DIFF
--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -53,7 +53,8 @@ export function SignUp() {
 		submitSignUpData(formData, {
 			onSuccess: () => {
 				toast.success('Success', {
-					description: 'Your account has been created! Please sign in with your new credentials.',
+					description: 'Your account has been created! Please check your email to finish activating your' +
+						' account.',
 					action: {
 						label: 'Dismiss',
 						onClick: () => toast.dismiss(),


### PR DESCRIPTION
When creating an account in the staging environment, I noticed that we send out activation emails from there. So I updated the messaging appropriately!