### PR TITLE
Prevent deleting self on clusters too

### DIFF
--- a/src/features/instance/config/users/index.tsx
+++ b/src/features/instance/config/users/index.tsx
@@ -18,7 +18,7 @@ const route = getRouteApi('');
 
 export function ConfigUsersIndex() {
 	const navigate = useNavigate();
-	const { instanceId, username } = route.useParams();
+	const { instanceId, clusterId, username } = route.useParams();
 	const {
 		data: localUsers,
 		refetch,
@@ -111,6 +111,7 @@ export function ConfigUsersIndex() {
 			/>
 			{isEditModalOpen && <EditUserModal
 				instanceId={instanceId}
+				clusterId={clusterId}
 				closeModal={closeEditModal}
 				data={selectedUser}
 				isModalOpen={isEditModalOpen}

--- a/src/features/instance/config/users/modals/EditUserModal.tsx
+++ b/src/features/instance/config/users/modals/EditUserModal.tsx
@@ -6,12 +6,14 @@ import { LocalUser } from '@/lib/api.patch';
 
 export function EditUserModal({
 	closeModal,
+	clusterId,
 	instanceId,
 	data,
 	isModalOpen,
 	onUserDeleted,
 	onUserUpdated,
 }: {
+	clusterId: string;
 	instanceId: string;
 	isModalOpen: boolean;
 	closeModal: () => void;
@@ -19,7 +21,7 @@ export function EditUserModal({
 	onUserDeleted: () => void;
 	onUserUpdated: () => void;
 }) {
-	const auth = useInstanceAuth(instanceId);
+	const auth = useInstanceAuth(instanceId || clusterId);
 	const isSelf = auth.user?.username === data.username;
 	const canDelete = !isSelf;
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -21,6 +21,6 @@ export function useAuth(entity?: Instance | Cluster | string | null): Authentica
 	return connection;
 }
 
-export function useInstanceAuth(entity: Instance | string | null): AuthenticatedInstanceConnection {
+export function useInstanceAuth(entity: Instance | Cluster | string | null): AuthenticatedInstanceConnection {
 	return useAuth(entity) as AuthenticatedInstanceConnection;
 }


### PR DESCRIPTION
I forgot to test the case of logging-in-through-a-cluster, which doesn't have an instanceId, so it wasn't preventing the user from deleting their own user. Fixed!

It does point out that the `useInstanceAuth` has a rather confusing name, however 😆 But I'm not sure what name would be better, since... you're connecting to an instance-within-a-cluster. 🤷 

https://harperdb.atlassian.net/browse/STUDIO-180