### PR TITLE
[STUDIO-290] Instant Region Validation Updates

### DIFF
--- a/src/features/clusters/modals/NewClusterModal/PriceDisplay.tsx
+++ b/src/features/clusters/modals/NewClusterModal/PriceDisplay.tsx
@@ -2,7 +2,7 @@ export function PriceDisplay({ price }: { readonly price?: number }) {
 	const numberFormat = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
 	const parts = numberFormat.formatToParts(price || 0);
 	return <span className="text-4xl">
-		{parts.map((part) => <PricePart key={part.type} type={part.type} value={part.value} />)}
+		{parts.map((part, index) => <PricePart key={index} type={part.type} value={part.value} />)}
 	</span>;
 }
 

--- a/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
+++ b/src/features/clusters/modals/NewClusterModal/components/RegionFormInputs.tsx
@@ -35,7 +35,6 @@ export function RegionFormInputs({
 	form,
 	index,
 	regionNameToLatencyToRegion,
-	// selectedPlan,
 }: RegionFormInputsProps) {
 	const availableRegionNames = useMemo(() =>
 		Object.keys(regionNameToLatencyToRegion), [regionNameToLatencyToRegion]);
@@ -44,18 +43,22 @@ export function RegionFormInputs({
 	const availableLatencyDescriptions = useMemo(() =>
 		Object.keys(regionNameToLatencyToRegion[selectedRegionName] || {}), [regionNameToLatencyToRegion, selectedRegionName]);
 
-	useEffect(function ensureValidLatencyDescriptionIsSelected() {
+	useEffect(function autoPickLatencyDescription() {
 		if (selectedRegionName && availableLatencyDescriptions?.length && !availableLatencyDescriptions?.includes(selectedLatencyDescription)) {
 			const oldValue = selectedLatencyDescription?.split(' ')[0].toLowerCase();
 			const newValue = availableLatencyDescriptions.find(description => !oldValue ? true : description.split(' ')[0].toLowerCase() === oldValue) || availableLatencyDescriptions[0];
 			form.setValue(`regionPlans.${index}.latencyDescription`, newValue);
+			form.trigger();
 		}
 	}, [availableLatencyDescriptions, form, index, selectedLatencyDescription, selectedRegionName]);
 
-	const onRemoveClicked = useCallback(() => fieldArray?.remove(index), [fieldArray, index]);
+	const onRemoveClicked = useCallback(() => {
+		fieldArray?.remove(index);
+		form.trigger();
+	}, [fieldArray, form, index]);
 
 	return (
-		<div className="md:col-span-6 col-span-3 p-4 rounded-md bg-accent gap-6 flex flex-wrap">
+		<div className="md:col-span-6 col-span-3 p-4 rounded-md bg-accent gap-6 flex flex-wrap items-start">
 			<FormField
 				control={control}
 				name={`regionPlans.${index}.regionName`}
@@ -63,7 +66,7 @@ export function RegionFormInputs({
 					<FormItem className="flex-1">
 						<FormLabel>Region {fieldArray.fields.length > 1 ? index + 1 : ''}</FormLabel>
 						<FormControl>
-							<Select onValueChange={regionField.onChange} {...regionField}>
+							<Select onValueChange={value => { regionField.onChange(value); form.trigger(); } } {...regionField}>
 								<SelectTrigger className="w-full">
 									<SelectValue placeholder="Choose Region" />
 								</SelectTrigger>
@@ -89,7 +92,7 @@ export function RegionFormInputs({
 					<FormItem className="flex-1">
 						<FormLabel>Latency &amp; Distribution</FormLabel>
 						<FormControl>
-							<Select onValueChange={regionField.onChange} {...regionField} disabled={!availableLatencyDescriptions?.length}>
+							<Select onValueChange={value => { regionField.onChange(value); form.trigger(); } } {...regionField} disabled={!availableLatencyDescriptions?.length}>
 								<SelectTrigger className="w-full">
 									<SelectValue placeholder="Choose Latency Tier" />
 								</SelectTrigger>
@@ -109,7 +112,7 @@ export function RegionFormInputs({
 			/>
 
 			{fieldArray?.fields?.length && fieldArray?.fields?.length > 1 && (
-				<div className="flex-none self-end mb-0.5">
+				<div className="flex-none mt-6">
 					<Button
 						type="button"
 						variant="destructiveOutline"

--- a/src/features/clusters/modals/NewClusterModal/index.tsx
+++ b/src/features/clusters/modals/NewClusterModal/index.tsx
@@ -98,14 +98,16 @@ export function NewClusterModal({
 	}, [deploymentToPerformanceToPlan, regionNameToLatencyToRegion]);
 
 	const form = useForm({
+		mode: 'onBlur',
 		resolver: zodResolver(NewClusterSchema.superRefine(refineZod)),
 		defaultValues: {
 			systemName: '',
 			abbreviatedName: '',
+			// TODO: How do we look these up at the start with the live values from the API?
 			deploymentDescription: 'Free',
-			performanceDescription: '',
+			performanceDescription: 'Basic (1K read/min)',
 			regionPlans: [
-				{ regionName: 'US', latencyDescription: '' },
+				{ regionName: 'Global', latencyDescription: 'Low distribution, 250ms latency' },
 			],
 		},
 	});
@@ -118,7 +120,7 @@ export function NewClusterModal({
 	const abbreviatedName = form.watch('abbreviatedName');
 	const selectedDeployment = form.watch('deploymentDescription');
 	const selectedPerformance = form.watch('performanceDescription');
-	const selectedRegions = form.watch('regionPlans');
+	const selectedRegionPlans = form.watch('regionPlans');
 
 	const calculatedNames = useMemo(() => {
 		const suggestedAbbreviatedName = collapseKebabsToMaxLength(
@@ -138,26 +140,28 @@ export function NewClusterModal({
 	useEffect(function autoSelectFirstAvailablePerformanceDescription() {
 		if (availablePerformanceDescriptions?.length && !availablePerformanceDescriptions.includes(selectedPerformance)) {
 			form.setValue('performanceDescription', availablePerformanceDescriptions[0]);
+			form.trigger();
 		}
 	}, [selectedDeployment, selectedPerformance, availablePerformanceDescriptions, form]);
 	useEffect(function autoSelectPlanAllowedRegionId() {
 		const allowedRegionIds = selectedPlan?.allowedRegionIds;
-		if (allowedRegionIds?.length && selectedRegions?.length === 1) {
-			const firstRegion = selectedRegions[0];
+		if (allowedRegionIds?.length && selectedRegionPlans?.length === 1) {
+			const firstRegion = selectedRegionPlans[0];
 			const firstSelectedRegion = regionNameToLatencyToRegion?.[firstRegion.regionName]?.[firstRegion.latencyDescription];
 			if (!allowedRegionIds.includes(firstSelectedRegion?.id)) {
 				const regionToSelect = regionLocations?.find(r => allowedRegionIds.includes(r.id));
 				if (regionToSelect) {
 					form.setValue('regionPlans.0.regionName', regionToSelect.region);
 					form.setValue('regionPlans.0.latencyDescription', regionToSelect.latencyDescription);
+					form.trigger();
 				}
 			}
 		}
-	}, [selectedPlan, selectedRegions, form, regionNameToLatencyToRegion, regionLocations]);
+	}, [selectedPlan, selectedRegionPlans, form, regionNameToLatencyToRegion, regionLocations]);
 
 	const totalPrice = !selectedPlan?.priceUsd
 		? 0
-		: selectedRegions.reduce((total, region) => {
+		: selectedRegionPlans.reduce((total, region) => {
 			const regionPlan = regionNameToLatencyToRegion?.[region.regionName!]?.[region.latencyDescription!];
 			return total + (!regionPlan
 				? 0
@@ -165,8 +169,13 @@ export function NewClusterModal({
 		}, 0);
 
 	const onAddARegionClick = useCallback(() => {
-		fieldArray.append({ regionName: 'US', latencyDescription: '' });
-	}, [fieldArray]);
+		const selectedRegionNames = selectedRegionPlans.map(region => regionNameToLatencyToRegion?.[region.regionName!]?.[region.latencyDescription!]?.region);
+		const firstRegionLocation = regionLocations?.find(r => !selectedRegionNames.includes(r.region));
+		if (firstRegionLocation) {
+			fieldArray.append({ regionName: firstRegionLocation.region, latencyDescription: firstRegionLocation.latencyDescription });
+			form.trigger();
+		}
+	}, [fieldArray, form, regionLocations, regionNameToLatencyToRegion, selectedRegionPlans]);
 	const onClusterCreatedCallback = useCallback(() => {
 		queryClient.invalidateQueries({ queryKey: [queryKeys.organization], refetchType: 'active' });
 		setIsModalOpen(false);
@@ -262,7 +271,10 @@ export function NewClusterModal({
 
 										<Suspense fallback={<TextLoadingSkeleton />}>
 											<FormControl>
-												<Select {...field} onValueChange={(deploymentDescription) => field.onChange(deploymentDescription)}>
+												<Select {...field} onValueChange={(deploymentDescription) => {
+													field.onChange(deploymentDescription);
+													form.trigger();
+												}}>
 													<SelectTrigger className="w-full">
 														<SelectValue placeholder="Choose Tier" />
 													</SelectTrigger>
@@ -294,7 +306,10 @@ export function NewClusterModal({
 
 										<Suspense fallback={<TextLoadingSkeleton />}>
 											<FormControl>
-												<Select {...field} onValueChange={(performanceDescription) => field.onChange(performanceDescription)}
+												<Select {...field} onValueChange={(performanceDescription) => {
+													field.onChange(performanceDescription);
+													form.trigger();
+												}}
 													disabled={!availablePerformanceDescriptions?.length}>
 													<SelectTrigger className="w-full">
 														<SelectValue placeholder="Choose Tier" />


### PR DESCRIPTION
Whenever we change one of the dropdowns, we'll trigger a revalidation of the form. This causes the error messages to immediately show or hide based on the user's selections.

That meant we'd trigger a validation error immediately when the form opens, because we weren't selecting everything about the free tier.

That also meant whenever you'd add a new region, we'd pick US, and cause another validation error once you tried to add it twice.

https://harperdb.atlassian.net/browse/STUDIO-290