### PR TITLE
[STUDIO-385] Responsive Breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -47,7 +47,7 @@ export function Breadcrumbs() {
 				</svg>,
 				<Link
 					to={path}
-					className="text-xs md:text-sm font-medium hover:text-grey"
+					className="text-xs md:text-sm font-medium hover:text-grey truncate max-w-48"
 				>
 					{name}
 					{id && <div className="text-gray-500 text-xs hidden md:block">{id}</div>}
@@ -60,7 +60,7 @@ export function Breadcrumbs() {
 
 
 	return (
-		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4">
+		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4 sm:max-w-9/10 max-w-[calc(100%-56px)]">
 			{...breadcrumbs}
 		</div>
 	);

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -50,7 +50,7 @@ export function Breadcrumbs() {
 					className="text-xs md:text-sm font-medium hover:text-grey"
 				>
 					{name}
-					{id && <div className="text-gray-500 text-xs">{id}</div>}
+					{id && <div className="text-gray-500 text-xs hidden md:block">{id}</div>}
 				</Link>,
 			);
 		}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -26,15 +26,17 @@ export function Breadcrumbs() {
 			const path = `/${routeHistory.slice(0, index + 1).join('/')}`;
 			let name = capitalizeWords(route);
 			let id: string | undefined;
-			if (name.startsWith('Org ')) {
+			if (route === 'databases' && routeHistory.length === index + 3) {
+				id = routeHistory[index + 1];
+				name = routeHistory[index + 2];
+				index += 2;
+			} else if (name.startsWith('Org ')) {
 				id = route.split('org-').pop();
 				name = routeContext?.organization?.name || 'Org';
-			}
-			else if (name.startsWith('Clu ')) {
+			} else if (name.startsWith('Clu ')) {
 				id = route.split('clu-').pop();
 				name = routeContext?.cluster?.name || 'Cluster';
-			}
-			else if (name.startsWith('Ins ')) {
+			} else if (name.startsWith('Ins ')) {
 				id = route.split('ins-').pop();
 				name = 'Instance';
 			}
@@ -58,7 +60,7 @@ export function Breadcrumbs() {
 
 
 	return (
-		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4 overflow-x-auto">
+		<div role="list" className="flex items-center space-x-0 lg:space-x-2 xl:space-x-4">
 			{...breadcrumbs}
 		</div>
 	);

--- a/src/features/instance/InstanceNavBar.tsx
+++ b/src/features/instance/InstanceNavBar.tsx
@@ -20,27 +20,27 @@ function DesktopInstanceNavBar() {
 		<div className="hidden md:flex items-center justify-between h-full text-sm text-white">
 			<Breadcrumbs />
 			<div className="flex space-x-2 *:hover:text-grey">
-				<Link to={buildAbsoluteLinkToPage(params)} className="p-2">
+				<Link to={buildAbsoluteLinkToPage(params)} className="p-2 text-center">
 					<Package className="inline-block" />
 					<span className="hidden xl:inline-block ml-1">Applications</span>
 					<span className="visible xl:hidden ml-1"> Apps</span>
 
 				</Link>
-				<Link to={buildAbsoluteLinkToPage(params, 'databases')} className="p-2">
+				<Link to={buildAbsoluteLinkToPage(params, 'databases')} className="p-2 text-center">
 					<DatabaseIcon className="inline-block" />
 					<span className="hidden xl:inline-block ml-1"> Databases</span>
 				</Link>
 				{canManage && (
 					<>
-						<Link to={buildAbsoluteLinkToPage(params, 'status')} className="p-2">
+						<Link to={buildAbsoluteLinkToPage(params, 'status')} className="p-2 text-center">
 							<GaugeIcon className="inline-block" />
 							<span className="hidden xl:inline-block ml-1">Status</span>
 						</Link>
-						<Link to={buildAbsoluteLinkToPage(params, 'logs')} className="p-2">
+						<Link to={buildAbsoluteLinkToPage(params, 'logs')} className="p-2 text-center">
 							<NotepadText className="inline-block" />
 							<span className="hidden xl:inline-block ml-1">Logs</span>
 						</Link>
-						<Link to={buildAbsoluteLinkToPage(params, 'config')} className="p-2">
+						<Link to={buildAbsoluteLinkToPage(params, 'config')} className="p-2 text-center">
 							<SettingsIcon className="inline-block" />
 							<span className="hidden xl:inline-block ml-1">Config</span>
 						</Link>


### PR DESCRIPTION
I made a few improvements for us:

## Centered Icons on Instance Nav Wrapping
We won't hit this one very often, but depending on the name lengths, there's a chance that the instance nav will wrap to two lines. Now it'll center the icons over the text, instead of left aligning the icons.
<img width="887" height="1325" alt="Screenshot 2025-09-10 at 11 02 45 AM" src="https://github.com/user-attachments/assets/71312bdc-22bd-4d6b-9586-2bcf2ea3b419" />

## Collapse "databases > data > tableName" to a single breadcrumb
When we find the "databases" route, if we have 2 entries after it, we'll collapse them down to a single breadcrumb. Clicking any of these breadcrumbs was rather useless when they were 3 anyway!
<img width="1545" height="1325" alt="Screenshot 2025-09-10 at 11 02 37 AM" src="https://github.com/user-attachments/assets/9ba54e3b-a7d0-42b5-b728-1e94db45ba7a" />

## Hide Names at Small Viewports
We'll hide the `id` tags at small viewports. They aren't as important as the main name.
<img width="845" height="1325" alt="Screenshot 2025-09-10 at 11 02 51 AM" src="https://github.com/user-attachments/assets/5d92c93b-940b-41e4-9d8a-2cd3fa0c3f49" />

## Set the Max Width & Truncation at Small Viewports
We'll cap each breadcrumb at max-w-48 with truncation. And when we're at the small viewport, we'll set the overall maximum width of the breadcrumbs so they don't push the moblie menu out of view. I tested this down to 320px, which seems much smaller than what we'll actually see from modern devices.
<img width="848" height="1030" alt="Screenshot 2025-09-10 at 11 03 18 AM" src="https://github.com/user-attachments/assets/a3cc75be-f5a0-41c7-b926-200f0b94199a" />


https://harperdb.atlassian.net/browse/STUDIO-385