### PR TITLE
feat: Let’s show the version tag in prod

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -31,6 +31,13 @@ jobs:
         run: pnpm test
       - name: Run lint
         run: pnpm lint
+      - name: Determine version tag for build
+        run: |
+          VERSION_TAG=$(git tag --points-at HEAD | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n1)
+          if [ -z "$VERSION_TAG" ]; then
+            VERSION_TAG="v0.0.0+${GITHUB_SHA:0:7}"
+          fi
+          echo "VITE_STUDIO_VERSION=$VERSION_TAG" >> $GITHUB_ENV
       - name: Build prod
         run: pnpm build:prod
       - name: Deploy to prod


### PR DESCRIPTION
This will show the versions from the latest tag that shows up in the prod branch. I had removed it because I was pretty sure it wasn't working, but now after more local testing, I'm pretty sure it will work. Great story, huh? 😆 