### PR TITLE
fix: Consistently trim and lowercase usernames and emails

### DIFF
--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -4,6 +4,7 @@ import { FormField } from '@/components/ui/form/FormField';
 import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
+import { zodRequireEmail } from '@/lib/zod/email';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useForgotPasswordMutation } from '@/features/auth/hooks/useForgotPassword';
 import { useForm } from 'react-hook-form';
@@ -14,11 +15,7 @@ import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 
 const ForgotPasswordSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		})
-		.max(75, { error: 'Email cannot be longer than 75 characters.' }),
+	email: zodRequireEmail,
 });
 
 export function ForgotPassword() {

--- a/src/features/auth/ResetPassword.tsx
+++ b/src/features/auth/ResetPassword.tsx
@@ -6,6 +6,7 @@ import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
+import { zodRequirePassword } from '@/lib/zod/password';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useEffect } from 'react';
@@ -16,8 +17,7 @@ import { useResetPasswordMutation } from './hooks/useResetPassword';
 
 const ResetPasswordSchema = z
 	.object({
-		password: z
-			.string()
+		password: zodRequirePassword
 			.min(8, { error: 'Password must be at least 8 characters long.' })
 			.max(50, { error: 'Password cannot be longer than 50 characters.' }),
 		confirmPassword: z.string(),

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -11,6 +11,8 @@ import { reoClient } from '@/integrations/reo/reo';
 import { authStore, OverallAppSignIn } from '@/lib/authStore';
 import { parseCompanyFromEmail } from '@/lib/string/parseCompanyFromEmail';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
+import { zodRequireEmail } from '@/lib/zod/email';
+import { zodRequirePassword } from '@/lib/zod/password';
 import { queryKeys } from '@/react-query/constants';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
@@ -19,13 +21,8 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const SignInSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		}),
-	password: z
-		.string()
-		.nonempty({ error: 'Please enter your password.' }),
+	email: zodRequireEmail,
+	password: zodRequirePassword,
 });
 
 export function SignIn() {

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -7,6 +7,8 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useSignUpMutation } from '@/features/auth/hooks/useSignUp';
+import { zodRequireEmail } from '@/lib/zod/email';
+import { zodRequirePassword } from '@/lib/zod/password';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { useForm } from 'react-hook-form';
@@ -14,12 +16,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 const SignInSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		})
-		.trim()
-		.toLowerCase()
+	email: zodRequireEmail
 		.max(80, { error: 'Email cannot be longer than 80 characters.' }),
 	firstname: z
 		.string()
@@ -31,8 +28,7 @@ const SignInSchema = z.object({
 		.trim()
 		.min(2, { error: 'Please enter your last name.' })
 		.max(80, { error: 'Last name cannot be longer than 80 characters.' }),
-	password: z
-		.string()
+	password: zodRequirePassword
 		.min(8, { error: 'Password must be at least 8 characters long.' }),
 });
 
@@ -150,7 +146,10 @@ export function SignUp() {
 							</FormItem>
 						)}
 					/>
-					<p className="text-xs">By creating an account, you agree to the <a rel="noopener" href="https://www.harpersystems.dev/legal/privacy-policy" target="_blank" className="underline">Privacy Policy</a> and <a rel="noopener" href="https://www.harpersystems.dev/legal/harperdb-cloud-terms-of-service" target="_blank" className="underline">Terms of Service</a></p>
+					<p className="text-xs">By creating an account, you agree to
+						the <a rel="noopener" href="https://www.harpersystems.dev/legal/privacy-policy" target="_blank" className="underline">Privacy
+							Policy</a> and <a rel="noopener" href="https://www.harpersystems.dev/legal/harperdb-cloud-terms-of-service" target="_blank" className="underline">Terms
+							of Service</a></p>
 
 					<Button type="submit" variant="submit" className="w-full my-2 rounded-full">
 						Sign Up For Free

--- a/src/features/auth/VerifyEmail.tsx
+++ b/src/features/auth/VerifyEmail.tsx
@@ -7,6 +7,7 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useVerifyEmailMutation, VerifyEmailToken } from '@/features/auth/hooks/useVerifyEmail';
+import { zodRequireEmail } from '@/lib/zod/email';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useEffect } from 'react';
@@ -16,11 +17,7 @@ import { z } from 'zod';
 import { useResendEmailVerification } from './hooks/useResendEmailVerification';
 
 const VerifyEmailSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		})
