### PR TITLE
feat: Limit what we deploy to only the built contents

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,5 +40,9 @@ jobs:
         run: npm install -g harperdb@4.6.0
       - name: Deploy to dev
         run: |
-          rm -rf node_modules # Clean up node_modules, harper will install
+          mkdir deploy
+          cp config.yaml deploy/
+          mv web deploy/
+          cd deploy
+          echo "{}" > package.json
           CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_DEV }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_DEV }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET_DEV }}' restart=true

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -42,5 +42,9 @@ jobs:
         run: npm install -g harperdb@4.6.0
       - name: Deploy to prod
         run: |
-          rm -rf node_modules # Clean up node_modules, harper will install
+          mkdir deploy
+          cp config.yaml deploy/
+          mv web deploy/
+          cd deploy
+          echo "{}" > package.json
           CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_PROD }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_PROD }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET_PROD }}' restart=true

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Deploy to stage
         if: ${{ github.event_name == 'push' }}
         run: |
-          rm -rf node_modules # Clean up node_modules, harper will install
+          mkdir deploy
+          cp config.yaml deploy/
+          mv web deploy/
+          cd deploy
           echo "{}" > package.json
           CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET }}' restart=true

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,3 @@ static:
   files: web/**
   index: true
   extensions: ["html"]
-  notFound:
-    - file: index.html
-    - code: 200


### PR DESCRIPTION
This does a few things fancy for us:
1. We only need the build `web` folder! Nothing else.
2. We can isolate it, plus our config.yaml, in to a new `deploy` folder at build time.
3. We don't need the notFound handler in the config. That was when we were doing browser based routing instead of hash routing.
4. Then we don't need to remove our `node_modules` anymore, resulting in cache _hits_ in our workflows! That'll speed stuff up too.
5. Harper needs a package.json, but we don't need any of the node_modules once built, so we can create an bare `{}` package.json instead in the `deploy` folder.
6. Once we `cd deploy`, we can do our normal harper deploy!