### PR TITLE
Tweaks to Browse

### DIFF
--- a/src/components/ConfirmDeletionModal.tsx
+++ b/src/components/ConfirmDeletionModal.tsx
@@ -6,8 +6,10 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	DialogTrigger,
 } from '@/components/ui/dialog';
 import { ArrowLeft, Trash, TriangleAlert } from 'lucide-react';
+import { ReactNode } from 'react';
 
 export function ConfirmDeletionModal({
 	typeOfThingBeingDeleted,
@@ -16,6 +18,7 @@ export function ConfirmDeletionModal({
 	setIsModalOpen,
 	deletionConfirmed,
 	deletionPending,
+	trigger,
 }: {
 	typeOfThingBeingDeleted: string;
 	nameOfThingBeingDeleted?: string;
@@ -23,9 +26,15 @@ export function ConfirmDeletionModal({
 	setIsModalOpen: (isOpen: boolean) => void;
 	deletionConfirmed: () => void;
 	deletionPending: boolean;
+	trigger?: ReactNode;
 }) {
 	return (
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+			{trigger && (
+				<DialogTrigger asChild>
+					{trigger}
+				</DialogTrigger>
+			)}
 			<DialogContent className="sm:max-w-[750px]">
 				<DialogHeader>
 					<DialogTitle>Are you sure you want to delete this {typeOfThingBeingDeleted}?</DialogTitle>

--- a/src/features/instance/browse/components/BrowseDataTable.tsx
+++ b/src/features/instance/browse/components/BrowseDataTable.tsx
@@ -1,21 +1,22 @@
 'use client';
 
-import {
-	ColumnDef, flexRender, getCoreRowModel, getPaginationRowModel, PaginationState, Row, SortingState, useReactTable,
-} from '@tanstack/react-table';
-
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHeader,
-	TableHeadSortable,
-	TableRow,
-} from '@/components/ui/table';
+import { Loading } from '@/components/Loading';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHeader, TableHeadSortable, TableRow } from '@/components/ui/table';
+import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
+import {
+	ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getPaginationRowModel,
+	PaginationState,
+	Row,
+	SortingState,
+	useReactTable,
+} from '@tanstack/react-table';
+import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
 import React, { Dispatch, SetStateAction } from 'react';
-import { Loading } from '@/components/Loading';
 
 interface BrowseDataTableProps<TData, TValue> {
 	columns: ColumnDef<TData, TValue>[];
@@ -60,53 +61,22 @@ export function BrowseDataTable<TData, TValue>({
 		onPaginationChange: setPagination,
 	});
 
-	const paging = <>
-		<div className="flex items-center space-x-2">
-			<p className="text-sm font-medium">Rows per page</p>
-			<Select defaultValue={table.getState().pagination.pageSize.toString()} onValueChange={(value) => {
-				table.setPageSize(Number(value));
-			}}>
-				<SelectTrigger className="h-8 w-[80px]">
-					<SelectValue />
-				</SelectTrigger>
-				<SelectContent side="top">
-					{[20, 50, 100, 250].map((pageSize) => (<SelectItem key={pageSize} value={`${pageSize}`}>
-						{pageSize}
-					</SelectItem>))}
-				</SelectContent>
-			</Select>
-		</div>
-		<span>Total Rows: {totalRecords}</span>
-		<Button variant="defaultOutline" size="sm" onClick={table.previousPage} className="select-none"
-				disabled={paginationState.pageIndex === 0}>
-			Previous
-		</Button>
-		<Button variant="defaultOutline" size="sm" onClick={table.nextPage} className="select-none"
-				disabled={paginationState.pageIndex === totalPages - 1}>
-			Next
-		</Button>
-	</>;
-
 	return (<>
-		<div className="flex items-center justify-end space-x-2 py-4">
-			<div className="grow lg:hidden"></div>
-			{children}
-			<div className="grow hidden lg:visible"></div>
-			<div className="items-center justify-end space-x-2 hidden lg:flex">{paging}</div>
-		</div>
-		<Table containerClassName="rounded-md bg-black-dark">
+		{children}
+		<Table containerClassName="rounded-md bg-black-dark grow max-h-[calc(100vh-128px-16px-112px-80px)]">
 			<TableHeader>
 				{table.getHeaderGroups().map((headerGroup) => (<TableRow key={headerGroup.id} className="border-none">
-					{headerGroup.headers.map((header) => <TableHeadSortable key={header.id} header={header} onColumnClick={onColumnClick} />)}
+					{headerGroup.headers.map((header) =>
+						<TableHeadSortable key={header.id} header={header} onColumnClick={onColumnClick} />)}
 				</TableRow>))}
 			</TableHeader>
 			<TableBody className="bg-black border border-grey-700">
 				{table.getRowModel().rows?.length ? (table.getRowModel().rows.map((row) => (
 					<TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}
-							  onClick={() => onRowClick?.(row)}
-							  className="hover:bg-muted/10 data-[state=selected]:bg-muted">
+						onClick={() => onRowClick?.(row)}
+						className="hover:bg-muted/10 data-[state=selected]:bg-muted">
 						{row.getVisibleCells().map((cell) => (<TableCell key={cell.id}
-																		 className="py-2 px-2 overflow-x-hidden max-w-32 text-ellipsis whitespace-nowrap">
+							className="py-2 px-2 overflow-x-hidden max-w-32 text-ellipsis whitespace-nowrap">
 							{flexRender(cell.column.columnDef.cell, cell.getContext())}
 						</TableCell>))}
 					</TableRow>))) : (<TableRow>
@@ -116,6 +86,54 @@ export function BrowseDataTable<TData, TValue>({
 				</TableRow>)}
 			</TableBody>
 		</Table>
-		<div className="flex items-center justify-end py-4 space-x-2 lg:invisible">{paging}</div>
+		<div className="flex items-center justify-end py-4 space-x-2">
+			<Button variant="defaultOutline" size="sm" onClick={table.previousPage} className="select-none"
+				disabled={paginationState.pageIndex === 0}>
+				<ArrowLeftIcon />
+				Previous
+			</Button>
+
+			<div className="grow"></div>
+
+			<div className="text-center">
+				<dt className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Records</dt>
+				<dd className="font-semibold tracking-tight">{addCommasToNumbers(totalRecords)}</dd>
+			</div>
+			{totalRecords > 0 && (<>
+				<div>
+					<Select defaultValue={table.getState().pagination.pageSize.toString()} onValueChange={(value) => {
+						table.setPageSize(Number(value));
+					}}>
+						<SelectTrigger className="h-10 w-[80px]">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent side="top">
+							{[20, 50, 100, 250].map((pageSize) => (<SelectItem key={pageSize} value={`${pageSize}`}>
+								{pageSize}
+							</SelectItem>))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				{totalPages > 1 && (<>
+					<div className="text-center">
+						<dt className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Pages</dt>
+						<dd className="font-semibold tracking-tight">{addCommasToNumbers(totalPages)}</dd>
+					</div>
+					<div className="text-center">
+						<dt className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Page</dt>
+						<dd className="font-semibold tracking-tight">{addCommasToNumbers(paginationState.pageIndex + 1)}</dd>
+					</div>
+				</>)}
+			</>)}
+
+			<div className="grow"></div>
+
+			<Button variant="defaultOutline" size="sm" onClick={table.nextPage} className="select-none"
+				disabled={paginationState.pageIndex === totalPages - 1}>
+				Next
+				<ArrowRightIcon />
+			</Button>
+		</div>
 	</>);
 }

--- a/src/features/instance/browse/components/BrowseDataTableView.tsx
+++ b/src/features/instance/browse/components/BrowseDataTableView.tsx
@@ -1,9 +1,11 @@
+import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { Button } from '@/components/ui/button';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { BrowseDataTable } from '@/features/instance/browse/components/BrowseDataTable';
 import { formatBrowseDataTableHeader } from '@/features/instance/browse/functions/formatBrowseDataTableHeader';
 import { AddTableRowModal } from '@/features/instance/browse/modals/AddTableRowModal';
 import { EditTableRowModal } from '@/features/instance/browse/modals/EditTableRowModal';
+import { useDeleteTableMutation } from '@/features/instance/operations/mutations/deleteTable';
 import { useDeleteTableRecords } from '@/features/instance/operations/mutations/deleteTableRecords';
 import { useInsertTableRecords } from '@/features/instance/operations/mutations/insertTableRecords';
 import { useUpdateTableRecords } from '@/features/instance/operations/mutations/updateTableRecords';
@@ -11,11 +13,13 @@ import { getDescribeTableQueryOptions } from '@/features/instance/operations/que
 import { getSearchByIdOptions } from '@/features/instance/operations/queries/getSearchById';
 import { getSearchByValueOptions } from '@/features/instance/operations/queries/getSearchByValue';
 import { useEffectedState } from '@/hooks/useEffectedState';
-import { useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
+import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
+import { useRefreshClick } from '@/hooks/useRefreshClick';
+import { queryClient } from '@/react-query/queryClient';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { getRouteApi } from '@tanstack/react-router';
+import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import { PaginationState, Row } from '@tanstack/react-table';
-import { PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { PlusIcon, RefreshCwIcon, Trash } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -29,12 +33,14 @@ export function BrowseDataTableView() {
 		tableName: string;
 	} = route.useParams();
 
+	const navigate = useNavigate();
 	const instanceParams = useInstanceClientIdParams();
 	const { clusterId, instanceId, databaseName, tableName } = allParams;
 
 	const canAddRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'insert');
 	const canEditRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'update');
 	const canDeleteRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'delete');
+	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 
 	const { data: describeTableData, refetch: refetchDescribeTableQueryOptions } = useSuspenseQuery(
 		getDescribeTableQueryOptions({
@@ -97,6 +103,7 @@ export function BrowseDataTableView() {
 	const { mutate: addTableRecords, isPending: isAddTableRecordsPending } = useInsertTableRecords();
 	const { mutate: updateTableRecords, isPending: isUpdateTableRecordsPending } = useUpdateTableRecords();
 	const { mutate: deleteTableRecords, isPending: isDeleteTableRecordsPending } = useDeleteTableRecords();
+	const { mutate: deleteTable, isPending: isDeletingTable } = useDeleteTableMutation();
 
 	useEffect(() => {
 		setTotalRecords(describeTableData.record_count);
@@ -167,13 +174,40 @@ export function BrowseDataTableView() {
 			descending: !isAscending,
 		});
 	};
-	const onRefreshClick = useCallback(() => {
-		void refetchSearchByValueOptions?.();
-	}, [refetchSearchByValueOptions]);
+	const onRefreshClick = useRefreshClick(refetchSearchByValueOptions);
 
 	const onAddClicked = useCallback(() => {
 		setIsAddModalOpen(true);
 	}, [setIsAddModalOpen]);
+
+	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+	const onDeleteTable = useCallback((targetDatabaseName: string, targetTableName: string) => {
+		deleteTable({
+			databaseName: targetDatabaseName,
+			tableName: targetTableName,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
+			onSuccess: async () => {
+				setIsDeleteModalOpen(false);
+				await queryClient.invalidateQueries({
+					queryKey: [instanceParams.entityId, 'describe_all'],
+					refetchType: 'all',
+				});
+				toast.success(`Table ${targetTableName} deleted successfully`);
+				if (targetTableName === tableName) {
+					void navigate({ to: '../' });
+				}
+			},
+		});
+	}, [deleteTable, instanceParams, navigate, tableName]);
+
+	const onDeletionConfirmed = useCallback(() => {
+		if (databaseName && tableName) {
+			onDeleteTable(databaseName, tableName);
+		}
+	}, [databaseName, onDeleteTable, tableName]);
 
 	return (
 		<>
@@ -189,20 +223,34 @@ export function BrowseDataTableView() {
 				sortingState={sortingState}
 				setPagination={setPagination}
 			>
-				{/*canAddRecords && (<UploadCSVModal />)*/}
-				<Button variant="defaultOutline" onClick={onRefreshClick} disabled={tableDataFetching}>
-					<RefreshCwIcon />
-				</Button>
-				{/*<Button variant="defaultOutline" onClick={notYetImplemented}><SearchIcon /></Button>*/}
-				{canAddRecords && (
-					<Button
-						variant="positiveOutline"
-						onClick={onAddClicked}
-						disabled={isAddModalOpen || isAddTableRecordsPending}
-					>
-						<PlusIcon />
+				<div className="flex items-center justify-start space-x-2 pt-15 pb-4">
+					{canAddRecords && (
+						<Button
+							variant="positiveOutline"
+							onClick={onAddClicked}
+							disabled={isAddModalOpen || isAddTableRecordsPending}
+							accessKey="n"
+						>
+							<PlusIcon />
+							<span>
+								Add <u>N</u>ew Record(s)
+							</span>
+						</Button>
+					)}
+					<Button variant="defaultOutline" onClick={onRefreshClick} disabled={tableDataFetching}>
+						<RefreshCwIcon />
 					</Button>
-				)}
+
+					<div className="grow"></div>
+
+					{canManageBrowseInstance && (<Button
+						variant="destructiveOutline"
+						onClick={() => setIsDeleteModalOpen(true)}
+					>
+						<Trash className="inline-block " />
+						Drop Table
+					</Button>)}
+				</div>
 			</BrowseDataTable>
 			{canAddRecords && (
 				<AddTableRowModal
@@ -224,6 +272,14 @@ export function BrowseDataTableView() {
 				onDeleteRecord={onDeleteRecord}
 				isUpdateTableRecordsPending={isUpdateTableRecordsPending}
 				isDeleteTableRecordsPending={isDeleteTableRecordsPending}
+			/>
+			<ConfirmDeletionModal
+				typeOfThingBeingDeleted="table"
+				nameOfThingBeingDeleted={tableName}
+				isModalOpen={isDeleteModalOpen}
+				setIsModalOpen={() => setIsDeleteModalOpen(false)}
+				deletionConfirmed={onDeletionConfirmed}
+				deletionPending={isDeletingTable}
 			/>
 		</>
 	);

--- a/src/features/instance/browse/components/BrowseSidebar.tsx
+++ b/src/features/instance/browse/components/BrowseSidebar.tsx
@@ -1,42 +1,17 @@
-import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { Button } from '@/components/ui/button';
-import { Form } from '@/components/ui/form/Form';
-import { FormControl } from '@/components/ui/form/FormControl';
-import { FormField } from '@/components/ui/form/FormField';
-import { FormItem } from '@/components/ui/form/FormItem';
-import { FormLabel } from '@/components/ui/form/FormLabel';
-import { FormMessage } from '@/components/ui/form/FormMessage';
-import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scrollArea';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { CreateNewDatabaseModal } from '@/features/instance/browse/modals/CreateNewDatabaseModal';
 import { CreateNewTableModal } from '@/features/instance/browse/modals/CreateNewTableModal';
-import { useCreateDatabaseSubmitMutation } from '@/features/instance/operations/mutations/createDatabase';
-import { useDeleteDatabaseMutation } from '@/features/instance/operations/mutations/deleteDatabase';
-import { useDeleteTableMutation } from '@/features/instance/operations/mutations/deleteTable';
+import { DeleteDatabaseModal } from '@/features/instance/browse/modals/DeleteDatabaseModal';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/lib/api.patch';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
 import { getRouteApi, useNavigate, useRouter } from '@tanstack/react-router';
-import { ArrowRight, Check, Minus, Plus, Trash } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { ArrowRight } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const route = getRouteApi('');
-
-const NewDatabaseSchema = z.object({
-	databaseName: z
-		.string({
-			message: 'Please enter a valid database name.',
-		})
-		.min(1, { message: 'Database name is required' })
-		.max(75, { message: 'Database name must be less than 75 characters' })
-		.regex(/^[a-zA-Z0-9_]+$/, { message: 'Database name can only contain letters, numbers, and underscores' }),
-});
 
 export function BrowseSidebar() {
 	const router = useRouter();
@@ -45,19 +20,10 @@ export function BrowseSidebar() {
 		tableName?: string;
 	} = route.useParams();
 	const instanceDatabaseMap = route.useLoaderData() as InstanceDatabaseMap;
-	const instanceParams = useInstanceClientIdParams();
 	const navigate = useNavigate();
-	const queryClient = useQueryClient();
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
-	const [typeOfThingBeingDeleted, setTypeOfThingBeingDeleted] = useState('');
-	const [nameOfThingBeingDeleted, setNameOfThingBeingDeleted] = useState('');
-	const [deletionTarget, setDeletionTarget] = useState<{ databaseName?: string; tableName?: string; }>({});
-	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 	const [isCreatingDatabase, setIsCreatingDatabase] = useState(false);
-
-	const { mutate: createNewDatabase } = useCreateDatabaseSubmitMutation();
-	const { mutate: deleteDatabase, isPending: isDeletingDatabase } = useDeleteDatabaseMutation();
-	const { mutate: deleteTable, isPending: isDeletingTable } = useDeleteTableMutation();
+	const [firstTime, setFirstTime] = useState(true);
 
 	const { databaseNames, tableNames } = useMemo(() => {
 		const databaseNames = Object.keys(instanceDatabaseMap || {}).sort();
@@ -68,12 +34,12 @@ export function BrowseSidebar() {
 		};
 	}, [instanceDatabaseMap, selectedDatabaseName]);
 
-	const form = useForm({
-		resolver: zodResolver(NewDatabaseSchema),
-		defaultValues: {
-			databaseName: '',
-		},
-	});
+	useEffect(() => {
+		if (!databaseNames.length && firstTime) {
+			setIsCreatingDatabase(canManageBrowseInstance);
+		}
+		setFirstTime(false);
+	}, [canManageBrowseInstance, databaseNames.length, firstTime]);
 
 	const onSelectDatabase = useCallback((newDatabaseName: string | undefined) => {
 		const tableNames = newDatabaseName ? Object.keys(instanceDatabaseMap[newDatabaseName] || []).sort() : [];
@@ -85,89 +51,20 @@ export function BrowseSidebar() {
 		}
 	}, [instanceDatabaseMap, selectedDatabaseName, selectedTableName, router, navigate]);
 
+	const onDatabaseDeleted = useCallback(() => {
+		onSelectDatabase(undefined);
+	}, [onSelectDatabase]);
+
 	const onSelectTable = useCallback((newTableName: string | undefined) => {
 		const parts = [selectedTableName ? '..' : '', newTableName].filter(Boolean);
 		void navigate({ to: parts.join('/') });
 	}, [selectedTableName, navigate]);
 
-	const submitNewDatabase = useCallback((formData: z.infer<typeof NewDatabaseSchema>) => {
-		createNewDatabase({
-			...formData,
-			...instanceParams,
-			replicated: instanceParams.entityType === 'cluster',
-		}, {
-			onSuccess: async () => {
-				await queryClient.invalidateQueries({
-					queryKey: [instanceParams.entityId, 'describe_all'],
-					refetchType: 'all',
-				});
-				await router.invalidate();
-				setIsCreatingDatabase(false);
-				form.reset();
-				toast.success(`Database ${formData.databaseName} created successfully`);
-				onSelectDatabase(formData.databaseName);
-			},
-		});
-	}, [createNewDatabase, form, instanceParams, onSelectDatabase, queryClient, router]);
-
-	const onDeleteTable = useCallback((targetDatabaseName: string, targetTableName: string) => {
-		deleteTable({
-			databaseName: targetDatabaseName,
-			tableName: targetTableName,
-			...instanceParams,
-			replicated: instanceParams.entityType === 'cluster',
-		}, {
-			onSuccess: async () => {
-				setIsDeleteModalOpen(false);
-				await queryClient.invalidateQueries({
-					queryKey: [instanceParams.entityId, 'describe_all'],
-					refetchType: 'all',
-				});
-				await router.invalidate();
-				toast.success(`Table ${targetTableName} deleted successfully`);
-				if (targetTableName === selectedTableName) {
-					onSelectTable(undefined);
-				}
-			},
-		});
-	}, [deleteTable, instanceParams, onSelectTable, queryClient, router, selectedTableName]);
-
-	const onDeleteDatabase = useCallback((targetDatabaseName: string) => {
-		deleteDatabase({
-			databaseName: targetDatabaseName,
-			...instanceParams,
-			replicated: instanceParams.entityType === 'cluster',
-		}, {
-			onSuccess: async () => {
-				setIsDeleteModalOpen(false);
-				await queryClient.invalidateQueries({
-					queryKey: [instanceParams.entityId, 'describe_all'],
-					refetchType: 'all',
-				});
-				await router.invalidate();
-				toast.success(`Database ${targetDatabaseName} deleted successfully`);
-				onSelectDatabase(undefined);
-			},
-		});
-	}, [deleteDatabase, instanceParams, onSelectDatabase, queryClient, router]);
-
-	const onDeletionConfirmed = useCallback(() => {
-		const targetDatabaseName = deletionTarget.databaseName;
-		const targetTableName = deletionTarget.tableName;
-		if (targetDatabaseName) {
-			if (targetTableName) {
-				onDeleteTable(targetDatabaseName, targetTableName);
-			} else {
-				onDeleteDatabase(targetDatabaseName);
-			}
-		}
-	}, [deletionTarget.databaseName, deletionTarget.tableName, onDeleteDatabase, onDeleteTable]);
-
 	return (
 		<div>
 			<h1 className="pb-6 text-3xl">Browse</h1>
 			<div className="">
-				<div className="flex space-x-2">
+				{databaseNames?.length > 0 && (<div className="flex space-x-2">
 					<Select
 						name="databaseSelect"
 						value={selectedDatabaseName || ''}
@@ -188,58 +85,7 @@ export function BrowseSidebar() {
 							</SelectGroup>
 						</SelectContent>
 					</Select>
-					{canManageBrowseInstance && (<>
-						<Button
-							className="inline-block"
-							aria-label="Add a new database"
-							variant="positiveOutline"
-							onClick={() => setIsCreatingDatabase(!isCreatingDatabase)}
-						>
-							{!isCreatingDatabase ? <Plus /> : <Minus />}
-						</Button>
-						<Button
-							className="inline-block"
-							aria-label="Delete selected database"
-							variant="destructiveOutline"
-							disabled={!selectedDatabaseName}
-							onClick={() => {
-								if (selectedDatabaseName) {
-									setTypeOfThingBeingDeleted('database');
-									setNameOfThingBeingDeleted(selectedDatabaseName);
-									setDeletionTarget({ databaseName: selectedDatabaseName });
-									setIsDeleteModalOpen(true);
-								}
-							}}
-						>
-							<Trash />
-						</Button>
-					</>)}
-				</div>
-				{isCreatingDatabase ? (
-					<Form {...form}>
-						<form className="items-center pl-4 mt-2 space-x-2" onSubmit={form.handleSubmit(submitNewDatabase)}>
-							<FormField
-								control={form.control}
-								name="databaseName"
-								render={({ field }) => (
-									<FormItem className="my-4">
-										<FormLabel htmlFor="databaseName">New Database</FormLabel>
-										<FormControl>
-											<Input type="text" placeholder="Enter new database name" {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-							<Button type="submit" variant="positiveOutline" className="w-full">
-								<Check />
-								Create Database
-							</Button>
-						</form>
-					</Form>
-				) : (
-					''
-				)}
+				</div>)}
 			</div>
 			<Tabs defaultValue="tables" className="py-6">
 				<TabsList className="w-full">
@@ -250,32 +96,20 @@ export function BrowseSidebar() {
 						{(tableNames ?? []).length === 0 && selectedDatabaseName?.length ? (
 							<div className="w-full h-full text-center">
 								<p className="py-6">No tables found in this database.</p>
-								{canManageBrowseInstance && (<div className="mx-auto max-w-48">
-									<CreateNewTableModal databaseName={selectedDatabaseName} onSelectTable={onSelectTable} />
-								</div>)}
+								{canManageBrowseInstance && (<p>
+									Tap "Create a Table" below!
+								</p>)}
 							</div>
 						) : (tableNames ?? []).length === 0 && !selectedDatabaseName?.length ? (
 							// If no database is selected, show a message
-							<p className="pt-2 text-sm text-center">Please select a database.</p>
+							<p className="pt-2 text-sm text-center">Please {databaseNames?.length === 0 ? 'create' : 'select'} a
+								database.</p>
 						) : (
 							''
 						)}
 						<ul>
 							{(tableNames ?? []).map((tableName) => (
 								<li key={tableName} className="flex items-center p-2 border-b hover:bg-grey-700/80 border-grey-700">
-									{canManageBrowseInstance && (<Button
-										variant="destructiveOutline"
-										onClick={() => {
-											if (tableName) {
-												setTypeOfThingBeingDeleted('table');
-												setNameOfThingBeingDeleted(tableName);
-												setDeletionTarget({ databaseName: selectedDatabaseName, tableName });
-												setIsDeleteModalOpen(true);
-											}
-										}}
-									>
-										<Trash className="inline-block " />
-									</Button>)}
 									<Button
 										onClick={() => onSelectTable(tableName)}
 										size="lg"
@@ -292,17 +126,27 @@ export function BrowseSidebar() {
 					</TabsContent>
 				</ScrollArea>
 			</Tabs>
-			{selectedDatabaseName?.length && canManageBrowseInstance && (
-				<CreateNewTableModal databaseName={selectedDatabaseName} onSelectTable={onSelectTable} />
-			)}
-			<ConfirmDeletionModal
-				typeOfThingBeingDeleted={typeOfThingBeingDeleted}
-				nameOfThingBeingDeleted={nameOfThingBeingDeleted}
-				isModalOpen={isDeleteModalOpen}
-				setIsModalOpen={() => setIsDeleteModalOpen(false)}
-				deletionConfirmed={onDeletionConfirmed}
-				deletionPending={isDeletingDatabase || isDeletingTable}
-			/>
+			{canManageBrowseInstance && (<div className="flex flex-col gap-2">
+				{selectedDatabaseName?.length && (
+					<CreateNewTableModal
+						databaseName={selectedDatabaseName}
+						onSelectTable={onSelectTable}
+					/>)}
+
+				<CreateNewDatabaseModal
+					onSelectDatabase={onSelectDatabase}
+					isCreatingDatabase={isCreatingDatabase}
+					setIsCreatingDatabase={setIsCreatingDatabase}
+				/>
+
+				{selectedDatabaseName?.length && (<>
+					<div aria-hidden="true" className="w-full border-t border-gray-700 dark:border-white/15 my-4" />
+					<DeleteDatabaseModal
+						databaseName={selectedDatabaseName}
+						onDeleted={onDatabaseDeleted}
+					/>
+				</>)}
+			</div>)}
 		</div>
 	);
 }

--- a/src/features/instance/browse/index.tsx
+++ b/src/features/instance/browse/index.tsx
@@ -13,7 +13,7 @@ export function Browse() {
 			<section className="col-span-1 text-white md:col-span-4 lg:col-span-3">
 				<BrowseSidebar />
 			</section>
-			<section className="col-span-1 text-white md:col-span-8 lg:col-span-9">
+			<section className="col-span-1 text-white md:col-span-8 lg:col-span-9 flex flex-col">
 				{!databaseName ? (
 					<div className="flex items-center justify-center h-full">
 						<p className="pt-2 text-sm text-center">Please select a database.</p>
@@ -25,8 +25,7 @@ export function Browse() {
 				) : (
 					<Suspense
 						fallback={
-							<Loading className="flex flex-col items-center justify-center h-full"
-								text="Loading Data Table" />
+							<Loading centered text="Loading Data Table" />
 						}
 					>
 						<Outlet />

--- a/src/features/instance/browse/modals/AddTableRowModal.tsx
+++ b/src/features/instance/browse/modals/AddTableRowModal.tsx
@@ -25,7 +25,9 @@ export function AddTableRowModal({
 			onSaveChanges(JSON.parse(addTableRecordData));
 		}
 	}, [addTableRecordData, onSaveChanges, isValidJSON]);
+	const [madeChanges, setMadeChanges] = useState(false);
 	const onValidate = useCallback((markers: unknown[]) => {
+		setMadeChanges(true);
 		setIsValidJSON(markers.length === 0);
 	}, [setIsValidJSON]);
 	const sampleJSON = useMemo(() => {
@@ -42,7 +44,9 @@ export function AddTableRowModal({
 	return <Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
 		{/* NOTE - Is this okay to do for the aria describedby? */}
 		<DialogContent aria-describedby={undefined} onEscapeKeyDown={(event) => {
-			event.preventDefault();
+			if (madeChanges) {
+				event.preventDefault();
+			}
 		}}>
 			<DialogHeader>
 				<DialogTitle>Add New {instanceTable.name}</DialogTitle>

--- a/src/features/instance/browse/modals/CreateNewDatabaseModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewDatabaseModal.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog';
+import { Form } from '@/components/ui/form/Form';
+import { FormControl } from '@/components/ui/form/FormControl';
+import { FormField } from '@/components/ui/form/FormField';
+import { FormItem } from '@/components/ui/form/FormItem';
+import { FormLabel } from '@/components/ui/form/FormLabel';
+import { FormMessage } from '@/components/ui/form/FormMessage';
+import { Input } from '@/components/ui/input';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useCreateDatabaseSubmitMutation } from '@/features/instance/operations/mutations/createDatabase';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { Plus, Table } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+const NewDatabaseSchema = z.object({
+	databaseName: z
+		.string({
+			message: 'Please enter a valid database name.',
+		})
+		.min(1, { message: 'Database name is required' })
+		.max(75, { message: 'Database name must be less than 75 characters' })
+		.regex(/^[a-zA-Z0-9_]+$/, { message: 'Database name can only contain letters, numbers, and underscores' }),
+});
+
+export function CreateNewDatabaseModal({
+	onSelectDatabase,
+	isCreatingDatabase,
+	setIsCreatingDatabase,
+}: {
+	readonly onSelectDatabase: (databaseName: string | undefined) => void;
+	readonly isCreatingDatabase: boolean;
+	readonly setIsCreatingDatabase: (isCreating: boolean) => void;
+}) {
+	const queryClient = useQueryClient();
+	const instanceParams = useInstanceClientIdParams();
+	const router = useRouter();
+	const form = useForm({
+		resolver: zodResolver(NewDatabaseSchema),
+		defaultValues: {
+			databaseName: '',
+		},
+	});
+
+	const { mutate: createNewDatabase } = useCreateDatabaseSubmitMutation();
+
+	const submitForm = async (formData: z.infer<typeof NewDatabaseSchema>) => {
+		createNewDatabase({
+			databaseName: formData.databaseName,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
+			onSuccess: async () => {
+				await queryClient.invalidateQueries({
+					queryKey: [instanceParams.entityId, 'describe_all'],
+					refetchType: 'all',
+				});
+				toast.success(`Database ${formData.databaseName} created successfully`);
+				setIsCreatingDatabase(false);
+				form.reset();
+				onSelectDatabase(formData.databaseName);
+				await router.invalidate();
+			},
+		});
+	};
+
+	return (
+		<Dialog open={isCreatingDatabase} onOpenChange={setIsCreatingDatabase}>
+			<DialogTrigger asChild>
+				<Button variant="positiveOutline" className="w-full rounded-full" size="lg" accessKey="d">
+					<Plus />
+					<span>
+						Create a <u>D</u>atabase
+					</span>
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-[425px]">
+				<DialogHeader>
+					<DialogTitle>Create a New Database</DialogTitle>
+					<DialogDescription>
+						What would you like to name your first database?
+					</DialogDescription>
+				</DialogHeader>
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(submitForm)} className="grid gap-6 text-white">
+						<FormField
+							control={form.control}
+							name="databaseName"
+							render={({ field }) => (
+								<FormItem className="">
+									<FormLabel className="pb-1">Database Name</FormLabel>
+									<FormControl>
+										<Input type="text" placeholder="ex. Data" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<DialogFooter>
+							<Button type="submit" variant="submit" className="rounded-full">
+								<Table />
+								Create New Database
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/instance/browse/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewTableModal.tsx
@@ -88,8 +88,9 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 	return (
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
 			<DialogTrigger asChild>
-				<Button variant="positiveOutline" className="w-full rounded-full" size="lg">
-					<Plus /> Create a Table
+				<Button variant="positiveOutline" className="w-full rounded-full" size="lg" accessKey="t">
+					<Plus />
+					<span>Create a <u>T</u>able</span>
 				</Button>
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-[425px]">

--- a/src/features/instance/browse/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewTableModal.tsx
@@ -16,15 +16,15 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { Plus, Table } from 'lucide-react';
-import { useForm } from 'react-hook-form';
-import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useCreateTableMutation } from '@/features/instance/operations/mutations/createTable';
-import { toast } from 'sonner';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
+import { Plus, Table } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
 
 const CreateTableSchema = z.object({
 	tableName: z

--- a/src/features/instance/browse/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/browse/modals/CreateNewTableModal.tsx
@@ -40,10 +40,7 @@ const CreateTableSchema = z.object({
 		}),
 	primaryKey: z
 		.string()
-		.min(1, {
-			message: 'Primary key is required.',
-		})
-		.regex(/^[a-zA-Z0-9_]+$/, {
+		.regex(/^[a-zA-Z0-9_]*$/, {
 			message: 'Primary key can only contain letters, numbers, and underscores.',
 		})
 		.max(14, {
@@ -70,13 +67,13 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 	const { mutate: submitNewTableData } = useCreateTableMutation();
 
 	const submitForm = async (formData: z.infer<typeof CreateTableSchema>) => {
-		const updatedFormData = {
-			...formData,
-			...instanceParams,
+		submitNewTableData({
+			tableName: formData.tableName,
+			primaryKey: formData.primaryKey || 'id',
 			databaseName,
+			...instanceParams,
 			replicated: instanceParams.entityType === 'cluster',
-		};
-		submitNewTableData(updatedFormData, {
+		}, {
 			onSuccess: async () => {
 				await queryClient.invalidateQueries({ queryKey: [instanceParams.entityId, 'describe_all'], refetchType: 'all' });
 				toast.success(`Table ${formData.tableName} created successfully`);
@@ -124,7 +121,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 								<FormItem className="">
 									<FormLabel className="pb-1">Primary Key</FormLabel>
 									<FormControl>
-										<Input type="text" placeholder="ex. id" {...field} />
+										<Input type="text" placeholder="id" {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/src/features/instance/browse/modals/DeleteDatabaseModal.tsx
+++ b/src/features/instance/browse/modals/DeleteDatabaseModal.tsx
@@ -1,0 +1,66 @@
+import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
+import { Button } from '@/components/ui/button';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useDeleteDatabaseMutation } from '@/features/instance/operations/mutations/deleteDatabase';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { Trash } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+export function DeleteDatabaseModal({ databaseName, onDeleted }: {
+	readonly databaseName: string;
+	readonly onDeleted: () => void;
+}) {
+	const canManageBrowseInstance = useInstanceBrowseManagePermission();
+	const queryClient = useQueryClient();
+	const instanceParams = useInstanceClientIdParams();
+	const router = useRouter();
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	const { mutate: deleteDatabase, isPending: isDeletingDatabase } = useDeleteDatabaseMutation();
+
+	const onDeleteDatabase = useCallback(() => {
+		deleteDatabase({
+			databaseName,
+			...instanceParams,
+			replicated: instanceParams.entityType === 'cluster',
+		}, {
+			onSuccess: async () => {
+				setIsModalOpen(false);
+				await queryClient.invalidateQueries({
+					queryKey: [instanceParams.entityId, 'describe_all'],
+					refetchType: 'all',
+				});
+				await router.invalidate();
+				toast.success(`Database ${databaseName} deleted successfully`);
+				onDeleted();
+			},
+		});
+	}, [databaseName, deleteDatabase, instanceParams, onDeleted, queryClient, router]);
+
+	if (!canManageBrowseInstance || !databaseName) {
+		return <></>;
+	}
+
+	return (
+		<ConfirmDeletionModal
+			typeOfThingBeingDeleted="database"
+			nameOfThingBeingDeleted={databaseName}
+			isModalOpen={isModalOpen}
+			setIsModalOpen={setIsModalOpen}
+			deletionConfirmed={onDeleteDatabase}
+			deletionPending={isDeletingDatabase}
+			trigger={<Button
+				className="w-full rounded-full"
+				size="sm"
+				aria-label="Delete selected database"
+				variant="destructiveOutline"
+				disabled={isDeletingDatabase}
+				onClick={() => setIsModalOpen(true)}
+			>
+				<Trash /> Drop Database
+			</Button>}
+		/>
+	);
+}

--- a/src/features/instance/browse/modals/EditTableRowModal.tsx
+++ b/src/features/instance/browse/modals/EditTableRowModal.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import Editor from '@monaco-editor/react';
 import { Save, Trash } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 export function EditTableRowModal({
 	canEditRecords,
@@ -29,12 +29,18 @@ export function EditTableRowModal({
 	isDeleteTableRecordsPending: boolean;
 }) {
 	const [isValidJSON, setIsValidJSON] = useState(true);
+	const [madeChanges, setMadeChanges] = useState(false);
 	const [updatedTableRecordData, setUpdatedTableRecordData] = useState<string>();
+
 	const value = useMemo(() => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const dataWithoutTimes = data?.map(({ __createdtime__, __updatedtime__, ...rowWithoutTime  }) => rowWithoutTime);
+		const dataWithoutTimes = data?.map(({ __createdtime__, __updatedtime__, ...rowWithoutTime }) => rowWithoutTime);
 		return JSON.stringify(dataWithoutTimes, null, 4);
 	}, [data]);
+	const onValidate = useCallback((markers: unknown[]) => {
+		setMadeChanges(true);
+		setIsValidJSON(markers.length === 0);
+	}, [setIsValidJSON]);
 
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
@@ -42,7 +48,9 @@ export function EditTableRowModal({
 			<DialogContent
 				aria-describedby={undefined}
 				onEscapeKeyDown={canEditRecords ? (event) => {
-					event.preventDefault();
+					if (madeChanges) {
+						event.preventDefault();
+					}
 				} : undefined}
 			>
 				<DialogHeader>
@@ -55,9 +63,7 @@ export function EditTableRowModal({
 						theme="vs-dark"
 						options={canEditRecords ? undefined : { readOnly: true }}
 						value={value}
-						onValidate={(markers) => {
-							setIsValidJSON(markers.length === 0);
-						}}
+						onValidate={onValidate}
 						onChange={(updatedValue) => {
 							setUpdatedTableRecordData(updatedValue);
 						}}

--- a/src/lib/addCommasToNumbers.test.ts
+++ b/src/lib/addCommasToNumbers.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { addCommasToNumbers } from './addCommasToNumbers';
+
+// We mock Intl.NumberFormat to avoid locale-dependent output differences
+// and to verify that the function calls it without custom options.
+
+// Preserve original reference to restore after tests
+const OriginalIntl = globalThis.Intl;
+
+let lastConstructorArgs: unknown[] | null = null;
+
+class MockNumberFormat {
+	// Capture the constructor args to ensure defaults are used
+	constructor(...args: unknown[]) {
+		lastConstructorArgs = args;
+	}
+
+	format(n: number): string {
+		// Deterministic comma insertion for thousands separators
+		const sign = n < 0 ? '-' : '';
+		const abs = Math.abs(n);
+		const str = abs.toString();
+		const [intPart, fracPart] = str.split('.');
+		const intWithCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+		return sign + intWithCommas + (fracPart ? `.${fracPart}` : '');
+	}
+}
+
+beforeAll(() => {
+	// Replace only NumberFormat, keep the rest of Intl intact
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(globalThis as any).Intl = { ...OriginalIntl, NumberFormat: MockNumberFormat };
+});
+
+afterAll(() => {
+	// Restore original Intl
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(globalThis as any).Intl = OriginalIntl;
+});
+
+describe('addCommasToNumbers', () => {
+	it('uses Intl.NumberFormat with default arguments', () => {
+		lastConstructorArgs = null;
+		const out = addCommasToNumbers(1234);
+		expect(out).toBe('1,234');
+		// Default constructor should receive no arguments
+		expect(lastConstructorArgs).toEqual([]);
+	});
+
+	it('formats small integers and zero', () => {
+		expect(addCommasToNumbers(0)).toBe('0');
+		expect(addCommasToNumbers(5)).toBe('5');
+		expect(addCommasToNumbers(12)).toBe('12');
+		expect(addCommasToNumbers(999)).toBe('999');
+	});
+
+	it('adds thousands separators for large integers', () => {
+		expect(addCommasToNumbers(1000)).toBe('1,000');
+		expect(addCommasToNumbers(1234567)).toBe('1,234,567');
+		expect(addCommasToNumbers(1234567890123)).toBe('1,234,567,890,123');
+	});
+
+	it('handles negative numbers and decimals', () => {
+		expect(addCommasToNumbers(-1)).toBe('-1');
+		expect(addCommasToNumbers(-1234)).toBe('-1,234');
+		expect(addCommasToNumbers(1234.5)).toBe('1,234.5');
+		expect(addCommasToNumbers(-9876543.21)).toBe('-9,876,543.21');
+	});
+
+	it('returns a string type', () => {
+		const result = addCommasToNumbers(42);
+		expect(typeof result).toBe('string');
+	});
+});

--- a/src/lib/addCommasToNumbers.ts
+++ b/src/lib/addCommasToNumbers.ts
@@ -1,0 +1,3 @@
+export function addCommasToNumbers(input: number): string {
+	return new Intl.NumberFormat().format(input);
+}

--- a/src/lib/humanNumber.ts
+++ b/src/lib/humanNumber.ts
@@ -1,3 +1,5 @@
+import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
+
 const units = ['K', 'M', 'B', 'T', 'Qa', 'Qi', 'Sx', 'Sp', 'Oc', 'No', 'Dc'];
 
 export function humanNumber(input: number): string {
@@ -16,5 +18,5 @@ export function humanNumber(input: number): string {
 		++u;
 	} while (Math.round(Math.abs(value) * r) / r >= thresh && u < units.length - 1);
 
-	return `${new Intl.NumberFormat().format(Math.round(value))} ${units[u]}`;
+	return `${addCommasToNumbers(Math.round(value))} ${units[u]}`;
 }


### PR DESCRIPTION
I made a few improvements to the browse page:

1. The "[primaryKey](https://harperdb.atlassian.net/browse/STUDIO-288)" when creating a table is now optional, and it will default to "id" (which is the placeholder).
2. The [current and total pages](https://harperdb.atlassian.net/browse/STUDIO-310) will now show up in the footer.
3. I de-prioritized the database and table deletion buttons, moving them away from the most important sight lines.
4. I used all of the available viewport, fixing the header and footer in place and scrolling the table when we have more records than we can show on the screen (except at smaller viewports).
5. The database creation is now in a modal, which will pop open automatically once when you have 0 databases.
6. I added access keys for creating databases, tables, and records.
7. When creating or editing a record, if you don't make changes, you can hit ESC to close the modal.


<img width="1500" height="1307" alt="1-please-createa-a-database" src="https://github.com/user-attachments/assets/46c04f99-231d-4946-a2b4-fe568cfa32e3" />
<img width="1500" height="1307" alt="2-create-a-database" src="https://github.com/user-attachments/assets/81586a0f-474a-4b19-bb37-da5dc9e3d841" />
<img width="1500" height="1307" alt="3-create-a-table" src="https://github.com/user-attachments/assets/c2c129b6-34d9-4cb0-a42b-4f80c7adccbb" />
<img width="1500" height="1307" alt="4-browsing-data" src="https://github.com/user-attachments/assets/56e99475-c164-4409-a7d9-2798e7b86252" />


