### PR TITLE
fix: Allow waiting longer for things to restart

### DIFF
--- a/src/components/ui/utils/badgeLogLevel.tsx
+++ b/src/components/ui/utils/badgeLogLevel.tsx
@@ -11,7 +11,7 @@ export type BadgeLogLevelVariant =
 
 type BadgeStatusVariantValues = 'warning' | 'success' | 'secondary' | 'destructive';
 
-const renderBadgeLogLevelVariant = (value: BadgeLogLevelVariant): BadgeStatusVariantValues => {
+export function renderBadgeLogLevelVariant(value: BadgeLogLevelVariant): BadgeStatusVariantValues {
 	switch (value) {
 		case 'warn':
 			return 'warning';
@@ -29,26 +29,4 @@ const renderBadgeLogLevelVariant = (value: BadgeLogLevelVariant): BadgeStatusVar
 		default:
 			return value;
 	}
-};
-
-const BADGE_STATUS_TEXT = {
-	notify: 'Notify',
-	error: 'Error',
-	warn: 'Warn',
-	info: 'Info',
-	debug: 'Debug',
-	trace: 'Trace',
-	stdout: 'Stdout',
-	stderr: 'Stderr',
-	undefined: 'Unknown',
-} as const;
-
-export type BadgeStatus = keyof typeof BADGE_STATUS_TEXT;
-
-const renderBadgeLogLevelText = (value: BadgeStatus) => {
-	const status = BADGE_STATUS_TEXT[value];
-	if (status) return status;
-	throw new Error('Unsupported Status');
-};
-
-export { renderBadgeLogLevelVariant, renderBadgeLogLevelText };
+}

--- a/src/components/ui/utils/badgeStatus.tsx
+++ b/src/components/ui/utils/badgeStatus.tsx
@@ -1,5 +1,3 @@
-import { Cluster } from '@/lib/api.patch';
-
 export type BadgeStatusVariant =
 	| string
 	| 'PROVISIONING'
@@ -17,10 +15,11 @@ export type BadgeStatusVariant =
 
 export type BadgeStatusVariantValues = 'warning' | 'success' | 'secondary' | 'destructive' | 'outline' | 'default';
 
-const renderBadgeStatusVariant = (value: BadgeStatusVariant): BadgeStatusVariantValues => {
+export function renderBadgeStatusVariant(value: BadgeStatusVariant): BadgeStatusVariantValues {
 	switch (value) {
 		case 'PROVISIONING':
 		case 'CLONE_PENDING':
+		case 'CLONING':
 		case 'CLONE_READY':
 		case 'UPDATING_HDB_NODES':
 		case 'UPDATING':
@@ -30,36 +29,12 @@ const renderBadgeStatusVariant = (value: BadgeStatusVariant): BadgeStatusVariant
 			return 'success';
 		case 'STOPPED':
 			return 'secondary';
-		case 'TERMINATED':
 		case 'TERMINATING':
-		case 'ERROR':
+		case 'TERMINATED':
 		case 'REMOVED':
-		default:
+		case 'ERROR':
 			return 'destructive';
+		default:
+			return 'default';
 	}
-};
-
-const BADGE_STATUS_TEXT: Record<Exclude<Cluster['status'], undefined>, string> = {
-	PROVISIONING: 'Provisioning',
-	RUNNING: 'Running',
-	STOPPED: 'Stopped',
-	TERMINATED: 'Terminated',
-	CLONE_PENDING: 'Clone Pending',
-	UPDATING_HDB_NODES: 'Updating HDB Nodes',
-	UPDATING: 'Updating',
-	UPDATED: 'Updated',
-	ERROR: 'Error',
-	TERMINATING: 'Terminating',
-	CLONE_READY: 'Clone Ready',
-	REMOVED: 'Removed',
-} as const;
-
-export type BadgeStatus = keyof typeof BADGE_STATUS_TEXT;
-
-const renderBadgeStatusText = (value: BadgeStatus) => {
-	const status = BADGE_STATUS_TEXT[value];
-	if (status) return status;
-	throw new Error('Unsupported Status');
-};
-
-export { renderBadgeStatusVariant, renderBadgeStatusText };
+}

