### PR TITLE
[STUDIO-270] Handle defaults with super, structure and cluster users

### DIFF
--- a/src/features/instance/config/roles/defaultCalculator.ts
+++ b/src/features/instance/config/roles/defaultCalculator.ts
@@ -20,6 +20,9 @@ export function calculateDefaultPermissions({
 	const permissionStructure: LocalRolePermission = {
 		...currentRolePermissions,
 	};
+	if (currentRolePermissions.super_user || currentRolePermissions.structure_user || currentRolePermissions.cluster_user) {
+		return currentRolePermissions;
+	}
 	const [major, minor, patch] = version.split('.').map(number => parseInt(number, 10));
 	const legacy = version !== '2.0.000' && major <= 2 && minor <= 1 && patch <= 2;
 

--- a/src/features/instance/config/roles/modals/EditRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/EditRoleModal.tsx
@@ -9,7 +9,7 @@ import { useDeleteRoleMutation } from '@/features/instance/operations/mutations/
 import { getDescribeAllQueryOptions } from '@/features/instance/operations/queries/getDescribeAll';
 import { getRegistrationInfoQueryOptions } from '@/features/instance/operations/queries/getRegistrationInfo';
 import { useInstanceAuth } from '@/hooks/useAuth';
-import { LocalRole } from '@/lib/api.patch';
+import { LocalRole, LocalRolePermission } from '@/lib/api.patch';
 import { useCheckboxCallback } from '@/hooks/useCheckboxCallback';
 import { safeParse } from '@/lib/string/safeParse';
 import { Editor } from '@monaco-editor/react';
@@ -69,12 +69,23 @@ export function EditRoleModal({
 
 	useEffect(() => {
 		setUpdatedPermissions(defaultValue);
-	}, [defaultValue])
+	}, [defaultValue]);
 
 	const onRoleUpdated = useCallback(
 		(updatedPermissions: string) => {
 			if (updatedPermissions) {
-				const parsedPermissions = JSON.parse(updatedPermissions);
+				const parsedPermissions = JSON.parse(updatedPermissions) as LocalRolePermission;
+				if (parsedPermissions.super_user || parsedPermissions.structure_user || parsedPermissions.cluster_user) {
+					for (const parsedPermissionsKey in parsedPermissions) {
+						if (parsedPermissionsKey !== 'super_user' && parsedPermissionsKey !== 'structure_user' && parsedPermissionsKey !== 'cluster_user') {
+							// If you're a super, structure or cluster user, you don't need more specific permissions.
+							delete parsedPermissions[parsedPermissionsKey];
+						} else if (parsedPermissions[parsedPermissionsKey] === false) {
+							// If you've set one of the top-level properties, clear out any others set to false.
+							delete parsedPermissions[parsedPermissionsKey];
+						}
+					}
+				}
 				alterRole(
 					{
 						id: data.id,

--- a/src/features/instance/operations/mutations/alterRole.ts
+++ b/src/features/instance/operations/mutations/alterRole.ts
@@ -1,9 +1,10 @@
-import { useMutation } from '@tanstack/react-query';
 import { instanceClient } from '@/config/instanceClient';
+import { LocalRolePermission } from '@/lib/api.patch';
+import { useMutation } from '@tanstack/react-query';
 
 export interface AlterRoleRequestBody {
 	id: string;
-	permission: string;
+	permission: LocalRolePermission;
 	operationsUrl?: string;
 }
 


### PR DESCRIPTION
Super, structure, and cluster users can't have additional (schema -> table) properties set. The API returns an error if we try. Plus, if you have `super_user: true, structure_user: false`, you'll get an error. We can prevent both of those errors by interpreting what the user intends to do and cleaning up the request for them.

https://harperdb.atlassian.net/browse/STUDIO-270