### PR TITLE
Fix dedicated references

### DIFF
--- a/src/features/cluster/queries/getPlanTypesQuery.ts
+++ b/src/features/cluster/queries/getPlanTypesQuery.ts
@@ -2,17 +2,19 @@ import { apiClient } from '@/config/apiClient';
 import { queryKeys } from '@/react-query/constants';
 import { queryOptions } from '@tanstack/react-query';
 
-const getPlanTypes = async () => {
-	const { data } = await apiClient.get(`/Plan/`);
+async function getPlanTypes(organizationId: string) {
+	const { data } = await apiClient.get(`/Plan/`, {
+		params: {
+			organizationId,
+		},
+	});
 	return data;
-};
+}
 
-function getPlanTypesOptions() {
+export function getPlanTypesOptions(organizationId: string) {
 	return queryOptions({
-		queryKey: [queryKeys.cluster, 'instancePlan'],
-		queryFn: getPlanTypes,
+		queryKey: [queryKeys.organization, organizationId, 'instancePlan'],
+		queryFn: () => getPlanTypes(organizationId),
 		retry: false,
 	});
 }
-
-export { getPlanTypesOptions };

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -135,7 +135,7 @@ export function ClusterForm({
 	useEffect(() => {
 		setLimitRegionParameters({
 			availableHosts: selectedDeployment !== 'Dedicated' ? true : undefined,
-			organizationId: selectedDeployment === 'Dedicated' ? organizationId : undefined,
+			organizationId,
 		});
 	}, [organizationId, selectedDeployment, setLimitRegionParameters]);
 

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -134,8 +134,8 @@ export function ClusterForm({
 
 	useEffect(() => {
 		setLimitRegionParameters({
-			availableHosts: selectedDeployment !== 'Dedicated for Cluster' ? true : undefined,
-			organizationId: selectedDeployment === 'Dedicated for Organization' ? organizationId : undefined,
+			availableHosts: selectedDeployment !== 'Dedicated' ? true : undefined,
+			organizationId: selectedDeployment === 'Dedicated' ? organizationId : undefined,
 		});
 	}, [organizationId, selectedDeployment, setLimitRegionParameters]);
 

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -30,7 +30,7 @@ export function UpsertCluster() {
 
 	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId));
 	const { data: organization } = useQuery(getOrganizationQueryOptions(organizationId));
-	const { data: planTypes } = useQuery(getPlanTypesOptions());
+	const { data: planTypes } = useQuery(getPlanTypesOptions(organizationId));
 	const { data: regionLocations } = useQuery(getRegionLocationsOptions(limitRegionParameters));
 
 	const deploymentToPerformanceToPlan = useMemo<Record<string, Record<string, SchemaPlan>>>(() =>


### PR DESCRIPTION
When we renamed some of the plan deploymentTypes, I didn't catch the downstream changes. This fixes that. It would be nice to get these enums described in the OpenAPI types, which we'll get to... someday...

Passing the organizationId when loading the plan types was also requested.

- [x] We waited to deploy this until the API changes are ready, which they are! Yay.