### PR TITLE
Fix browse record selection

### DIFF
--- a/src/features/instance/browse/BrowseDataTableView.tsx
+++ b/src/features/instance/browse/BrowseDataTableView.tsx
@@ -29,17 +29,12 @@ export function BrowseDataTableView() {
 		}),
 	);
 
-	const [searchByHashParams, setSearchByHashParams] = useState({
-		instanceId,
-		schemaName,
-		tableName,
-		hashAttribute: [''],
-	});
+	const [selectedHashAttribute, setSelectedHashAttribute] = useState<null | unknown>(null);
+	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-	const { data: searchByHashData } = useQuery(getSearchByHashOptions(searchByHashParams));
+	const { data: searchByHashData } = useQuery(getSearchByHashOptions(isEditModalOpen, instanceId, schemaName, tableName, selectedHashAttribute));
 
 	const { dataTableColumns, hash_attribute } = formatBrowseDataTableHeader(describeTableData);
-	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 	const [isAddModalOpen, setIsAddModalOpen] = useState(false);
 	const [sortTableDataParams, setSortTableDataParams] = useState({
 		attribute: hash_attribute,
@@ -132,12 +127,7 @@ export function BrowseDataTableView() {
 		);
 	};
 	const onRowClick = (rowData: Row<Record<string, unknown>>) => {
-		setSearchByHashParams({
-			instanceId,
-			schemaName,
-			tableName,
-			hashAttribute: rowData.original[hash_attribute] as string[],
-		});
+		setSelectedHashAttribute(rowData.original[hash_attribute]);
 		setIsEditModalOpen(!isEditModalOpen);
 	};
 	const onColumnClick = (accessorKey: string, isAscending: boolean) => {

--- a/src/features/instance/browse/BrowseDataTableView.tsx
+++ b/src/features/instance/browse/BrowseDataTableView.tsx
@@ -6,7 +6,7 @@ import { getDescribeTableQueryOptions } from '@/features/instance/operations/que
 import { getSearchByValueOptions } from '@/features/instance/operations/queries/getSearchByValue';
 import { BrowseDataTable } from '@/features/instance/browse/components/BrowseDataTable';
 import { EditTableRowModal } from '@/features/instance/modals/EditTableRowModal';
-import { getSearchByHashOptions } from '@/features/instance/operations/queries/getSearchByHash';
+import { getSearchByIdOptions } from '@/features/instance/operations/queries/getSearchById';
 import { formatBrowseDataTableHeader } from '@/features/instance/browse/functions/formatBrowseDataTableHeader';
 import { PaginationState, Row } from '@tanstack/react-table';
 import { useUpdateTableRecords } from '@/features/instance/operations/mutations/updateTableRecords';
@@ -29,10 +29,10 @@ export function BrowseDataTableView() {
 		}),
 	);
 
-	const [selectedHashAttribute, setSelectedHashAttribute] = useState<null | unknown>(null);
+	const [selectedIds, setSelectedIds] = useState<null | unknown[]>(null);
 	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-	const { data: searchByHashData } = useQuery(getSearchByHashOptions(isEditModalOpen, instanceId, schemaName, tableName, selectedHashAttribute));
