### PR TITLE
fix: Link directly to sign-in

### DIFF
--- a/src/components/ErrorComponent.tsx
+++ b/src/components/ErrorComponent.tsx
@@ -36,7 +36,7 @@ export function ErrorComponent({ className, error, title, showReturnToHome }: Er
 						</Button>
 					</Link>
 				) : (
-					<Link to="/">
+					<Link to="/sign-in">
 						<Button>
 							{' '}
 							<ArrowLeft /> Go to Sign In Page

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -252,7 +252,7 @@ function AnonymousNav() {
 					</NavigationMenuItem>
 					<NavigationMenuItem>
 						<NavigationMenuLink asChild>
-							<Link to="/" className="flex-row items-center" activeProps={activeLinkProps}>
+							<Link to="/sign-in" className="flex-row items-center" activeProps={activeLinkProps}>
 								<LogInIcon /> Sign In
 							</Link>
 						</NavigationMenuLink>

--- a/src/components/NotFoundComponent.tsx
+++ b/src/components/NotFoundComponent.tsx
@@ -26,7 +26,7 @@ export function NotFoundComponent() {
 							</Button>
 						</Link>
 					) : (
-						<Link to="/">
+						<Link to="/sign-in">
 							<Button>
 								{' '}
 								<ArrowLeft /> Go Sign In Page

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -78,7 +78,7 @@ export function ForgotPassword() {
 				</form>
 			</Form>
 			<div className="flex px-4 mt-4 underline place-content-between">
-				<Link className="text-sm" to="/">
+				<Link className="text-sm" to="/sign-in">
 					Sign in to your account
 				</Link>
 				<Link className="text-sm" to="/sign-up">

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -157,7 +157,7 @@ export function SignUp() {
 				</form>
 			</Form>
 			<div className="flex px-4 mt-4 underline place-content-between">
-				<Link className="m-auto text-sm" to="/">
+				<Link className="m-auto text-sm" to="/sign-in">
 					Already have an account? Sign in instead.
 				</Link>
 			</div>


### PR DESCRIPTION
Some of the links to the sign-in page weren't updated when we changed it from being located at `/` to `/sign-in`. Because of that, when you went to them, you'd get redirected from `/` to `/sign-in`, with a `?redirect=` from your original page. That was getting you to `/sign-in?redirect=/sign-up`, which... wasn't a great experience.

https://harperdb.atlassian.net/browse/STUDIO-405