### PR TITLE
[STUDIO-277] Respect if the user can’t remove people from roles

### DIFF
--- a/src/features/organization/users/components/OrgUserRoleCheckbox.tsx
+++ b/src/features/organization/users/components/OrgUserRoleCheckbox.tsx
@@ -5,16 +5,19 @@ import { useRemoveUserFromOrganizationRole } from '@/features/organization/mutat
 import { useCheckboxCallback } from '@/hooks/useCheckboxCallback';
 import { SchemaOrganizationRole, SchemaUser } from '@/lib/api.gen';
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 export function OrgUserRoleCheckbox({
 	data,
 	readOnly,
+	canRemove,
 	orgRole,
 	selectedRoles,
 	setChangesMade,
 }: {
 	data: SchemaUser;
 	readOnly: boolean;
+	canRemove: boolean;
 	orgRole: SchemaOrganizationRole,
 	selectedRoles: Record<string, SchemaOrganizationRole>,
 	setChangesMade: (value: boolean) => void,
@@ -33,6 +36,7 @@ export function OrgUserRoleCheckbox({
 						onSuccess: () => {
 							setWasChecked(isChecked);
 							setChangesMade(true);
+							toast.success(`Role added successfully`);
 						},
 					},
 				);
@@ -43,6 +47,7 @@ export function OrgUserRoleCheckbox({
 						onSuccess: () => {
 							setWasChecked(isChecked);
 							setChangesMade(true);
+							toast.success(`Role removed successfully`);
 						},
 					},
 				);
@@ -54,7 +59,7 @@ export function OrgUserRoleCheckbox({
 		<Input
 			type="checkbox"
 			className="w-6"
-			disabled={readOnly || isAddPending || isRemovePending}
+			disabled={readOnly || isAddPending || isRemovePending || (!canRemove && isChecked)}
 			checked={isChecked}
 			onChange={onCheckedChanged}
 		/>

--- a/src/features/organization/users/modals/EditUserModal.tsx
+++ b/src/features/organization/users/modals/EditUserModal.tsx
@@ -24,7 +24,7 @@ export function EditUserModal({
 }) {
 	const { organizationId } = route.useParams();
 	const auth = useCloudAuth();
-	const { update } = useOrganizationRolePermissions(organizationId);
+	const { update, remove } = useOrganizationRolePermissions(organizationId);
 	const isSelf = auth.user?.email === data.email;
 	const { data: orgRoles } = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
 	const selectedRoles = useMemo(() => data.roles ? keyBy(data.roles, 'roleName') : {}, [data]);
@@ -43,7 +43,15 @@ export function EditUserModal({
 				</DialogDescription>)}
 
 				{orgRoles.map((orgRole) => (
-					<OrgUserRoleCheckbox key={orgRole.id} readOnly={isSelf || !update} data={data} orgRole={orgRole} selectedRoles={selectedRoles} setChangesMade={setChangesMade} />
+					<OrgUserRoleCheckbox
+						key={orgRole.id}
+						readOnly={isSelf || !update}
+						canRemove={remove}
+						data={data}
+						orgRole={orgRole}
+						selectedRoles={selectedRoles}
+						setChangesMade={setChangesMade}
+					/>
 				))}
 			</DialogContent>
 		</Dialog>


### PR DESCRIPTION
If the user can update roles, but not delete them, then they can assign roles to users, but not unassign them! The API was enforcing this, and now the UI will as well. Neat.

Bonus points: when a role is added or removed from a user, we'll add a toast.

https://harperdb.atlassian.net/browse/STUDIO-277