### PR TITLE
[STUDIO-336] Clarify text displayed on the config overview page

### DIFF
--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -17,7 +17,7 @@ const DesktopConfigNavBar = () => {
 				inactiveProps={inactiveProps}
 				activeProps={activeProps}
 			>
-				<PieChartIcon className="inline-block" /> <span className="ms-3">Instance Overview</span>
+				<PieChartIcon className="inline-block" /> <span className="ms-3">Overview</span>
 			</Link>
 
 			<ul className="border-t border-gray-700 pt-4 mt-4 space-y-2">

--- a/src/features/instance/config/overview/components/InstanceNodeName.tsx
+++ b/src/features/instance/config/overview/components/InstanceNodeName.tsx
@@ -1,4 +1,5 @@
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { useMemo } from 'react';
 
 export const InstanceNodeName = ({
 	loadingInstanceInfo,
@@ -7,10 +8,11 @@ export const InstanceNodeName = ({
 	loadingInstanceInfo?: boolean;
 	instanceInfo?: { name?: string } | undefined;
 }) => {
+	const simplifiedName = useMemo(() => instanceInfo?.name?.split('.')[0], [instanceInfo?.name]);
 	return (
 		<>
-			<dt className="font-bold text-sm/6">Instance Node Name (for clustering)</dt>
-			<dd className="text-sm/6 sm:mt-2">{loadingInstanceInfo ? <TextLoadingSkeleton /> : instanceInfo?.name}</dd>
+			<dt className="font-bold text-sm/6">Instance Name</dt>
+			<dd className="text-sm/6 sm:mt-2">{loadingInstanceInfo ? <TextLoadingSkeleton /> : simplifiedName}</dd>
 		</>
 	);
 };

--- a/src/features/instance/config/overview/components/InstanceURL.tsx
+++ b/src/features/instance/config/overview/components/InstanceURL.tsx
@@ -1,18 +1,17 @@
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
-import { Cluster } from '@/lib/api.patch';
+import { Instance } from '@/lib/api.patch';
 
 export const InstanceURL = ({
 	loadingInstanceInfo,
-	clusterInfo,
+	instanceInfo,
 }: {
 	loadingInstanceInfo?: boolean;
-	clusterInfo?: Cluster | undefined;
+	instanceInfo?: Instance | undefined;
 }) => {
 	return (
 		<>
 			<dt className="font-bold text-sm/6">Instance URL</dt>
-			{/* @ts-expect-error  tried following the types and it seems we are stacking them we have to figure out a better way to type this so url doesn't cause a type error */}
-			<dd className="text-sm/6 sm:mt-2">{loadingInstanceInfo ? <TextLoadingSkeleton /> : clusterInfo?.url}</dd>
+			<dd className="text-sm/6 sm:mt-2">{loadingInstanceInfo ? <TextLoadingSkeleton /> : instanceInfo?.instanceFqdn}</dd>
 		</>
 	);
 };

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -54,12 +54,12 @@ export function ConfigOverviewIndex() {
 				</LocalStudioOverview>
 			) : (
 				<CloudStudioOverview>
-					<dl className="flex-none grid grid-cols-1 sm:grid-cols-3">
+					<dl className="flex-none grid grid-cols-1 sm:grid-cols-4">
 						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
-							<InstanceURL loadingInstanceInfo={loadingInstanceInfo} clusterInfo={clusterInfo} />
+							<HarperVersion loadingRegistration={loadingRegistration} registrationInfo={registrationInfo} />
 						</div>
-						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
-							<ApplicationURL loadingInstanceInfo={loadingInstanceInfo} clusterInfo={clusterInfo} />
+						<div className="px-4 pb-4 sm:col-span-2 sm:px-0">
+							<InstanceURL loadingInstanceInfo={loadingInstanceInfo} instanceInfo={instanceInfo} />
 						</div>
 						<div className="px-4 pb-4 text-right sm:col-span-1 sm:px-0">
 							<RestartButton targetNoun={targetNoun} instanceClient={instanceParams.instanceClient} operation="restart" />
@@ -67,14 +67,18 @@ export function ConfigOverviewIndex() {
 						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
 							<InstanceNodeName loadingInstanceInfo={loadingInstanceInfo} instanceInfo={instanceInfo} />
 						</div>
-						<div className="px-4 pb-4 sm:col-span-1 sm:px-0">
-							<HarperVersion loadingRegistration={loadingRegistration} registrationInfo={registrationInfo} />
+						<div className="px-4 pb-4 sm:col-span-2 sm:px-0">
+							<ApplicationURL loadingInstanceInfo={loadingInstanceInfo} clusterInfo={clusterInfo} />
 						</div>
 					</dl>
 				</CloudStudioOverview>
 			)}
 
 			<h3 className="flex-none font-bold text-sm/6">Instance Config (read only)</h3>
+			{!instanceId && (
+				<p className="text-muted-foreground italic text-sm mb-2">
+					You are viewing the config for one instance in your cluster, based on what the load balancer
+					selected for you.</p>)}
 			<div className="grow">
 				{!loadingConfig ? (
 					<Editor


### PR DESCRIPTION
https://harperdb.atlassian.net/browse/STUDIO-336

<img width="1791" height="967" alt="Screenshot 2025-09-05 at 1 20 59 PM" src="https://github.com/user-attachments/assets/6b31b7ab-d8a6-4658-ab6e-e9ad62e5c6f1" />
<img width="1791" height="967" alt="Screenshot 2025-09-05 at 1 21 21 PM" src="https://github.com/user-attachments/assets/db6794e3-c134-44ba-b389-6362caf21e24" />
