### PR TITLE
Pass replicated: true on requested operations

### DIFF
--- a/src/features/instance/browse/components/BrowseDataTableView.tsx
+++ b/src/features/instance/browse/components/BrowseDataTableView.tsx
@@ -22,16 +22,16 @@ const route = getRouteApi('');
 
 export function BrowseDataTableView() {
 	const allParams = route.useParams();
-	const { clusterId, instanceId, schemaName, tableName } = allParams;
+	const { clusterId, instanceId, databaseName, tableName } = allParams;
 
-	const canAddRecords = useInstanceSchemaTablePermission(instanceId || clusterId, schemaName, tableName, 'insert');
-	const canEditRecords = useInstanceSchemaTablePermission(instanceId || clusterId, schemaName, tableName, 'update');
-	const canDeleteRecords = useInstanceSchemaTablePermission(instanceId || clusterId, schemaName, tableName, 'delete');
+	const canAddRecords = useInstanceSchemaTablePermission(instanceId || clusterId, databaseName, tableName, 'insert');
+	const canEditRecords = useInstanceSchemaTablePermission(instanceId || clusterId, databaseName, tableName, 'update');
+	const canDeleteRecords = useInstanceSchemaTablePermission(instanceId || clusterId, databaseName, tableName, 'delete');
 
 	const { data: describeTableData, refetch: refetchDescribeTableQueryOptions } = useSuspenseQuery(
 		getDescribeTableQueryOptions({
 			instanceOrClusterId: instanceId ?? clusterId,
-			schemaName,
+			databaseName,
 			tableName,
 		}),
 	);
@@ -39,7 +39,7 @@ export function BrowseDataTableView() {
 	const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
 	const { data: searchByIdData } = useQuery(
-		getSearchByIdOptions(isEditModalOpen, instanceId, schemaName, tableName, selectedIds),
+		getSearchByIdOptions(isEditModalOpen, instanceId, databaseName, tableName, selectedIds),
 	);
 
 	const { dataTableColumns, hashAttribute } = formatBrowseDataTableHeader(describeTableData);
@@ -73,7 +73,7 @@ export function BrowseDataTableView() {
 	} = useQuery(
 		getSearchByValueOptions({
 			instanceId,
-			schemaName,
+			databaseName,
 			tableName,
 			searchAttribute: hashAttribute,
 			sortTableDataParams,
@@ -92,7 +92,7 @@ export function BrowseDataTableView() {
 	const onRecordAdd = (data: Record<string, unknown>[] | Record<string, unknown>) => {
 		addTableRecords(
 			{
-				databaseName: schemaName,
+				databaseName,
 				tableName,
 				records: Array.isArray(data) ? data : [data],
 			},
@@ -109,7 +109,7 @@ export function BrowseDataTableView() {
 	const onRecordUpdate = (data: Record<string, unknown>[]) => {
 		updateTableRecords(
 			{
-				databaseName: schemaName,
+				databaseName,
 				tableName,
 				records: data,
 			},
@@ -126,7 +126,7 @@ export function BrowseDataTableView() {
 	const onDeleteRecord = (hashes: unknown[]) => {
 		deleteTableRecords(
 			{
-				databaseName: schemaName,
+				databaseName,
 				tableName,
 				hash_values: hashes,
 			},

--- a/src/features/instance/browse/components/BrowseSidebar.tsx
+++ b/src/features/instance/browse/components/BrowseSidebar.tsx
@@ -25,10 +25,10 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 type BrowseSidebarProps = {
-	databases: string[];
-	onSelectDatabase: (schemaName: string | undefined) => void;
+	databaseNames: string[];
+	onSelectDatabase: (databaseName: string | undefined) => void;
+	tableNames?: string[];
 	onSelectTable: (tableName: string | undefined) => void;
-	tables?: string[];
 };
 
 const route = getRouteApi('');
@@ -43,10 +43,10 @@ const NewDatabaseSchema = z.object({
 		.regex(/^[a-zA-Z0-9_]+$/, { message: 'Database name can only contain letters, numbers, and underscores' }),
 });
 
-export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTable }: BrowseSidebarProps) {
+export function BrowseSidebar({ databaseNames, onSelectDatabase, tableNames, onSelectTable }: BrowseSidebarProps) {
 	const router = useRouter();
 	const queryClient = useQueryClient();
-	const { clusterId, instanceId, schemaName, tableName } = route.useParams();
+	const { clusterId, instanceId, databaseName: selectedDatabaseName, tableName: selectedTableName } = route.useParams();
 	const canManageBrowseInstance = useInstanceBrowseManagePermission(instanceId || clusterId);
 	const [typeOfThingBeingDeleted, setTypeOfThingBeingDeleted] = useState("");
 	const [nameOfThingBeingDeleted, setNameOfThingBeingDeleted] = useState("");
@@ -93,7 +93,7 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 						});
 						await router.invalidate();
 						toast.success(`Table ${targetTableName} deleted successfully`);
-						if (targetTableName === tableName) {
+						if (targetTableName === selectedTableName) {
 							onSelectTable(undefined);
 						}
 					},
@@ -113,7 +113,7 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 				});
 			}
 		}
-	}, [deleteDatabase, deleteTable, deletionTarget, instanceId, onSelectDatabase, onSelectTable, queryClient, router, tableName]);
+	}, [deleteDatabase, deleteTable, deletionTarget, instanceId, onSelectDatabase, onSelectTable, queryClient, router, selectedTableName]);
 
 	return (
 		<div>
@@ -122,7 +122,7 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 				<div className="flex space-x-2">
 					<Select
 						name="databaseSelect"
-						value={schemaName || ''}
+						value={selectedDatabaseName || ''}
 						onValueChange={(selectedDatabaseName) => {
 							onSelectDatabase(selectedDatabaseName);
 						}}
@@ -132,9 +132,9 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 						</SelectTrigger>
 						<SelectContent>
 							<SelectGroup>
-								{databases?.map((schema) => (
-									<SelectItem key={schema} value={schema}>
-										{schema}
+								{databaseNames?.map((databaseName) => (
+									<SelectItem key={databaseName} value={databaseName}>
+										{databaseName}
 									</SelectItem>
 								))}
 							</SelectGroup>
@@ -153,12 +153,12 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 							className="inline-block"
 							aria-label="Delete selected database"
 							variant="destructiveOutline"
-							disabled={!schemaName}
+							disabled={!selectedDatabaseName}
 							onClick={() => {
-								if (schemaName) {
+								if (selectedDatabaseName) {
 									setTypeOfThingBeingDeleted('database');
-									setNameOfThingBeingDeleted(schemaName);
-									setDeletionTarget({ databaseName: schemaName });
+									setNameOfThingBeingDeleted(selectedDatabaseName);
+									setDeletionTarget({ databaseName: selectedDatabaseName });
 									setIsDeleteModalOpen(true);
 								}
 							}}
@@ -199,29 +199,29 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 				</TabsList>
 				<ScrollArea className="border rounded-md h-80 border-grey-700">
 					<TabsContent value="tables" className="h-full">
-						{(tables ?? []).length === 0 && schemaName?.length ? (
+						{(tableNames ?? []).length === 0 && selectedDatabaseName?.length ? (
 							<div className="w-full h-full text-center">
 								<p className="py-6">No tables found in this database.</p>
 								{canManageBrowseInstance && (<div className="mx-auto max-w-48">
-									<CreateNewTableModal databaseName={schemaName} instanceId={instanceId} onSelectTable={onSelectTable} />
+									<CreateNewTableModal databaseName={selectedDatabaseName} instanceId={instanceId} onSelectTable={onSelectTable} />
 								</div>)}
 							</div>
-						) : (tables ?? []).length === 0 && !schemaName?.length ? (
+						) : (tableNames ?? []).length === 0 && !selectedDatabaseName?.length ? (
 							// If no database is selected, show a message
 							<p className="pt-2 text-sm text-center">Please select a database.</p>
 						) : (
 							''
 						)}
 						<ul>
-							{(tables ?? []).map((table) => (
-								<li key={table} className="flex items-center p-2 border-b hover:bg-grey-700/80 border-grey-700">
+							{(tableNames ?? []).map((tableName) => (
+								<li key={tableName} className="flex items-center p-2 border-b hover:bg-grey-700/80 border-grey-700">
 									{canManageBrowseInstance && (<Button
 										variant="destructiveOutline"
 										onClick={() => {
-											if (table) {
+											if (tableName) {
 												setTypeOfThingBeingDeleted("table");
-												setNameOfThingBeingDeleted(table);
-												setDeletionTarget({ databaseName: schemaName, tableName: table });
+												setNameOfThingBeingDeleted(tableName);
+												setDeletionTarget({ databaseName: selectedDatabaseName, tableName });
 												setIsDeleteModalOpen(true);
 											}
 										}}
@@ -229,13 +229,13 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 										<Trash className="inline-block " />
 									</Button>)}
 									<Button
-										onClick={() => onSelectTable(table)}
+										onClick={() => onSelectTable(tableName)}
 										size="lg"
 										className="items-center justify-between w-full bg-transparent border-none shadow-none hover:bg-transparent"
 									>
-										{table}
+										{tableName}
 										<span>
-											{tableName === table && <ArrowRight />}
+											{tableName === tableName && <ArrowRight />}
 										</span>
 									</Button>
 								</li>
@@ -244,8 +244,8 @@ export function BrowseSidebar({ databases, onSelectDatabase, tables, onSelectTab
 					</TabsContent>
 				</ScrollArea>
 			</Tabs>
-			{schemaName?.length && canManageBrowseInstance && (
-				<CreateNewTableModal databaseName={schemaName} instanceId={instanceId} onSelectTable={onSelectTable} />
+			{selectedDatabaseName?.length && canManageBrowseInstance && (
+				<CreateNewTableModal databaseName={selectedDatabaseName} instanceId={instanceId} onSelectTable={onSelectTable} />
 			)}
 			<ConfirmDeletionModal
 				typeOfThingBeingDeleted={typeOfThingBeingDeleted}

--- a/src/features/instance/browse/index.tsx
+++ b/src/features/instance/browse/index.tsx
@@ -1,4 +1,4 @@
-import { InstanceSchemaMap } from '@/lib/api.patch';
+import { InstanceDatabaseMap } from '@/lib/api.patch';
 import { Suspense, useCallback, useMemo } from 'react';
 import { getRouteApi, Outlet, useNavigate, useRouter } from '@tanstack/react-router';
 import { Loading } from '@/components/Loading';
@@ -9,27 +9,27 @@ const route = getRouteApi('');
 export function Browse() {
 	const router = useRouter();
 	const navigate = useNavigate();
-	const { schemaName, tableName } = route.useParams();
-	const structure = route.useLoaderData() as InstanceSchemaMap;
+	const { databaseName, tableName } = route.useParams();
+	const structure = route.useLoaderData() as InstanceDatabaseMap;
 
-	const { databaseList, tables } = useMemo(() => {
-		const databaseList = Object.keys(structure || {}).sort();
-		const tables = schemaName ? Object.keys(structure[schemaName] || []).sort() : [];
+	const { databaseNames, tableNames } = useMemo(() => {
+		const databaseNames = Object.keys(structure || {}).sort();
+		const tableNames = databaseName ? Object.keys(structure[databaseName] || []).sort() : [];
 		return {
-			databaseList,
-			tables,
+			databaseNames,
+			tableNames,
 		};
-	}, [structure, schemaName]);
+	}, [structure, databaseName]);
 
-	const onSelectDatabase = useCallback((newSchemaName: string | undefined) => {
-		const tables = newSchemaName ? Object.keys(structure[newSchemaName] || []).sort() : [];
-		const parts = [schemaName ? '..' : '', tableName ? '..' : '', newSchemaName, tables[0]].filter(Boolean);
-		if (!schemaName) {
+	const onSelectDatabase = useCallback((newDatabaseName: string | undefined) => {
+		const tableNames = newDatabaseName ? Object.keys(structure[newDatabaseName] || []).sort() : [];
+		const parts = [databaseName ? '..' : '', tableName ? '..' : '', newDatabaseName, tableNames[0]].filter(Boolean);
+		if (!databaseName) {
 			router.invalidate();
 		} else {
 			void navigate({ to: parts.join('/') });
 		}
-	}, [structure, schemaName, tableName, router, navigate]);
+	}, [structure, databaseName, tableName, router, navigate]);
 
 	const onSelectTable = useCallback((newTableName: string | undefined) => {
 		const parts = [tableName ? '..' : '', newTableName].filter(Boolean);
@@ -40,14 +40,14 @@ export function Browse() {
 		<main className="grid grid-cols-1 gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))]">
 			<section className="col-span-1 text-white md:col-span-4 lg:col-span-3">
 				<BrowseSidebar
-					databases={databaseList}
+					databaseNames={databaseNames}
 					onSelectDatabase={onSelectDatabase}
 					onSelectTable={onSelectTable}
-					tables={tables}
+					tableNames={tableNames}
 				/>
 			</section>
 			<section className="col-span-1 text-white md:col-span-8 lg:col-span-9">
-				{!schemaName ? (
+				{!databaseName ? (
 					<div className="flex items-center justify-center h-full">
 						<p className="pt-2 text-sm text-center">Please select a database.</p>
 					</div>

--- a/src/features/instance/browse/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewTableModal.tsx
@@ -71,7 +71,7 @@ export function CreateNewTableModal({ databaseName, instanceId, onSelectTable }:
 	const submitForm = async (formData: z.infer<typeof CreateTableSchema>) => {
 		const updatedFormData = {
 			...formData,
-			databaseName: databaseName,
+			databaseName,
 		};
 		submitNewTableData(updatedFormData, {
 			onSuccess: async () => {

--- a/src/features/instance/browse/route.load.ts
+++ b/src/features/instance/browse/route.load.ts
@@ -7,27 +7,27 @@ export async function loadInstanceBrowseData(
 	params: {
 		clusterId?: string;
 		instanceId?: string;
-		schemaName?: string;
+		databaseName?: string;
 		tableName?: string;
 	}
 ) {
 	const data = await queryClient.ensureQueryData(getDescribeAllQueryOptions(params.instanceId ?? params.clusterId));
-	let newSchemaName: string | undefined;
+	let newDatabaseName: string | undefined;
 	let newTableName: string | undefined;
 	if (data) {
-		if (!params.schemaName) {
-			newSchemaName = Object.keys(data).sort()[0];
+		if (!params.databaseName) {
+			newDatabaseName = Object.keys(data).sort()[0];
 		}
-		const schemaName = params.schemaName ?? newSchemaName;
-		if (!params.tableName && schemaName && data[schemaName]) {
-			newTableName = Object.keys(data[schemaName]).sort()[0];
+		const databaseName = params.databaseName ?? newDatabaseName;
+		if (!params.tableName && databaseName && data[databaseName]) {
+			newTableName = Object.keys(data[databaseName]).sort()[0];
 		}
 	}
-	if (newSchemaName || newTableName) {
+	if (newDatabaseName || newTableName) {
 		const to = [
-			params.schemaName ? '..' : '',
+			params.databaseName ? '..' : '',
 			params.tableName ? '..' : '',
-			newSchemaName ?? params.schemaName,
+			newDatabaseName ?? params.databaseName,
 			newTableName,
 		]
 			.filter(Boolean)

--- a/src/features/instance/browse/routes.ts
+++ b/src/features/instance/browse/routes.ts
@@ -13,12 +13,12 @@ export function createBrowseRouteTree(instanceLayoutRoute: ReturnType<typeof cre
 	});
 	const browseDatabaseRoute = createRoute({
 		getParentRoute: () => instanceBrowseRoute,
-		path: '$schemaName',
+		path: '$databaseName',
 		loader: ({ context, params }) => loadInstanceBrowseData(context.queryClient, params),
 	});
 	const browseTableRoute = createRoute({
 		getParentRoute: () => instanceBrowseRoute,
-		path: '$schemaName/$tableName',
+		path: '$databaseName/$tableName',
 		component: BrowseDataTableView,
 		loader: ({ context, params }) => loadInstanceBrowseData(context.queryClient, params),
 	});

--- a/src/features/instance/config/roles/defaultCalculator.ts
+++ b/src/features/instance/config/roles/defaultCalculator.ts
@@ -1,5 +1,5 @@
 import {
-	InstanceSchemaMap,
+	InstanceDatabaseMap,
 	LocalLegacyRolePermissionTable,
 	LocalRolePermission,
 	LocalRolePermissionTable,
@@ -7,12 +7,12 @@ import {
 import { keyBy } from '@/lib/keyBy';
 
 export function calculateDefaultPermissions({
-	instanceSchema,
+	instanceDatabaseMap,
 	currentRolePermissions,
 	version,
 	showAttributes,
 }: {
-	instanceSchema: InstanceSchemaMap,
+	instanceDatabaseMap: InstanceDatabaseMap,
 	currentRolePermissions: LocalRolePermission;
 	version: string;
 	showAttributes: boolean;
@@ -26,21 +26,21 @@ export function calculateDefaultPermissions({
 	const [major, minor, patch] = version.split('.').map(number => parseInt(number, 10));
 	const legacy = version !== '2.0.000' && major <= 2 && minor <= 1 && patch <= 2;
 
-	for (const schema in instanceSchema) {
-		permissionStructure[schema] = {
+	for (const databaseName in instanceDatabaseMap) {
+		permissionStructure[databaseName] = {
 			tables: {},
 		};
-		for (const table in instanceSchema[schema]) {
-			const thisTable = instanceSchema[schema][table];
+		for (const tableName in instanceDatabaseMap[databaseName]) {
+			const thisTable = instanceDatabaseMap[databaseName][tableName];
 			const attributes = thisTable.attributes.map((a) => a.attribute).sort();
 			if (legacy) {
 				const extantTablePermissions =
-					currentRolePermissions && currentRolePermissions[schema] && currentRolePermissions[schema].tables[table];
-				permissionStructure[schema].tables[table] = buildLegacy(extantTablePermissions as LocalLegacyRolePermissionTable, attributes, showAttributes);
+					currentRolePermissions && currentRolePermissions[databaseName] && currentRolePermissions[databaseName].tables[tableName];
+				permissionStructure[databaseName].tables[tableName] = buildLegacy(extantTablePermissions as LocalLegacyRolePermissionTable, attributes, showAttributes);
 			} else {
 				const extantTablePermissions =
-					currentRolePermissions && currentRolePermissions[schema] && currentRolePermissions[schema].tables[table];
-				permissionStructure[schema].tables[table] = buildCurrent(extantTablePermissions as LocalRolePermissionTable, attributes, showAttributes);
+					currentRolePermissions && currentRolePermissions[databaseName] && currentRolePermissions[databaseName].tables[tableName];
+				permissionStructure[databaseName].tables[tableName] = buildCurrent(extantTablePermissions as LocalRolePermissionTable, attributes, showAttributes);
 			}
 		}
 	}

--- a/src/features/instance/config/roles/modals/EditRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/EditRoleModal.tsx
@@ -37,7 +37,7 @@ export function EditRoleModal({
 	const { role, permission: initialPermissions } = data;
 	const [updatedPermissions, setUpdatedPermissions] = useState<string | undefined>(JSON.stringify(initialPermissions, null, 2));
 	const [isValidJSON, setIsValidJSON] = useState(true);
-	const { data: instanceSchema } = useQuery(getDescribeAllQueryOptions(instanceId));
+	const { data: instanceDatabaseMap } = useQuery(getDescribeAllQueryOptions(instanceId));
 	const { data: registrationInfo } = useQuery(
 		getRegistrationInfoQueryOptions(instanceId),
 	);
@@ -57,15 +57,15 @@ export function EditRoleModal({
 	);
 
 	const defaultValue = useMemo(() => {
-		return JSON.stringify(instanceSchema && registrationInfo && calculateDefaultPermissions({
-			instanceSchema,
+		return JSON.stringify(instanceDatabaseMap && registrationInfo && calculateDefaultPermissions({
+			instanceDatabaseMap,
 			currentRolePermissions: updatedPermissions && safeParse(updatedPermissions) || initialPermissions,
 			version: registrationInfo.version,
 			showAttributes: showAttributes,
 		}), null, 2);
 		// We exclude updatedPermissions on purpose from the deps.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [initialPermissions, instanceSchema, registrationInfo, showAttributes]);
+	}, [initialPermissions, instanceDatabaseMap, registrationInfo, showAttributes]);
 
 	useEffect(() => {
 		setUpdatedPermissions(defaultValue);

--- a/src/features/instance/operations/mutations/createComponent.ts
+++ b/src/features/instance/operations/mutations/createComponent.ts
@@ -10,6 +10,7 @@ const onCreateComponentSubmit = async (formData: CreateComponentFormData) => {
 	const { data } = await instanceClient.post('/', {
 		operation: 'add_component',
 		project: newApplicationName,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/createDatabase.ts
+++ b/src/features/instance/operations/mutations/createDatabase.ts
@@ -2,14 +2,14 @@ import { useMutation } from '@tanstack/react-query';
 import { instanceClient } from '@/config/instanceClient';
 
 type CreateDatabaseFormData = {
-	newDatabaseName: string;
+	databaseName: string;
 };
 
 const onCreateDatabaseSubmit = async (formData: CreateDatabaseFormData) => {
-	const { newDatabaseName } = formData;
+	const { databaseName } = formData;
 	const { data } = await instanceClient.post('/', {
 		operation: 'create_database',
-		database: newDatabaseName,
+		database: databaseName,
 		replicated: true,
 	});
 	return data;

--- a/src/features/instance/operations/mutations/createDatabase.ts
+++ b/src/features/instance/operations/mutations/createDatabase.ts
@@ -10,6 +10,7 @@ const onCreateDatabaseSubmit = async (formData: CreateDatabaseFormData) => {
 	const { data } = await instanceClient.post('/', {
 		operation: 'create_database',
 		database: newDatabaseName,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/createTable.ts
+++ b/src/features/instance/operations/mutations/createTable.ts
@@ -14,6 +14,7 @@ const onCreateTableSubmit = async (formData: CreateDatabaseFormData) => {
 		database: databaseName,
 		table: tableName,
 		primary_key: primaryKey,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/deleteComponentFolderFile.ts
+++ b/src/features/instance/operations/mutations/deleteComponentFolderFile.ts
@@ -12,6 +12,7 @@ const onDeleteComponentFolderFile = async (componentFileData: DeleteComponentFil
 		operation: 'drop_component',
 		file,
 		project,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/deleteDatabase.ts
+++ b/src/features/instance/operations/mutations/deleteDatabase.ts
@@ -5,6 +5,7 @@ const onDeleteDatabase = async (databaseName: string) => {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_database',
 		schema: databaseName,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/deleteDatabase.ts
+++ b/src/features/instance/operations/mutations/deleteDatabase.ts
@@ -4,7 +4,7 @@ import { instanceClient } from '@/config/instanceClient';
 const onDeleteDatabase = async (databaseName: string) => {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_database',
-		schema: databaseName,
+		database: databaseName,
 		replicated: true,
 	});
 	return data;

--- a/src/features/instance/operations/mutations/deleteTable.ts
+++ b/src/features/instance/operations/mutations/deleteTable.ts
@@ -6,11 +6,11 @@ type DeleteTableData = {
 	tableName: string;
 };
 
-const onDeleteTable = async (tableData: DeleteTableData) => {
+const onDeleteTable = async ({ databaseName, tableName }: DeleteTableData) => {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_table',
-		schema: tableData.databaseName,
-		table: tableData.tableName,
+		database: databaseName,
+		table: tableName,
 		replicated: true,
 	});
 	return data;

--- a/src/features/instance/operations/mutations/deleteTable.ts
+++ b/src/features/instance/operations/mutations/deleteTable.ts
@@ -11,6 +11,7 @@ const onDeleteTable = async (tableData: DeleteTableData) => {
 		operation: 'drop_table',
 		schema: tableData.databaseName,
 		table: tableData.tableName,
+		replicated: true,
 	});
 	return data;
 };

--- a/src/features/instance/operations/mutations/deleteTableRecords.ts
+++ b/src/features/instance/operations/mutations/deleteTableRecords.ts
@@ -11,7 +11,7 @@ const onDeleteTableRecords = async (recordsData: DeleteTableRecordsData) => {
 	const { databaseName, tableName, hash_values } = recordsData;
 	const { data } = await instanceClient.post('/', {
 		operation: 'delete',
-		schema: databaseName,
+		database: databaseName,
 		table: tableName,
 		hash_values: hash_values,
 	});

--- a/src/features/instance/operations/mutations/deployComponent.ts
+++ b/src/features/instance/operations/mutations/deployComponent.ts
@@ -14,6 +14,7 @@ const onDeployComponentSubmit = async (formData: DeployComponentFormData) => {
 			operation: 'deploy_component',
 			package: applicationUrl,
 			project: newApplicationName,
+			replicated: true,
 		},
 		{ timeout: 60000 }
 	);

--- a/src/features/instance/operations/mutations/insertTableRecords.ts
+++ b/src/features/instance/operations/mutations/insertTableRecords.ts
@@ -11,7 +11,7 @@ const onInsertTableRecords = async (recordsData: InsertTableRecordsData) => {
 	const { databaseName, tableName, records } = recordsData;
 	const { data } = await instanceClient.post('/', {
 		operation: 'insert',
-		schema: databaseName,
+		database: databaseName,
 		table: tableName,
 		records: records,
 	});

--- a/src/features/instance/operations/mutations/updateTableRecords.ts
+++ b/src/features/instance/operations/mutations/updateTableRecords.ts
@@ -11,7 +11,7 @@ const onUpdateTableRecords = async (recordsData: UpdateTableRecordsData) => {
 	const { databaseName, tableName, records } = recordsData;
 	const { data } = await instanceClient.post('/', {
 		operation: 'update',
-		schema: databaseName,
+		database: databaseName,
 		table: tableName,
 		records: records,
 	});

--- a/src/features/instance/operations/queries/getDescribeAll.ts
+++ b/src/features/instance/operations/queries/getDescribeAll.ts
@@ -1,5 +1,5 @@
 import { instanceClient } from '@/config/instanceClient';
-import { InstanceSchemaMap } from '@/lib/api.patch';
+import { InstanceDatabaseMap } from '@/lib/api.patch';
 
 import { queryOptions } from '@tanstack/react-query';
 
@@ -7,7 +7,7 @@ export function getDescribeAllQueryOptions(instanceOrClusterId?: string) {
 	return queryOptions({
 		queryKey: [instanceOrClusterId, 'describe_all'] as const,
 		queryFn: async () => {
-			const { data } = await instanceClient.post<InstanceSchemaMap>('/', {
+			const { data } = await instanceClient.post<InstanceDatabaseMap>('/', {
 				operation: 'describe_all',
 			});
 			return data;

--- a/src/features/instance/operations/queries/getDescribeTable.ts
+++ b/src/features/instance/operations/queries/getDescribeTable.ts
@@ -5,25 +5,25 @@ import { queryOptions } from '@tanstack/react-query';
 
 export function getDescribeTableQueryOptions({
 	instanceOrClusterId,
-	schemaName,
+	databaseName,
 	tableName,
 }: {
 	instanceOrClusterId: string;
-	schemaName: string;
+	databaseName: string;
 	tableName: string;
 }) {
 	return queryOptions({
-		queryKey: [instanceOrClusterId, schemaName, tableName, 'describe_table'] as const,
+		queryKey: [instanceOrClusterId, databaseName, tableName, 'describe_table'] as const,
 		queryFn: async () => {
 			const { data } = await instanceClient.post<InstanceTable>('/', {
 				operation: 'describe_table',
-				schema: schemaName,
+				database: databaseName,
 				table: tableName,
 			});
 			return data;
 		},
 		staleTime: 5000,
-		enabled: !!instanceOrClusterId && !!schemaName && !!tableName,
+		enabled: !!instanceOrClusterId && !!databaseName && !!tableName,
 		retry: false,
 	});
 }

--- a/src/features/instance/operations/queries/getReadLog.ts
+++ b/src/features/instance/operations/queries/getReadLog.ts
@@ -35,6 +35,7 @@ function getReadLogQueryOptions({
 			const { data } = await instanceClient.post('/', {
 				operation: 'read_log',
 				start: 0,
+				replicated: true,
 				...logFilters,
 			});
 			return data as ReadLogItem[];

--- a/src/features/instance/operations/queries/getSearchById.ts
+++ b/src/features/instance/operations/queries/getSearchById.ts
@@ -4,12 +4,12 @@ import { queryOptions } from '@tanstack/react-query';
 function getSearchByIdOptions(
 	isEditModalOpen: boolean,
 	instanceId: string,
-	schemaName: string,
+	databaseName: string,
 	tableName: string,
 	ids: unknown[] | null,
 ) {
 	return queryOptions({
-		queryKey: ['search_by_id', instanceId, schemaName, tableName, ids] as const,
+		queryKey: ['search_by_id', instanceId, databaseName, tableName, ids] as const,
 		queryFn: () =>
 			instanceClient.post('/', {
 				get_attributes: ['*'],
@@ -17,7 +17,7 @@ function getSearchByIdOptions(
 				noCacheStore: true,
 				onlyIfCached: true,
 				operation: 'search_by_id',
-				schema: schemaName,
+				database: databaseName,
 				table: tableName,
 			}),
 		enabled: isEditModalOpen && !!ids?.length,

--- a/src/features/instance/operations/queries/getSearchByValue.ts
+++ b/src/features/instance/operations/queries/getSearchByValue.ts
@@ -11,7 +11,7 @@ type SearchConditions = {
 type SearchByValueRequest = {
 	operation: 'search_by_value',
 	conditions?: [SearchConditions];
-	schema: string;
+	database: string;
 	table: string;
 	search_attribute: string;
 	search_value: string;
@@ -26,14 +26,14 @@ type SearchByValueRequest = {
 
 function getSearchByValueOptions({
 	instanceId,
-	schemaName,
+	databaseName,
 	tableName,
 	searchAttribute,
 	sortTableDataParams,
 	pagination,
 }: {
 	instanceId: string;
-	schemaName: string;
+	databaseName: string;
 	tableName: string;
 	searchAttribute: string;
 	sortTableDataParams: {
@@ -52,7 +52,7 @@ function getSearchByValueOptions({
 			instanceId,
 			pagination.pageIndex || 0,
 			pagination.pageSize || 0,
-			schemaName,
+			databaseName,
 			sortTableDataParams.attribute || 'default',
 			sortTableDataParams.descending || false,
 			tableName,
@@ -62,7 +62,7 @@ function getSearchByValueOptions({
 			instanceClient.post<Record<string, unknown>[]>('/', {
 				operation: 'search_by_value',
 				get_attributes: ['*'],
-				schema: schemaName,
+				database: databaseName,
 				table: tableName,
 				search_attribute: searchAttribute,
 				search_value: '*',

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -108,7 +108,7 @@ export function useInstanceBrowseManagePermission(entityId: EntityIds): boolean 
 	return permission.super_user === true || permission.structure_user === true;
 }
 
-export function useInstanceSchemaTablePermission(entityId: EntityIds, schemaName: string, tableName: string, action: LocalRolePermissionAction): boolean {
+export function useInstanceSchemaTablePermission(entityId: EntityIds, databaseName: string, tableName: string, action: LocalRolePermissionAction): boolean {
 	const { user } = useInstanceAuth(entityId);
 	const permission = user?.role?.permission;
 	if (!permission) {
@@ -119,11 +119,11 @@ export function useInstanceSchemaTablePermission(entityId: EntityIds, schemaName
 	if (permission.super_user === true || permission.structure_user === true) {
 		return true;
 	}
-	const specificPermission = permission[schemaName];
+	const specificPermission = permission[databaseName];
 	return specificPermission?.tables?.[tableName][action] === true;
 }
 
-export function useInstanceSchemaTableAttributePermission(entityId: EntityIds, schemaName: string, tableName: string, attributeName: string, action: LocalRoleAttributePermissionAction): boolean {
+export function useInstanceSchemaTableAttributePermission(entityId: EntityIds, databaseName: string, tableName: string, attributeName: string, action: LocalRoleAttributePermissionAction): boolean {
 	const { user } = useInstanceAuth(entityId);
 	const permission = user?.role?.permission;
 	if (!permission) {
@@ -134,7 +134,7 @@ export function useInstanceSchemaTableAttributePermission(entityId: EntityIds, s
 	if (permission.super_user === true || permission.structure_user === true) {
 		return true;
 	}
-	const specificPermission = permission[schemaName];
+	const specificPermission = permission[databaseName];
 	if (specificPermission?.tables?.[tableName][action] === true) {
 		return true;
 	}

--- a/src/lib/api.patch.d.ts
+++ b/src/lib/api.patch.d.ts
@@ -37,7 +37,7 @@ export interface LocalRolePermission {
 	cluster_user?: boolean;
 	structure_user?: boolean;
 
-	[schemaName: string]: LocalRoleSchemaRecord;
+	[databaseName: string]: LocalRoleSchemaRecord;
 }
 
 export interface LocalRoleSchemaRecord {
@@ -88,11 +88,11 @@ export interface Cluster extends SchemaCluster {
 	status?: string | 'PROVISIONING' | 'UPDATING' | 'RUNNING' | 'TERMINATED';
 }
 
-export interface InstanceSchemaMap {
-	[schemaName: string]: InstanceSchema;
+export interface InstanceDatabaseMap {
+	[databaseName: string]: InstanceDatabaseTableMap;
 }
 
-export interface InstanceSchema {
+export interface InstanceDatabaseTableMap {
 	[tableName: string]: InstanceTable;
 }
 


### PR DESCRIPTION
I added `replicated: true` to the requested instance operations that Kris pointed out. Some in his list weren't in our codebase (yet?), so I opted to ignore those ones for the time being...

I checked a few to make sure they're still working:
- [x] Creating a database
- [x] Creating a table
- [x] Dropping a table
- [x] Dropping a database
- [x] Reading logs

Then I switched from `schema` to `database` in a few of the spots where we were using the older name, and I updated our code to consistently refer to things as `databaseName`, `databaseNames`, `tableName`, and `tableNames`. I walked through all of the codepaths pretty carefully, and I exercised the database, table and record CRUD locally after making the changes.

https://harperdb.atlassian.net/browse/STUDIO-287