### PR TITLE
Fix: fixed mobile view of /applications editor

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -58,7 +58,7 @@ export function Breadcrumbs() {
 
 
 	return (
-		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4">
+		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4 overflow-x-scroll">
 			{...breadcrumbs}
 		</div>
 	);

--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -24,7 +24,7 @@ export function RestartButton({
 		<TooltipTrigger asChild>
 			<Button
 				variant="positiveOutline"
-				className="mx-4 rounded-full cursor-pointer"
+				className="mx-0 md:mx-4 rounded-full cursor-pointer"
 				onClick={targetNoun === 'Cluster' && operation === 'restart' ? onRestartClusterClick : onRestartClick}
 				disabled={isRestartPending || isRestartClusterPending}
 			>

--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
@@ -81,7 +81,7 @@ function FiletypeIcon({ extension }: { readonly extension: string | null }) {
 		case 'css':
 			return <i className={'file-icon filetype-css fas fa-file text-blue'} />;
 		case 'html':
-			return <i className={'file-icon filetype-html fas fa-html5 text-orange'} />;
+			return <i className={'file-icon filetype-unknown far fa-file-alt'} />; //NOTE: Using unknown icon for HTML file due to not finding one in font awesome.
 		case 'json':
 			return <i className={'file-icon filetype-json fas fa-cog'} />;
 		case 'ts':

--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -55,10 +55,10 @@ export function TextEditorView() {
 		<div className="h-[calc(100vh-theme(spacing.52))]">
 			<div className="flex items-center justify-between py-1 border-b border-gray-700">
 				<span className="p-2">{selectedFolderFile.filePath ? crumbPath : 'Select a file'}</span>
-				<div>
+				<div className='flex flex-col justify-end space-y-2 md:justify-normal md:flex-row '>
 					<Button
 						variant="positiveOutline"
-						className="w-32 rounded-full"
+						className="w-38 rounded-full"
 						onClick={() => {
 							if (updateFileContent !== null) {
 								onSaveFile(
@@ -96,7 +96,7 @@ export function TextEditorView() {
 			{!selectedFolderFile.filePath || isFolder(selectedFolderFile.entries) ? (
 				<div className="flex flex-col items-center justify-center h-full space-y-4">
 					<span className="text-white">No file selected</span>
-					<div>
+					<div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
 						<Button variant="positiveOutline" className="ms-4" size="lg" onClick={() => {
 							setIsNewProjectModalOpen(true);
 							setAppType('create');

--- a/src/features/instance/applications/index.tsx
+++ b/src/features/instance/applications/index.tsx
@@ -12,7 +12,7 @@ export function ApplicationsEditor() {
 	return (
 		<EditorViewProvider>
 			<div className="grid grid-cols-1 gap-4 md:grid-cols-12 h-[calc(100vh-theme(spacing.40))]">
-				<section className="col-span-1 overflow-y-scroll text-white md:col-span-4 lg:col-span-3">
+				<section className="col-span-1 overflow-y-scroll min-h-48 text-white md:col-span-4 lg:col-span-3">
 					<ApplicationsSidebar fileTreeQueryData={getComponentsQueryData} />
 				</section>
 				<section className="col-span-1 text-white md:col-span-8 lg:col-span-9">


### PR DESCRIPTION
Ticket:

[STUDIO-385](https://harperdb.atlassian.net/browse/STUDIO-385)

Overview:
Fixed mobile view of `/applications` editor.

<img width="481" height="945" alt="Screenshot 2025-09-09 at 1 45 25 PM" src="https://github.com/user-attachments/assets/ea6aba55-e131-4086-a23e-04b1fc06b172" />

<img width="484" height="936" alt="Screenshot 2025-09-09 at 1 45 52 PM" src="https://github.com/user-attachments/assets/f6b0273a-b7ba-4850-b308-f341359320cf" />


[STUDIO-385]: https://harperdb.atlassian.net/browse/STUDIO-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