-		.max(75, { error: 'Email cannot be longer than 75 characters.' }),
+	email: zodRequireEmail,
 });
 
 function SendEmailVerification() {

--- a/src/features/instance/operations/schemas/addUserFormSchema.ts
+++ b/src/features/instance/operations/schemas/addUserFormSchema.ts
@@ -1,19 +1,16 @@
+import { zodRequirePassword } from '@/lib/zod/password';
+import { zodRequireUsername } from '@/lib/zod/username';
 import { z } from 'zod';
 
 export const AddUserFormSchema = z
 	.object({
-		username: z
-			.string()
-			.trim()
-			.toLowerCase()
-			.nonempty({ error: 'Please enter a username.' }),
+		username: zodRequireUsername,
 		role: z
 			.string()
 			.nonempty({
 				error: 'Please select a role.',
 			}),
-		password: z
-			.string()
+		password: zodRequirePassword
 			.min(8, { error: 'Password must be at least 8 characters long.' }),
 		confirmPassword: z.string(),
 	})

--- a/src/features/instance/operations/schemas/deleteUserFormSchema.ts
+++ b/src/features/instance/operations/schemas/deleteUserFormSchema.ts
@@ -1,16 +1,14 @@
+import { zodRequireUsername } from '@/lib/zod/username';
 import { z } from 'zod';
 
 export const DeleteUserFormSchema = z.object({
-	username: z
-		.string()
-		.nonempty({
-			error: 'Please enter a username.',
-		}),
+	username: zodRequireUsername,
 	confirmUsernameForDeletion: z
 		.string()
 		.nonempty({
 			error: 'Please type the username again to confirm deletion.',
-		}),
+		})
+		.toLowerCase(),
 })
 	.refine((data) => data.username === data.confirmUsernameForDeletion, {
 		error: 'Username does not match.',

--- a/src/features/instance/operations/schemas/signInSchema.ts
+++ b/src/features/instance/operations/schemas/signInSchema.ts
@@ -1,10 +1,8 @@
+import { zodRequirePassword } from '@/lib/zod/password';
+import { zodRequireUsername } from '@/lib/zod/username';
 import { z } from 'zod';
 
 export const SignInSchema = z.object({
-	username: z
-		.string()
-		.nonempty({ error: 'Please enter your username.' }),
-	password: z
-		.string()
-		.nonempty({ error: 'Please enter your password.' }),
+	username: zodRequireUsername,
+	password: zodRequirePassword,
 });

--- a/src/features/organization/mutations/addUserToOrganizationRole.ts
+++ b/src/features/organization/mutations/addUserToOrganizationRole.ts
@@ -1,13 +1,11 @@
 import { apiClient } from '@/config/apiClient';
+import { zodRequireEmail } from '@/lib/zod/email';
 import { useMutation } from '@tanstack/react-query';
 import z from 'zod';
 
 export const AddOrganizationRoleSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		})
-		.max(75, { error: 'Email cannot be longer than 75 characters.' }),
+	email: zodRequireEmail
+		.max(80, { error: 'Email cannot be longer than 80 characters.' }),
 	roleId: z.string().nonempty({ error: 'Please select a role.' }),
 });
 

--- a/src/features/organization/mutations/inviteUserToOrganizationRole.ts
+++ b/src/features/organization/mutations/inviteUserToOrganizationRole.ts
@@ -1,13 +1,11 @@
 import { apiClient } from '@/config/apiClient';
+import { zodRequireEmail } from '@/lib/zod/email';
 import { useMutation } from '@tanstack/react-query';
 import z from 'zod';
 
 export const InviteOrganizationRoleSchema = z.object({
-	email: z
-		.email({
-			error: 'Please enter a valid email address.',
-		})
-		.max(75, { error: 'Email cannot be longer than 75 characters.' }),
+	email: zodRequireEmail
+		.max(80, { error: 'Email cannot be longer than 80 characters.' }),
 	roleId: z.string().nonempty({ error: 'Please select a role.' }),
 });
 

--- a/src/lib/zod/email.ts
+++ b/src/lib/zod/email.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const zodRequireEmail = z
+	.email({
+		error: 'Please enter a valid email address.',
+	})
+	.toLowerCase()
+	.trim();

--- a/src/lib/zod/password.ts
+++ b/src/lib/zod/password.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const zodRequirePassword = z
+	.string()
+	.nonempty({ error: 'Please enter your password.' });

--- a/src/lib/zod/username.ts
+++ b/src/lib/zod/username.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const zodRequireUsername = z
+	.string()
+	.nonempty({ error: 'Please enter a username.' })
+	.trim()
+	.toLowerCase();

--- a/src/lib/zod/username.ts
+++ b/src/lib/zod/username.ts
@@ -2,6 +2,4 @@ import { z } from 'zod';
 
 export const zodRequireUsername = z
 	.string()
-	.nonempty({ error: 'Please enter a username.' })
-	.trim()
-	.toLowerCase();
+	.nonempty({ error: 'Please enter a username.' });


### PR DESCRIPTION
I extracted a few shared zod constants that we can use, and grow in the future.

The effective changes are as follows:
1. When specifying a username or email, we'll always trim it, and lowercase it, regardless of signing-up or signing-in, for both cloud and instances.
2. When signing-up, we'll also apply the length restrictions.
3. Sign in, reset password and forgot password won't apply the length restrictions (since they aren't creating a user).

Plus, my auto-formatter wrapped the new privacy statement to meet the column wrap lint.

https://harperdb.atlassian.net/browse/STUDIO-420