### PR TITLE
Stubs for Edit Cluster

### DIFF
--- a/.github/workflows/deploy-fabric-dev.yaml
+++ b/.github/workflows/deploy-fabric-dev.yaml
@@ -2,7 +2,7 @@ name: Deploy Fabric Dev
 on:
   workflow_dispatch:
 jobs:
-  deployToStage:
+  deployToDev:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-fabric-prod.yaml
+++ b/.github/workflows/deploy-fabric-prod.yaml
@@ -2,7 +2,7 @@ name: Deploy Fabric Prod
 on:
   workflow_dispatch:
 jobs:
-  deployToStage:
+  deployToProd:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/verify-fabric-pr.yaml
+++ b/.github/workflows/verify-fabric-pr.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [harper/fabric]
 jobs:
-  deployToStage:
+  verifyFabricPR:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/src/AppRouted.tsx
+++ b/src/AppRouted.tsx
@@ -15,6 +15,7 @@ export function AppRouted() {
 		defaultNotFoundComponent: NotFoundComponent,
 		defaultErrorComponent: ErrorComponent,
 		defaultPreload: 'intent',
+		trailingSlash: 'never',
 		// Since we're using React Query, we don't want loader calls to ever be stale
 		// This will ensure that the loader is always called when the route is preloaded or visited
 		defaultPreloadStaleTime: 0,

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -21,10 +21,13 @@ export function Breadcrumbs() {
 			const route = routeHistory[index];
 			const path = `/${routeHistory.slice(0, index + 1).join('/')}`;
 			let name = capitalizeWords(route);
+			let id: string | undefined;
 			if (name.startsWith('Org ')) {
+				id = route.split('org-').pop();
 				name = 'Org';
 			}
 			else if (name.startsWith('Clu ')) {
+				id = route.split('clu-').pop();
 				name = 'Cluster';
 			}
 
@@ -37,6 +40,7 @@ export function Breadcrumbs() {
 					className="text-xs md:text-sm font-medium hover:text-grey"
 				>
 					{name}
+					{id && <div className="text-gray-500 text-xs">{id}</div>}
 				</Link>,
 			);
 		}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,3 +1,4 @@
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { Link, useLocation } from '@tanstack/react-router';
 import { HomeIcon } from 'lucide-react';
 import { useMemo } from 'react';
@@ -18,12 +19,14 @@ export function Breadcrumbs() {
 		// Start at 1 to skip over the first top level route. The home icon will cover that.
 		for (let index = 1; index < routeHistory.length; index++) {
 			const route = routeHistory[index];
-			const name = route.startsWith('org-')
-				? 'Org'
-				: route.startsWith('clu-')
-					? 'Cluster'
-					: route.slice(0, 1).toUpperCase() + route.slice(1);
 			const path = `/${routeHistory.slice(0, index + 1).join('/')}`;
+			let name = capitalizeWords(route);
+			if (name.startsWith('Org ')) {
+				name = 'Org';
+			}
+			else if (name.startsWith('Clu ')) {
+				name = 'Cluster';
+			}
 
 			breadcrumbs.push(
 				<svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-5 shrink-0 text-grey">

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,50 @@
+import { Link, useLocation } from '@tanstack/react-router';
+import { HomeIcon } from 'lucide-react';
+import { useMemo } from 'react';
+
+export function Breadcrumbs() {
+	const location = useLocation();
+	const breadcrumbs = useMemo(() => {
+		const routeHistory = location.pathname.split('/')
+			.filter((x) => x && x.length > 0);
+
+		const breadcrumbs = [
+			<Link to="/">
+				<HomeIcon aria-hidden="true" className="size-5 shrink-0" />
+				<span className="sr-only">Home</span>
+			</Link>,
+		];
+
+		// Start at 1 to skip over the first top level route. The home icon will cover that.
+		for (let index = 1; index < routeHistory.length; index++) {
+			const route = routeHistory[index];
+			const name = route.startsWith('org-')
+				? 'Org'
+				: route.startsWith('clu-')
+					? 'Cluster'
+					: route.slice(0, 1).toUpperCase() + route.slice(1);
+			const path = `/${routeHistory.slice(0, index + 1).join('/')}`;
+
+			breadcrumbs.push(
+				<svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-5 shrink-0 text-grey">
+					<path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+				</svg>,
+				<Link
+					to={path}
+					className="text-xs md:text-sm font-medium hover:text-grey"
+				>
+					{name}
+				</Link>,
+			);
+		}
+
+		return breadcrumbs;
+	}, [location.pathname]);
+
+
+	return (
+		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4">
+			{...breadcrumbs}
+		</div>
+	);
+}

--- a/src/components/SubNavMenu.tsx
+++ b/src/components/SubNavMenu.tsx
@@ -1,55 +1,11 @@
-import { Link, ParsedLocation, useLocation } from '@tanstack/react-router';
-import { HomeIcon } from 'lucide-react';
+import { Breadcrumbs } from '@/components/Breadcrumbs';
+import { ReactNode } from 'react';
 
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createBreadcrumbs(location: ParsedLocation<any>) {
-
-	const route_history = location.pathname.split('/').filter((x) => x && x.length > 0);
-
-	return route_history.map((route, index) => {
-		const path = `/${route_history.slice(0, index + 1).join('/')}`;
-		return { name: route, path };
-	});
-}
-
-export function SubNavMenu({ children }: { children?: React.ReactNode }) {
-	const location = useLocation();
-
-	const breadcrumb_routes = createBreadcrumbs(location);
-	
-  //NOTE: Removes the organization id from the breadcrumb
-	breadcrumb_routes.splice(1, 1);
-
+export function SubNavMenu({ children }: { children?: ReactNode }) {
 	return (
-		<nav className="fixed top-20 w-full  md:h-12 z-39 py-2 px-4 md:px-12 bg-grey-700">
+		<nav className="fixed top-20 w-full md:h-12 z-39 py-2 px-4 md:px-12 bg-grey-700">
 			<div className="md:flex items-center h-full space-x-8">
-				<ol role="list" className="flex items-center space-x-0 md:space-x-4 pb-2">
-					<li>
-						<div>
-							<Link to="/">
-								<HomeIcon aria-hidden="true" className="size-5 shrink-0" />
-								<span className="sr-only">Home</span>
-							</Link>
-						</div>
-					</li>
-					{breadcrumb_routes.map((page) => (
-						<li key={page.name}>
-							<div className="flex items-center">
-								<svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-5 shrink-0 text-grey">
-									<path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-								</svg>
-								<Link
-									to={page.path}
-									aria-current={page.name ? 'page' : undefined}
-									className="ml-4 text-xs md:text-sm font-medium hover:text-grey"
-								>
-									{page.name}
-								</Link>
-							</div>
-						</li>
-					))}
-				</ol>
+				<Breadcrumbs />
 				{children}
 			</div>
 		</nav>

--- a/src/features/cluster/ClusterInstanceSignIn.tsx
+++ b/src/features/cluster/ClusterInstanceSignIn.tsx
@@ -97,7 +97,7 @@ export function ClusterInstanceSignIn() {
 	}, [cluster, instance, instanceClient, navigate, noun, operationsUrl, redirect, router, submitInstanceLogin]);
 
 	if (cluster?.resetPassword) {
-		return <Navigate to="../set-password" />;
+		return <Navigate to="../set-password" replace={true} />;
 	}
 
 	return (

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -94,7 +94,7 @@ export function ClusterSetPassword() {
 	}, [cluster, clusterId, instanceClient, navigate, operationsUrl, redirect, router, submitInstanceResetPassword, tempPassword]);
 
 	if (cluster && !cluster.resetPassword) {
-		return <Navigate to="../sign-in" />;
+		return <Navigate to="../sign-in" replace={true} />;
 	}
 
 	// TODO: There's a lot we can DRY up between the sign in form variants.

--- a/src/features/cluster/index.tsx
+++ b/src/features/cluster/index.tsx
@@ -1,4 +1,5 @@
 import { DataTable } from '@/components/DataTable';
+import { SubNavMenu } from '@/components/SubNavMenu';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -80,16 +81,7 @@ export function ClusterIndex() {
 	);
 	return (
 		<>
-			<nav className="fixed top-20 w-full h-12 z-39 px-4 md:px-12 bg-grey-700">
-				{cluster?.instances?.length ? (
-					<div className="flex items-center justify-between h-full text-sm text-white">
-						<div className="w-full text-white">
-							<h2 className="text-xl font-semibold">{cluster.name}</h2>
-							<p className="text-xs md:text-sm">Cluster ID: {clusterId}</p>
-						</div>
-					</div>
-				) : null}
-			</nav>
+			<SubNavMenu />
 			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<Card className="p-0 mt-4 min-h-96">
 					<CardContent className="p-0 min-h-96">

--- a/src/features/clusters/EditCluster.tsx
+++ b/src/features/clusters/EditCluster.tsx
@@ -1,7 +1,13 @@
+import { Loading } from '@/components/Loading';
+import { SubNavMenu } from '@/components/SubNavMenu';
+
 export function EditCluster() {
-  return (
-    <div>
-      <h1>Edit Cluster Modal</h1>
-    </div>
-  )
+	return (
+		<>
+			<SubNavMenu />
+			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+				<Loading className="mt-36" centered={true} text="Still setting this up..." />
+			</div>
+		</>
+	);
 }

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -15,9 +15,11 @@ import { onInstanceLogoutSubmit } from '@/features/instance/operations/mutations
 import { useInstanceAuth } from '@/hooks/useAuth';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
+import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { authStore } from '@/lib/authStore';
+import { notYetImplemented } from '@/lib/notYetImplemented';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
-import { useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { Ellipsis } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 
@@ -33,15 +35,12 @@ export function ClusterCard({
 }) {
 	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
 	const auth = useInstanceAuth(cluster.id);
-	const navigate = useNavigate();
 
-	const isReadyForInteraction = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster]);
-	const canDelete = useMemo(() => remove && cluster.status && !deletedClusterStatuses.includes(cluster.status), [cluster.status, remove]);
-
+	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
+	const notTerminated = useMemo(() => cluster.status && !deletedClusterStatuses.includes(cluster.status), [cluster.status]);
 	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
 	const instanceClient = useInstanceClient(operationsUrl);
 
-	const onInstancesClick = useCallback(() => navigate({ to: cluster.id }), [navigate, cluster]);
 	const onSignOutClick = useCallback(async () => {
 		await onInstanceLogoutSubmit({ instanceClient });
 		authStore.setUserForEntity(cluster, null);
@@ -56,12 +55,28 @@ export function ClusterCard({
 		onDeleteClusterModal(cluster);
 	}, [cluster, onDeleteClusterModal]);
 
+	const menuItems = [
+		isActive && update && (
+			<DropdownMenuItem onClick={notYetImplemented}>Edit</DropdownMenuItem>),
+		isActive && view && (
+			<Link to={cluster.id}><DropdownMenuItem>Instances</DropdownMenuItem></Link>),
+		isActive && view && !!operationsUrl && !auth.isLoading && auth.user && (
+			<DropdownMenuItem onClick={onSignOutClick}>Sign Out</DropdownMenuItem>),
+		notTerminated && remove && (
+			<DropdownMenuItem
+				className="bg-red focus:bg-red/70 focus:text-white"
+				onClick={onDeleteClick}>
+				Delete
+			</DropdownMenuItem>
+		),
+	].filter(excludeFalsy);
+
 	return (
 		<Card className="relative">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
 					<span className="truncate">{cluster.id}</span>
-					{(isReadyForInteraction && (view || update) || canDelete) && (<DropdownMenu>
+					<DropdownMenu>
 						<DropdownMenuTrigger>
 							<Ellipsis aria-label="Cluster options" />
 						</DropdownMenuTrigger>
@@ -75,22 +90,12 @@ export function ClusterCard({
 									: <Badge variant="warning">OFF</Badge>}
 								</DropdownMenuLabel>
 							))}
-							<DropdownMenuSeparator />
-							<DropdownMenuLabel className="text-gray-600 text-xs">Options</DropdownMenuLabel>
-							{isReadyForInteraction && view && (
-								<DropdownMenuItem onClick={onInstancesClick}>Instances</DropdownMenuItem>)}
-							{isReadyForInteraction && view && !!operationsUrl && !auth.isLoading && auth.user && (
-								<DropdownMenuItem onClick={onSignOutClick}>Sign Out</DropdownMenuItem>)}
-							{/*{isReadyForInteraction && update && (<DropdownMenuItem>Edit</DropdownMenuItem>)}*/}
-							{canDelete && (
-								<DropdownMenuItem
-									className="bg-red focus:bg-red/70 focus:text-white"
-									onClick={onDeleteClick}>
-									Delete
-								</DropdownMenuItem>
-							)}
+							{menuItems.length > 0 && (<>
+								<DropdownMenuSeparator />
+								{...menuItems}
+							</>)}
 						</DropdownMenuContent>
-					</DropdownMenu>)}
+					</DropdownMenu>
 				</CardDescription>
 				<CardTitle>
 					<h2>{cluster.name}</h2>
@@ -99,7 +104,7 @@ export function ClusterCard({
 			<CardContent className="flex justify-between">
 				{cluster.status && (
 					<Badge variant={renderBadgeStatusVariant(cluster.status)}>{renderBadgeStatusText(cluster.status)}</Badge>)}
-				{isReadyForInteraction && view && (<ClusterCardAction cluster={cluster} />)}
+				{isActive && view && (<ClusterCardAction cluster={cluster} />)}
 			</CardContent>
 		</Card>
 	);

--- a/src/features/clusters/index.tsx
+++ b/src/features/clusters/index.tsx
@@ -1,7 +1,0 @@
-import { Outlet } from '@tanstack/react-router';
-
-export function ClustersLayoutComponent() {
-	return <Outlet />;
-}
-
-

--- a/src/features/clusters/routes.ts
+++ b/src/features/clusters/routes.ts
@@ -1,12 +1,10 @@
-import { createRoute } from '@tanstack/react-router';
-import { ClustersLayoutComponent } from '@/features/clusters/index';
 import { ClustersList as ClusterList } from '@/features/clusters/ClustersList';
 import { orgLayoutRoute } from '@/features/organization/routes';
+import { createRoute } from '@tanstack/react-router';
 
 export const clustersLayoutRoute = createRoute({
 	getParentRoute: () => orgLayoutRoute,
-	path: 'clusters',
-	component: ClustersLayoutComponent,
+	id: '_orgLayout',
 });
 
 const clustersIndexRoute = createRoute({

--- a/src/features/clusters/routes.ts
+++ b/src/features/clusters/routes.ts
@@ -1,4 +1,5 @@
 import { ClustersList as ClusterList } from '@/features/clusters/ClustersList';
+import { EditCluster } from '@/features/clusters/EditCluster';
 import { orgLayoutRoute } from '@/features/organization/routes';
 import { createRoute } from '@tanstack/react-router';
 
@@ -13,6 +14,20 @@ const clustersIndexRoute = createRoute({
 	component: ClusterList,
 });
 
+const newClusterRoute = createRoute({
+	getParentRoute: () => orgLayoutRoute,
+	path: '/new-cluster',
+	component: EditCluster,
+});
+
+const editClusterRoute = createRoute({
+	getParentRoute: () => orgLayoutRoute,
+	path: '$clusterId/edit',
+	component: EditCluster,
+});
+
 export const clustersRoutes = [
 	clustersIndexRoute,
+	newClusterRoute,
+	editClusterRoute,
 ];

--- a/src/features/instance/InstanceNavBar.tsx
+++ b/src/features/instance/InstanceNavBar.tsx
@@ -1,4 +1,4 @@
-import { createBreadcrumbs } from '@/components/SubNavMenu';
+import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -9,39 +9,14 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
 import { useInstanceManagePermission } from '@/hooks/usePermissions';
-import { Link, useLocation } from '@tanstack/react-router';
-import { ChartBarBig, GaugeIcon, HomeIcon, List, Menu, NotepadText, Package } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { ChartBarBig, GaugeIcon, List, Menu, NotepadText, Package } from 'lucide-react';
 
-function DesktopInstanceNavBar({ breadcrumb_routes }: { breadcrumb_routes: { name: string; path: string }[] }) {
+function DesktopInstanceNavBar() {
 	const canManage = useInstanceManagePermission();
 	return (
 		<div className="hidden md:flex items-center justify-between h-full text-sm text-white">
-			<ol role="list" className="flex items-center space-x-0 md:space-x-2 pb-2">
-					<li>
-						<div>
-							<Link to="/">
-								<HomeIcon aria-hidden="true" className="size-5 shrink-0" />
-								<span className="sr-only">Home</span>
-							</Link>
-						</div>
-					</li>
-					{breadcrumb_routes.map((page) => (
-						<li key={page.name}>
-							<div className="flex items-center">
-								<svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-5 shrink-0 text-grey">
-									<path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-								</svg>
-								<Link
-									to={page.path}
-									aria-current={page.name ? 'page' : undefined}
-									className="ml-4 text-xs md:text-sm font-medium hover:text-grey"
-								>
-									{page.name}
-								</Link>
-							</div>
-						</li>
-					))}
-				</ol>
+			<Breadcrumbs />
 			<div className="flex space-x-2 *:hover:text-grey">
 				<Link to="browse" className="p-2">
 					<List className="inline-block" /> Browse
@@ -67,37 +42,12 @@ function DesktopInstanceNavBar({ breadcrumb_routes }: { breadcrumb_routes: { nam
 	);
 }
 
-function MobileInstanceNavBar({breadcrumb_routes}: {breadcrumb_routes: { name: string; path: string }[]}) {
+function MobileInstanceNavBar() {
 	const canManage = useInstanceManagePermission();
 	return (
 		<>
 		<div className="flex md:hidden items-center justify-between p-2 text-white">
-			<ol role="list" className="flex items-center space-x-0pb-2">
-					<li>
-						<div>
-							<Link to="/">
-								<HomeIcon aria-hidden="true" className="size-5 shrink-0" />
-								<span className="sr-only">Home</span>
-							</Link>
-						</div>
-					</li>
-					{breadcrumb_routes.map((page) => (
-						<li key={page.name}>
-							<div className="flex items-center">
-								<svg fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" className="size-5 shrink-0 text-grey">
-									<path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-								</svg>
-								<Link
-									to={page.path}
-									aria-current={page.name ? 'page' : undefined}
-									className=" text-xs font-medium hover:text-grey"
-								>
-									{page.name}
-								</Link>
-							</div>
-						</li>
-					))}
-				</ol>
+			<Breadcrumbs />
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<Button variant="ghost" className="p-0">
@@ -134,14 +84,10 @@ function MobileInstanceNavBar({breadcrumb_routes}: {breadcrumb_routes: { name: s
 }
 
 export function InstanceNavBar() {
-	const location = useLocation();
-	const breadcrumb_routes = createBreadcrumbs(location);
-	breadcrumb_routes.splice(1, 1);
-	breadcrumb_routes.splice(2, 1);
 	return (
 		<>
-			<DesktopInstanceNavBar breadcrumb_routes={breadcrumb_routes} />
-			<MobileInstanceNavBar breadcrumb_routes={breadcrumb_routes} />
+			<DesktopInstanceNavBar />
+			<MobileInstanceNavBar />
 		</>
 	);
 }

--- a/src/features/instance/browse/route.load.ts
+++ b/src/features/instance/browse/route.load.ts
@@ -40,7 +40,7 @@ export async function loadInstanceBrowseData(
 			.filter(Boolean)
 			.join('/');
 		if (!preload) {
-			throw redirect({ to });
+			throw redirect({ to, replace: true });
 		}
 	}
 	return data;

--- a/src/features/instance/instanceLayoutRoute.ts
+++ b/src/features/instance/instanceLayoutRoute.ts
@@ -21,7 +21,7 @@ export function createInstanceLayoutRoute(mode: 'local' | 'cluster' | 'instance'
 			beforeLoad: async ({ context, params }) => {
 				const auth = context.authentication[params.clusterId];
 				if (!auth || (!auth.isLoading && !auth.user)) {
-					const to = `/orgs/${params.organizationId}/clusters/${params.clusterId}/sign-in`;
+					const to = `/orgs/${params.organizationId}/${params.clusterId}/sign-in`;
 					throw redirect({ to, search: { redirect: currentUrlAfterHash() } });
 				}
 				return await context.queryClient.ensureQueryData(getInstanceInfoQueryOptions(params));
@@ -35,7 +35,7 @@ export function createInstanceLayoutRoute(mode: 'local' | 'cluster' | 'instance'
 		beforeLoad: async ({ context, params }) => {
 			const auth = context.authentication[params.instanceId];
 			if (!auth || (!auth.isLoading && !auth.user)) {
-				const to = `/orgs/${params.organizationId}/clusters/${params.clusterId}/instance/${params.instanceId}/sign-in`;
+				const to = `/orgs/${params.organizationId}/${params.clusterId}/instance/${params.instanceId}/sign-in`;
 				throw redirect({ to, search: { redirect: currentUrlAfterHash() } });
 			}
 			return await context.queryClient.ensureQueryData(getInstanceInfoQueryOptions(params));

--- a/src/features/organization/OrganizationLayout.tsx
+++ b/src/features/organization/OrganizationLayout.tsx
@@ -1,5 +1,0 @@
-import { Outlet } from '@tanstack/react-router';
-
-export function OrganizationLayout() {
-	return <Outlet />;
-}

--- a/src/features/organization/billing/confirm/ProcessSetupIntent.tsx
+++ b/src/features/organization/billing/confirm/ProcessSetupIntent.tsx
@@ -21,7 +21,7 @@ export function ProcessSetupIntent() {
 	const stripe = useStripe();
 	const processStripePaymentMethod = useProcessStripePaymentMethod(organizationId);
 	const navigateBack = useCallback(() => {
-		const to = savedClusterState ? '../../clusters' : '../';
+		const to = savedClusterState ? '../../' : '../';
 		window.history.replaceState(null, '', currentUrlIncludingHash());
 		void navigate({ search: undefined, to });
 	}, [navigate, savedClusterState]);

--- a/src/features/organization/routes.ts
+++ b/src/features/organization/routes.ts
@@ -1,6 +1,4 @@
 import { createBillingRouteTree } from '@/features/organization/billing/routes';
-import { OrganizationIndex } from '@/features/organization/index';
-import { OrganizationLayout } from '@/features/organization/OrganizationLayout';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { OrgConfigRolesIndex } from '@/features/organization/roles';
 import { OrgConfigUsersIndex } from '@/features/organization/users';
@@ -13,13 +11,6 @@ export const orgLayoutRoute = createRoute({
 	loader: (opts) => {
 		return opts.context.queryClient.ensureQueryData(getOrganizationQueryOptions(opts.params.organizationId));
 	},
-	component: OrganizationLayout,
-});
-
-const orgIndexRoute = createRoute({
-	getParentRoute: () => orgLayoutRoute,
-	path: '/',
-	component: OrganizationIndex,
 });
 
 const orgRolesRoute = createRoute({
@@ -45,7 +36,6 @@ const orgUserRoute = createRoute({
 });
 
 export const orgRoutes = [
-	orgIndexRoute,
 	createBillingRouteTree(orgLayoutRoute),
 	orgRolesRoute,
 	orgRoleRoute,

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -54,7 +54,7 @@ export function OrgCard({
 			<CardContent className="flex justify-between">
 				<Badge>{roleName}</Badge>
 				<Link
-					to={`${organizationId}/clusters`}
+					to={organizationId}
 					className="text-sm"
 					aria-label={`View ${organizationName}`}
 					title={`View ${organizationName}`}

--- a/src/lib/string/capitalizeWords.test.ts
+++ b/src/lib/string/capitalizeWords.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { capitalizeWords } from './capitalizeWords';
+
+describe('capitalizeWords', () => {
+	describe('examples from spec', () => {
+		it('org -> Org', () => {
+			expect(capitalizeWords('org')).toBe('Org');
+		});
+
+		it('new-cluster -> New Cluster', () => {
+			expect(capitalizeWords('new-cluster')).toBe('New Cluster');
+		});
+
+		it('newCluster -> New Cluster', () => {
+			expect(capitalizeWords('newCluster')).toBe('New Cluster');
+		});
+
+		it('newIDs -> New IDs', () => {
+			expect(capitalizeWords('newIDs')).toBe('New IDs');
+		});
+	});
+
+	describe('delimiters and whitespace', () => {
+		it('handles underscores', () => {
+			expect(capitalizeWords('new_cluster')).toBe('New Cluster');
+		});
+
+		it('collapses multiple delimiters and spaces', () => {
+			expect(capitalizeWords('  new--cluster__name  ')).toBe('New Cluster Name');
+		});
+	});
+
+	describe('camelCase and PascalCase', () => {
+		it('capitalizes PascalCase', () => {
+			expect(capitalizeWords('UserAccount')).toBe('User Account');
+		});
+
+		it('keeps acronyms in PascalCase', () => {
+			expect(capitalizeWords('APIResponse')).toBe('API Response');
+		});
+
+		it('handles numbers', () => {
+			expect(capitalizeWords('version2IDCheck')).toBe('Version 2 ID Check');
+		});
+	});
+
+	describe('acronyms and plurals', () => {
+		it('keeps acronym all-caps', () => {
+			expect(capitalizeWords('loadAPI')).toBe('Load API');
+		});
+
+		it('merges plural s after acronym', () => {
+			expect(capitalizeWords('processIDsNow')).toBe('Process IDs Now');
+		});
+
+		it('keeps single-word acronym', () => {
+			expect(capitalizeWords('CPU')).toBe('CPU');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('empty string', () => {
+			expect(capitalizeWords('')).toBe('');
+		});
+
+		it('spaces only', () => {
+			expect(capitalizeWords('   ')).toBe('');
+		});
+
+		it('single letter', () => {
+			expect(capitalizeWords('a')).toBe('A');
+		});
+	});
+});

--- a/src/lib/string/capitalizeWords.ts
+++ b/src/lib/string/capitalizeWords.ts
@@ -1,0 +1,57 @@
+export function capitalizeWords(name: string): string {
+	if (!name) return '';
+
+	// Normalize separators to single spaces and trim
+	const s = name
+		.replace(/[-_]+/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (!s) return '';
+
+	// Split into tokens handling camelCase/PascalCase, acronyms, and numbers
+	// Pattern parts:
+	// - [A-Z]+(?=[A-Z][a-z]) captures acronym at the start of a PascalCase word (e.g., "APIResponse" -> "API", "Response")
+	// - [A-Z]?[a-z]+ captures normal words (camel/pascal or lowercase)
+	// - [A-Z]+ captures remaining all-caps (acronyms)
+	// - [0-9]+ captures numbers
+	const baseTokens = s.match(/([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)/g);
+	if (!baseTokens) return '';
+
+	// Merge plural 's' following an acronym (length>=2), e.g., ["ID", "s"] -> ["IDs"]
+	const tokens: string[] = [];
+	for (let i = 0; i < baseTokens.length; i++) {
+		const tok = baseTokens[i];
+		const next = i + 1 < baseTokens.length ? baseTokens[i + 1] : undefined;
+		if (
+			// Case 1: full acronym then plural 's' as separate token -> merge
+			/^[A-Z]{2,}$/.test(tok) &&
+			next === 's'
+		) {
+			tokens.push(tok + 's');
+			i++; // skip the 's'
+		} else if (
+			// Case 2: single leading capital followed by capital + 's' (e.g., 'I' + 'Ds') -> merge to 'IDs'
+			/^[A-Z]$/.test(tok) &&
+			next !== undefined &&
+			/^[A-Z]s$/.test(next)
+		) {
+			tokens.push(tok + next);
+			i++; // skip merged next
+		} else {
+			tokens.push(tok);
+		}
+	}
+
+	// Capitalize tokens appropriately
+	const words = tokens.map(t => {
+		if (/^[A-Z]{2,}s?$/.test(t)) {
+			// Acronym (e.g., ID, API) possibly with plural 's' -> keep as is
+			return t;
+		}
+		if (/^[0-9]+$/.test(t)) return t; // numbers unchanged
+		// Normal word: capitalize first letter, lowercase rest
+		return t.charAt(0).toUpperCase() + t.slice(1).toLowerCase();
+	});
+
+	return words.join(' ');
+}


### PR DESCRIPTION
Here's a quick progression of small changes:
1. I turned on `trailingSlash: 'never'`, but I can't really tell if it's doing anything...
2. Our automatically redirected routes will now get replaced, so they only take up 1 history state. Now you can go back in your browser properly!
3. I extracted out the shared breadcrumb stuff across the 3 navs into a single component, so now there's the `SubNavMenu` that @BboyAkers created, and a `Breadcrumbs` that... he also created, but created three times, now once.
4. I tweaked the styles to be slightly denser, which became necessary because I...
5. Restored the links for the orgs and clusters, but then removed the first route (because the home icon fulfills that one), so you can click back to everything you need.
6. I capitalized the route names, and translated to "Org" and "Cluster" instead of showing the IDs. And then I thought... let's show the IDs below it! Our intern Junie wrote the capitalize function and unit tests, which seemed better than bringing in some external dependency to do the same thing. The logic is definitely more complicated than we need right now, but I don't think it'll hurt us.
7. I made two new routes that aren't linked to anywhere, but you can see them locally:

This will lead toward the real logic being implemented for https://harperdb.atlassian.net/browse/STUDIO-257

http://localhost:5173/#/orgs/org-4pu1rnepdr7johfg/new-cluster
<img width="469" height="144" alt="Screenshot 2025-08-25 at 6 21 42 PM" src="https://github.com/user-attachments/assets/38407eaa-d1a7-4949-ac68-a7448ac49b82" />

http://localhost:5173/#/orgs/org-4pu1rnepdr7johfg/clu-ylia1kv0sp80fpf5/edit
<img width="498" height="158" alt="Screenshot 2025-08-25 at 6 21 47 PM" src="https://github.com/user-attachments/assets/481fd5f3-7cd3-4a79-aba9-b7e2012e97e0" />
