### PR TITLE
[STUDIO-367] Handle empty plan and region responses

### DIFF
--- a/src/components/ErrorComponent.tsx
+++ b/src/components/ErrorComponent.tsx
@@ -1,22 +1,31 @@
-import { Link } from '@tanstack/react-router';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { ArrowLeft } from 'lucide-react';
-import { useOverallAuth } from '@/hooks/useAuth';
 import { isLocalStudio } from '@/config/constants';
+import { useOverallAuth } from '@/hooks/useAuth';
+import { cn } from '@/lib/cn';
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+import { ReactNode } from 'react';
 
-export function ErrorComponent({ error }: { error: Error }) {
+interface ErrorProps {
+	className?: string | undefined;
+	error: Error | { message: string | ReactNode };
+	title?: string;
+	showReturnToHome?: boolean;
+}
+
+export function ErrorComponent({ className, error, title, showReturnToHome }: ErrorProps) {
 	const { user, isLoading: isUserLoading } = useOverallAuth();
 
 	return (
-		<Card className="text-red p-5 border border-red rounded-md m-12 mt-36">
+		<Card className={cn('text-red p-5 border border-red rounded-md m-12 mt-36', className)}>
 			<CardHeader>
 				<CardTitle className="text-2xl">
-					<h2>Component Error</h2>
+					<h2>{title ?? 'Component Error'}</h2>
 				</CardTitle>
 				<CardDescription>{error.message}</CardDescription>
 			</CardHeader>
-			<CardContent>
+			{showReturnToHome !== false && (<CardContent>
 				{user && !isUserLoading ? (
 					<Link to={isLocalStudio ? '/browse' : '/orgs'}>
 						<Button>
@@ -32,7 +41,7 @@ export function ErrorComponent({ error }: { error: Error }) {
 						</Button>
 					</Link>
 				)}
-			</CardContent>
+			</CardContent>)}
 		</Card>
 	);
 }

--- a/src/components/SubNavSimpleLayout.tsx
+++ b/src/components/SubNavSimpleLayout.tsx
@@ -1,0 +1,11 @@
+import { SubNavMenu } from '@/components/SubNavMenu';
+import { ReactNode } from 'react';
+
+export function SubNavSimpleLayout({ children }: { children: ReactNode }) {
+	return (<>
+		<SubNavMenu />
+		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))] relative">
+			{children}
+		</div>
+	</>);
+}

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -132,7 +132,7 @@ export function ClusterForm({
 	const selectedInstances = form.watch('instances');
 	const selectedAutoRenew = form.watch('autoRenew');
 
-	useEffect(() => {
+	useEffect(function syncRegionsWithSelectedDeploymentType() {
 		setLimitRegionParameters({
 			availableHosts: selectedDeployment !== 'Dedicated for Cluster' ? true : undefined,
 			organizationId: selectedDeployment === 'Dedicated for Organization' ? organizationId : undefined,

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -1,3 +1,5 @@
+import { ContactUs } from '@/components/ContactUs';
+import { ErrorComponent } from '@/components/ErrorComponent';
 import { Button } from '@/components/ui/button';
 import { RegionFormInputs } from '@/features/clusters/upsert/components/RegionFormInputs';
 import { UpsertClusterSchema } from '@/features/clusters/upsert/upsertClusterSchema';
@@ -41,6 +43,22 @@ export function ClusterRegions({
 			void form.trigger();
 		}
 	}, [form, nextAvailableRegionToAdd, regionPlansFieldArray]);
+
+	if (!regionLocations?.length) {
+		return (<div className="md:col-span-6 col-span-3">
+			<ErrorComponent
+				className="mt-0 m-0"
+				title="No Regions Available"
+				showReturnToHome={false}
+				error={{
+					message: <>
+						The deployment type you selected currently has no available regions. Please try a different
+						deployment type, try again later, or <ContactUs />.
+					</>,
+				}}
+			/>
+		</div>);
+	}
 
 	return (<>
 		{regionPlansFieldArray.fields.map((field, index) => (

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -1,5 +1,7 @@
+import { ContactUs } from '@/components/ContactUs';
+import { ErrorComponent } from '@/components/ErrorComponent';
 import { Loading } from '@/components/Loading';
-import { SubNavMenu } from '@/components/SubNavMenu';
+import { SubNavSimpleLayout } from '@/components/SubNavSimpleLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { getPlanTypesOptions } from '@/features/cluster/queries/getPlanTypesQuery';
 import {
@@ -82,6 +84,9 @@ export function UpsertCluster() {
 				regionPlans.push(...defaults.regionPlans);
 			}
 		}
+		if (!isSelfManaged && !regionPlans.length) {
+			regionPlans.push({ regionName: '', latencyDescription: '' });
+		}
 
 		return {
 			autoRenew: cluster?.plans?.[0]?.autoRenew ?? true,
@@ -96,25 +101,44 @@ export function UpsertCluster() {
 	}, [cluster, clusterId, planTypes, regionLocations, savedClusterState]);
 
 	const isLoading = !defaultValues || !organization || !planTypes || !regionLocations;
+	if (isLoading) {
+		return (
+			<SubNavSimpleLayout>
+				<Loading centered={true} text="Loading..." />
+			</SubNavSimpleLayout>
+		);
+	}
 
-	return (<>
-		<SubNavMenu />
-		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))] relative">
-			{isLoading
-				? (<Loading centered={true} text="Loading..." />)
-				: (<ClusterForm
-					clusterId={clusterId}
-					defaultValues={defaultValues}
-					deploymentToPerformanceToPlan={deploymentToPerformanceToPlan}
-					organization={organization}
-					organizationId={organizationId}
-					planTypes={planTypes}
-					regionLocations={regionLocations}
-					regionNameToLatencyToRegion={regionNameToLatencyToRegion}
-					setLimitRegionParameters={setLimitRegionParameters}
-					setSavedClusterState={setSavedClusterState}
-					startOffOnBilling={!!savedClusterState}
-				/>)}
-		</div>
-	</>);
+	if (planTypes.length === 0) {
+		return (
+			<SubNavSimpleLayout>
+				<ErrorComponent
+					title={`Cluster ${clusterId ? 'Modification' : 'Creation'} Not Currently Allowed`}
+					error={{
+						message: <>
+							There are no available deployment types right now! Please try again later, or <ContactUs />.
+						</>,
+					}}
+				/>
+			</SubNavSimpleLayout>
+		);
+	}
+
+	return (
+		<SubNavSimpleLayout>
+			<ClusterForm
+				clusterId={clusterId}
+				defaultValues={defaultValues}
+				deploymentToPerformanceToPlan={deploymentToPerformanceToPlan}
+				organization={organization}
+				organizationId={organizationId}
+				planTypes={planTypes}
+				regionLocations={regionLocations}
+				regionNameToLatencyToRegion={regionNameToLatencyToRegion}
+				setLimitRegionParameters={setLimitRegionParameters}
+				setSavedClusterState={setSavedClusterState}
+				startOffOnBilling={!!savedClusterState}
+			/>
+		</SubNavSimpleLayout>
+	);
 }


### PR DESCRIPTION
When the server responds with 0 plans and/or 0 regions, we can handle the response from the server accordingly and degrade what the user can do. This is better than showing an empty select and a validation error. 😄 See JIRA ticket for screenshots and reproduction steps.

Aside from the obvious code for the plan and region limiting stuff... I made two adjustments that may be useful outside of this code, eventually:

1. The error component has a few more properties on it, letting us customize it and use it in other spots more easily. 💣 
2. There's a new `SubNavSimpleLayout` that we can probably use in some other spots. It has the proper top margin, the sub nav, and children rendered at the right spot. Nice and simple. 💋 

https://harperdb.atlassian.net/browse/STUDIO-367