### PR TITLE
Set initial cluster password flow

### DIFF
--- a/src/features/auth/hooks/useInstanceLoginMutation.ts
+++ b/src/features/auth/hooks/useInstanceLoginMutation.ts
@@ -7,7 +7,7 @@ export type InstanceLoginCredentials = {
 	operationsUrl?: string;
 };
 
-type LoginInfoResponse = {
+export type LoginInfoResponse = {
 	message: string;
 };
 

--- a/src/features/auth/hooks/useInstanceResetPasswordMutation.ts
+++ b/src/features/auth/hooks/useInstanceResetPasswordMutation.ts
@@ -1,0 +1,55 @@
+import { useMutation } from '@tanstack/react-query';
+import { LoginInfoResponse, onInstanceLoginSubmit } from '@/features/auth/hooks/useInstanceLoginMutation';
+import { onAlterUser } from '@/features/instance/operations/mutations/alterUser';
+import { onInstanceLogoutSubmit } from '@/features/auth/hooks/useInstanceLogoutMutation';
+import { resetPasswordUpdater } from '@/features/cluster/queries/resetPasswordUpdater';
+
+export interface InstanceResetPasswordParams {
+	clusterId: string;
+	username: string;
+	newPassword: string;
+	operationsUrl: string;
+	tempPassword: string | undefined;
+}
+
+export async function onInstanceResetPassword({
+	clusterId,
+	username,
+	newPassword,
+	operationsUrl,
+	tempPassword,
+}: InstanceResetPasswordParams): Promise<LoginInfoResponse> {
+	// Do we have a temporary password?
+	if (!tempPassword) {
+		throw new Error('You may not have permission to set the password on this cluster.');
+	}
+	try {
+		// Sign in with the temporary password,
+		const loginResponse = await onInstanceLoginSubmit({
+			username,
+			password: tempPassword,
+			operationsUrl,
+		});
+		// then change to the new password,
+		await onAlterUser({
+			username,
+			password: newPassword,
+			operationsUrl,
+		});
+		// and finally, tell the central manager that we changed their password.
+		await resetPasswordUpdater(clusterId);
+		return loginResponse;
+	} catch (err) {
+		// If something went wrong, logout as well.
+		await onInstanceLogoutSubmit({
+			operationsUrl,
+		});
+		throw err;
+	}
+}
+
+export function useInstanceResetPasswordMutation() {
+	return useMutation<LoginInfoResponse, Error, InstanceResetPasswordParams>({
+		mutationFn: (instanceData) => onInstanceResetPassword(instanceData),
+	});
+}

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -1,5 +1,4 @@
 import { getRouteApi, Navigate, useNavigate } from '@tanstack/react-router';
-import { useInstanceLoginMutation } from '@/features/auth/hooks/useInstanceLoginMutation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -11,27 +10,30 @@ import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo'
 import { authStore } from '@/lib/authStore';
 import { toast } from 'sonner';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { useInstanceResetPasswordMutation } from '@/features/auth/hooks/useInstanceResetPasswordMutation';
 
-const ClusterSignInSchema = z.object({
-	username: z
-		.string({
-			message: 'Please enter the cluster username.',
-		})
-		.max(75, { message: 'Username must be less than 75 characters' }),
-	password: z
-		.string({
-			message: 'Please enter your password',
-		})
-		.min(1, { message: 'Password is required' })
-		.max(50, { message: 'Password must be less than 50 characters' }),
-});
+const ClusterSetPasswordSchema = z
+	.object({
+		username: z.string(),
+		password: z
+			.string({
+				message: 'Please enter your password',
+			})
+			.min(1, { message: 'Password is required' })
+			.max(50, { message: 'Password must be less than 50 characters' }),
+		confirmPassword: z.string(),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: 'Passwords do not match',
+		path: ['confirmPassword'],
+	});
 
 const route = getRouteApi('');
 
-export function ClusterSignIn() {
+export function ClusterSetPassword() {
 	const { clusterId } = route.useParams();
 	const { data: cluster } = useQuery(
 		getClusterInfoQueryOptions(clusterId, true),
@@ -43,30 +45,30 @@ export function ClusterSignIn() {
 	// const router = useRouter();
 	// const queryClient = useQueryClient();
 
-	const form = useForm<z.infer<typeof ClusterSignInSchema>>({
-		resolver: zodResolver(ClusterSignInSchema),
+	const form = useForm<z.infer<typeof ClusterSetPasswordSchema>>({
+		resolver: zodResolver(ClusterSetPasswordSchema),
 		defaultValues: {
-			username: '',
+			username: 'HDB_ADMIN',
 			password: '',
+			confirmPassword: '',
 		},
 	});
-	useEffect(() => {
-		const currentValues = form.getValues();
-		const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;
-		if (!currentValues.username && !currentValues.password && cluster?.resetPassword && tempPassword) {
-			form.setValue('username', 'HDB_ADMIN');
-			form.setValue('password', tempPassword);
-		}
-	}, [form, cluster]);
+	const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;
 
-	const { mutate: submitInstanceLogin, isPending } = useInstanceLoginMutation();
+	const { mutate: submitInstanceResetPassword, isPending } = useInstanceResetPasswordMutation();
 
-	const submitForm = useCallback(async (formData: z.infer<typeof ClusterSignInSchema>) => {
+	const submitForm = useCallback(async (formData: z.infer<typeof ClusterSetPasswordSchema>) => {
 		if (!operationsUrl) {
 			toast.error('Cluster is not yet fully loaded, please wait a moment before trying to sign in.');
 			return;
 		}
-		submitInstanceLogin({ ...formData, operationsUrl }, {
+		submitInstanceResetPassword({
+			clusterId,
+			newPassword: formData.password,
+			operationsUrl,
+			tempPassword,
+			username: formData.username,
+		}, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
 				const user = await getUserInfo({ operationsUrl });
@@ -79,10 +81,10 @@ export function ClusterSignIn() {
 				await navigate({ to: '../browse' });
 			},
 		});
-	}, [cluster, navigate, operationsUrl, submitInstanceLogin]);
+	}, [cluster, clusterId, navigate, operationsUrl, submitInstanceResetPassword, tempPassword]);
 
-	if (cluster?.resetPassword) {
-		return <Navigate to="../set-password" />;
+	if (cluster && !cluster.resetPassword) {
+		return <Navigate to="../sign-in" />;
 	}
 
 	// TODO: There's a lot we can DRY up between the sign in form variants.
@@ -99,8 +101,7 @@ export function ClusterSignIn() {
 			</nav>
 			<div className="h-screen items-center justify-center flex">
 				<div className="text-white w-xs">
-					<h2 className="text-2xl font-light">
-						Sign in to Harper Cluster</h2>
+					<h2 className="text-2xl font-light">Set Harper Cluster Password</h2>
 					<Form {...form}>
 						<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
 							<FormField
@@ -111,6 +112,7 @@ export function ClusterSignIn() {
 										<FormLabel>Cluster User</FormLabel>
 										<FormControl>
 											<Input
+												disabled={true}
 												autoComplete="username"
 												type="text"
 												placeholder="harpersys"
@@ -140,8 +142,26 @@ export function ClusterSignIn() {
 									</FormItem>
 								)}
 							/>
+							<FormField
+								control={form.control}
+								name="confirmPassword"
+								render={({ field }) => (
+									<FormItem className="my-4">
+										<FormLabel>Confirm Password</FormLabel>
+										<FormControl>
+											<Input
+												type="password"
+												placeholder="confirm password"
+												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 							<Button disabled={isPending} type="submit" variant="submit" className="w-full my-2 rounded-full">
-								Sign In
+								Set Cluster Admin Password
 							</Button>
 						</form>
 					</Form>

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -109,13 +109,12 @@ export function ClusterSetPassword() {
 								name="username"
 								render={({ field }) => (
 									<FormItem className="my-4">
-										<FormLabel>Cluster User</FormLabel>
+										<FormLabel>Username</FormLabel>
 										<FormControl>
 											<Input
 												disabled={true}
 												autoComplete="username"
 												type="text"
-												placeholder="harpersys"
 												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 												{...field}
 											/>
@@ -129,11 +128,10 @@ export function ClusterSetPassword() {
 								name="password"
 								render={({ field }) => (
 									<FormItem className="my-4">
-										<FormLabel>Cluster Password</FormLabel>
+										<FormLabel>Password</FormLabel>
 										<FormControl>
 											<Input
 												type="password"
-												placeholder="password"
 												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 												{...field}
 											/>
@@ -151,7 +149,6 @@ export function ClusterSetPassword() {
 										<FormControl>
 											<Input
 												type="password"
-												placeholder="confirm password"
 												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 												{...field}
 											/>

--- a/src/features/cluster/ClusterSignIn.tsx
+++ b/src/features/cluster/ClusterSignIn.tsx
@@ -108,7 +108,7 @@ export function ClusterSignIn() {
 								name="username"
 								render={({ field }) => (
 									<FormItem className="my-4">
-										<FormLabel>Cluster User</FormLabel>
+										<FormLabel>Username</FormLabel>
 										<FormControl>
 											<Input
 												autoComplete="username"
@@ -127,7 +127,7 @@ export function ClusterSignIn() {
 								name="password"
 								render={({ field }) => (
 									<FormItem className="my-4">
-										<FormLabel>Cluster Password</FormLabel>
+										<FormLabel>Password</FormLabel>
 										<FormControl>
 											<Input
 												type="password"

--- a/src/features/cluster/queries/resetPasswordUpdater.ts
+++ b/src/features/cluster/queries/resetPasswordUpdater.ts
@@ -1,0 +1,7 @@
+import { apiClient } from '@/config/apiClient';
+
+export async function resetPasswordUpdater(clusterId: string) {
+	// TODO: Need to update our SDK, but the generated swagger is currently invalid >_<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	await apiClient.patch(`/ResetPasswordUpdater/${clusterId}` as any);
+}

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -4,6 +4,7 @@ import { ClusterLayout } from '@/features/cluster/ClusterLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterIndex } from '@/features/cluster/index';
 import { ClusterSignIn } from '@/features/cluster/ClusterSignIn';
+import { ClusterSetPassword } from '@/features/cluster/ClusterSetPassword';
 
 export const clusterLayoutRoute = createRoute({
 	getParentRoute: () => clustersLayoutRoute,
@@ -37,7 +38,14 @@ const clusterSignInRoute = createRoute({
 	// },
 });
 
+const clusterSetPasswordRoute = createRoute({
+	getParentRoute: () => clusterLayoutRoute,
+	path: 'set-password',
+	component: ClusterSetPassword,
+});
+
 export const clusterRouteTree = [
 	clusterIndexRoute,
 	clusterSignInRoute,
+	clusterSetPasswordRoute,
 ];

--- a/src/features/instance/operations/mutations/alterUser.ts
+++ b/src/features/instance/operations/mutations/alterUser.ts
@@ -1,0 +1,40 @@
+import { useMutation } from '@tanstack/react-query';
+import { instanceClient } from '@/config/instanceClient';
+
+interface AlterUserRequestBody {
+	username?: string;
+	password?: string;
+	role?: string;
+	active?: boolean;
+	operationsUrl?: string;
+}
+
+interface AlterUserResponse {
+	message: string;
+	skipped_hashes: string[];
+	txn_time: number;
+	update_hashes: string[];
+}
+
+export async function onAlterUser({
+	username,
+	password,
+	role,
+	active,
+	operationsUrl,
+}: AlterUserRequestBody): Promise<AlterUserResponse> {
+	const { data } = await instanceClient.post('/', {
+		operation: 'alter_user',
+		username,
+		password,
+		role,
+		active,
+	}, { baseURL: operationsUrl });
+	return data as AlterUserResponse;
+}
+
+export function useAlterUser() {
+	return useMutation({
+		mutationFn: (recordsData: AlterUserRequestBody) => onAlterUser(recordsData),
+	});
+}

--- a/src/features/organization/components/ClusterCard.tsx
+++ b/src/features/organization/components/ClusterCard.tsx
@@ -87,7 +87,7 @@ export function ClusterCard({
 							</Link>
 						)}
 						{!auth.isLoading && auth.user && (
-							<Link to={`${cluster.id}/browse`} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
+							<Link to={`${cluster.id}/browse`} preload={false} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
 								<span className="py-2 hover:border-b-2">
 									View <ArrowRight className="inline-block" />
 								</span>

--- a/src/features/organization/components/ClusterCard.tsx
+++ b/src/features/organization/components/ClusterCard.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { ArrowRight, Ellipsis } from 'lucide-react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Ellipsis } from 'lucide-react';
+import { useNavigate } from '@tanstack/react-router';
 import { renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import {
 	DropdownMenu,
@@ -17,6 +17,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { onInstanceLogoutSubmit } from '@/features/auth/hooks/useInstanceLogoutMutation';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { authStore } from '@/lib/authStore';
+import { ClusterCardAction } from '@/features/organization/components/ClusterCardAction';
 
 export function ClusterCard({
 	cluster,
@@ -71,30 +72,7 @@ export function ClusterCard({
 			<CardContent className="flex justify-between">
 				<Badge
 					variant={renderBadgeStatusVariant(cluster.status)}>{renderBadgeStatusText(cluster.status)}</Badge>
-				{isReadyForInteraction && <>
-					{isSelfManaged ? (
-						<Link to={cluster.id} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
-							<span className="py-2 hover:border-b-2">
-								Instances <ArrowRight className="inline-block" />
-							</span>
-						</Link>
-					) : <>
-						{!auth.isLoading && !auth.user && (
-							<Link to={`${cluster.id}/sign-in`} className="text-sm" aria-label={`Sign In to ${cluster.name}`} title={`Sign In to ${cluster.name}`}>
-								<span className="py-2 hover:border-b-2">
-									Sign In <ArrowRight className="inline-block" />
-								</span>
-							</Link>
-						)}
-						{!auth.isLoading && auth.user && (
-							<Link to={`${cluster.id}/browse`} preload={false} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
-								<span className="py-2 hover:border-b-2">
-									View <ArrowRight className="inline-block" />
-								</span>
-							</Link>
-						)}
-					</>}
-				</>}
+				{isReadyForInteraction && <ClusterCardAction cluster={cluster} />}
 			</CardContent>
 		</Card>
 	);

--- a/src/features/organization/components/ClusterCardAction.tsx
+++ b/src/features/organization/components/ClusterCardAction.tsx
@@ -1,0 +1,43 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowRight } from 'lucide-react';
+import { useMemo } from 'react';
+import { Cluster } from '@/lib/api.patch';
+import { useAuth } from '@/hooks/useAuth';
+
+export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
+	const auth = useAuth(cluster);
+	const isPendingResetPassword = useMemo(() => cluster.resetPassword, [cluster]);
+	const isSelfManaged = useMemo(() => !cluster.plans?.length || !!cluster.plans.find((p) => p.plan === 'self-managed'), [cluster]);
+
+	if (isSelfManaged) {
+		return <Link to={cluster.id} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
+			<span className="py-2 hover:border-b-2">
+				Instances <ArrowRight className="inline-block" />
+			</span>
+		</Link>;
+	}
+
+	if (isPendingResetPassword) {
+		return <Link to={`${cluster.id}/set-password`} className="text-sm" aria-label={`Set Password on ${cluster.name}`} title={`Set Password on ${cluster.name}`}>
+			<span className="py-2 hover:border-b-2">
+				Set Password <ArrowRight className="inline-block" />
+			</span>
+		</Link>;
+	}
+
+	if (auth.isLoading) {
+		return undefined;
+	}
+	if (auth.user) {
+		return <Link to={`${cluster.id}/browse`} preload={false} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
+			<span className="py-2 hover:border-b-2">
+				View <ArrowRight className="inline-block" />
+			</span>
+		</Link>;
+	}
+	return <Link to={`${cluster.id}/sign-in`} className="text-sm" aria-label={`Sign In to ${cluster.name}`} title={`Sign In to ${cluster.name}`}>
+		<span className="py-2 hover:border-b-2">
+			Sign In <ArrowRight className="inline-block" />
+		</span>
+	</Link>;
+}


### PR DESCRIPTION
<img width="612" height="878" alt="Screenshot 2025-07-10 at 5 45 53 PM" src="https://github.com/user-attachments/assets/f4f99996-078a-49d5-a245-cf0db4433c11" />


<img width="612" height="878" alt="Screenshot 2025-07-10 at 5 45 48 PM" src="https://github.com/user-attachments/assets/db83dfe3-7d14-40db-b953-7c2d4d318a1a" />


When you create a cluster, we'll detect the new `resetPassword` state on the cluster, and the `tempPassword` within the instance. We'll show different buttons and a new form to the user when signing into this cluster. We'll also redirect them if they try to get to the sign-in page for this cluster.

When setting up the password, the UI will sign in with the temp password, alter the password, tell central manager we've done our work, and then redirect the user. If any of that fails, we'll log the user out of the cluster, and show them the error message.

We have some work to do to later to DRY up the proliferation of sign-in, set-password, etc forms that are all very similar, and the code that handles the logins. But we can tackle that very soon. I didn't want to make this PR too big, after all. 😅 

https://harperdb.atlassian.net/browse/STUDIO-202