### PR TITLE
feat: Hide terminated clusters

### DIFF
--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -42,6 +42,7 @@ export function ClustersList() {
 		const groups = groupBy(
 			orgInfo?.clusters
 				?.slice()
+				.filter(cluster => cluster.status !== 'TERMINATED')
 				.filter(curryFilterByFuzzySearch<Cluster>(['id', 'name'], filterByNameValue))
 				.sort(byClusterStatusThenName) || [],
 			'status'


### PR DESCRIPTION
At some point in the future, we can give users a way to see these terminated clusters if we come up with useful functionality for them (like viewing past invoices or something). Until then… let’s just hide them completely.

https://harperdb.atlassian.net/browse/STUDIO-340