### PR TITLE
Improve success message when an app is created

### DIFF
--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -43,7 +43,7 @@ export function ImportProjectForm() {
 	const submitForm = async (formData: DeployComponentFormData) => {
 		deployNewApplication(formData, {
 			onSuccess: () => {
-				toast.success(`Application ${formData} created successfully`);
+				toast.success(`Application ${formData.newApplicationName} created successfully`);
 				navigate({ to: `../editor` });
 			},
 			onError: (error) => {


### PR DESCRIPTION
Without this, we see `Application [object Object] created successfully`. This doesn't actually fix the problem noticed in the ticket, but... the success is prettier!

https://harperdb.atlassian.net/browse/STUDIO-299