--- a/src/features/cluster/index.tsx
+++ b/src/features/cluster/index.tsx
@@ -3,13 +3,14 @@ import { SubNavMenu } from '@/components/SubNavMenu';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { BadgeStatus, renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
+import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { EmptyCluster } from '@/features/cluster/EmptyCluster';
 import { InstanceLogInCell } from '@/features/cluster/InstanceLogInCell';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { Instance } from '@/lib/api.patch';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { InstanceTypes, renderInstanceTypeOption } from '@/lib/InstanceType';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { ColumnDef } from '@tanstack/react-table';
@@ -43,8 +44,8 @@ export function ClusterIndex() {
 				accessorKey: 'status',
 				header: 'Status',
 				cell: (cell) => {
-					const status = cell.getValue() as BadgeStatus;
-					return <Badge variant={renderBadgeStatusVariant(status)}>{renderBadgeStatusText(status)}</Badge>;
+					const status = cell.getValue() as string;
+					return <Badge variant={renderBadgeStatusVariant(status)}>{capitalizeWords(status)}</Badge>;
 				},
 			},
 			{

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -3,7 +3,7 @@ import { SubNavMenu } from '@/components/SubNavMenu';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
+import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { ClusterCard } from '@/features/clusters/components/ClusterCard';
 import { useTerminateClusterMutation } from '@/features/clusters/mutations/terminateCluster';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
@@ -11,6 +11,7 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { byClusterStatusThenName } from '@/lib/arrays/sort/byClusterStatusThenName';
 import { groupBy } from '@/lib/groupBy';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { curryFilterByFuzzySearch } from '@/lib/string/filterByFuzzySearch';
 import { queryKeys } from '@/react-query/constants';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
@@ -125,7 +126,7 @@ export function ClustersList() {
 					clustersData.keys.map((clusterStatus) => (
 						<div key={clusterStatus}>
 							<h2 className="mb-2">
-								<Badge variant={renderBadgeStatusVariant(clusterStatus)}>{renderBadgeStatusText(clusterStatus)}</Badge>
+								<Badge variant={renderBadgeStatusVariant(clusterStatus)}>{capitalizeWords(clusterStatus)}</Badge>
 							</h2>
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
 								{clustersData.groups[clusterStatus].map((cluster) => (

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -8,7 +8,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
-import { renderBadgeStatusText, renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
+import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { useInstanceClient } from '@/config/useInstanceClient';
 import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterCardAction } from '@/features/clusters/components/ClusterCardAction';
@@ -18,6 +18,7 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { authStore } from '@/lib/authStore';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { Link } from '@tanstack/react-router';
 import { Ellipsis } from 'lucide-react';
@@ -134,7 +135,7 @@ export function ClusterCard({
 			</CardHeader>
 			<CardContent className="flex justify-between">
 				{cluster.status && (
-					<Badge variant={renderBadgeStatusVariant(cluster.status)}>{renderBadgeStatusText(cluster.status)}</Badge>
+					<Badge variant={renderBadgeStatusVariant(cluster.status)}>{capitalizeWords(cluster.status)}</Badge>
 				)}
 				{isActive && view && <ClusterCardAction cluster={cluster} />}
 			</CardContent>

--- a/src/features/instance/log/index.tsx
+++ b/src/features/instance/log/index.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@/components/ui/badge';
-import { renderBadgeLogLevelText, renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
+import { renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { LogsDataTable } from '@/features/instance/log/LogsDataTable';
 import { ViewLogModal } from '@/features/instance/log/modals/ViewLogModal';
@@ -8,6 +8,7 @@ import {
 	ReadLogItem,
 } from '@/features/instance/operations/queries/getReadLog';
 import { LogFiltersFormSchema } from '@/features/instance/operations/schemas/logFiltersFormSchema';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { ColumnDef } from '@tanstack/react-table';
@@ -42,7 +43,7 @@ const columns: ColumnDef<ReadLogItem>[] = [
 		header: 'Status',
 		cell: ({ row }) => {
 			const { level } = row.original;
-			return <Badge variant={renderBadgeLogLevelVariant(level)}>{renderBadgeLogLevelText(level)}</Badge>;
+			return <Badge variant={renderBadgeLogLevelVariant(level)}>{capitalizeWords(level)}</Badge>;
 		},
 	},
 	{
@@ -81,7 +82,7 @@ const columns: ColumnDef<ReadLogItem>[] = [
 					<TooltipContent className='bg-grey-700' arrowClassName='bg-grey-700 fill-grey-700'>{node}</TooltipContent>
 				</Tooltip>
 				) : null}
-			
+
 				</>
 			);
 		},

--- a/src/features/instance/log/modals/ViewLogModal.tsx
+++ b/src/features/instance/log/modals/ViewLogModal.tsx
@@ -2,7 +2,8 @@ import { Loading } from '@/components/Loading';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { BadgeStatus, renderBadgeLogLevelText, renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
+import { renderBadgeLogLevelVariant } from '@/components/ui/utils/badgeLogLevel';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import Editor from '@monaco-editor/react';
 import { Save, Trash } from 'lucide-react';
 import { ReadLogItem } from '@/features/instance/operations/queries/getReadLog';
@@ -41,7 +42,7 @@ export function ViewLogModal({
 						<div>
 							<h3 className="inline-block pr-2">Level:</h3>
 							<Badge variant={renderBadgeLogLevelVariant(data.level)}>
-								{renderBadgeLogLevelText(data.level as BadgeStatus)}
+								{capitalizeWords(data.level)}
 							</Badge>
 						</div>
 						<div>

--- a/src/features/instance/operations/mutations/restartInstance.ts
+++ b/src/features/instance/operations/mutations/restartInstance.ts
@@ -19,8 +19,8 @@ export async function restartInstance({ operation, replicated, instanceClient }:
 		service: operation === 'restart_service' ? 'http' : undefined,
 		replicated,
 	});
-	await sleep(3_000);
-	await axiosRetry(() => getInstanceUserInfo({ instanceClient, timeout: 10_000 }), 5, 3_000);
+	await sleep(10_000);
+	await axiosRetry(() => getInstanceUserInfo({ instanceClient, timeout: 3_000 }), 12, 15_000);
 	return data as UpdateRestartInstanceResponse;
 }
 

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -9,6 +9,7 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
 import { useOrganizationPermissions } from '@/hooks/usePermissions';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight, Ellipsis } from 'lucide-react';
 import { useCallback } from 'react';
@@ -52,7 +53,7 @@ export function OrgCard({
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="flex justify-between">
-				<Badge>{roleName}</Badge>
+				<Badge>{capitalizeWords(roleName)}</Badge>
 				<Link
 					to={organizationId}
 					className="text-sm"

--- a/src/hooks/useRestartInstanceClick.ts
+++ b/src/hooks/useRestartInstanceClick.ts
@@ -24,7 +24,7 @@ export function useRestartInstanceClick({
 	const onRestartClick = useCallback(() => {
 		const toastId = toast.loading('Restarting', {
 			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
-			duration: 60_000,
+			duration: 180_000,
 			action: {
 				label: 'Dismiss',
 				onClick: () => toast.dismiss(),

--- a/src/lib/string/capitalizeWords.test.ts
+++ b/src/lib/string/capitalizeWords.test.ts
@@ -18,6 +18,14 @@ describe('capitalizeWords', () => {
 		it('newIDs -> New IDs', () => {
 			expect(capitalizeWords('newIDs')).toBe('New IDs');
 		});
+
+		it('UPDATING_HDB_NODES -> Updating HDB Nodes', () => {
+			expect(capitalizeWords('UPDATING_HDB_NODES')).toBe('Updating HDB Nodes');
+		});
+
+		it('RUNNING -> Running', () => {
+			expect(capitalizeWords('RUNNING')).toBe('Running');
+		});
 	});
 
 	describe('delimiters and whitespace', () => {

--- a/src/lib/string/capitalizeWords.ts
+++ b/src/lib/string/capitalizeWords.ts
@@ -1,12 +1,23 @@
+const capitalizedCache = new Map<string, string>();
+
 export function capitalizeWords(name: string): string {
-	if (!name) return '';
+	if (!name) {
+		return '';
+	}
+
+	if (capitalizedCache.has(name)) {
+		return capitalizedCache.get(name) as string;
+	}
 
 	// Normalize separators to single spaces and trim
 	const s = name
 		.replace(/[-_]+/g, ' ')
 		.replace(/\s+/g, ' ')
 		.trim();
-	if (!s) return '';
+	if (!s) {
+		capitalizedCache.set(name, '');
+		return '';
+	}
 
 	// Split into tokens handling camelCase/PascalCase, acronyms, and numbers
 	// Pattern parts:
@@ -15,43 +26,52 @@ export function capitalizeWords(name: string): string {
 	// - [A-Z]+ captures remaining all-caps (acronyms)
 	// - [0-9]+ captures numbers
 	const baseTokens = s.match(/([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)/g);
-	if (!baseTokens) return '';
+	if (!baseTokens) {
+		capitalizedCache.set(name, '');
+		return '';
+	}
 
 	// Merge plural 's' following an acronym (length>=2), e.g., ["ID", "s"] -> ["IDs"]
 	const tokens: string[] = [];
 	for (let i = 0; i < baseTokens.length; i++) {
-		const tok = baseTokens[i];
+		const token = baseTokens[i];
 		const next = i + 1 < baseTokens.length ? baseTokens[i + 1] : undefined;
 		if (
 			// Case 1: full acronym then plural 's' as separate token -> merge
-			/^[A-Z]{2,}$/.test(tok) &&
+			/^[A-Z]{2,}$/.test(token) &&
 			next === 's'
 		) {
-			tokens.push(tok + 's');
+			tokens.push(token + 's');
 			i++; // skip the 's'
 		} else if (
 			// Case 2: single leading capital followed by capital + 's' (e.g., 'I' + 'Ds') -> merge to 'IDs'
-			/^[A-Z]$/.test(tok) &&
+			/^[A-Z]$/.test(token) &&
 			next !== undefined &&
 			/^[A-Z]s$/.test(next)
 		) {
-			tokens.push(tok + next);
+			tokens.push(token + next);
 			i++; // skip merged next
 		} else {
-			tokens.push(tok);
+			tokens.push(token);
 		}
 	}
 
-	// Capitalize tokens appropriately
-	const words = tokens.map(t => {
-		if (/^[A-Z]{2,}s?$/.test(t)) {
-			// Acronym (e.g., ID, API) possibly with plural 's' -> keep as is
-			return t;
-		}
-		if (/^[0-9]+$/.test(t)) return t; // numbers unchanged
-		// Normal word: capitalize first letter, lowercase rest
-		return t.charAt(0).toUpperCase() + t.slice(1).toLowerCase();
-	});
+	const words = tokens.map(capitalizeTokenWordsAppropriately);
 
-	return words.join(' ');
+	const result = words.join(' ');
+	capitalizedCache.set(name, result);
+	return result;
+}
+
+function capitalizeTokenWordsAppropriately(t: string): string {
+	if (/^[A-Z]{2,3}s?$/.test(t)) {
+		// Acronym (e.g., ID, API) possibly with plural 's' -> keep as is
+		return t;
+	}
+	if (/^[0-9]+$/.test(t)) {
+		// numbers unchanged
+		return t;
+	}
+	// Normal word: capitalize first letter, lowercase rest
+	return t.charAt(0).toUpperCase() + t.slice(1).toLowerCase();
 }


### PR DESCRIPTION
I tweaked things a bit so that the toast will show up for 3 minutes, and we'll wait a roughly corresponding amount of time through `axiosRetry`. Note that the last parameter to `axiosRetry` is the important one -- 15 seconds, the time between attempts. Before, we would immediately hit a 404 error, resulting in 5 tries x 3 seconds = 15 seconds that we'd actually wait. That wasn't long enough. Now you can see we'll wait 12 tries x 15 seconds, plus however long the requests take to fail.

https://harperdb.atlassian.net/browse/STUDIO-406