### PR TITLE
Make sure we’re not submitting forms on accident

### DIFF
--- a/src/features/instance/applications/modals/AddFolderFileModal.tsx
+++ b/src/features/instance/applications/modals/AddFolderFileModal.tsx
@@ -86,7 +86,7 @@ export function AddFolderFileModal({
 
 						<DialogFooter>
 							<div className="flex justify-between w-full">
-								<Button variant="destructiveOutline" className="rounded-full" onClick={() => setIsModalOpen(false)}>
+								<Button type="button" variant="destructiveOutline" className="rounded-full" onClick={() => setIsModalOpen(false)}>
 									<Ban /> Cancel
 								</Button>
 								<Button

--- a/src/features/instance/config/roles/modals/AddRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/AddRoleModal.tsx
@@ -67,6 +67,11 @@ export function AddRoleModal({
 		[addRole, form, onChangesSaved, setIsModalOpen],
 	);
 
+	const onClickCancel = useCallback(() => {
+		form.reset();
+		setIsModalOpen(false);
+	}, [form, setIsModalOpen]);
+
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
 			{/* NOTE - Is this okay to do for the aria describedby? */}
@@ -131,8 +136,9 @@ export function AddRoleModal({
 							<div className="flex justify-between w-full">
 								<Button
 									variant="destructiveOutline"
+									type="button"
 									className="rounded-full"
-									onClick={() => setIsModalOpen(false)}
+									onClick={onClickCancel}
 									disabled={isAddPending}
 								>
 									Cancel

--- a/src/features/instance/config/roles/modals/EditRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/EditRoleModal.tsx
@@ -152,6 +152,7 @@ export function EditRoleModal({
 				<DialogFooter>
 					{!isSelf && (<div className="flex justify-between w-full">
 						<Button
+							type="button"
 							variant="destructiveOutline"
 							className="rounded-full"
 							onClick={onRoleDeleteClick}

--- a/src/features/instance/log/modals/ViewLogModal.tsx
+++ b/src/features/instance/log/modals/ViewLogModal.tsx
@@ -77,7 +77,7 @@ export function ViewLogModal({
 				)}
 				<DialogFooter>
 					<div className="flex justify-between w-full">
-						<Button variant="destructive" className="rounded-full">
+						<Button type="button" variant="destructive" className="rounded-full">
 							<Trash /> Delete Row
 						</Button>
 						<Button variant="submit" className="rounded-full">

--- a/src/features/instance/modals/BrowseSettingsModal.tsx
+++ b/src/features/instance/modals/BrowseSettingsModal.tsx
@@ -23,7 +23,7 @@ export function BrowseSettingsModal() {
 
 				<DialogFooter>
 					<div className="flex justify-between w-full">
-						<Button variant="destructive" className="rounded-full">
+						<Button type="button" variant="destructive" className="rounded-full">
 							<Trash /> Delete Row
 						</Button>
 						<Button variant="submit" className="rounded-full">

--- a/src/features/instance/modals/RemoveInstanceModal.tsx
+++ b/src/features/instance/modals/RemoveInstanceModal.tsx
@@ -60,7 +60,7 @@ export function RemoveInstanceModal({
 
 				<DialogFooter>
 					<div className="flex justify-between w-full">
-						<Button variant="submit" className="rounded-full" onClick={() => setIsModalOpen(false)}>
+						<Button type="button" className="rounded-full" onClick={() => setIsModalOpen(false)}>
 							<Ban /> Cancel
 						</Button>
 						<Button

--- a/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
@@ -37,7 +37,7 @@ const ConfirmDeletionContent = ({
 		<DialogTitle>Confirm Role Deletion</DialogTitle>
 		<DialogDescription>Are you sure you want to delete this role? This action cannot be undone.</DialogDescription>
 		<DialogFooter>
-			<Button variant="defaultOutline" className="rounded-full" onClick={() => setIsConfirmingRoleDeletion(false)}>
+			<Button type="button" variant="defaultOutline" className="rounded-full" onClick={() => setIsConfirmingRoleDeletion(false)}>
 				Cancel
 			</Button>
 			<Button
@@ -249,6 +249,7 @@ export function EditOrganizationRoleModal({
 								{(remove || update) && (<DialogFooter className="col-span-2">
 									<div className="flex justify-between w-full">
 										{remove && (<Button
+											type="button"
 											variant="destructiveOutline"
 											className="rounded-full"
 											onClick={() => setIsConfirmingRoleDeletion(true)}


### PR DESCRIPTION
So we are using `submit` as the default button type, causing the cancel button in a few spots to submit the form too. I looked through all of our buttons and added `type="button"` to a handful of them for added safety.

https://harperdb.atlassian.net/browse/STUDIO-296