### PR TITLE
feat: Make the status page a little prettier

### DIFF
--- a/src/features/instance/operations/queries/getStatus.ts
+++ b/src/features/instance/operations/queries/getStatus.ts
@@ -1,27 +1,41 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { queryOptions } from '@tanstack/react-query';
 
-interface CoreStatus {
-	id: string;
-	status: string;
+interface SystemStatus {
+	id: 'availability' | 'maintenance' | 'primary' | string;
+	status: 'Available' | 'Unavailable' | string;
 	__updatedtime__: number;
 	__createdtime__: number;
 }
 
-interface AvailabilityStatus extends CoreStatus {
-	id: 'availability',
-	status: 'Available' | 'Unavailable',
+const enum ComponentStatusName {
+	'hdb.http' = 'hdb.http',
+	'hdb.authentication' = 'hdb.authentication',
+	'hdb.replication' = 'hdb.replication',
+	'hdb.logging' = 'hdb.logging',
+	'hdb.mqtt' = 'hdb.mqtt',
+	'hdb.operationsApi' = 'hdb.operationsApi',
+	'status-check.rest' = 'status-check.rest',
+	'status-check.jsResource' = 'status-check.jsResource',
 }
 
-interface MaintenanceStatus extends CoreStatus {
-	id: 'maintenance',
+interface ComponentStatus {
+	name: ComponentStatusName | string,
+	componentName: ComponentStatusName | string,
+	status: 'healthy' | string,
+	lastChecked: {
+		workers: Record<string, number>,
+		main: number
+	}
 }
 
-interface PrimaryStatus extends CoreStatus {
-	id: 'primary',
-}
+interface StatusResponse {
+	systemStatus: SystemStatus[];
+	restartRequired: boolean;
+	componentStatus: ComponentStatus[];
 
-type StatusResponse = Array<AvailabilityStatus | MaintenanceStatus | PrimaryStatus>;
+	[key: string]: unknown;
+}
 
 export function getStatusQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({

--- a/src/features/instance/operations/queries/getSystemInformation.ts
+++ b/src/features/instance/operations/queries/getSystemInformation.ts
@@ -92,6 +92,8 @@ interface SystemInformationResponse {
 		stats: Array<Record<string, unknown>>;
 		connections: Array<Record<string, unknown>>;
 	};
+
+	[key: string]: unknown;
 }
 
 export function getSystemInformationQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {

--- a/src/features/instance/status/CloudStatus.tsx
+++ b/src/features/instance/status/CloudStatus.tsx
@@ -1,0 +1,17 @@
+import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { getStatusQueryOptions } from '@/features/instance/operations/queries/getStatus';
+import { Status } from '@/features/instance/status/Status';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Suspense } from 'react';
+
+export function CloudStatus() {
+	const instanceParams = useInstanceClientIdParams();
+	const { data } = useSuspenseQuery(getStatusQueryOptions(instanceParams));
+
+	return (
+		<Suspense fallback={<TextLoadingSkeleton />}>
+			<Status data={data} />
+		</Suspense>
+	);
+}

--- a/src/features/instance/status/LocalStatus.tsx
+++ b/src/features/instance/status/LocalStatus.tsx
@@ -1,0 +1,17 @@
+import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { getSystemInformationQueryOptions } from '@/features/instance/operations/queries/getSystemInformation';
+import { Status } from '@/features/instance/status/Status';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Suspense } from 'react';
+
+export function LocalStatus() {
+	const instanceParams = useInstanceClientIdParams();
+	const { data } = useSuspenseQuery(getSystemInformationQueryOptions(instanceParams));
+
+	return (
+		<Suspense fallback={<TextLoadingSkeleton />}>
+			<Status data={data} />
+		</Suspense>
+	);
+}

--- a/src/features/instance/status/Status.tsx
+++ b/src/features/instance/status/Status.tsx
@@ -1,0 +1,19 @@
+import { crawlData, hasTitle } from '@/features/instance/status/crawlData';
+import { cn } from '@/lib/cn';
+import { useMemo } from 'react';
+
+export function Status({ data }: { data: Record<string, unknown> }) {
+	const items = useMemo(() => crawlData(data), [data]);
+	return <div className="max-w-96 grid mb-12">
+		{items.map((item, index) =>
+			hasTitle(item) ? (
+				<div key={index} className={cn('font-semibold text-xl', index !== 0 && 'mt-4')} style={{ paddingLeft: item.depth * 12 + 'px' }}>{item.title}</div>
+			) : (<>
+				<div key={index} style={{ paddingLeft: item.depth * 12 + 'px' }}>
+					<span className="text-muted-foreground">{item.name}: </span>
+					{item.value}
+				</div>
+			</>),
+		)}
+	</div>;
+}

--- a/src/features/instance/status/crawlData.ts
+++ b/src/features/instance/status/crawlData.ts
@@ -1,0 +1,78 @@
+import { humanFileSize } from '@/lib/humanFileSize';
+import { translateSecondsToAgo } from '@/lib/translateSecondsToAgo';
+
+const startOf2025 = new Date(2025, 0).getTime();
+const oneDayInMs = 24 * 60 * 60 * 1000;
+
+interface TitleItem {
+	title: string;
+	depth: number;
+}
+
+interface NameValuePairItem {
+	name: string;
+	value: string;
+	depth: number;
+}
+
+type ItemForDisplay = TitleItem | NameValuePairItem;
+
+export function crawlData(data: Record<string, unknown>): ItemForDisplay[] {
+	const sections: ItemForDisplay[] = [];
+	for (const key in data) {
+		const value = data[key];
+		sections.push(...parseValue(key, value, 0));
+	}
+	return sections;
+}
+
+export function hasTitle(item: ItemForDisplay): item is TitleItem {
+	return !!(item as TitleItem).title;
+}
+
+function parseValue(name: string, value: unknown, depth: number, parentName?: string): ItemForDisplay[] {
+	if (value && Array.isArray(value)) {
+		const array = value;
+		return value.map((item, index) =>
+			parseValue(
+				array.length > 1 ? name + ' ' + (index + 1) : name,
+				item,
+				depth + 1,
+				name,
+			)).flat(1);
+	}
+	if (isObject(value)) {
+		const obj = value;
+		return [
+			{ title: name, depth },
+			...Object.keys(value).map(subKey => parseValue(
+				String(subKey),
+				obj[subKey],
+				depth + 1,
+				name,
+			)).flat(1),
+		];
+	}
+	if (name === '__updatedtime__' || name === '__createdtime__') {
+		name = name.replace(/_/g, '').replace('time', '');
+	}
+	if (typeof value === 'number') {
+		if (value > startOf2025 && value < Date.now() + oneDayInMs) {
+			const elapsed = Date.now() - value;
+			value = translateSecondsToAgo(elapsed, value);
+		} else if (parentName === 'memory') {
+			value = humanFileSize(value);
+		} else if (!name.startsWith('raw') && name.toLowerCase().includes('load')) {
+			value = Math.round(value * 10) / 10 + '%';
+		}
+	} else if (typeof value === 'boolean') {
+		value = value ? 'Yes' : 'No';
+	}
+	return [
+		{ name, value: String(value), depth },
+	];
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object';
+}

--- a/src/features/instance/status/index.tsx
+++ b/src/features/instance/status/index.tsx
@@ -1,33 +1,7 @@
-import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { isLocalStudio } from '@/config/constants';
-import { useInstanceClientIdParams } from '@/config/useInstanceClient';
-import { getStatusQueryOptions } from '@/features/instance/operations/queries/getStatus';
-import { getSystemInformationQueryOptions } from '@/features/instance/operations/queries/getSystemInformation';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { Suspense } from 'react';
+import { CloudStatus } from '@/features/instance/status/CloudStatus';
+import { LocalStatus } from '@/features/instance/status/LocalStatus';
 
 export function StatusIndex() {
 	return isLocalStudio ? (<LocalStatus />) : (<CloudStatus />);
-}
-
-function LocalStatus() {
-	const instanceParams = useInstanceClientIdParams();
-	const { data } = useSuspenseQuery(getSystemInformationQueryOptions(instanceParams));
-
-	return (<div className="grid grid-cols-1 gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))]">
-		<Suspense fallback={<TextLoadingSkeleton />}>
-			<pre>{JSON.stringify(data, null, '\t')}</pre>
-		</Suspense>
-	</div>);
-}
-
-function CloudStatus() {
-	const instanceParams = useInstanceClientIdParams();
-	const { data } = useSuspenseQuery(getStatusQueryOptions(instanceParams));
-
-	return (<div className="grid grid-cols-1 gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))]">
-		<Suspense fallback={<TextLoadingSkeleton />}>
-			<pre>{JSON.stringify(data, null, '\t')}</pre>
-		</Suspense>
-	</div>);
 }


### PR DESCRIPTION
I got a little fancy with the recursion, let me know if that doesn't seem sustainable, and we can rethink it.

The end result of this is that we'll render a flat list of key-value pairs, with a padding depth added to them, and reasonable value formatting.

On the left is a colocated cluster, and on the right is local mode.

<img width="1598" height="1108" alt="image" src="https://github.com/user-attachments/assets/6ee1aad9-218f-4d5d-94a9-cb83f8c8845d" />


https://harperdb.atlassian.net/browse/STUDIO-404