### PR TITLE
Tweak cluster grouping and available actions

### DIFF
--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -1,9 +1,11 @@
 import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { NewClusterModal } from '@/features/clusters/modals/NewClusterModal';
 import { ClusterCard } from '@/features/organization/components/ClusterCard';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
-import { sortByName } from '@/lib/arrays/sort/byName';
+import { byClusterStatusThenName } from '@/lib/arrays/sort/byClusterStatusThenName';
 import { groupBy } from '@/lib/group-by';
 import { queryKeys } from '@/react-query/constants';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
@@ -27,18 +29,16 @@ export function ClustersList() {
 		name: '',
 	});
 
-	const clusterGroups = useMemo(() => {
-		if (isSuccess && orgInfo?.clusters) {
-			const { RUNNING, PROVISIONING, CLONE_READY, UPDATED, ...others } = groupBy(orgInfo.clusters, 'status');
-			const successBuckets = [...(RUNNING || []), ...(PROVISIONING || []), ...(CLONE_READY || []), ...(UPDATED || [])].sort(sortByName);
-			const otherBuckets = [...Object.values(others).flat()].sort(sortByName);
-			return [
-				{ name: 'Running', clusters: successBuckets },
-				{ name: 'Inactive', clusters: otherBuckets },
-			].filter(group => group.clusters.length);
-		}
-		return null;
-	}, [isSuccess, orgInfo]);
+	const clustersData = useMemo(
+		() => {
+			const groups = groupBy(orgInfo?.clusters?.sort(byClusterStatusThenName) || [], 'status');
+			return {
+				keys: Object.keys(groups),
+				groups,
+			}
+		},
+		[orgInfo],
+	);
 
 	const handleDeleteCluster = useCallback((clusterInfo: { id: string; name: string }) => {
 		if (clusterInfo) {
@@ -96,12 +96,14 @@ export function ClustersList() {
 				) : null}
 			</nav>
 			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
-				{clusterGroups?.length ?
-					clusterGroups?.map(clusterGroup =>
-						<div key={clusterGroup.name}>
-							<h2 className="mb-2">{clusterGroup.name}</h2>
+				{clustersData.keys.length
+					? clustersData.keys.map(clusterStatus =>
+						<div key={clusterStatus}>
+							<h2 className="mb-2">
+								<Badge variant={renderBadgeStatusVariant(clusterStatus)}>{renderBadgeStatusText(clusterStatus)}</Badge>
+							</h2>
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
-								{clusterGroup.clusters.map((cluster) => (
+								{clustersData.groups[clusterStatus].map((cluster) => (
 									<div key={cluster.id}
 										 className="cols-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">
 										<ClusterCard

--- a/src/features/organization/components/ClusterCard.tsx
+++ b/src/features/organization/components/ClusterCard.tsx
@@ -19,8 +19,8 @@ import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluste
 import { authStore } from '@/lib/authStore';
 import { ClusterCardAction } from '@/features/organization/components/ClusterCardAction';
 
-const activeClusterStatuses = ['CLONE_READY', 'RUNNING', 'UPDATED'];
-const deletableClusterStatuses = ['TERMINATING', 'TERMINATED', 'REMOVED'];
+const activeClusterStatuses = ['RUNNING'];
+const deletedClusterStatuses = ['TERMINATING', 'TERMINATED', 'REMOVED'];
 
 export function ClusterCard({
 	cluster,
@@ -34,7 +34,7 @@ export function ClusterCard({
 
 	const isSelfManaged = useMemo(() => !cluster.plans?.length || !!cluster.plans.find((p) => p.plan === 'self-managed'), [cluster]);
 	const isReadyForInteraction = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster]);
-	const canDelete = useMemo(() => cluster.status && !deletableClusterStatuses.includes(cluster.status), [cluster]);
+	const canDelete = useMemo(() => cluster.status && !deletedClusterStatuses.includes(cluster.status), [cluster]);
 
 	const onInstancesClick = useCallback(() => navigate({ to: cluster.id }), [navigate, cluster]);
 	const onSignOutClick = useCallback(async () => {
@@ -48,7 +48,7 @@ export function ClusterCard({
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
 					<span className="truncate">CLUSTER ID: {cluster.id}</span>
-					<DropdownMenu>
+					{(isReadyForInteraction || canDelete) && <DropdownMenu>
 						<DropdownMenuTrigger>
 							<Ellipsis aria-label="Cluster options" />
 						</DropdownMenuTrigger>
@@ -57,7 +57,7 @@ export function ClusterCard({
 							<DropdownMenuSeparator />
 							{isReadyForInteraction && <DropdownMenuItem onClick={onInstancesClick}>Instances</DropdownMenuItem>}
 							{isReadyForInteraction && !isSelfManaged && !auth.isLoading && auth.user && <DropdownMenuItem onClick={onSignOutClick}>Sign Out</DropdownMenuItem>}
-							<DropdownMenuItem>Edit</DropdownMenuItem>
+							{isReadyForInteraction && <DropdownMenuItem>Edit</DropdownMenuItem>}
 							{canDelete &&
 								<DropdownMenuItem
 									className="bg-red focus:bg-red/70 focus:text-white"
@@ -66,7 +66,7 @@ export function ClusterCard({
 								</DropdownMenuItem>
 							}
 						</DropdownMenuContent>
-					</DropdownMenu>
+					</DropdownMenu>}
 				</CardDescription>
 				<CardTitle>
 					<h2>{cluster.name}</h2>

--- a/src/lib/api.patch.d.ts
+++ b/src/lib/api.patch.d.ts
@@ -70,5 +70,5 @@ export interface Plan extends SchemaPlan {
 
 export interface Cluster extends SchemaCluster {
 	// TODO: Can we return enums from the server to make this easier?
-	status?: string | 'PROVISIONING' | 'RUNNING' | 'UPDATING_HDB_NODES' | 'UPDATING' | 'ERROR' | 'TERMINATING' | 'REMOVED' | 'STOPPED' | 'CLONE_READY' | 'CLONE_PENDING' | 'UPDATED' | 'TERMINATED';
+	status?: string | 'PROVISIONING' | 'UPDATING' | 'RUNNING' | 'TERMINATED';
 }

--- a/src/lib/arrays/sort/byClusterStatusThenName.test.ts
+++ b/src/lib/arrays/sort/byClusterStatusThenName.test.ts
@@ -1,0 +1,55 @@
+import { Cluster } from '@/lib/api.patch';
+import { byClusterStatusThenName } from '@/lib/arrays/sort/byClusterStatusThenName';
+import { describe, expect, it } from 'vitest';
+
+describe('byClusterStatusThenName', () => {
+	const clusterDefaults: Cluster = {
+		abbreviatedName: '',
+		id: '',
+		name: '',
+		organizationId: '',
+		status: 'RUNNING',
+	};
+
+	it('should sort by names', () => {
+		const clusters = [
+			{ ...clusterDefaults, name: 'Cluster D' },
+			{ ...clusterDefaults, name: 'Cluster A' },
+			{ ...clusterDefaults, name: 'Cluster C' },
+			{ ...clusterDefaults, name: 'Cluster B' },
+		];
+		clusters.sort(byClusterStatusThenName);
+		expect(clusters.map(c => c.name)).toEqual([
+			'Cluster A',
+			'Cluster B',
+			'Cluster C',
+			'Cluster D',
+		]);
+	});
+
+	it('should sort by status', () => {
+		const clusters = [
+			{ ...clusterDefaults, status: 'PROVISIONING' },
+			{ ...clusterDefaults, status: 'TERMINATED' },
+			{ ...clusterDefaults, status: 'UPDATING' },
+			{ ...clusterDefaults, status: 'RUNNING' },
+			{ ...clusterDefaults, status: 'PROVISIONING' },
+			{ ...clusterDefaults, status: 'UPDATING' },
+			{ ...clusterDefaults, status: 'RUNNING' },
+			{ ...clusterDefaults, status: 'TERMINATED' },
+			{ ...clusterDefaults, status: 'UPDATING' },
+		];
+		clusters.sort(byClusterStatusThenName);
+		expect(clusters.map(c => c.status)).toEqual([
+			'UPDATING',
+			'UPDATING',
+			'UPDATING',
+			'PROVISIONING',
+			'PROVISIONING',
+			'RUNNING',
+			'RUNNING',
+			'TERMINATED',
+			'TERMINATED',
+		]);
+	});
+});

--- a/src/lib/arrays/sort/byClusterStatusThenName.ts
+++ b/src/lib/arrays/sort/byClusterStatusThenName.ts
@@ -1,0 +1,20 @@
+import { Cluster } from '@/lib/api.patch';
+
+const statusPriority: Record<string, number> = {
+  'UPDATING': 0,
+  'PROVISIONING': 1,
+  'RUNNING': 2,
+  'TERMINATED': 3
+};
+
+const DEFAULT_PRIORITY = statusPriority.RUNNING;
+
+export function byClusterStatusThenName(a: Cluster, b: Cluster) {
+  if (a.status === b.status) {
+    return a.name.localeCompare(b.name);
+  }
+
+  const priorityA = a.status ? statusPriority[a.status] ?? DEFAULT_PRIORITY : DEFAULT_PRIORITY;
+  const priorityB = b.status ? statusPriority[b.status] ?? DEFAULT_PRIORITY : DEFAULT_PRIORITY;
+  return priorityA - priorityB;
+}


### PR DESCRIPTION
The server is returning fewer statuses than we originally thought, so we can tweak the logic a bit to group them properly. I also added unit tests to ensure we’re getting them into the right order before grouping them.

https://harperdb.atlassian.net/browse/STUDIO-243