### PR TITLE
[STUDIO-332] Cluster and Instance Restart

### DIFF
--- a/.github/workflows/verify-fabric-pr.yaml
+++ b/.github/workflows/verify-fabric-pr.yaml
@@ -1,0 +1,23 @@
+name: Verify Fabric PR
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [harper/fabric]
+jobs:
+  deployToStage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run unit tests
+        run: pnpm test
+      - name: Run lint
+        run: pnpm lint
+      - name: Build
+        run: pnpm build

--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { InstanceClientConfig } from '@/config/instanceClientConfig';
-import { useRestartClick } from '@/hooks/useRestartClick';
+import { useRestartClusterClick } from '@/hooks/useRestartClusterClick';
+import { useRestartInstanceClick } from '@/hooks/useRestartInstanceClick';
 
 interface RestartButtonParams extends InstanceClientConfig {
 	targetNoun: 'Instance' | 'Cluster';
@@ -13,14 +14,18 @@ export function RestartButton({
 	instanceClient,
 	operation,
 }: RestartButtonParams) {
-	const { onRestartClick, isRestartPending } = useRestartClick({ targetNoun, operation, instanceClient });
+	const {
+		onRestartClick: onRestartClusterClick,
+		isRestartPending: isRestartClusterPending,
+	} = useRestartClusterClick();
+	const { onRestartClick, isRestartPending } = useRestartInstanceClick({ targetNoun, operation, instanceClient });
 	return (<Tooltip>
 		<TooltipTrigger asChild>
 			<Button
 				variant="positiveOutline"
 				className="ml-4 rounded-full cursor-pointer"
-				onClick={onRestartClick}
-				disabled={isRestartPending}
+				onClick={targetNoun === 'Cluster' && operation === 'restart' ? onRestartClusterClick : onRestartClick}
+				disabled={isRestartPending || isRestartClusterPending}
 			>
 				Restart {targetNoun}
 			</Button>

--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { InstanceClientConfig } from '@/config/instanceClientConfig';
+import { useRestartClick } from '@/hooks/useRestartClick';
+
+interface RestartButtonParams extends InstanceClientConfig {
+	targetNoun: 'Instance' | 'Cluster';
+	operation: 'restart_service' | 'restart';
+}
+
+export function RestartButton({
+	targetNoun,
+	instanceClient,
+	operation,
+}: RestartButtonParams) {
+	const { onRestartClick, isRestartPending } = useRestartClick({ targetNoun, operation, instanceClient });
+	return (<Tooltip>
+		<TooltipTrigger asChild>
+			<Button
+				variant="positiveOutline"
+				className="ml-4 rounded-full cursor-pointer"
+				onClick={onRestartClick}
+				disabled={isRestartPending}
+			>
+				Restart {targetNoun}
+			</Button>
+		</TooltipTrigger>
+		<TooltipContent>
+			{operation === 'restart_service'
+				? 'Restarts all service threads to apply changes. No downtime expected. Performance may be briefly slower during restart.'
+				: 'This fully restarts the Harper service and causes downtime.'}
+		</TooltipContent>
+	</Tooltip>);
+}

--- a/src/config/getInstanceClient.ts
+++ b/src/config/getInstanceClient.ts
@@ -1,7 +1,12 @@
 import { authStore, EntityIds, OverallAppSignIn } from '@/lib/authStore';
 import axios from 'axios';
 
-export function getInstanceClient(id: EntityIds = OverallAppSignIn, operationsUrl?: string | null) {
+interface InstanceClient {
+	id?: EntityIds;
+	operationsUrl?: string | null;
+}
+
+export function getInstanceClient({ id = OverallAppSignIn, operationsUrl }: InstanceClient = {}) {
 	const baseURL = operationsUrl || authStore.getOperationsUrl(id);
 	return axios.create({
 		withCredentials: true,

--- a/src/config/instanceClientConfig.ts
+++ b/src/config/instanceClientConfig.ts
@@ -5,7 +5,10 @@ export interface InstanceClientConfig {
 	instanceClient: AxiosInstance;
 }
 
-export interface InstanceClientIdConfig {
-	instanceClient: AxiosInstance;
+export interface InstanceClientIdConfig extends InstanceClientConfig {
 	entityId: EntityIds;
+}
+
+export interface InstanceTypeConfig {
+	entityType: 'instance' | 'cluster';
 }

--- a/src/config/useInstanceClient.tsx
+++ b/src/config/useInstanceClient.tsx
@@ -1,6 +1,6 @@
 import { isLocalStudio } from '@/config/constants';
 import { getInstanceClient } from '@/config/getInstanceClient';
-import { InstanceClientConfig, InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { InstanceClientConfig, InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { OverallAppSignIn } from '@/lib/authStore';
 import { useParams } from '@tanstack/react-router';
 
@@ -10,15 +10,16 @@ export function useInstanceClient(operationsUrl?: string | null) {
 	return getInstanceClient(id, operationsUrl);
 }
 
-export function useInstanceClientParams(operationsUrl?: string | null): InstanceClientConfig {
+export function useInstanceClientParams(operationsUrl?: string | null): InstanceClientConfig & InstanceTypeConfig {
 	const { instanceId, clusterId }: { instanceId?: string; clusterId?: string; } = useParams({ strict: false });
 	const id = isLocalStudio ? OverallAppSignIn : instanceId ?? clusterId;
 	return {
 		instanceClient: getInstanceClient(id, operationsUrl),
+		entityType: (isLocalStudio || instanceId) ? 'instance' : 'cluster',
 	};
 }
 
-export function useInstanceClientIdParams(operationsUrl?: string | null): InstanceClientIdConfig {
+export function useInstanceClientIdParams(operationsUrl?: string | null): InstanceClientIdConfig & InstanceTypeConfig {
 	const { instanceId, clusterId }: { instanceId?: string; clusterId?: string; } = useParams({ strict: false });
 	const id = isLocalStudio ? OverallAppSignIn : instanceId ?? clusterId;
 	if (!id) {
@@ -27,5 +28,6 @@ export function useInstanceClientIdParams(operationsUrl?: string | null): Instan
 	return {
 		instanceClient: getInstanceClient(id, operationsUrl),
 		entityId: id,
+		entityType: (isLocalStudio || instanceId) ? 'instance' : 'cluster',
 	};
 }

--- a/src/config/useInstanceClient.tsx
+++ b/src/config/useInstanceClient.tsx
@@ -7,14 +7,14 @@ import { useParams } from '@tanstack/react-router';
 export function useInstanceClient(operationsUrl?: string | null) {
 	const { instanceId, clusterId }: { instanceId?: string; clusterId?: string; } = useParams({ strict: false });
 	const id = isLocalStudio ? OverallAppSignIn : instanceId ?? clusterId;
-	return getInstanceClient(id, operationsUrl);
+	return getInstanceClient({ id, operationsUrl });
 }
 
 export function useInstanceClientParams(operationsUrl?: string | null): InstanceClientConfig & InstanceTypeConfig {
 	const { instanceId, clusterId }: { instanceId?: string; clusterId?: string; } = useParams({ strict: false });
 	const id = isLocalStudio ? OverallAppSignIn : instanceId ?? clusterId;
 	return {
-		instanceClient: getInstanceClient(id, operationsUrl),
+		instanceClient: getInstanceClient({ id, operationsUrl }),
 		entityType: (isLocalStudio || instanceId) ? 'instance' : 'cluster',
 	};
 }
@@ -26,7 +26,7 @@ export function useInstanceClientIdParams(operationsUrl?: string | null): Instan
 		throw new Error('id could not be automatically calculated in useInstanceClientIdParams');
 	}
 	return {
-		instanceClient: getInstanceClient(id, operationsUrl),
+		instanceClient: getInstanceClient({ id, operationsUrl }),
 		entityId: id,
 		entityType: (isLocalStudio || instanceId) ? 'instance' : 'cluster',
 	};

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -18,7 +18,7 @@ import { authStore } from '@/lib/authStore';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
-import { getRouteApi, Navigate, useNavigate, useSearch } from '@tanstack/react-router';
+import { getRouteApi, Navigate, useNavigate, useRouter, useSearch } from '@tanstack/react-router';
 import { useCallback, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -56,6 +56,7 @@ export function ClusterSetPassword() {
 	const instanceClient = useInstanceClient(operationsUrl);
 
 	const { redirect } = useSearch({ strict: false });
+	const router = useRouter();
 
 	const form = useForm<z.infer<typeof ClusterSetPasswordSchema>>({
 		resolver: zodResolver(ClusterSetPasswordSchema),
@@ -86,10 +87,11 @@ export function ClusterSetPassword() {
 				toast.success(response.message);
 				const user = await getInstanceUserInfo({ instanceClient });
 				authStore.setUserForEntity(cluster || null, user);
-				await navigate({ to: redirect?.startsWith('/') ? redirect : '/browse' });
+				router.invalidate();
+				await navigate({ to: redirect?.startsWith('/') ? redirect : '../browse' });
 			},
 		});
-	}, [cluster, clusterId, instanceClient, navigate, operationsUrl, redirect, submitInstanceResetPassword, tempPassword]);
+	}, [cluster, clusterId, instanceClient, navigate, operationsUrl, redirect, router, submitInstanceResetPassword, tempPassword]);
 
 	if (cluster && !cluster.resetPassword) {
 		return <Navigate to="../sign-in" />;

--- a/src/features/instance/applications/context/EditorViewContext.tsx
+++ b/src/features/instance/applications/context/EditorViewContext.tsx
@@ -9,8 +9,7 @@ export type EditorViewContextValue = {
 	canDeleteFolder?: boolean;
 	isFolder: (entry: DirectoryEntry[] | undefined) => boolean;
 	handleFileSelect: (params: HandleFileSelectParams) => void;
-	updateEditorContent?: (content: string) => void;
-	onSaveFile: (data: SetComponentFileRequest) => void;
+	onSaveFile: (data: SetComponentFileRequest, filePath: string) => void;
 	isSavingFile: boolean;
 };
 

--- a/src/features/instance/applications/context/EditorViewProvider.tsx
+++ b/src/features/instance/applications/context/EditorViewProvider.tsx
@@ -58,17 +58,16 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 		});
 	}, []);
 
-	const updateEditorContent = useCallback((content: string) => {
-		setSelectedFolderFile((prev) => ({
-			...prev,
-			content: content,
-		}));
-	}, []);
-
 	const onSaveFile = useCallback(
-		(data: SetComponentFileRequest) => {
+		(data: SetComponentFileRequest, filePath: string) => {
 			saveComponentFile(data, {
 				onSuccess: () => {
+					if (selectedFolderFile?.filePath === filePath) {
+						setSelectedFolderFile({
+							...selectedFolderFile,
+							content: data.payload,
+						});
+					}
 					toast.success('Success', {
 						description: `${data.file.split('/').pop()} saved successfully. A restart is required to see changes.`,
 						action: {
@@ -82,18 +81,17 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 				},
 			});
 		},
-		[saveComponentFile],
+		[saveComponentFile, selectedFolderFile],
 	);
 
 	const value = useMemo<EditorViewContextValue>(() => {
 		return {
 			selectedFolderFile: selectedFolderFile,
 			handleFileSelect,
-			updateEditorContent,
 			onSaveFile,
 			isSavingFile,
 			isFolder,
 		};
-	}, [selectedFolderFile, handleFileSelect, updateEditorContent, onSaveFile, isSavingFile]);
+	}, [selectedFolderFile, handleFileSelect, onSaveFile, isSavingFile]);
 	return <EditorViewContext.Provider value={value}>{children}</EditorViewContext.Provider>;
 }

--- a/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/FileMenuActionButtons.tsx
+++ b/src/features/instance/applications/editor/components/ApplicationsSidebar/FileTreeExplorer/FileMenuActionButtons.tsx
@@ -42,6 +42,7 @@ export function FileMenuActionButtons() {
 			{
 				file: `${selectedFolderFile.filePath.split('/').slice(2).join('/')}`,
 				project: selectedFolderFile.projectName,
+				replicated: instanceParams.entityType === 'cluster',
 				...instanceParams,
 			},
 			{

--- a/src/features/instance/applications/editor/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/editor/components/TextEditorView/index.tsx
@@ -1,13 +1,11 @@
+import { RestartButton } from '@/components/RestartButton';
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
-import { useUpdateRestartInstance } from '@/features/instance/operations/mutations/updateRestartInstance';
 import { Editor } from '@monaco-editor/react';
 import { useParams } from '@tanstack/react-router';
 import { Save } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
 import { useEditorView } from '../../../hooks/useEditorView';
 
 function parseFileExtension(filename: string) {
@@ -36,42 +34,9 @@ export function TextEditorView() {
 	const [updateFileContent, setUpdateFileContent] = useState<string>(selectedFolderFile.content || '');
 	const { instanceId }: { instanceId: string } = useParams({ strict: false });
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
-	const { mutate: restartInstance, isPending: isRestartInstancePending } = useUpdateRestartInstance();
 	const instanceParams = useInstanceClientParams();
 
 	const crumbPath = selectedFolderFile.filePath.split('/').slice(1).join('/').replace(/\//g, ' > ');
-
-	const restartingInstance = () => {
-		const toastId = toast.loading('Restarting', {
-			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
-			duration: 60000, // Keep the toast open until dismissed
-			action: {
-				label: 'Dismiss',
-				onClick: () => toast.dismiss(),
-			},
-		});
-		restartInstance(instanceParams, {
-			onSuccess: () => {
-				toast.dismiss(toastId);
-				toast.success('Success', {
-					description: `${targetNoun} restarted!`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-			onError: () => {
-				toast.error('Error', {
-					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-		});
-	};
 
 	useEffect(() => {
 		const extension = parseFileExtension(selectedFolderFile.filePath) as keyof typeof extensionToLanguageMap;
@@ -104,23 +69,7 @@ export function TextEditorView() {
 						<Save />
 						<span className="ms-1">Save</span>
 					</Button>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant="defaultOutline"
-								className="ml-4 rounded-full cursor-pointer"
-								onClick={restartingInstance}
-								disabled={isRestartInstancePending}
-							>
-								Restart {targetNoun}
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent>
-							Restarts all service threads to apply changes. No downtime expected. Performance may be
-							briefly slower
-							during restart.
-						</TooltipContent>
-					</Tooltip>
+					<RestartButton targetNoun={targetNoun} instanceClient={instanceParams.instanceClient} operation="restart_service" />
 				</div>
 			</div>
 			{!selectedFolderFile.filePath || isFolder(selectedFolderFile.entries) ? (

--- a/src/features/instance/applications/editor/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/editor/components/TextEditorView/index.tsx
@@ -2,6 +2,7 @@ import { RestartButton } from '@/components/RestartButton';
 import { Button } from '@/components/ui/button';
 import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
+import { useEffectedState } from '@/hooks/useEffectedState';
 import { Editor } from '@monaco-editor/react';
 import { useParams } from '@tanstack/react-router';
 import { Save } from 'lucide-react';
@@ -31,7 +32,7 @@ const extensionToLanguageMap = {
 export function TextEditorView() {
 	const { selectedFolderFile, onSaveFile, isSavingFile, isFolder } = useEditorView();
 	const [language, setLanguage] = useState('javascript');
-	const [updateFileContent, setUpdateFileContent] = useState<string>(selectedFolderFile.content || '');
+	const [updateFileContent, setUpdateFileContent] = useEffectedState<string | null>(selectedFolderFile.content || null, [selectedFolderFile.filePath]);
 	const { instanceId }: { instanceId: string } = useParams({ strict: false });
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
 	const instanceParams = useInstanceClientParams();
@@ -53,16 +54,19 @@ export function TextEditorView() {
 						variant="positiveOutline"
 						className="w-32 rounded-full"
 						onClick={() => {
-							onSaveFile({
-								...instanceParams,
-								file: selectedFolderFile.filePath.split('/').slice(2).join('/'),
-								payload: updateFileContent,
-								project: selectedFolderFile.projectName,
-							});
+							if (updateFileContent !== null) {
+								onSaveFile({
+									...instanceParams,
+									file: selectedFolderFile.filePath.split('/').slice(2).join('/'),
+									payload: updateFileContent,
+									project: selectedFolderFile.projectName,
+								}, selectedFolderFile.filePath);
+							}
 						}}
 						disabled={
 							!selectedFolderFile.filePath ||
-							(selectedFolderFile.filePath && updateFileContent == selectedFolderFile.content) ||
+							updateFileContent === null ||
+							updateFileContent === selectedFolderFile.content ||
 							isSavingFile
 						}
 					>

--- a/src/features/instance/applications/new/CreateNewProjectForm.tsx
+++ b/src/features/instance/applications/new/CreateNewProjectForm.tsx
@@ -23,6 +23,7 @@ const NewProjectSchema = z.object({
 		.min(1, { message: 'Project name is required' })
 		.max(75, { message: 'Project name must be less than 75 characters' })
 		.regex(/^[a-zA-Z0-9-_]+$/, { message: 'Can only contain letters, numbers, dashes and underscores' }),
+	replicated: z.boolean(),
 });
 
 export function CreateNewProjectForm({
@@ -37,6 +38,7 @@ export function CreateNewProjectForm({
 		resolver: zodResolver(NewProjectSchema),
 		defaultValues: {
 			newApplicationName: '',
+			replicated: instanceParams.entityType === 'cluster',
 		},
 	});
 

--- a/src/features/instance/applications/new/CreateNewProjectForm.tsx
+++ b/src/features/instance/applications/new/CreateNewProjectForm.tsx
@@ -27,11 +27,11 @@ const NewProjectSchema = z.object({
 });
 
 export function CreateNewProjectForm({
-	restartingInstanceOrCluster,
-	isRestartInstanceOrClusterPending,
+	triggerRestart,
+	isRestartPending,
 }: {
-	restartingInstanceOrCluster: () => void;
-	isRestartInstanceOrClusterPending: boolean;
+	triggerRestart: () => void;
+	isRestartPending: boolean;
 }) {
 	const instanceParams = useInstanceClientParams();
 	const form = useForm<z.infer<typeof NewProjectSchema>>({
@@ -47,7 +47,7 @@ export function CreateNewProjectForm({
 		createNewProject({ ...formData, ...instanceParams }, {
 			onSuccess: () => {
 				toast.success(`Project ${formData.newApplicationName} created successfully`);
-				restartingInstanceOrCluster();
+				triggerRestart();
 			},
 			onError: (error) => {
 				toast.error(`Error creating project: ${error.message}`);
@@ -75,7 +75,7 @@ export function CreateNewProjectForm({
 						className="w-full mt-4"
 						variant="submit"
 						type="submit"
-						disabled={!form.formState.isDirty || isRestartInstanceOrClusterPending}
+						disabled={!form.formState.isDirty || isRestartPending}
 					>
 						Create <ArrowRight />
 					</Button>

--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -31,10 +31,8 @@ const ImportProjectSchema = z.object({
 });
 
 export function ImportProjectForm({
-	triggerRestart,
 	isRestartPending,
 }: {
-	triggerRestart: () => void;
 	isRestartPending: boolean;
 }) {
 	const instanceParams = useInstanceClientParams();
@@ -52,7 +50,6 @@ export function ImportProjectForm({
 		deployNewApplication({ ...formData, ...instanceParams }, {
 			onSuccess: () => {
 				toast.success(`Application ${formData.newApplicationName} created successfully`);
-				triggerRestart();
 			},
 			onError: (error) => {
 				toast.error(`Error creating Application: ${error.message}`);

--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -31,11 +31,11 @@ const ImportProjectSchema = z.object({
 });
 
 export function ImportProjectForm({
-	restartingInstanceOrCluster,
-	isRestartInstanceOrClusterPending,
+	triggerRestart,
+	isRestartPending,
 }: {
-	restartingInstanceOrCluster: () => void;
-	isRestartInstanceOrClusterPending: boolean;
+	triggerRestart: () => void;
+	isRestartPending: boolean;
 }) {
 	const instanceParams = useInstanceClientParams();
 	const form = useForm<z.infer<typeof ImportProjectSchema>>({
@@ -52,7 +52,7 @@ export function ImportProjectForm({
 		deployNewApplication({ ...formData, ...instanceParams }, {
 			onSuccess: () => {
 				toast.success(`Application ${formData.newApplicationName} created successfully`);
-				restartingInstanceOrCluster();
+				triggerRestart();
 			},
 			onError: (error) => {
 				toast.error(`Error creating Application: ${error.message}`);
@@ -119,7 +119,7 @@ export function ImportProjectForm({
 						className="w-full mt-4"
 						variant="submit"
 						type="submit"
-						disabled={!form.formState.isDirty || isDeployComponentPending || isRestartInstanceOrClusterPending}
+						disabled={!form.formState.isDirty || isDeployComponentPending || isRestartPending}
 					>
 						{!isDeployComponentPending ? (
 							<>

--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -27,6 +27,7 @@ const ImportProjectSchema = z.object({
 		.max(75, { message: 'Project name must be less than 75 characters' })
 		.regex(/^[a-zA-Z0-9-_]+$/, { message: 'Can only contain letters, numbers, dashes and underscores' }),
 	applicationUrl: z.string(),
+	replicated: z.boolean(),
 });
 
 export function ImportProjectForm({
@@ -42,6 +43,7 @@ export function ImportProjectForm({
 		defaultValues: {
 			newApplicationName: '',
 			applicationUrl: '',
+			replicated: instanceParams.entityType === 'cluster',
 		},
 	});
 

--- a/src/features/instance/applications/new/index.tsx
+++ b/src/features/instance/applications/new/index.tsx
@@ -4,53 +4,24 @@ import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
 import { CreateNewProjectForm } from '@/features/instance/applications/new/CreateNewProjectForm';
 import { ImportProjectForm } from '@/features/instance/applications/new/ImportProjectForm';
-import { useUpdateRestartInstance } from '@/features/instance/operations/mutations/updateRestartInstance';
+import { useRestartClick } from '@/hooks/useRestartClick';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { ArrowLeft, FolderPlus, Import } from 'lucide-react';
-import { useState } from 'react';
-import { toast } from 'sonner';
+import { useCallback, useState } from 'react';
 
 export function NewApplications() {
 	const [appType, setAppType] = useState('');
 
-	const { instanceId }: { instanceId?: string; clusterId: string; } = useParams({ strict: false });
-	const instanceParams = useInstanceClientParams();
-	const { mutate: restartInstance, isPending: isRestartInstanceOrClusterPending } = useUpdateRestartInstance();
+	const { instanceId }: { instanceId?: string; } = useParams({ strict: false });
+	const { instanceClient } = useInstanceClientParams();
 	const navigate = useNavigate();
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
 
-	const restartingInstanceOrCluster = () => {
-		const toastId = toast.loading('Restarting', {
-			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
-			duration: 60000, // Keep the toast open until dismissed
-			action: {
-				label: 'Dismiss',
-				onClick: () => toast.dismiss(),
-			},
-		});
-		restartInstance(instanceParams, {
-			onSuccess: () => {
-				toast.dismiss(toastId);
-				toast.success('Success', {
-					description: `${targetNoun} restarted!`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-				void navigate({ to: `../editor` });
-			},
-			onError: () => {
-				toast.error('Error', {
-					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-		});
-	};
+	const onRestartedSuccessfully = useCallback(() => {
+		void navigate({ to: `../editor` });
+	}, [navigate]);
+	const { onRestartClick, isRestartPending } = useRestartClick({ targetNoun, instanceClient, onRestartedSuccessfully });
+
 	return (
 		<div className="flex items-center justify-center gap-4 min-h-[calc(80vh-theme(spacing.20))]">
 			<Card className="w-full h-full max-w-xl">
@@ -85,13 +56,13 @@ export function NewApplications() {
 					<div className="mt-6">
 						{appType === 'create' ? (
 							<CreateNewProjectForm
-								restartingInstanceOrCluster={restartingInstanceOrCluster}
-								isRestartInstanceOrClusterPending={isRestartInstanceOrClusterPending}
+								triggerRestart={onRestartClick}
+								isRestartPending={isRestartPending}
 							/>
 						) : appType === 'import' ? (
 							<ImportProjectForm
-								restartingInstanceOrCluster={restartingInstanceOrCluster}
-								isRestartInstanceOrClusterPending={isRestartInstanceOrClusterPending}
+								triggerRestart={onRestartClick}
+								isRestartPending={isRestartPending}
 							/>
 						) : (
 							<p className="text-center">Please select an option to continue.</p>

--- a/src/features/instance/applications/new/index.tsx
+++ b/src/features/instance/applications/new/index.tsx
@@ -66,7 +66,6 @@ export function NewApplications() {
 							/>
 						) : appType === 'import' ? (
 							<ImportProjectForm
-								triggerRestart={onRestartClick}
 								isRestartPending={isRestartPending}
 							/>
 						) : (

--- a/src/features/instance/applications/new/index.tsx
+++ b/src/features/instance/applications/new/index.tsx
@@ -4,7 +4,7 @@ import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
 import { CreateNewProjectForm } from '@/features/instance/applications/new/CreateNewProjectForm';
 import { ImportProjectForm } from '@/features/instance/applications/new/ImportProjectForm';
-import { useRestartClick } from '@/hooks/useRestartClick';
+import { useRestartInstanceClick } from '@/hooks/useRestartInstanceClick';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { ArrowLeft, FolderPlus, Import } from 'lucide-react';
 import { useCallback, useState } from 'react';
@@ -20,7 +20,12 @@ export function NewApplications() {
 	const onRestartedSuccessfully = useCallback(() => {
 		void navigate({ to: `../editor` });
 	}, [navigate]);
-	const { onRestartClick, isRestartPending } = useRestartClick({ targetNoun, instanceClient, onRestartedSuccessfully });
+	const { onRestartClick, isRestartPending } = useRestartInstanceClick({
+		operation: 'restart_service',
+		targetNoun,
+		instanceClient,
+		onRestartedSuccessfully,
+	});
 
 	return (
 		<div className="flex items-center justify-center gap-4 min-h-[calc(80vh-theme(spacing.20))]">

--- a/src/features/instance/browse/components/BrowseSidebar.tsx
+++ b/src/features/instance/browse/components/BrowseSidebar.tsx
@@ -91,7 +91,11 @@ export function BrowseSidebar() {
 	}, [selectedTableName, navigate]);
 
 	const submitNewDatabase = useCallback((formData: z.infer<typeof NewDatabaseSchema>) => {
-		createNewDatabase({ ...formData, ...instanceParams }, {
+		createNewDatabase({
+			...formData,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
 			onSuccess: async () => {
 				await queryClient.invalidateQueries({
 					queryKey: [instanceParams.entityId, 'describe_all'],
@@ -107,7 +111,12 @@ export function BrowseSidebar() {
 	}, [createNewDatabase, form, instanceParams, onSelectDatabase, queryClient, router]);
 
 	const onDeleteTable = useCallback((targetDatabaseName: string, targetTableName: string) => {
-		deleteTable({ databaseName: targetDatabaseName, tableName: targetTableName, ...instanceParams }, {
+		deleteTable({
+			databaseName: targetDatabaseName,
+			tableName: targetTableName,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
 			onSuccess: async () => {
 				setIsDeleteModalOpen(false);
 				await queryClient.invalidateQueries({
@@ -124,7 +133,11 @@ export function BrowseSidebar() {
 	}, [deleteTable, instanceParams, onSelectTable, queryClient, router, selectedTableName]);
 
 	const onDeleteDatabase = useCallback((targetDatabaseName: string) => {
-		deleteDatabase({ databaseName: targetDatabaseName, ...instanceParams }, {
+		deleteDatabase({
+			databaseName: targetDatabaseName,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
 			onSuccess: async () => {
 				setIsDeleteModalOpen(false);
 				await queryClient.invalidateQueries({

--- a/src/features/instance/browse/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewTableModal.tsx
@@ -74,6 +74,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 			...formData,
 			...instanceParams,
 			databaseName,
+			replicated: instanceParams.entityType === 'cluster',
 		};
 		submitNewTableData(updatedFormData, {
 			onSuccess: async () => {

--- a/src/features/instance/browse/route.load.ts
+++ b/src/features/instance/browse/route.load.ts
@@ -17,7 +17,7 @@ export async function loadInstanceBrowseData(
 	const entityId = params.instanceId ?? params.clusterId ?? OverallAppSignIn;
 	const data = await queryClient.ensureQueryData(getDescribeAllQueryOptions({
 		entityId,
-		instanceClient: getInstanceClient(entityId),
+		instanceClient: getInstanceClient({ id: entityId }),
 	}));
 	let newDatabaseName: string | undefined;
 	let newTableName: string | undefined;

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -1,6 +1,5 @@
+import { RestartButton } from '@/components/RestartButton';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
-import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { getInstanceInfoQueryOptions } from '@/features/cluster/queries/getInstanceInfoQuery';
@@ -8,14 +7,12 @@ import { ApplicationURL } from '@/features/instance/config/overview/components/A
 import { HarperVersion } from '@/features/instance/config/overview/components/HarperVersion';
 import { InstanceNodeName } from '@/features/instance/config/overview/components/InstanceNodeName';
 import { InstanceURL } from '@/features/instance/config/overview/components/InstanceURL';
-import { useUpdateRestartInstance } from '@/features/instance/operations/mutations/updateRestartInstance';
 import { getConfigurationQueryOptions } from '@/features/instance/operations/queries/getConfiguration';
 import { getRegistrationInfoQueryOptions } from '@/features/instance/operations/queries/getRegistrationInfo';
 import Editor from '@monaco-editor/react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { ReactNode } from 'react';
-import { toast } from 'sonner';
 
 const LocalStudioOverview = ({ children }: { children: ReactNode }) => {
 	return <>{children}</>;
@@ -30,7 +27,6 @@ export function ConfigOverviewIndex() {
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
 	const instanceParams = useInstanceClientIdParams();
 
-	const { mutate: restartInstance, isPending: isRestartInstancePending } = useUpdateRestartInstance();
 	const { data: info, isLoading: loadingInstanceInfo } = useSuspenseQuery(
 		getInstanceInfoQueryOptions({ clusterId, instanceId }),
 	);
@@ -43,61 +39,16 @@ export function ConfigOverviewIndex() {
 		getConfigurationQueryOptions(instanceParams),
 	);
 
-	const restartingInstance = () => {
-		const toastId = toast.loading('Restarting', {
-			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
-			duration: 60000, // Keep the toast open until dismissed
-			action: {
-				label: 'Dismiss',
-				onClick: () => toast.dismiss(),
-			},
-		});
-		restartInstance(instanceParams, {
-			onSuccess: () => {
-				toast.dismiss(toastId);
-				toast.success('Success', {
-					description: `${targetNoun} restarted!`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-			onError: () => {
-				toast.error('Error', {
-					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-		});
-	};
-
 	return (
 		<div className="h-full flex flex-col">
 			{isLocalStudio ? (
 				<LocalStudioOverview>
 					<dl className="grid grid-cols-1 sm:grid-cols-3">
-						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
+						<div className="px-4 pb-4 sm:col-span-2 sm:px-0">
 							<HarperVersion loadingRegistration={loadingRegistration} registrationInfo={registrationInfo} />
 						</div>
 						<div className="px-4 pb-4 text-right sm:col-span-1 sm:px-0">
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="positiveOutline"
-										className="ml-4 rounded-full cursor-pointer"
-										onClick={restartingInstance}
-										disabled={isRestartInstancePending}
-									>
-										Restart {targetNoun}
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent>This fully restarts the Harper service and causes
-									downtime.</TooltipContent>
-							</Tooltip>
+							<RestartButton targetNoun={targetNoun} instanceClient={instanceParams.instanceClient} operation="restart" />
 						</div>
 					</dl>
 				</LocalStudioOverview>
@@ -111,25 +62,11 @@ export function ConfigOverviewIndex() {
 							<ApplicationURL loadingInstanceInfo={loadingInstanceInfo} clusterInfo={clusterInfo} />
 						</div>
 						<div className="px-4 pb-4 text-right sm:col-span-1 sm:px-0">
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										variant="positiveOutline"
-										className="ml-4 rounded-full cursor-pointer"
-										onClick={restartingInstance}
-										disabled={isRestartInstancePending}
-									>
-										Restart {targetNoun}
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent>This fully restarts the Harper service and causes
-									downtime.</TooltipContent>
-							</Tooltip>
+							<RestartButton targetNoun={targetNoun} instanceClient={instanceParams.instanceClient} operation="restart" />
 						</div>
 						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
 							<InstanceNodeName loadingInstanceInfo={loadingInstanceInfo} instanceInfo={instanceInfo} />
 						</div>
-
 						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
 							<HarperVersion loadingRegistration={loadingRegistration} registrationInfo={registrationInfo} />
 						</div>

--- a/src/features/instance/log/index.tsx
+++ b/src/features/instance/log/index.tsx
@@ -98,7 +98,11 @@ export function Logs() {
 	const {
 		data: instanceLogs,
 		isLoading,
-	} = useQuery(getReadLogQueryOptions({ ...instanceParams, logFilters }));
+	} = useQuery(getReadLogQueryOptions({
+		logFilters,
+		...instanceParams,
+		replicated: instanceParams.entityType === 'cluster',
+	}));
 
 	const form = useForm<z.infer<typeof LogFiltersSchema>>({
 		resolver: zodResolver(LogFiltersSchema),

--- a/src/features/instance/operations/mutations/createComponent.ts
+++ b/src/features/instance/operations/mutations/createComponent.ts
@@ -3,13 +3,18 @@ import { useMutation } from '@tanstack/react-query';
 
 export interface CreateComponentFormData {
 	newApplicationName: string;
+	replicated: boolean;
 }
 
-async function onCreateComponentSubmit({ newApplicationName, instanceClient }: CreateComponentFormData & InstanceClientConfig) {
+async function onCreateComponentSubmit({
+	newApplicationName,
+	instanceClient,
+	replicated,
+}: CreateComponentFormData & InstanceClientConfig) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'add_component',
 		project: newApplicationName,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/createDatabase.ts
+++ b/src/features/instance/operations/mutations/createDatabase.ts
@@ -3,13 +3,14 @@ import { useMutation } from '@tanstack/react-query';
 
 interface CreateDatabaseFormData extends InstanceClientConfig {
 	databaseName: string;
+	replicated: boolean;
 }
 
-async function onCreateDatabaseSubmit({ databaseName, instanceClient }: CreateDatabaseFormData) {
+async function onCreateDatabaseSubmit({ databaseName, replicated, instanceClient }: CreateDatabaseFormData) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'create_database',
 		database: databaseName,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/createTable.ts
+++ b/src/features/instance/operations/mutations/createTable.ts
@@ -5,15 +5,22 @@ interface CreateTableFormData extends InstanceClientConfig {
 	databaseName: string;
 	tableName: string;
 	primaryKey: string;
+	replicated: boolean;
 }
 
-async function onCreateTableSubmit({ databaseName, tableName, primaryKey, instanceClient }: CreateTableFormData) {
+async function onCreateTableSubmit({
+	databaseName,
+	tableName,
+	primaryKey,
+	replicated,
+	instanceClient,
+}: CreateTableFormData) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'create_table',
 		database: databaseName,
 		table: tableName,
 		primary_key: primaryKey,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/deleteComponentFolderFile.ts
+++ b/src/features/instance/operations/mutations/deleteComponentFolderFile.ts
@@ -4,14 +4,15 @@ import { useMutation } from '@tanstack/react-query';
 interface DeleteComponentFileRequest extends InstanceClientConfig {
 	project: string;
 	file: string | undefined;
+	replicated: boolean;
 }
 
-async function onDeleteComponentFolderFile({ file, project, instanceClient }: DeleteComponentFileRequest) {
+async function onDeleteComponentFolderFile({ file, project, replicated, instanceClient }: DeleteComponentFileRequest) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_component',
 		file: file || undefined,
 		project,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/deleteDatabase.ts
+++ b/src/features/instance/operations/mutations/deleteDatabase.ts
@@ -3,13 +3,14 @@ import { useMutation } from '@tanstack/react-query';
 
 interface DeleteDatabaseParams extends InstanceClientConfig {
 	databaseName: string;
+	replicated: boolean;
 }
 
-async function onDeleteDatabase({ databaseName, instanceClient }: DeleteDatabaseParams) {
+async function onDeleteDatabase({ databaseName, replicated, instanceClient }: DeleteDatabaseParams) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_database',
 		database: databaseName,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/deleteTable.ts
+++ b/src/features/instance/operations/mutations/deleteTable.ts
@@ -4,14 +4,15 @@ import { useMutation } from '@tanstack/react-query';
 interface DeleteTableData extends InstanceClientConfig {
 	databaseName: string;
 	tableName: string;
+	replicated: boolean;
 }
 
-async function onDeleteTable({ databaseName, tableName, instanceClient }: DeleteTableData) {
+async function onDeleteTable({ databaseName, tableName, replicated, instanceClient }: DeleteTableData) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'drop_table',
 		database: databaseName,
 		table: tableName,
-		replicated: true,
+		replicated,
 	});
 	return data;
 }

--- a/src/features/instance/operations/mutations/deployComponent.ts
+++ b/src/features/instance/operations/mutations/deployComponent.ts
@@ -20,6 +20,7 @@ async function onDeployComponentSubmit({
 			package: applicationUrl,
 			project: newApplicationName,
 			replicated,
+			restart: 'rolling',
 		},
 		{ timeout: 60000 },
 	);

--- a/src/features/instance/operations/mutations/deployComponent.ts
+++ b/src/features/instance/operations/mutations/deployComponent.ts
@@ -4,12 +4,14 @@ import { useMutation } from '@tanstack/react-query';
 export interface DeployComponentFormData {
 	newApplicationName: string;
 	applicationUrl: string;
+	replicated: boolean;
 }
 
 async function onDeployComponentSubmit({
 	newApplicationName,
 	applicationUrl,
 	instanceClient,
+	replicated,
 }: DeployComponentFormData & InstanceClientConfig) {
 	const { data } = await instanceClient.post(
 		'/',
@@ -17,7 +19,7 @@ async function onDeployComponentSubmit({
 			operation: 'deploy_component',
 			package: applicationUrl,
 			project: newApplicationName,
-			replicated: true,
+			replicated,
 		},
 		{ timeout: 60000 },
 	);

--- a/src/features/instance/operations/mutations/restartInstance.ts
+++ b/src/features/instance/operations/mutations/restartInstance.ts
@@ -4,22 +4,25 @@ import { axiosRetry } from '@/lib/axiosRetry';
 import { sleep } from '@/lib/sleep';
 import { useMutation } from '@tanstack/react-query';
 
+interface RestartInstanceParams {
+	operation: 'restart_service' | 'restart';
+}
+
 interface UpdateRestartInstanceResponse {
 	message: string;
 }
 
-async function onUpdateRestartInstance({ instanceClient }: InstanceClientConfig) {
+async function onRestartInstance({ operation, instanceClient }: RestartInstanceParams & InstanceClientConfig) {
 	const { data } = await instanceClient.post('/', {
-		operation: 'restart',
-		restart: 'rolling',
+		operation,
 	});
 	await sleep(3_000);
 	await axiosRetry(() => getInstanceUserInfo({ instanceClient, timeout: 10_000 }), 5, 3_000);
 	return data as UpdateRestartInstanceResponse;
 }
 
-export function useUpdateRestartInstance() {
+export function useRestartInstance() {
 	return useMutation({
-		mutationFn: onUpdateRestartInstance,
+		mutationFn: onRestartInstance,
 	});
 }

--- a/src/features/instance/operations/mutations/restartInstance.ts
+++ b/src/features/instance/operations/mutations/restartInstance.ts
@@ -6,15 +6,18 @@ import { useMutation } from '@tanstack/react-query';
 
 interface RestartInstanceParams {
 	operation: 'restart_service' | 'restart';
+	replicated: boolean;
 }
 
 interface UpdateRestartInstanceResponse {
 	message: string;
 }
 
-async function onRestartInstance({ operation, instanceClient }: RestartInstanceParams & InstanceClientConfig) {
+async function onRestartInstance({ operation, replicated, instanceClient }: RestartInstanceParams & InstanceClientConfig) {
 	const { data } = await instanceClient.post('/', {
 		operation,
+		service: operation === 'restart_service' ? 'http' : undefined,
+		replicated,
 	});
 	await sleep(3_000);
 	await axiosRetry(() => getInstanceUserInfo({ instanceClient, timeout: 10_000 }), 5, 3_000);

--- a/src/features/instance/operations/mutations/restartInstance.ts
+++ b/src/features/instance/operations/mutations/restartInstance.ts
@@ -13,7 +13,7 @@ interface UpdateRestartInstanceResponse {
 	message: string;
 }
 
-async function onRestartInstance({ operation, replicated, instanceClient }: RestartInstanceParams & InstanceClientConfig) {
+export async function restartInstance({ operation, replicated, instanceClient }: RestartInstanceParams & InstanceClientConfig) {
 	const { data } = await instanceClient.post('/', {
 		operation,
 		service: operation === 'restart_service' ? 'http' : undefined,
@@ -26,6 +26,6 @@ async function onRestartInstance({ operation, replicated, instanceClient }: Rest
 
 export function useRestartInstance() {
 	return useMutation({
-		mutationFn: onRestartInstance,
+		mutationFn: restartInstance,
 	});
 }

--- a/src/features/instance/operations/queries/getReadLog.ts
+++ b/src/features/instance/operations/queries/getReadLog.ts
@@ -20,23 +20,25 @@ export const LogFiltersSchema = z.object({
 
 interface GetReadLogParams {
 	logFilters: z.infer<typeof LogFiltersSchema>;
+	replicated: boolean;
 }
 
 export function getReadLogQueryOptions({
 	entityId,
 	instanceClient,
 	logFilters,
+	replicated,
 }: GetReadLogParams & InstanceClientIdConfig) {
 	if (logFilters.level === 'undefined') {
 		logFilters.level = undefined;
 	}
 	return queryOptions({
-		queryKey: [entityId, 'read_log', logFilters.limit, logFilters.level, logFilters.from, logFilters.until, logFilters.order] as const,
+		queryKey: [entityId, 'read_log', logFilters.limit, logFilters.level, logFilters.from, logFilters.until, logFilters.order, replicated] as const,
 		queryFn: async () => {
 			const { data } = await instanceClient.post('/', {
 				operation: 'read_log',
 				start: 0,
-				replicated: true,
+				replicated,
 				...logFilters,
 			});
 			return data as ReadLogItem[];

--- a/src/hooks/useRestartClick.ts
+++ b/src/hooks/useRestartClick.ts
@@ -1,0 +1,61 @@
+import { InstanceClientConfig } from '@/config/instanceClientConfig';
+import { useRestartInstance } from '@/features/instance/operations/mutations/restartInstance';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+
+interface RestartClickParams extends InstanceClientConfig {
+	targetNoun: 'Instance' | 'Cluster';
+	operation: 'restart_service' | 'restart';
+	onRestartedSuccessfully?: () => void;
+}
+
+interface RestartClickResponse {
+	onRestartClick: () => void;
+	isRestartPending: boolean;
+}
+
+export function useRestartClick({
+	targetNoun,
+	operation,
+	instanceClient,
+	onRestartedSuccessfully,
+}: RestartClickParams): RestartClickResponse {
+	const { mutate: restartInstance, isPending: isRestartPending } = useRestartInstance();
+	const onRestartClick = useCallback(() => {
+		const toastId = toast.loading('Restarting', {
+			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
+			duration: 60_000,
+			action: {
+				label: 'Dismiss',
+				onClick: () => toast.dismiss(),
+			},
+		});
+		restartInstance({ operation, instanceClient }, {
+			onSuccess: () => {
+				toast.dismiss(toastId);
+				toast.success('Success', {
+					description: `${targetNoun} restarted!`,
+					action: {
+						label: 'Dismiss',
+						onClick: () => toast.dismiss(),
+					},
+				});
+				onRestartedSuccessfully?.();
+			},
+			onError: () => {
+				toast.error('Error', {
+					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
+					action: {
+						label: 'Dismiss',
+						onClick: () => toast.dismiss(),
+					},
+				});
+			},
+		});
+	}, [instanceClient, onRestartedSuccessfully, operation, restartInstance, targetNoun]);
+
+	return {
+		onRestartClick,
+		isRestartPending,
+	};
+}

--- a/src/hooks/useRestartClick.ts
+++ b/src/hooks/useRestartClick.ts
@@ -30,7 +30,11 @@ export function useRestartClick({
 				onClick: () => toast.dismiss(),
 			},
 		});
-		restartInstance({ operation, instanceClient }, {
+		restartInstance({
+			operation,
+			replicated: operation === 'restart_service' && targetNoun === 'Cluster',
+			instanceClient,
+		}, {
 			onSuccess: () => {
 				toast.dismiss(toastId);
 				toast.success('Success', {
@@ -43,6 +47,7 @@ export function useRestartClick({
 				onRestartedSuccessfully?.();
 			},
 			onError: () => {
+				toast.dismiss(toastId);
 				toast.error('Error', {
 					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
 					action: {

--- a/src/hooks/useRestartClusterClick.tsx
+++ b/src/hooks/useRestartClusterClick.tsx
@@ -1,0 +1,119 @@
+import { getInstanceClient } from '@/config/getInstanceClient';
+import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
+import { restartInstance } from '@/features/instance/operations/mutations/restartInstance';
+import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
+import { useParams } from '@tanstack/react-router';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+interface RestartClusterClickParams {
+	onRestartedSuccessfully?: () => void;
+}
+
+interface RestartClusterClickResponse {
+	onRestartClick: () => void;
+	isRestartPending: boolean;
+}
+
+export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClusterClickParams = {}): RestartClusterClickResponse {
+	const { clusterId }: { clusterId?: string; } = useParams({ strict: false });
+	const [isRestartPending, setIsRestartPending] = useState(false);
+	const onRestartClick = useCallback(async () => {
+		if (!clusterId) {
+			throw new Error('clusterId must be set in the route to invoke useRestartClusterClick');
+		}
+		setIsRestartPending(true);
+
+		let canceled = false;
+		const toastConfig = {
+			duration: 60_000,
+			action: {
+				label: 'Cancel',
+				onClick: () => {
+					canceled = true;
+					toast.dismiss();
+				},
+			},
+		};
+
+
+		const toastId = toast.loading('Restarting', {
+			...toastConfig,
+			description: renderProgressUpdate(),
+		});
+
+		const cluster = await getClusterInfo(clusterId);
+		let succeeded = false;
+		if (cluster) {
+			const instanceClients = cluster.instances?.map(instance => {
+				return getInstanceClient({ id: instance.id, operationsUrl: getOperationsUrlForInstance(instance) });
+			});
+			if (instanceClients?.length) {
+				for (let i = 0; i < instanceClients.length; i++) {
+					const instanceClient = instanceClients[i];
+					if (!canceled) {
+						toast.loading('Restarting', {
+							...toastConfig,
+							id: toastId,
+							description: renderProgressUpdate(i, instanceClients.length),
+						});
+						await restartInstance({
+							operation: 'restart',
+							replicated: false,
+							instanceClient,
+						});
+					}
+				}
+				succeeded = true;
+			}
+		}
+
+		setIsRestartPending(false);
+
+		if (canceled) {
+			toast.error('Cancelled', {
+				id: toastId,
+				description: `The restart was partially cancelled.`,
+				action: {
+					label: 'Dismiss',
+					onClick: () => toast.dismiss(),
+				},
+			});
+		} else if (succeeded) {
+			onRestartedSuccessfully?.();
+			toast.success('Success', {
+				id: toastId,
+				description: `Cluster restarted!`,
+				action: {
+					label: 'Dismiss',
+					onClick: () => toast.dismiss(),
+				},
+			});
+		} else {
+			toast.error('Error', {
+				id: toastId,
+				description: `Failed to restart cluster.`,
+				action: {
+					label: 'Dismiss',
+					onClick: () => toast.dismiss(),
+				},
+			});
+		}
+	}, [clusterId, onRestartedSuccessfully]);
+
+
+	return {
+		onRestartClick,
+		isRestartPending,
+	};
+}
+
+function renderProgressUpdate(current?: number, total?: number) {
+	return (<>
+		Restarting cluster instances.
+		{current !== undefined && total !== undefined && total > 0 && (
+			<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+				<div className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500" style={{ width: (current === 0 ? 0 : (current / total * 100)) + '%' }}></div>
+			</div>)}
+	</>);
+}

--- a/src/hooks/useRestartClusterClick.tsx
+++ b/src/hooks/useRestartClusterClick.tsx
@@ -31,11 +31,9 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 				label: 'Cancel',
 				onClick: () => {
 					canceled = true;
-					toast.dismiss();
 				},
 			},
 		};
-
 
 		const toastId = toast.loading('Restarting', {
 			...toastConfig,

--- a/src/hooks/useRestartInstanceClick.ts
+++ b/src/hooks/useRestartInstanceClick.ts
@@ -3,23 +3,23 @@ import { useRestartInstance } from '@/features/instance/operations/mutations/res
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-interface RestartClickParams extends InstanceClientConfig {
+interface RestartInstanceClickParams extends InstanceClientConfig {
 	targetNoun: 'Instance' | 'Cluster';
 	operation: 'restart_service' | 'restart';
 	onRestartedSuccessfully?: () => void;
 }
 
-interface RestartClickResponse {
+interface RestartInstanceClickResponse {
 	onRestartClick: () => void;
 	isRestartPending: boolean;
 }
 
-export function useRestartClick({
+export function useRestartInstanceClick({
 	targetNoun,
 	operation,
 	instanceClient,
 	onRestartedSuccessfully,
-}: RestartClickParams): RestartClickResponse {
+}: RestartInstanceClickParams): RestartInstanceClickResponse {
 	const { mutate: restartInstance, isPending: isRestartPending } = useRestartInstance();
 	const onRestartClick = useCallback(() => {
 		const toastId = toast.loading('Restarting', {

--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -145,7 +145,7 @@ class AuthStore {
 				continue;
 			}
 			try {
-				const instanceClient = getInstanceClient(entityId);
+				const instanceClient = getInstanceClient({ id: entityId });
 				await onInstanceLogoutSubmit({ instanceClient });
 			} catch (err: unknown) {
 				console.error(`Failed to log out from ${entityId}, carrying on`, err);
@@ -248,7 +248,7 @@ class AuthStore {
 					user = await getCurrentUser();
 				}
 			} else if (id) {
-				user = await getInstanceUserInfo({ instanceClient: getInstanceClient(id) });
+				user = await getInstanceUserInfo({ instanceClient: getInstanceClient({ id }) });
 			}
 		} catch (error) {
 			// TODO: Only catch the errors we expect here (401? 403? w/e)


### PR DESCRIPTION
- Cluster mode will send replicated: true
- Instance and local mode will send replicated: false
- There's a new shared restart button that encompasses all this logic
- Cluster set password's redirect is now fixed
- When you haven't changed a file, or when you click around between files, we'll detect the dirty editor state properly now and only enable Save when appropriate.
- Editor page does a restart_service: http now instead of a full restart.
- When restarting a cluster, we'll iterate through the instances and restart them one by one.
- Deploy component will do a rolling restart now with its new shiny param (that has been there for years, I'm sure, but it's new to this code haha)
https://harperdb.atlassian.net/browse/STUDIO-332