### PR TITLE
[STUDIO-248] Allow customizing the credentials during initial setup

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,3 +2,4 @@ export const isLocalStudio = import.meta.env.VITE_LOCAL_STUDIO === 'true';
 export const localStudioDevUrl = import.meta.env.VITE_LOCAL_STUDIO_DEV_URL;
 export const defaultOperationsApiPort = 9925;
 export const defaultOperationsApiSecure = true;
+export const defaultClusterUsername = 'HDB_ADMIN';

--- a/src/features/auth/hooks/useInstanceResetPasswordMutation.ts
+++ b/src/features/auth/hooks/useInstanceResetPasswordMutation.ts
@@ -1,3 +1,6 @@
+import { defaultClusterUsername } from '@/config/constants';
+import { onAddUserSubmit } from '@/features/instance/operations/mutations/addUser';
+import { onDeleteUser } from '@/features/instance/operations/mutations/deleteUser';
 import { useMutation } from '@tanstack/react-query';
 import { LoginInfoResponse, onInstanceLoginSubmit } from '@/features/auth/hooks/useInstanceLoginMutation';
 import { onAlterUser } from '@/features/instance/operations/mutations/alterUser';
@@ -6,7 +9,8 @@ import { resetPasswordUpdater } from '@/features/cluster/queries/resetPasswordUp
 
 export interface InstanceResetPasswordParams {
 	clusterId: string;
-	username: string;
+	initialUsername: string;
+	desiredUsername: string;
 	newPassword: string;
 	operationsUrl: string;
 	tempPassword: string | undefined;
@@ -14,7 +18,8 @@ export interface InstanceResetPasswordParams {
 
 export async function onInstanceResetPassword({
 	clusterId,
-	username,
+	initialUsername,
+	desiredUsername,
 	newPassword,
 	operationsUrl,
 	tempPassword,
@@ -26,16 +31,35 @@ export async function onInstanceResetPassword({
 	try {
 		// Sign in with the temporary password,
 		const loginResponse = await onInstanceLoginSubmit({
-			username,
+			username: initialUsername,
 			password: tempPassword,
 			operationsUrl,
 		});
-		// then change to the new password,
-		await onAlterUser({
-			username,
-			password: newPassword,
-			operationsUrl,
-		});
+		// then create a new user
+		if (desiredUsername === defaultClusterUsername) {
+			await onAlterUser({
+				username: desiredUsername,
+				password: newPassword,
+				operationsUrl,
+			});
+		} else {
+			await onAddUserSubmit({
+				username: desiredUsername,
+				password: newPassword,
+				role: 'super_user',
+				active: true,
+				operationsUrl,
+			});
+			await onDeleteUser({
+				username: defaultClusterUsername,
+				operationsUrl,
+			});
+			await onInstanceLoginSubmit({
+				username: desiredUsername,
+				password: newPassword,
+				operationsUrl,
+			});
+		}
 		// and finally, tell the central manager that we changed their password.
 		await resetPasswordUpdater(clusterId);
 		return loginResponse;

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -1,3 +1,4 @@
+import { defaultClusterUsername } from '@/config/constants';
 import { getRouteApi, Navigate, useNavigate } from '@tanstack/react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -15,10 +16,12 @@ import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useInstanceResetPasswordMutation } from '@/features/auth/hooks/useInstanceResetPasswordMutation';
 
-const forcedUsername = 'HDB_ADMIN';
 const ClusterSetPasswordSchema = z
 	.object({
-		username: z.string().regex(new RegExp(forcedUsername), { message: `Initial username must be ${forcedUsername}, did your password manager change it?` }),
+		username: z.string({
+			message: 'Please enter a username.',
+			// TODO: usernames must have only letters, numbers, hyphens, and underscores
+		}).min(1, { message: 'Please enter a username.' }),
 		password: z
 			.string({
 				message: 'Please enter your password',
@@ -49,7 +52,7 @@ export function ClusterSetPassword() {
 	const form = useForm<z.infer<typeof ClusterSetPasswordSchema>>({
 		resolver: zodResolver(ClusterSetPasswordSchema),
 		defaultValues: {
-			username: forcedUsername,
+			username: '',
 			password: '',
 			confirmPassword: '',
 		},
@@ -68,7 +71,8 @@ export function ClusterSetPassword() {
 			newPassword: formData.password,
 			operationsUrl,
 			tempPassword,
-			username: forcedUsername,
+			initialUsername: defaultClusterUsername,
+			desiredUsername: formData.username,
 		}, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
@@ -113,8 +117,6 @@ export function ClusterSetPassword() {
 										<FormLabel>Username</FormLabel>
 										<FormControl>
 											<Input
-												disabled={true}
-												readOnly={true}
 												autoComplete="username"
 												type="text"
 												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -119,7 +119,6 @@ export function ClusterSetPassword() {
 											<Input
 												autoComplete="username"
 												type="text"
-												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 												{...field}
 											/>
 										</FormControl>

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -15,9 +15,10 @@ import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useInstanceResetPasswordMutation } from '@/features/auth/hooks/useInstanceResetPasswordMutation';
 
+const forcedUsername = 'HDB_ADMIN';
 const ClusterSetPasswordSchema = z
 	.object({
-		username: z.string(),
+		username: z.string().regex(new RegExp(forcedUsername), { message: `Initial username must be ${forcedUsername}, did your password manager change it?` }),
 		password: z
 			.string({
 				message: 'Please enter your password',
@@ -48,7 +49,7 @@ export function ClusterSetPassword() {
 	const form = useForm<z.infer<typeof ClusterSetPasswordSchema>>({
 		resolver: zodResolver(ClusterSetPasswordSchema),
 		defaultValues: {
-			username: 'HDB_ADMIN',
+			username: forcedUsername,
 			password: '',
 			confirmPassword: '',
 		},
@@ -67,7 +68,7 @@ export function ClusterSetPassword() {
 			newPassword: formData.password,
 			operationsUrl,
 			tempPassword,
-			username: formData.username,
+			username: forcedUsername,
 		}, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
@@ -113,6 +114,7 @@ export function ClusterSetPassword() {
 										<FormControl>
 											<Input
 												disabled={true}
+												readOnly={true}
 												autoComplete="username"
 												type="text"
 												className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"

--- a/src/features/cluster/ClusterSignIn.tsx
+++ b/src/features/cluster/ClusterSignIn.tsx
@@ -1,19 +1,19 @@
-import { getRouteApi, Navigate, useNavigate } from '@tanstack/react-router';
-import { useInstanceLoginMutation } from '@/features/auth/hooks/useInstanceLoginMutation';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { useQuery } from '@tanstack/react-query';
+import { useInstanceLoginMutation } from '@/features/auth/hooks/useInstanceLoginMutation';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
 import { authStore } from '@/lib/authStore';
-import { toast } from 'sonner';
-import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
-import { useCallback, useEffect, useMemo } from 'react';
-import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { getRouteApi, Navigate, useNavigate } from '@tanstack/react-router';
+import { useCallback, useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
 
 const ClusterSignInSchema = z.object({
 	username: z
@@ -50,14 +50,6 @@ export function ClusterSignIn() {
 			password: '',
 		},
 	});
-	useEffect(() => {
-		const currentValues = form.getValues();
-		const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;
-		if (!currentValues.username && !currentValues.password && cluster?.resetPassword && tempPassword) {
-			form.setValue('username', 'HDB_ADMIN');
-			form.setValue('password', tempPassword);
-		}
-	}, [form, cluster]);
 
 	const { mutate: submitInstanceLogin, isPending } = useInstanceLoginMutation();
 

--- a/src/features/instance/operations/mutations/addUser.ts
+++ b/src/features/instance/operations/mutations/addUser.ts
@@ -7,6 +7,7 @@ export type AddUserFormData = {
 	password: string;
 	role: string;
 	username: string;
+	operationsUrl?: string;
 };
 
 export const AddUserFormSchema = z.object({
@@ -34,16 +35,17 @@ export const AddUserFormSchema = z.object({
 		path: ['confirmPassword'], // This specifies where the error message should be attached
 	});
 
-const onAddUserSubmit = async (formData: AddUserFormData) => {
+export async function onAddUserSubmit(formData: AddUserFormData) {
+	const { operationsUrl, ...userData } = formData;
 	const { data } = await instanceClient.post('/', {
 		operation: 'add_user',
-		...formData,
-	});
+		...userData,
+	}, { baseURL: operationsUrl });
 	return data;
-};
+}
 
-export const useAddUserMutation = () => {
+export function useAddUserMutation() {
 	return useMutation({
 		mutationFn: (formData: AddUserFormData) => onAddUserSubmit(formData),
 	});
-};
+}

--- a/src/features/instance/operations/mutations/deleteUser.ts
+++ b/src/features/instance/operations/mutations/deleteUser.ts
@@ -2,11 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { instanceClient } from '@/config/instanceClient';
 import { z } from 'zod';
 
-type DeleteUserData = {
+export type DeleteUserData = {
 	username: string;
+	operationsUrl?: string;
 };
 
-type DeleteUserResponse = {
+export type DeleteUserResponse = {
 	message: string;
 }
 
@@ -25,19 +26,16 @@ export const DeleteUserFormSchema = z.object({
 		path: ['confirmUsernameForDeletion'], // This specifies where the error message should be attached
 	});
 
-const onDeleteUser = async (userData: DeleteUserData) => {
+export async function onDeleteUser({ username, operationsUrl }: DeleteUserData) {
 	const { data } = await instanceClient.post<DeleteUserResponse>('/', {
 		operation: 'drop_user',
-		username: userData.username,
-	});
+		username,
+	}, { baseURL: operationsUrl });
 	return data;
-};
+}
 
-const useDeleteUserMutation = () => {
+export function useDeleteUserMutation() {
 	return useMutation({
 		mutationFn: (data: DeleteUserData) => onDeleteUser(data),
 	});
-};
-
-export { useDeleteUserMutation };
-export type { DeleteUserData };
+}

--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -70,8 +70,8 @@ class AuthStore {
 		if (!id || !key) {
 			return;
 		}
-		this.users[key] = user;
-		this.loading[key] = false;
+		this.users[id] = user;
+		this.loading[id] = false;
 		if (user) {
 			this.flagKeyAsSignedIn(id, key);
 		} else {


### PR DESCRIPTION
I started off trying to prevent the password manager from setting the username, but @Devin-Holland had the great idea to actually let the user change their username 😄 so let's do that!

I also found and fixed a bug preventing the authStore from storing that initial user properly without having to refresh the page (which also showed up when logging out from the cluster or instance).

https://harperdb.atlassian.net/browse/STUDIO-248