### PR TITLE
fix: Disable session replays

### DIFF
--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -30,8 +30,8 @@ export function useDatadog() {
 				trackViewsManually: true,
 
 				sessionSampleRate: 100,
-				sessionReplaySampleRate: 20,
-				defaultPrivacyLevel: 'mask-user-input',
+				sessionReplaySampleRate: 0,
+				defaultPrivacyLevel: 'mask',
 
 				plugins: [reactPlugin()],
 			});


### PR DESCRIPTION
Let’s turn this off for now. In the future, we may make a way to selectively turn it on if a user opts in.

With it on `mask` mode, it would capture something like the following when enabled. But we have it disabled by setting it to 0.

<img width="720" height="425" alt="image" src="https://github.com/user-attachments/assets/09723125-c6b2-4f34-8ed0-c5193dc1a706" />
