### PR TITLE
[STUDIO-245] Refresh Org List After Creating Org

### DIFF
--- a/.run/Watch All Tests.run.xml
+++ b/.run/Watch All Tests.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Watch All Tests" type="JavaScriptTestRunnerVitest">
+    <node-interpreter value="project" />
+    <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
+    <working-dir value="$PROJECT_DIR$" />
+    <vitest-options value="watch" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/features/auth/LocalSignIn.tsx
+++ b/src/features/auth/LocalSignIn.tsx
@@ -13,7 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { queryKeys } from '@/react-query/constants';
 import { useQueryClient } from '@tanstack/react-query';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { authStore, OverallAppSignIn } from '@/lib/authStore';
 import { toast } from 'sonner';
 
@@ -51,7 +51,7 @@ export function LocalSignIn() {
 		submitInstanceLogin(formData, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
-				const user = await getUserInfo();
+				const user = await getInstanceUserInfo();
 				authStore.setUserForEntity(OverallAppSignIn, user);
 				await queryClient.invalidateQueries({ queryKey: [queryKeys.user], refetchType: 'none' });
 				router.invalidate();

--- a/src/features/auth/queries/getCurrentUser.ts
+++ b/src/features/auth/queries/getCurrentUser.ts
@@ -1,7 +1,9 @@
 import { User } from '@/lib/api.patch';
 import { apiClient } from '@/config/apiClient';
+import { queryKeys } from '@/react-query/constants';
+import { queryOptions } from '@tanstack/react-query';
 
-export async function getCloudUser(): Promise<User> {
+export async function getCurrentUser(): Promise<User> {
 	const { data } = await apiClient.get('/User/current' as '/User/{id}');
 	return data as User;
 }

--- a/src/features/auth/queries/getCurrentUser.ts
+++ b/src/features/auth/queries/getCurrentUser.ts
@@ -7,3 +7,11 @@ export async function getCurrentUser(): Promise<User> {
 	const { data } = await apiClient.get('/User/current' as '/User/{id}');
 	return data as User;
 }
+
+export function getCurrentUserQueryOptions() {
+	return queryOptions({
+		queryKey: [queryKeys.user],
+		queryFn: getCurrentUser,
+		retry: false,
+	});
+}

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useQuery } from '@tanstack/react-query';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { authStore } from '@/lib/authStore';
 import { toast } from 'sonner';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
@@ -81,7 +81,7 @@ export function ClusterSetPassword() {
 		}, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
-				const user = await getUserInfo({ operationsUrl });
+				const user = await getInstanceUserInfo({ operationsUrl });
 				authStore.setUserForEntity(cluster || null, user);
 				// TODO: What should we invalidate for the cluster?
 				//  await queryClient.invalidateQueries({ queryKey: [queryKeys.user], refetchType: 'none' });

--- a/src/features/cluster/ClusterSignIn.tsx
+++ b/src/features/cluster/ClusterSignIn.tsx
@@ -9,7 +9,7 @@ import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useInstanceLoginMutation } from '@/features/auth/hooks/useInstanceLoginMutation';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { authStore } from '@/lib/authStore';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -66,7 +66,7 @@ export function ClusterSignIn() {
 		submitInstanceLogin({ ...formData, operationsUrl }, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
-				const user = await getUserInfo({ operationsUrl });
+				const user = await getInstanceUserInfo({ operationsUrl });
 				authStore.setUserForEntity(cluster || null, user);
 				// TODO: What should we invalidate for the cluster?
 				//  await queryClient.invalidateQueries({ queryKey: [queryKeys.user], refetchType: 'none' });

--- a/src/features/cluster/modals/InstanceLoginModal.tsx
+++ b/src/features/cluster/modals/InstanceLoginModal.tsx
@@ -23,7 +23,7 @@ import { useForm } from 'react-hook-form';
 import { useCallback, useState } from 'react';
 import { useInstanceLoginMutation } from '@/features/auth/hooks/useInstanceLoginMutation';
 import { authStore } from '@/lib/authStore';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { Instance } from '@/lib/api.patch';
 import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
 
@@ -57,7 +57,7 @@ export function InstanceLogInModal({ instance }: { readonly instance: Instance; 
 		}, {
 			onSuccess: async (response) => {
 				toast.success(response.message);
-				const user = await getUserInfo({ operationsUrl });
+				const user = await getInstanceUserInfo({ operationsUrl });
 				authStore.setUserForEntity(instance, user);
 				setIsModalOpen(false);
 				form.reset();

--- a/src/features/instance/operations/mutations/updateRestartInstance.ts
+++ b/src/features/instance/operations/mutations/updateRestartInstance.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 import { instanceClient } from '@/config/instanceClient';
 import { sleep } from '@/lib/sleep';
 import { axiosRetry } from '@/lib/axiosRetry';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 
 type UpdateRestartInstanceResponse = {
 	message: string;
@@ -14,7 +14,7 @@ async function onUpdateRestartInstance() {
 		operation: 'restart',
 	});
 	await sleep(3000);
-	await axiosRetry(() => getUserInfo({ timeout: 10000, operationsUrl }), 5, 3000);
+	await axiosRetry(() => getInstanceUserInfo({ timeout: 10000, operationsUrl }), 5, 3000);
 	return data as UpdateRestartInstanceResponse;
 }
 

--- a/src/features/instance/operations/queries/getInstanceUserInfo.ts
+++ b/src/features/instance/operations/queries/getInstanceUserInfo.ts
@@ -2,7 +2,7 @@ import { instanceClient } from '@/config/instanceClient';
 import { LocalUser } from '@/lib/api.patch';
 import type { AxiosRequestConfig } from 'axios';
 
-export async function getUserInfo(params?: { operationsUrl?: string } & AxiosRequestConfig) {
+export async function getInstanceUserInfo(params?: { operationsUrl?: string } & AxiosRequestConfig) {
 	const { operationsUrl, ...config } = params ?? {};
 	const { data } = await instanceClient.post('/', {
 		...config,

--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -1,15 +1,12 @@
+import { getCurrentUserQueryOptions } from '@/features/auth/queries/getCurrentUser';
 import { OrgCard } from '@/features/organizations/components/OrgCard';
 import { NewOrganizationModal } from '@/features/organizations/modals/NewOrganizationModal';
-import { isLocalUser } from '@/lib/types/isLocalUser';
-import { useAuth } from '@/hooks/useAuth';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 export function OrganizationsIndex() {
-	const { user } = useAuth();
+	const { data: user } = useSuspenseQuery(getCurrentUserQueryOptions());
 
-	if (isLocalUser(user)) {
-		throw new Error('Local users cannot access organizations.');
-	}
 	const sortedRoles = useMemo(() => user?.roles.slice().sort((a, b) => a.organizationName > b.organizationName ? 1 : -1) || [], [user]);
 	return (
 		<>

--- a/src/features/organizations/modals/NewOrganizationModal.tsx
+++ b/src/features/organizations/modals/NewOrganizationModal.tsx
@@ -52,7 +52,7 @@ export function NewOrganizationModal() {
 		},
 	});
 
-	const { mutate: submitNewOrganizationData } = useCreateNewOrganizationMutation();
+	const { mutate: submitNewOrganizationData, isPending } = useCreateNewOrganizationMutation();
 	const queryClient = useQueryClient();
 
 	const submitForm = async (formData: Omit<SchemaOrganization, "id">) => {
@@ -105,7 +105,7 @@ export function NewOrganizationModal() {
 							)}
 						/>
 						<DialogFooter>
-							<Button type="submit" variant="submit" className="rounded-full">
+							<Button type="submit" variant="submit" className="rounded-full" disabled={isPending}>
 								Create New Organization <ArrowRight />
 							</Button>
 						</DialogFooter>

--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -1,6 +1,6 @@
 import { isLocalStudio } from '@/config/constants';
-import { getCloudUser } from '@/features/auth/queries/getCurrentUser';
-import { getUserInfo } from '@/features/instance/operations/queries/getUserInfo';
+import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { SchemaCluster, SchemaHdbInstance } from '@/lib/api.gen';
 import { Cluster, Instance, LocalUser, User } from '@/lib/api.patch';
 import { sleep } from '@/lib/sleep';
@@ -151,12 +151,12 @@ class AuthStore {
 		try {
 			if (id === OverallAppSignIn) {
 				if (isLocalStudio) {
-					user = await getUserInfo();
+					user = await getInstanceUserInfo();
 				} else {
-					user = await getCloudUser();
+					user = await getCurrentUser();
 				}
 			} else if (id) {
-				user = await getUserInfo({ operationsUrl: key });
+				user = await getInstanceUserInfo({ operationsUrl: key });
 			}
 		} catch (error) {
 			// TODO: Only catch the errors we expect here (401? 403? w/e)

--- a/src/react-query/queryClient.test.ts
+++ b/src/react-query/queryClient.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { errorHandler } from './queryClient';
-import { toast } from 'sonner';
 import { AxiosError } from 'axios';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
+import { errorHandler } from './queryClient';
 
 // Mock the toast module
 vi.mock('sonner', () => ({
@@ -14,13 +14,21 @@ vi.mock('sonner', () => ({
 }));
 
 describe('errorHandler', () => {
+  let consoleMock: MockInstance<Console['error']>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    consoleMock = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleMock.mockReset();
   });
 
   it('should display default error message when no specific error info is available', () => {
     // Call errorHandler with a generic error
     errorHandler(new Error());
+    expect(consoleMock).toHaveBeenCalled();
 
     // Verify toast.error was called with the default message
     expect(toast.error).toHaveBeenCalledWith('Error', {


### PR DESCRIPTION
Instead of using the auth user, I changed this page to look up the user again. That makes it easier for us to refresh the user. We'll want to think about the user stored in auth more carefully in the future, too. But we can tackle that another time.

https://harperdb.atlassian.net/browse/STUDIO-245

I added a few more things too while I was fixing this:
1. WebStorm lets us add shared config files for run configurations. I added one for "Watch All Tests", that runs the tests via Vite but with the full IDE integration, so it will highlight in the editor where failures are happening.
2. The get user methods between instance and cloud weren't very clear, so I added "Instance" to the name for one of them.
3. When creating an org, the button will get disabled now.