### PR TITLE
[STUDIO-268] Org and Cluster Card Height Consistency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 onlyBuiltDependencies:
+  - '@tailwindcss/oxide'
   - esbuild

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -71,7 +71,7 @@ export function ClusterCard({
 	].filter(excludeFalsy);
 
 	return (
-		<Card className="relative">
+		<Card className="relative h-full justify-between">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
 					<span className="truncate">{cluster.id}</span>

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -28,7 +28,7 @@ export function OrgCard({
 	}, [onDeleteOrgModal, organizationRole]);
 
 	return (
-		<Card className="relative">
+		<Card className="relative h-full justify-between">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
 					<span className="truncate">{organizationId}</span>


### PR DESCRIPTION
I made the cards take up the full height available to them with justify-between to anchor the actions to the bottom of the card. Now when we have long names, the cards will all size up accordingly.

When doing a `pnpm install` I also noticed that it wasn't letting oxide build. I flagged that as allowed.

https://harperdb.atlassian.net/browse/STUDIO-268