+	const { data: searchByIdData } = useQuery(getSearchByIdOptions(isEditModalOpen, instanceId, schemaName, tableName, selectedIds));
 
 	const { dataTableColumns, hash_attribute } = formatBrowseDataTableHeader(describeTableData);
 	const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -127,7 +127,7 @@ export function BrowseDataTableView() {
 		);
 	};
 	const onRowClick = (rowData: Row<Record<string, unknown>>) => {
-		setSelectedHashAttribute(rowData.original[hash_attribute]);
+		setSelectedIds([rowData.original[hash_attribute]]);
 		setIsEditModalOpen(!isEditModalOpen);
 	};
 	const onColumnClick = (accessorKey: string, isAscending: boolean) => {
@@ -175,7 +175,7 @@ export function BrowseDataTableView() {
 			<EditTableRowModal
 				setIsModalOpen={setIsEditModalOpen}
 				isModalOpen={isEditModalOpen}
-				data={searchByHashData?.data}
+				data={searchByIdData?.data}
 				onSaveChanges={onRecordUpdate}
 				onDeleteRecord={onDeleteRecord}
 				isUpdateTableRecordsPending={isUpdateTableRecordsPending}

--- a/src/features/instance/operations/queries/getSearchByHash.ts
+++ b/src/features/instance/operations/queries/getSearchByHash.ts
@@ -1,37 +1,15 @@
 import { instanceClient } from '@/config/instanceClient';
 import { queryOptions } from '@tanstack/react-query';
 
-// type SearchConditions = {
-// 	search_attribute: string;
-// 	search_type: string;
-// 	search_value: string;
-// };
-
-// type SearchByValueRequest = {
-// 	conditions?: [SearchConditions];
-// 	schema: string;
-// 	table: string;
-// 	search_attribute: string;
-// 	search_value: string;
-// 	// get_attributes: string[];
-// 	limit: number;
-// 	offset: number;
-// };
-function getSearchByHashOptions({
-	instanceId,
-	schemaName,
-	tableName,
-	hashAttribute,
-}: // ...options
-{
-	instanceId: string;
-	schemaName: string;
-	tableName: string;
-	hashAttribute: string[];
-	// options?: SearchByValueRequest;
-}) {
+function getSearchByHashOptions(
+	isEditModalOpen: boolean,
+	instanceId: string,
+	schemaName: string,
+	tableName: string,
+	hashAttribute?: unknown,
+) {
 	return queryOptions({
-		queryKey: [instanceId, 'search_by_hash'] as const,
+		queryKey: ['search_by_hash', instanceId, schemaName, tableName, hashAttribute] as const,
 		queryFn: () =>
 			instanceClient.post('/', {
 				operation: 'search_by_hash',
@@ -43,7 +21,7 @@ function getSearchByHashOptions({
 				table: tableName,
 				search_value: '*',
 			}),
-		enabled: false,
+		enabled: isEditModalOpen && !!hashAttribute,
 		retry: false,
 	});
 }

--- a/src/features/instance/operations/queries/getSearchById.ts
+++ b/src/features/instance/operations/queries/getSearchById.ts
@@ -1,29 +1,28 @@
 import { instanceClient } from '@/config/instanceClient';
 import { queryOptions } from '@tanstack/react-query';
 
-function getSearchByHashOptions(
+function getSearchByIdOptions(
 	isEditModalOpen: boolean,
 	instanceId: string,
 	schemaName: string,
 	tableName: string,
-	hashAttribute?: unknown,
+	ids: unknown[] | null,
 ) {
 	return queryOptions({
-		queryKey: ['search_by_hash', instanceId, schemaName, tableName, hashAttribute] as const,
+		queryKey: ['search_by_id', instanceId, schemaName, tableName, ids] as const,
 		queryFn: () =>
 			instanceClient.post('/', {
-				operation: 'search_by_hash',
+				get_attributes: ['*'],
+				ids,
 				noCacheStore: true,
 				onlyIfCached: true,
-				get_attributes: ['*'],
-				hash_values: [hashAttribute],
+				operation: 'search_by_id',
 				schema: schemaName,
 				table: tableName,
-				search_value: '*',
 			}),
-		enabled: isEditModalOpen && !!hashAttribute,
+		enabled: isEditModalOpen && !!ids?.length,
 		retry: false,
 	});
 }
 
-export { getSearchByHashOptions };
+export { getSearchByIdOptions };


### PR DESCRIPTION
The instance browse page's "select a record" feature wasn't working, it wasn't loading the data. I simplified the logic a bit, so now it will load up properly.

While in there, I also extracted out sub-routes for the browse pages, preparing for the same treatment to the config users (and roles, soon, too).