### PR TITLE
feat: Show a toast during cluster saving

### DIFF
--- a/src/components/EstimatedProgressBar.tsx
+++ b/src/components/EstimatedProgressBar.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+
+export function EstimatedProgressBar({ duration, message, lateMessage }: { duration: number, message: ReactNode, lateMessage: ReactNode }) {
+	const animationFrameId = useRef<number>(0);
+	const previousTimeRef = useRef<number>(0);
+	const [finished, setFinished] = useState(false);
+	const minPercentage = 5;
+	const [style, setStyle] = useState({ width: `${minPercentage}%` });
+
+	const animate = useCallback((time: number) => {
+		if (!previousTimeRef.current) {
+			previousTimeRef.current = time;
+		}
+		const timeElapsed = time - previousTimeRef.current;
+		const percentage = Math.min(timeElapsed / duration, 1);
+		setStyle({ width: Math.max(minPercentage, percentage * 100) + '%' });
+
+		if (percentage < 1) {
+			animationFrameId.current = requestAnimationFrame(animate);
+		} else {
+			setFinished(true);
+		}
+	}, [duration]);
+
+	useEffect(() => {
+		animationFrameId.current = requestAnimationFrame(animate);
+		return () => cancelAnimationFrame(animationFrameId.current);
+	}, [animate]);
+
+	return (<>
+		{!finished ? message : lateMessage}
+		<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+			<div
+				className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500 mt-2"
+				style={style}
+			></div>
+		</div>
+	</>);
+}

