### PR TITLE
fix: Name or deploy so we get the right directory out there

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -47,4 +47,4 @@ jobs:
           mv web deploy/
           cd deploy
           echo "{}" > package.json
-          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_DEV }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_DEV }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET_DEV }}' restart=true
+          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_DEV }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_DEV }}' harperdb deploy project='hdbms' target='${{ secrets.CLI_DEPLOY_TARGET_DEV }}' restart=true

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -49,4 +49,4 @@ jobs:
           mv web deploy/
           cd deploy
           echo "{}" > package.json
-          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_PROD }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_PROD }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET_PROD }}' restart=true
+          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME_PROD }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD_PROD }}' harperdb deploy project='hdbms' target='${{ secrets.CLI_DEPLOY_TARGET_PROD }}' restart=true

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -66,4 +66,4 @@ jobs:
           mv web deploy/
           cd deploy
           echo "{}" > package.json
-          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD }}' harperdb deploy target='${{ secrets.CLI_DEPLOY_TARGET }}' restart=true
+          CLI_TARGET_USERNAME=${{ secrets.CLI_TARGET_USERNAME }} CLI_TARGET_PASSWORD='${{ secrets.HARPERDB_CLI_TARGET_PASSWORD }}' harperdb deploy project='hdbms' target='${{ secrets.CLI_DEPLOY_TARGET }}' restart=true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+deploy
 web
 dist-ssr
 *.local


### PR DESCRIPTION
We were deploying into a `deploy` folder instead of into `hdbms`, so we weren't putting stuff in the right spot. Whoops!

I verified these changes by using the dev branch, experimenting, and aiming it at our stage environment. What's up in https://stage.studio.harperfabric.com/ will reflect that, proving that this works. You'll notice the odd version of v2c4161e which is how dev is designed to work, showing the commit that is deployed.

https://github.com/HarperDB/hdbms/commit/2c4161eab3686de4142e914ae0c98523a4827669