### PR TITLE
When the fqdn is missing the schema, assume it is https

### DIFF
--- a/src/lib/getOperationsUrlForInstance.test.ts
+++ b/src/lib/getOperationsUrlForInstance.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { getOperationsUrlForInstance } from '@/lib/getOperationsUrlForInstance';
+
+describe('getOperationsUrlForInstance', () => {
+	it('parses through the url', () => {
+		expect(getOperationsUrlForInstance({
+			instanceFqdn: 'http://localhost:1/',
+			operationsApiPort: 1,
+			operationsApiSecure: false,
+		})).toBe('http://localhost:1/');
+	});
+
+	it('can add the port', () => {
+		expect(getOperationsUrlForInstance({
+			instanceFqdn: 'http://localhost/',
+			operationsApiPort: 2,
+			operationsApiSecure: false,
+		})).toBe('http://localhost:2/');
+	});
+
+	it('can change the port', () => {
+		expect(getOperationsUrlForInstance({
+			instanceFqdn: 'http://localhost:1/',
+			operationsApiPort: 2,
+			operationsApiSecure: false,
+		})).toBe('http://localhost:2/');
+	});
+
+	it('can change the protocol', () => {
+		expect(getOperationsUrlForInstance({
+			instanceFqdn: 'http://localhost:1/',
+			operationsApiPort: 1,
+			operationsApiSecure: true,
+		})).toBe('https://localhost:1/');
+	});
+
+	it('can add the protocol', () => {
+		expect(getOperationsUrlForInstance({
+			instanceFqdn: 'localhost',
+			operationsApiPort: 1,
+			operationsApiSecure: true,
+		})).toBe('https://localhost:1/');
+	});
+});

--- a/src/lib/getOperationsUrlForInstance.ts
+++ b/src/lib/getOperationsUrlForInstance.ts
@@ -1,7 +1,11 @@
 import { Instance } from '@/lib/api.patch';
 
-export function getOperationsUrlForInstance(instance: Instance): string {
-	const url = new URL(instance.instanceFqdn);
+export function getOperationsUrlForInstance(instance: Pick<Instance, 'instanceFqdn' | 'operationsApiSecure' | 'operationsApiPort'>): string {
+	let fqdn = instance.instanceFqdn;
+	if (!fqdn.match(/^https?:\/\//i)) {
+		fqdn = `https://${fqdn}`;
+	}
+	const url = new URL(fqdn);
 	if (instance.operationsApiPort) {
 		url.port = String(instance.operationsApiPort);
 	}


### PR DESCRIPTION
operationsApiSecure can pull us back down to http if necessary. This will let us handle the instanceFqdns I'm seeing now of `us-ord1.north-east.acme.harperfabric.com`.