--- a/src/features/auth/VerifyEmail.tsx
+++ b/src/features/auth/VerifyEmail.tsx
@@ -89,7 +89,6 @@ export function VerifyEmail() {
 		(emailToken: VerifyEmailToken) => {
 			submitEmailVerificationToken(emailToken, {
 				onSuccess: () => {
-					//TODO - Trigger a success toast message
 					toast.success('Success', {
 						description: 'Email verified successfully',
 						action: {
@@ -97,7 +96,7 @@ export function VerifyEmail() {
 							onClick: () => toast.dismiss(),
 						},
 					});
-					navigate({ to: '/' });
+					void navigate({ to: '/' });
 				},
 			});
 		},

--- a/src/features/clusters/hooks/useCreateNewCluster.ts
+++ b/src/features/clusters/hooks/useCreateNewCluster.ts
@@ -1,11 +1,15 @@
 import { apiClient } from '@/config/apiClient';
-import { useMutation } from '@tanstack/react-query';
 import { SchemaCluster, SchemaClusterUpsert } from '@/lib/api.gen';
+import { useMutation } from '@tanstack/react-query';
 
-export async function onNewClusterSubmit(
+async function onNewClusterSubmit(
 	clusterInfo: SchemaClusterUpsert,
 ): Promise<SchemaCluster> {
-	const { data } = await apiClient.post('/Cluster/', clusterInfo);
+	const { data } = await apiClient.post(
+		'/Cluster/',
+		clusterInfo,
+		{ timeout: 120_000 },
+	);
 	return data;
 }
 

--- a/src/features/clusters/hooks/useUpdateCluster.ts
+++ b/src/features/clusters/hooks/useUpdateCluster.ts
@@ -2,12 +2,14 @@ import { apiClient } from '@/config/apiClient';
 import { SchemaCluster, SchemaClusterUpsert } from '@/lib/api.gen';
 import { useMutation } from '@tanstack/react-query';
 
-export async function onEditClusterSubmit(
+async function onEditClusterSubmit(
 	clusterInfo: Pick<SchemaCluster, 'id'> & Pick<SchemaClusterUpsert, 'regionPlans'>,
 ): Promise<SchemaCluster> {
-	const { data } = await apiClient.put(`/Cluster/${clusterInfo.id}` as '/Cluster/{id}', {
-		regionPlans: clusterInfo.regionPlans,
-	});
+	const { data } = await apiClient.put(
+		`/Cluster/${clusterInfo.id}` as '/Cluster/{id}',
+		{ regionPlans: clusterInfo.regionPlans },
+		{ timeout: 120_000 },
+	);
 	return data;
 }
 

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -1,8 +1,8 @@
+import { EstimatedProgressBar } from '@/components/EstimatedProgressBar';
 import { Form } from '@/components/ui/form/Form';
 import { defaultOperationsApiPort } from '@/config/constants';
 import { useCreateNewClusterMutation } from '@/features/clusters/hooks/useCreateNewCluster';
 import { useEditClusterMutation } from '@/features/clusters/hooks/useUpdateCluster';
-import { GetRegionLocationsParams } from '@/features/clusters/queries/getRegionLocationsQuery';
 import { ClusterBilling } from '@/features/clusters/upsert/ClusterBilling';
 import { ClusterDetails } from '@/features/clusters/upsert/ClusterDetails';
 import { calculateInstanceFQDN } from '@/features/clusters/upsert/lib/calculateInstanceFQDN';
@@ -34,7 +34,7 @@ interface ClusterFormProps {
 	planTypes: SchemaPlan[];
 	regionLocations: SchemaRegion[];
 	regionNameToLatencyToRegion: Record<string, Record<string, SchemaRegion>>;
-	setLimitRegionParameters: (value: GetRegionLocationsParams) => void;
+	setOnlyShowAvailableHosts: (value: boolean) => void;
 	setSavedClusterState: (value: null | ({ clusterId?: string } & z.infer<typeof UpsertClusterSchema>)) => void;
 	startOffOnBilling: boolean;
 }
@@ -48,7 +48,7 @@ export function ClusterForm({
 	planTypes,
 	regionLocations,
 	regionNameToLatencyToRegion,
-	setLimitRegionParameters,
+	setOnlyShowAvailableHosts,
 	setSavedClusterState,
 	startOffOnBilling,
 }: ClusterFormProps) {
@@ -132,11 +132,8 @@ export function ClusterForm({
 	const selectedInstances = form.watch('instances');
 
 	useEffect(function syncRegionsWithSelectedDeploymentType() {
-		setLimitRegionParameters({
-			availableHosts: selectedDeployment !== 'Dedicated' ? true : undefined,
-			organizationId,
-		});
-	}, [organizationId, selectedDeployment, setLimitRegionParameters]);
+		setOnlyShowAvailableHosts(selectedDeployment !== 'Dedicated');
+	}, [organizationId, selectedDeployment, setOnlyShowAvailableHosts]);
 
 	useEffect(function syncInstancesAndRegionsWithSelfManagedSelection() {
 		const values = form.getValues();
@@ -226,16 +223,42 @@ export function ClusterForm({
 					: selectedPlan.priceUsd * regionPlan.instanceCount / 2);
 			}, 0);
 
-	const onClusterCreatedCallback = useCallback(() => {
-		void queryClient.invalidateQueries({ queryKey: [queryKeys.organization], refetchType: 'active' });
-		void navigate({ to: '../' });
-		toast.success('Cluster Created', { description: 'It is being provisioned now.' });
-	}, [navigate, queryClient]);
+	const onStartSaving = useCallback(({
+		creating,
+		deploymentDescription,
+	}: {
+		creating: boolean;
+		deploymentDescription: string;
+	}) =>
+		toast.message(creating ? 'Creating Cluster' : 'Updating Cluster', {
+			description: <EstimatedProgressBar
+				message="This may take a little bit, hold tight!"
+				lateMessage="Still working on it... why don't you grab a coffee, and I'll let you know when it's done?"
+				duration={deploymentDescription === 'Dedicated' ? 60_000 : 5_000}
+			/>,
+			duration: 120_000,
+		}), []);
 
-	const onClusterEditedCallback = useCallback(() => {
+	const onClusterSavedCallback = useCallback(({
+		creating,
+		toastId,
+		isSelfManaged,
+	}: {
+		creating: boolean;
+		isSelfManaged: boolean;
+		toastId: string | number;
+	}) => {
 		void queryClient.invalidateQueries({ queryKey: [queryKeys.organization], refetchType: 'active' });
-		void navigate({ to: '../../' });
-		toast.success('Cluster Edited', { description: 'The updates are being applied now.' });
+		void navigate({ to: creating ? '../' : '../../' });
+		toast.success(creating ? 'Cluster Created' : 'Cluster Updated', {
+			id: toastId,
+			description: isSelfManaged
+				? undefined
+				: creating
+					? 'It is being provisioned now.'
+					: 'The updates are being provisioned now.',
+			duration: 5_000,
+		});
 	}, [navigate, queryClient]);
 
 	const submitCreateCluster = useCallback(async () => {
@@ -265,11 +288,16 @@ export function ClusterForm({
 			}
 		}
 		setSavedClusterState(null);
+		const toastId = onStartSaving({ creating: !clusterId, deploymentDescription: formData.deploymentDescription });
+		const clearToast = () => toast.dismiss(toastId);
 		if (clusterId) {
 			submitEditClusterData({
 				id: clusterId,
 				regionPlans: plans,
-			}, { onSuccess: onClusterEditedCallback });
+			}, {
+				onSuccess: () => onClusterSavedCallback({ isSelfManaged, creating: false, toastId }),
+				onError: clearToast,
+			});
 		} else {
 			submitNewClusterData({
 				abbreviatedName: isSelfManaged ? undefined : (formData.abbreviatedName || calculatedNames.suggestedAbbreviatedName),
@@ -278,9 +306,12 @@ export function ClusterForm({
 				name: formData.systemName,
 				organizationId,
 				regionPlans: plans,
-			}, { onSuccess: onClusterCreatedCallback });
+			}, {
+				onSuccess: () => onClusterSavedCallback({ isSelfManaged, creating: true, toastId }),
+				onError: clearToast,
+			});
 		}
-	}, [calculatedNames.suggestedAbbreviatedName, clusterId, deploymentToPerformanceToPlan, form, onClusterCreatedCallback, onClusterEditedCallback, organizationId, regionNameToLatencyToRegion, setSavedClusterState, submitEditClusterData, submitNewClusterData]);
+	}, [calculatedNames.suggestedAbbreviatedName, clusterId, deploymentToPerformanceToPlan, form, onClusterSavedCallback, onStartSaving, organizationId, regionNameToLatencyToRegion, setSavedClusterState, submitEditClusterData, submitNewClusterData]);
 
 	const submitClusterDetailsForm = useCallback(() => {
 		if (totalPrice > 0) {

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -4,10 +4,7 @@ import { Loading } from '@/components/Loading';
 import { SubNavSimpleLayout } from '@/components/SubNavSimpleLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { getPlanTypesOptions } from '@/features/cluster/queries/getPlanTypesQuery';
-import {
-	getRegionLocationsOptions,
-	GetRegionLocationsParams,
-} from '@/features/clusters/queries/getRegionLocationsQuery';
+import { getRegionLocationsOptions } from '@/features/clusters/queries/getRegionLocationsQuery';
 import { ClusterForm } from '@/features/clusters/upsert/ClusterForm';
 import {
 	calculateDefaultDeploymentPerformanceAndRegionPlans,
@@ -25,7 +22,7 @@ import { z } from 'zod';
 
 export function UpsertCluster() {
 	const { organizationId, clusterId }: { organizationId: string; clusterId?: string } = useParams({ strict: false });
-	const [limitRegionParameters, setLimitRegionParameters] = useState<GetRegionLocationsParams>({ availableHosts: true });
+	const [onlyShowAvailableHosts, setOnlyShowAvailableHosts] = useState(true);
 	const [savedClusterState, setSavedClusterState] = useLocalStorage<null | ({
 		clusterId?: string
 	} & z.infer<typeof UpsertClusterSchema>)>(LocalStorageKeys.SavedClusterState, null);
@@ -33,7 +30,12 @@ export function UpsertCluster() {
 	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId));
 	const { data: organization } = useQuery(getOrganizationQueryOptions(organizationId));
 	const { data: planTypes } = useQuery(getPlanTypesOptions(organizationId));
-	const { data: regionLocations } = useQuery(getRegionLocationsOptions(limitRegionParameters));
+	const { data: regionLocationsAvailableHosts } = useQuery(getRegionLocationsOptions({
+		availableHosts: true,
+		organizationId,
+	}));
+	const { data: regionLocationsAll } = useQuery(getRegionLocationsOptions({ organizationId }));
+	const regionLocations = onlyShowAvailableHosts ? regionLocationsAvailableHosts : regionLocationsAll;
 
 	const deploymentToPerformanceToPlan = useMemo<Record<string, Record<string, SchemaPlan>>>(() =>
 		groupThenKeyBy(planTypes?.sort(sortByField('priceUsd')) || [], 'deploymentDescription', 'performanceDescription'), [planTypes]);
@@ -44,7 +46,7 @@ export function UpsertCluster() {
 		if (savedClusterState) {
 			return savedClusterState;
 		}
-		if (!planTypes || !regionLocations || (clusterId && !cluster)) {
+		if (!planTypes || !regionLocationsAvailableHosts || !regionLocationsAll || (clusterId && !cluster)) {
 			return null;
 		}
 
@@ -52,6 +54,7 @@ export function UpsertCluster() {
 
 		const regionPlans: z.infer<typeof UpsertClusterSchema.shape.regionPlans> = [];
 		const instances: z.infer<typeof UpsertClusterSchema.shape.instances> = [];
+		const regionLocations = onlyShowAvailableHosts ? regionLocationsAvailableHosts : regionLocationsAll;
 		const defaults = calculateDefaultDeploymentPerformanceAndRegionPlans(planTypes, regionLocations);
 
 		let isSelfManaged = false;
@@ -98,7 +101,7 @@ export function UpsertCluster() {
 			instances,
 			regionPlans,
 		};
-	}, [cluster, clusterId, planTypes, regionLocations, savedClusterState]);
+	}, [cluster, clusterId, onlyShowAvailableHosts, planTypes, regionLocationsAll, regionLocationsAvailableHosts, savedClusterState]);
 
 	const isLoading = !defaultValues || !organization || !planTypes || !regionLocations;
 	if (isLoading) {
@@ -135,7 +138,7 @@ export function UpsertCluster() {
 				planTypes={planTypes}
 				regionLocations={regionLocations}
 				regionNameToLatencyToRegion={regionNameToLatencyToRegion}
-				setLimitRegionParameters={setLimitRegionParameters}
+				setOnlyShowAvailableHosts={setOnlyShowAvailableHosts}
 				setSavedClusterState={setSavedClusterState}
 				startOffOnBilling={!!savedClusterState}
 			/>


### PR DESCRIPTION
Check the JIRA ticket for the rules on the timings we should show. I also removed an old comment, and fixed a bug when we'd swap `setLimitRegionParameters` that would wipe out your form. Instead, we'll look up both sets of data when the form loads, and then pick one when they switch.

https://harperdb.atlassian.net/browse/STUDIO-422