### PR TITLE
Fix lint await errors on file selection and log filtering

### DIFF
--- a/src/features/instance/applications/context/EditorViewProvider.tsx
+++ b/src/features/instance/applications/context/EditorViewProvider.tsx
@@ -20,10 +20,15 @@ export const EditorViewProvider = ({ children }: PropsWithChildren) => {
 		content: '',
 	});
 
-	const { data: getComponentFileQueryData, refetch: refetchComponentFile } = useQuery(
+	const { data: getComponentFileQueryData } = useQuery(
 		getComponentFileQuery(
 			{
-				file: selectedFolderFile.filePath.split('/').slice(2).join('/'), // removes the first two segments (/components/<projectName>)
+				file: selectedFolderFile.entries == undefined
+					// removes the first two segments
+					// (/components/<projectName>)
+					? selectedFolderFile.filePath.split('/').slice(2).join('/')
+					// don't try to load the contents of folders
+					: '',
 				project: selectedFolderFile.projectName,
 			},
 			instanceId,
@@ -46,14 +51,11 @@ export const EditorViewProvider = ({ children }: PropsWithChildren) => {
 
 	const handleFileSelect = useCallback(
 		async (selectedFileInfo: HandleFileSelectParams) => {
-			await setSelectedFolderFile({
+			setSelectedFolderFile({
 				...selectedFileInfo,
 			});
-			if (!isFolder(selectedFileInfo.entries) && selectedFileInfo.entries == undefined) {
-				await refetchComponentFile();
-			}
 		},
-		[refetchComponentFile],
+		[],
 	);
 
 	const updateEditorContent = useCallback((content: string) => {

--- a/src/features/instance/log/index.tsx
+++ b/src/features/instance/log/index.tsx
@@ -1,28 +1,28 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form/Form';
 import { FormControl } from '@/components/ui/form/FormControl';
 import { FormField } from '@/components/ui/form/FormField';
 import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { ColumnDef } from '@tanstack/react-table';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { renderBadgeLogLevelText, renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
+import { LogsDataTable } from '@/features/instance/log/LogsDataTable';
+import { ViewLogModal } from '@/features/instance/log/modals/ViewLogModal';
 import {
 	getReadLogQueryOptions,
 	LogFiltersSchema,
 	ReadLogItem,
 } from '@/features/instance/operations/queries/getReadLog';
-import { getRouteApi } from '@tanstack/react-router';
-import { LogsDataTable } from '@/features/instance/log/LogsDataTable';
-import { ViewLogModal } from '@/features/instance/log/modals/ViewLogModal';
-import { useState } from 'react';
-import { Badge } from '@/components/ui/badge';
-import { renderBadgeLogLevelText, renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
-import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { useForm } from 'react-hook-form';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
+import { ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 type RowData = {
 	original: ReadLogItem;
@@ -88,7 +88,7 @@ const isValidDateRange = (startDate?: Date, endDate?: Date) => {
 const route = getRouteApi('');
 
 export function Logs() {
-	const { instanceId } = route.useParams();
+	const { instanceId, clusterId } = route.useParams();
 	const [logFilters, setLogFilters] = useState<z.infer<typeof LogFiltersSchema>>({
 		limit: 1000,
 		order: 'desc',
@@ -99,8 +99,7 @@ export function Logs() {
 	const {
 		data: instanceLogs,
 		isLoading,
-		refetch: refetchInstanceLogs,
-	} = useSuspenseQuery(getReadLogQueryOptions({ instanceId, logFilters }));
+	} = useQuery(getReadLogQueryOptions({ instanceId: instanceId ?? clusterId, logFilters }));
 
 	const form = useForm<z.infer<typeof LogFiltersSchema>>({
 		resolver: zodResolver(LogFiltersSchema),
@@ -127,20 +126,18 @@ export function Logs() {
 			});
 			return;
 		}
-		await setLogFilters(data);
-		refetchInstanceLogs();
+		setLogFilters(data);
 	};
 
 	const resetFilters = async () => {
 		form.reset();
-		await setLogFilters({
+		setLogFilters({
 			limit: 1000,
 			level: undefined,
 			from: undefined,
 			until: undefined,
 			order: 'desc',
 		});
-		refetchInstanceLogs();
 	};
 
 	return (
@@ -299,7 +296,7 @@ export function Logs() {
 					<div>Loading...</div>
 				) : (
 					<div className="h-32">
-						<LogsDataTable columns={columns} data={instanceLogs} onRowClick={onRowClick} />
+						<LogsDataTable columns={columns} data={instanceLogs || []} onRowClick={onRowClick} />
 					</div>
 				)}
 			</section>

--- a/src/features/instance/operations/queries/getComponentFile.ts
+++ b/src/features/instance/operations/queries/getComponentFile.ts
@@ -35,7 +35,7 @@ function getComponentFileQuery(getComponentFileRequest: GetComponentFileRequest,
 				...data,
 			};
 		},
-		enabled: false, // Disable by default
+		enabled: !!getComponentFileRequest.file,
 		retry: false,
 	});
 }

--- a/src/features/instance/operations/queries/getReadLog.ts
+++ b/src/features/instance/operations/queries/getReadLog.ts
@@ -25,13 +25,12 @@ function getReadLogQueryOptions({
 	instanceId: string;
 	logFilters: z.infer<typeof LogFiltersSchema>;
 }) {
+	if (logFilters.level === 'undefined') {
+		logFilters.level = undefined;
+	}
 	return queryOptions({
-		queryKey: [instanceId, 'read_log'] as const,
+		queryKey: [instanceId, 'read_log', logFilters.limit, logFilters.level, logFilters.from, logFilters.until, logFilters.order] as const,
 		queryFn: async () => {
-			if (logFilters.level === 'undefined') {
-				logFilters.level = undefined;
-			}
-
 			const { data } = await instanceClient.post('/', {
 				operation: 'read_log',
 				start: 0,


### PR DESCRIPTION
When you set state, it immediately returns, you can't await it. But the state won't be set until the next render of the component. So the refetch is very likely to use the old values when we do this.

Instead, we can utilize react-query and remove the manual refetch calls. It will refetch automatically when the parameters in the queryKey change.