### PR TITLE
[STUDIO-402] Fix Preload Error by Preventing on Mobile

### DIFF
--- a/src/AppRouted.tsx
+++ b/src/AppRouted.tsx
@@ -1,6 +1,7 @@
 import { ErrorComponent } from '@/components/ErrorComponent';
 import { NotFoundComponent } from '@/components/NotFoundComponent';
 import { useRootAuthenticationContext } from '@/hooks/useAuth';
+import { browserIsTouchBased } from '@/lib/browserIsTouchBased';
 import { queryClient } from '@/react-query/queryClient';
 import { rootRouteTree } from '@/router/rootRouteTree';
 import { createHashHistory, createRouter, RouterProvider } from '@tanstack/react-router';
@@ -14,7 +15,7 @@ export function AppRouted() {
 		history: hashHistory,
 		defaultNotFoundComponent: NotFoundComponent,
 		defaultErrorComponent: ErrorComponent,
-		defaultPreload: 'intent',
+		defaultPreload: browserIsTouchBased() ? false : 'intent',
 		trailingSlash: 'never',
 		// Since we're using React Query, we don't want loader calls to ever be stale
 		// This will ensure that the loader is always called when the route is preloaded or visited

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -20,7 +20,7 @@ export const clusterLayoutRoute = createRoute({
 
 const clusterIndexRoute = createRoute({
 	getParentRoute: () => clusterLayoutRoute,
-	path: '/instances',
+	path: 'instances',
 	component: ClusterIndex,
 });
 

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -37,7 +37,7 @@ export function ClusterCard({
 	const auth = useInstanceAuth(cluster.id);
 
 	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
-	const notTerminated = useMemo(() => cluster.status && !deletedClusterStatuses.includes(cluster.status), [cluster.status]);
+	const isTerminated = useMemo(() => cluster.status && deletedClusterStatuses.includes(cluster.status), [cluster.status]);
 	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
 	const instanceClient = useInstanceClient(operationsUrl);
 	const [signingOut, setSigningOut] = useState(false);
@@ -68,7 +68,7 @@ export function ClusterCard({
 			<Link to={`${cluster.id}/instances`} disabled={signingOut}><DropdownMenuItem>Instances</DropdownMenuItem></Link>),
 		isActive && view && !!operationsUrl && !auth.isLoading && auth.user && (
 			<DropdownMenuItem onClick={onSignOutClick} disabled={signingOut}>Sign Out</DropdownMenuItem>),
-		notTerminated && remove && (
+		!isTerminated && remove && (
 			<DropdownMenuItem
 				className="bg-red focus:bg-red/70 focus:text-white"
 				onClick={onTerminateClick}>
@@ -82,7 +82,7 @@ export function ClusterCard({
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
 					<span className="truncate">{cluster.id}</span>
-					<DropdownMenu>
+					{!isTerminated && (<DropdownMenu>
 						<DropdownMenuTrigger>
 							<Ellipsis aria-label="Cluster options" />
 						</DropdownMenuTrigger>
@@ -101,7 +101,7 @@ export function ClusterCard({
 								{...menuItems}
 							</>)}
 						</DropdownMenuContent>
-					</DropdownMenu>
+					</DropdownMenu>)}
 				</CardDescription>
 				<CardTitle>
 					<h2>{cluster.name}</h2>

--- a/src/features/clusters/routes.ts
+++ b/src/features/clusters/routes.ts
@@ -5,7 +5,7 @@ import { createRoute } from '@tanstack/react-router';
 
 export const clustersLayoutRoute = createRoute({
 	getParentRoute: () => orgLayoutRoute,
-	id: '_orgLayout',
+	id: '_clusterLayout',
 });
 
 const clustersIndexRoute = createRoute({

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -44,7 +44,6 @@ export function ProfileIndex() {
 				updateUser(formData, {
 					onSuccess: (data) => {
 						form.reset(data);
-						toast.success('Profile updated successfully!');
 						if (formData.newPassword) {
 							toast.success('Profile updated successfully!', {
 								description: 'Please sign in with your new password.',

--- a/src/lib/browserIsTouchBased.ts
+++ b/src/lib/browserIsTouchBased.ts
@@ -1,0 +1,3 @@
+export function browserIsTouchBased(): boolean {
+	return 'ontouchstart' in window || navigator['maxTouchPoints'] > 0;
+}


### PR DESCRIPTION
This was an odd one. If you do this on certain phones, tanstack will preload incorrectly (specifically the `$orgId/$orgId` when looking at the org page). The second $orgId is used as the cluster id, which we try to lookup as the cluster, which 404s.

For now, let's detect touch based browsers, and disable preloading for them.

https://harperdb.atlassian.net/browse/STUDIO-402