### PR TITLE
Break toggleVariants out to appease fast refresh

### DIFF
--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,51 +1,10 @@
-import * as React from 'react';
-import * as TogglePrimitive from '@radix-ui/react-toggle';
-import { cva, type VariantProps } from 'class-variance-authority';
-
+import { toggleVariants } from '@/components/ui/toggleVariants';
 import { cn } from '@/lib/cn';
+import * as TogglePrimitive from '@radix-ui/react-toggle';
+import { type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
 
-const toggleVariants = cva(
-	`inline-flex 
-  items-center 
-  justify-center 
-  gap-2 
-  whitespace-nowrap 
-  rounded-lg 
-  text-sm  
-  transition-[color,box-shadow] 
-  disabled:pointer-events-none 
-  disabled:opacity-50 
-  [&_svg]:pointer-events-none 
-  [&_svg:not([class*='size-'])]:size-4 
-  [&_svg]:shrink-0 
-  ring-ring/10 
-  dark:ring-ring/20 
-  dark:outline-ring/40 
-  outline-ring/50 
-  focus-visible:ring-1 
-  focus-visible:outline-1 
-  focus-visible:ring-purple-200 
-  aria-invalid:focus-visible:ring-0`,
-	{
-		variants: {
-			variant: {
-				default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90',
-				outline: 'border bg-default border-primary border-2 text-white shadow-xs hover:-translate-y-1 transition duration-200 hover:bg-grey-700/40',
-			},
-			size: {
-				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 px-1.5 min-w-8',
-				lg: 'h-10 px-2.5 min-w-10',
-			},
-		},
-		defaultVariants: {
-			variant: 'default',
-			size: 'default',
-		},
-	}
-);
-
-function Toggle({
+export function Toggle({
 	className,
 	variant,
 	size,
@@ -55,5 +14,3 @@ function Toggle({
 		<TogglePrimitive.Root data-slot="toggle" className={cn(toggleVariants({ variant, size, className }))} {...props} />
 	);
 }
-
-export { Toggle, toggleVariants };

--- a/src/components/ui/toggleVariants.tsx
+++ b/src/components/ui/toggleVariants.tsx
@@ -1,0 +1,42 @@
+import { cva } from 'class-variance-authority';
+
+export const toggleVariants = cva(
+	`inline-flex 
+  items-center 
+  justify-center 
+  gap-2 
+  whitespace-nowrap 
+  rounded-lg 
+  text-sm  
+  transition-[color,box-shadow] 
+  disabled:pointer-events-none 
+  disabled:opacity-50 
+  [&_svg]:pointer-events-none 
+  [&_svg:not([class*='size-'])]:size-4 
+  [&_svg]:shrink-0 
+  ring-ring/10 
+  dark:ring-ring/20 
+  dark:outline-ring/40 
+  outline-ring/50 
+  focus-visible:ring-1 
+  focus-visible:outline-1 
+  focus-visible:ring-purple-200 
+  aria-invalid:focus-visible:ring-0`,
+	{
+		variants: {
+			variant: {
+				default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90',
+				outline: 'border bg-default border-primary border-2 text-white shadow-xs hover:-translate-y-1 transition duration-200 hover:bg-grey-700/40',
+			},
+			size: {
+				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+				sm: 'h-8 px-1.5 min-w-8',
+				lg: 'h-10 px-2.5 min-w-10',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	},
+);


### PR DESCRIPTION
This fixes the lint warning that told us fast refresh wouldn't be very happy with us.

```
.../hdbms/src/components/ui/toggle.tsx
  59:18  warning  Fast refresh only works when a file only exports components.
  Use a new file to share constants or functions between components
    react-refresh/only-export-components

✖ 1 problem (0 errors, 1 warning)
```