### PR TITLE
fix: Reset page index when swapping between dbs and tables

### DIFF
--- a/src/features/instance/databases/components/BrowseDataTable.tsx
+++ b/src/features/instance/databases/components/BrowseDataTable.tsx
@@ -11,13 +11,11 @@ import {
 	flexRender,
 	getCoreRowModel,
 	getPaginationRowModel,
-	PaginationState,
 	Row,
-	SortingState,
 	useReactTable,
 } from '@tanstack/react-table';
 import { ArrowLeftIcon, ArrowRightIcon } from 'lucide-react';
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useCallback } from 'react';
 
 interface BrowseDataTableProps<TData, TValue> {
 	columns: ColumnDef<TData, TValue>[];
@@ -27,11 +25,10 @@ interface BrowseDataTableProps<TData, TValue> {
 	totalRecords: number;
 	onRowClick?: (row: Row<TData>) => void;
 	onColumnClick?: (accessorKey: string, isDescending: boolean) => void;
-	paginationState: {
-		pageIndex: number; pageSize: number;
-	};
-	sortingState: SortingState;
-	setPagination: Dispatch<SetStateAction<PaginationState>>;
+	pageIndex: number;
+	pageSize: number;
+	setPageIndex: Dispatch<SetStateAction<number>>;
+	setPageSize: Dispatch<SetStateAction<number>>;
 	children: React.ReactNode;
 }
 
@@ -43,9 +40,10 @@ export function BrowseDataTable<TData, TValue>({
 	totalRecords,
 	onRowClick,
 	onColumnClick,
-	paginationState,
-	sortingState,
-	setPagination,
+	pageIndex,
+	setPageIndex,
+	pageSize,
+	setPageSize,
 	children,
 }: BrowseDataTableProps<TData, TValue>) {
 	const table = useReactTable({
@@ -56,11 +54,14 @@ export function BrowseDataTable<TData, TValue>({
 		rowCount: totalRecords,
 		getCoreRowModel: getCoreRowModel(),
 		getPaginationRowModel: getPaginationRowModel(),
-		initialState: {
-			pagination: paginationState, sorting: sortingState,
-		},
-		onPaginationChange: setPagination,
 	});
+
+	const previousPage = useCallback(() => {
+		setPageIndex(pageIndex - 1);
+	}, [pageIndex, setPageIndex]);
+	const nextPage = useCallback(() => {
+	    setPageIndex(pageIndex + 1);
+	}, [pageIndex, setPageIndex]);
 
 	return (<>
 		{children}
@@ -88,8 +89,8 @@ export function BrowseDataTable<TData, TValue>({
 			</TableBody>
 		</Table>
 		<div className="flex items-center justify-end py-4 space-x-2">
-			<Button variant="defaultOutline" size="sm" onClick={table.previousPage} className="select-none"
-				disabled={paginationState.pageIndex === 0}>
+			<Button variant="defaultOutline" size="sm" onClick={previousPage} className="select-none"
+				disabled={pageIndex === 0}>
 				<ArrowLeftIcon />
 				Previous
 			</Button>
@@ -102,8 +103,8 @@ export function BrowseDataTable<TData, TValue>({
 			</div>
 			{totalRecords > 0 && (<>
 				<div>
-					<Select defaultValue={table.getState().pagination.pageSize.toString()} onValueChange={(value) => {
-						table.setPageSize(Number(value));
+					<Select defaultValue={pageSize.toString()} onValueChange={(value) => {
+						setPageSize(Number(value));
 					}}>
 						<SelectTrigger className="h-10 w-[80px]">
 							<SelectValue />
@@ -123,15 +124,15 @@ export function BrowseDataTable<TData, TValue>({
 					</div>
 					<div className="text-center">
 						<dt className="text-sm/6 font-medium text-gray-500 dark:text-gray-400">Page</dt>
-						<dd className="font-semibold tracking-tight">{addCommasToNumbers(paginationState.pageIndex + 1)}</dd>
+						<dd className="font-semibold tracking-tight">{addCommasToNumbers(pageIndex + 1)}</dd>
 					</div>
 				</>)}
 			</>)}
 
 			<div className="grow"></div>
 
-			<Button variant="defaultOutline" size="sm" onClick={table.nextPage} className="select-none"
-				disabled={paginationState.pageIndex === totalPages - 1}>
+			<Button variant="defaultOutline" size="sm" onClick={nextPage} className="select-none"
+				disabled={pageIndex === totalPages - 1}>
 				Next
 				<ArrowRightIcon />
 			</Button>

--- a/src/features/instance/databases/components/BrowseDataTableView.tsx
+++ b/src/features/instance/databases/components/BrowseDataTableView.tsx
@@ -18,9 +18,9 @@ import { useRefreshClick } from '@/hooks/useRefreshClick';
 import { queryClient } from '@/react-query/queryClient';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
-import { PaginationState, Row } from '@tanstack/react-table';
+import { Row } from '@tanstack/react-table';
 import { PlusIcon, RefreshCwIcon, Trash } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 export function BrowseDataTableView() {
@@ -67,22 +67,10 @@ export function BrowseDataTableView() {
 		descending: false,
 	}, allParams);
 
-	const sortingState = useMemo(
-		() => [
-			{
-				desc: sortTableDataParams.descending,
-				id: sortTableDataParams.attribute,
-			},
-		],
-		[sortTableDataParams],
-	);
-
 	const [totalRecords, setTotalRecords] = useState(describeTableData.record_count);
-	const [pagination, setPagination] = useState<PaginationState>({
-		pageIndex: 0,
-		pageSize: 20,
-	});
-	const [totalPages, setTotalPages] = useState(Math.ceil(describeTableData.record_count / pagination.pageSize));
+	const [pageIndex, setPageIndex] = useEffectedState(0, [databaseName, tableName]);
+	const [pageSize, setPageSize] = useState(20);
+	const [totalPages, setTotalPages] = useState(Math.ceil(describeTableData.record_count / pageSize));
 
 	const {
 		data: tableData,
@@ -95,7 +83,8 @@ export function BrowseDataTableView() {
 			tableName,
 			searchAttribute: hashAttribute,
 			sortTableDataParams,
-			pagination,
+			pageSize,
+			pageIndex,
 		}),
 	);
 	const { mutate: addTableRecords, isPending: isAddTableRecordsPending } = useInsertTableRecords();
@@ -105,8 +94,8 @@ export function BrowseDataTableView() {
 
 	useEffect(() => {
 		setTotalRecords(describeTableData.record_count);
-		setTotalPages(Math.ceil(describeTableData.record_count / pagination.pageSize));
-	}, [describeTableData, pagination.pageSize, pagination.pageIndex]);
+		setTotalPages(Math.ceil(describeTableData.record_count / pageSize));
+	}, [describeTableData, pageSize]);
 
 	const onRecordAdd = (data: Record<string, unknown>[] | Record<string, unknown>) => {
 		addTableRecords(
@@ -217,9 +206,10 @@ export function BrowseDataTableView() {
 				onColumnClick={onColumnClick}
 				totalPages={totalPages}
 				totalRecords={totalRecords}
-				paginationState={pagination}
-				sortingState={sortingState}
-				setPagination={setPagination}
+				pageIndex={pageIndex}
+				pageSize={pageSize}
+				setPageIndex={setPageIndex}
+				setPageSize={setPageSize}
 			>
 				<div className="flex items-center justify-start space-x-2 pt-15 pb-4">
 					{canAddRecords && (

--- a/src/features/instance/operations/queries/getSearchByValue.ts
+++ b/src/features/instance/operations/queries/getSearchByValue.ts
@@ -9,10 +9,8 @@ interface GetSearchByValueParams extends InstanceClientIdConfig {
 		attribute: string;
 		descending: boolean;
 	};
-	pagination: {
-		pageIndex: number;
-		pageSize: number;
-	};
+	pageIndex: number;
+	pageSize: number;
 }
 
 interface SearchConditions {
@@ -44,15 +42,16 @@ export function getSearchByValueOptions({
 	tableName,
 	searchAttribute,
 	sortTableDataParams,
-	pagination,
+	pageSize,
+	pageIndex,
 }: GetSearchByValueParams) {
 	return queryOptions({
 		queryKey: [
 			entityId,
 			'search_by_value',
 			searchAttribute,
-			pagination.pageIndex || 0,
-			pagination.pageSize || 0,
+			pageIndex || 0,
+			pageSize || 0,
 			databaseName,
 			sortTableDataParams.attribute || 'default',
 			sortTableDataParams.descending || false,
@@ -69,8 +68,8 @@ export function getSearchByValueOptions({
 				search_attribute: searchAttribute,
 				search_value: '*',
 				sort: sortTableDataParams.attribute.length ? sortTableDataParams : undefined,
-				limit: pagination.pageSize,
-				offset: pagination.pageIndex * pagination.pageSize,
+				limit: pageSize,
+				offset: pageIndex * pageSize,
 			} satisfies SearchByValueRequest),
 	});
 }


### PR DESCRIPTION
I simplified some stuff a bit and removed the single `pagination` object in favor of splitting them apart. This let me tune the two separately:
1. Page index? Let's have that useEffectedState so it will reset whenever the database or table name changes! 🥇 
2. Page size? Let's useState on that, so it will stay the same! What you pick will stick. 🥳 

With that refactored, I noticed a few lovely bits that weren't being used, that I could remove. Instead of using `table.nextPage` and `table.previousPage`, I wrote direct callbacks, too. Such simples. So cutes.

https://harperdb.atlassian.net/browse/STUDIO-378