### PR TITLE
feat: Restore Husky

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           cache: 'pnpm'
+      - name: Disable Husky
+        run: echo "HUSKY=0" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install
       - name: Run unit tests

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           cache: 'pnpm'
+      - name: Disable Husky
+        run: echo "HUSKY=0" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install
       - name: Run unit tests

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           cache: 'pnpm'
+      - name: Disable Husky
+        run: echo "HUSKY=0" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install
       - name: Run unit tests

--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           cache: 'pnpm'
+      - name: Disable Husky
+        run: echo "HUSKY=0" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install
       - name: Run unit tests

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"update-sdk": "npx -y dotenv-cli -e .env.local -- npm run update-sdk:fetch && npx -y openapi-typescript --root-types --alphabetize --enum ./dist/central-manager.json -o ./src/lib/api.gen.d.ts",
 		"update-sdk:fetch": "mkdir -p dist && curl --location \"$VITE_CENTRAL_MANAGER_API_URL/openapi\" -u \"$HDB_ADMIN_USERNAME_FOR_OPENAPI:$HDB_ADMIN_PASSWORD_FOR_OPENAPI\" -o ./dist/central-manager.json",
 		"lint": "eslint .",
+		"prepare": "husky",
 		"preview": "vite preview",
 		"test": "vitest run",
 		"test:watch": "vitest"
@@ -147,6 +148,7 @@
 		"eslint-plugin-react-hooks": "^5.0.0",
 		"eslint-plugin-react-refresh": "^0.4.18",
 		"globals": "^16.0.0",
+		"husky": "^9.1.7",
 		"semantic-release": "^24.1.0",
 		"typescript": "~5.9.0",
 		"typescript-eslint": "^8.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.4.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       semantic-release:
         specifier: ^24.1.0
         version: 24.2.7(typescript@5.9.2)
@@ -2338,6 +2341,11 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5874,6 +5882,8 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
This should work now that we've sorted out our deployments running `npm install` when we don't want them to.

I verified this is working by pushing this to dev. https://github.com/HarperDB/hdbms/actions/runs/17649700845/job/50157074931 The run failed because we haven't configured dev yet, but it got all the way to the actual deployment, which is what we want to see! (`TypeError: Invalid URL` is a symptom of dev not being configured yet.)