### PR TITLE
[STUDIO-293] Fix instance logout

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,8 +4,6 @@ import { NavigationMenuItem } from '@/components/ui/navigation/NavigationMenuIte
 import { NavigationMenuLink } from '@/components/ui/navigation/NavigationMenuLink';
 import { NavigationMenuList } from '@/components/ui/navigation/NavigationMenuList';
 import { isLocalStudio } from '@/config/constants';
-import { useInstanceLogoutMutation } from '@/features/auth/hooks/useInstanceLogoutMutation';
-
 import { useLogoutMutation } from '@/features/auth/hooks/useLogout';
 import { useOverallAuth } from '@/hooks/useAuth';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
@@ -248,10 +246,8 @@ function Logo() {
 	);
 }
 
-const useLogout = isLocalStudio ? useInstanceLogoutMutation : useLogoutMutation;
-
 export function Navbar() {
-	const { mutate: signOut } = useLogout();
+	const { mutate: signOut } = useLogoutMutation();
 	const navigate = useNavigate();
 	const { user } = useOverallAuth();
 	const router = useRouter();

--- a/src/features/auth/hooks/useInstanceLogoutMutation.ts
+++ b/src/features/auth/hooks/useInstanceLogoutMutation.ts
@@ -1,4 +1,3 @@
-import { authStore } from '@/lib/authStore';
 import { useMutation } from '@tanstack/react-query';
 import { instanceClient } from '@/config/instanceClient';
 import { logoutOnSuccess } from '@/features/auth/handlers/logoutOnSuccess';
@@ -12,7 +11,6 @@ type LogoutInfoResponse = {
 };
 
 export async function onInstanceLogoutSubmit(variables: LogoutVariables | void): Promise<LogoutInfoResponse> {
-	await authStore.signOutFromPotentiallyAuthenticatedInstances();
 	const { data } = await instanceClient.post('/', {
 		operation: 'logout',
 	}, { baseURL: variables?.operationsUrl });

--- a/src/features/auth/hooks/useLogout.ts
+++ b/src/features/auth/hooks/useLogout.ts
@@ -1,11 +1,17 @@
 import { apiClient } from '@/config/apiClient';
+import { isLocalStudio } from '@/config/constants';
+import { logoutOnSuccess } from '@/features/auth/handlers/logoutOnSuccess';
+import { onInstanceLogoutSubmit } from '@/features/auth/hooks/useInstanceLogoutMutation';
 import { authStore } from '@/lib/authStore';
 import { useMutation } from '@tanstack/react-query';
-import { logoutOnSuccess } from '@/features/auth/handlers/logoutOnSuccess';
 
 export async function onLogoutSubmit() {
 	await authStore.signOutFromPotentiallyAuthenticatedInstances();
-	await apiClient.post('/Logout/');
+	if (isLocalStudio) {
+		await onInstanceLogoutSubmit();
+	} else {
+		await apiClient.post('/Logout/');
+	}
 }
 
 export function useLogoutMutation() {


### PR DESCRIPTION
Logging out of a cluster or instance shouldn't log you out everywhere. (I was being over zealous with `signOutFromPotentiallyAuthenticatedInstances `.) I simplified the code a bit so that we have a single top-level logout mutation that we can use, and it handles the logic internally. Then the instance logout mutation can focus on just the instance.

https://harperdb.atlassian.net/browse/STUDIO-293