### PR TITLE
fix: We don’t need to install harper globally anymore

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -33,8 +33,6 @@ jobs:
         run: pnpm lint
       - name: Build prod
         run: pnpm build:prod
-      - name: Install HarperDB
-        run: npm install -g harperdb@4.6.0
       - name: Deploy to prod
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -55,9 +55,6 @@ jobs:
       - name: Build stage for release
         if: ${{ github.event_name == 'push' }}
         run: pnpm build:stage
-      - name: Install HarperDB
-        if: ${{ github.event_name == 'push' }}
-        run: npm install -g harperdb@4.6.0
       - name: Deploy to stage
         if: ${{ github.event_name == 'push' }}
         run: |


### PR DESCRIPTION
We have it pinned in our package.json now and cached. So we can remove this from the stage and prod workflows. I missed it 😄 dev hasn't had it for a while, and it's been ok.