### PR TITLE
Only show 1 error when org delete fails

### DIFF
--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -58,17 +58,7 @@ export function OrganizationsIndex() {
 						queryClient.invalidateQueries({ queryKey: [queryKeys.organization], refetchType: 'active' });
 						setIsDeleteOrgModalOpen(false);
 					},
-					onError: () => {
-						toast.error('Error', {
-							description: `Failed to delete organization: ${org.organizationName}.`,
-							duration: 5000,
-							action: {
-								label: 'Dismiss',
-								onClick: () => toast.dismiss(),
-							},
-						});
-						setIsDeleteOrgModalOpen(false);
-					},
+					onError: () => setIsDeleteOrgModalOpen(false),
 				});
 			}
 		},


### PR DESCRIPTION
We are currently showing 2 error toasts when deleting an org. I'm removing the less useful one. Now the user will only see an error saying that you can't delete an org with active clusters.

https://harperdb.atlassian.net/browse/STUDIO-327