### PR TITLE
fix: Don’t send to instances when we have an instanceId already

### DIFF
--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -97,7 +97,7 @@ export function ClusterInstanceSignIn() {
 			});
 	}, [cluster, instance, instanceClient, navigate, queryClient, redirect, router, submitInstanceLogin]);
 
-	if (cluster && !cluster?.fqdn) {
+	if (!instanceId && cluster && !cluster?.fqdn) {
 		return <Navigate to="../instances" replace={true} />;
 	}
 


### PR DESCRIPTION
The guard against someone trying to sign-in to a self-managed cluster without a FQDN wasn't detecting when we were trying to sign in to an instance of such a cluster. Now we'll guard it properly.

https://harperdb.atlassian.net/browse/STUDIO-400