### PR TITLE
feat: UI Tweaks

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -23,22 +23,25 @@ export function Breadcrumbs() {
 				continue;
 			}
 
-			const path = `/${routeHistory.slice(0, index + 1).join('/')}`;
+			let path = `/${routeHistory.slice(0, index + 1).join('/')}`;
 			let name = capitalizeWords(route);
 			let id: string | undefined;
 			if (route === 'databases' && routeHistory.length === index + 3) {
-				id = routeHistory[index + 1];
+				// id = routeHistory[index + 1];
 				name = routeHistory[index + 2];
 				index += 2;
 			} else if (name.startsWith('Org ')) {
-				id = route.split('org-').pop();
+				// id = route.split('org-').pop();
 				name = routeContext?.organization?.name || 'Org';
 			} else if (name.startsWith('Clu ')) {
-				id = route.split('clu-').pop();
+				// id = route.split('clu-').pop();
 				name = routeContext?.cluster?.name || 'Cluster';
+				if (routeHistory[index + 1] === 'instance') {
+					path += '/instances';
+				}
 			} else if (name.startsWith('Ins ')) {
-				id = route.split('ins-').pop();
-				name = 'Instance';
+				// id = route.split('ins-').pop();
+				name = routeContext?.instance?.name?.split('.')?.shift() || 'Instance';
 			}
 
 			breadcrumbs.push(

--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -102,7 +102,7 @@ export function ClusterInstanceSignIn() {
 	}
 
 	if (cluster?.resetPassword) {
-		return <Navigate to="../set-password" replace={true} />;
+		return <Navigate to={instance ? '../../set-password' : '../set-password'} replace={true} />;
 	}
 
 	return (

--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/index.tsx
@@ -1,6 +1,6 @@
 import { GetComponentsResponse, DirectoryEntry } from '@/features/instance/operations/queries/getComponents';
 import './filetree.css';
-import { useState } from 'react';
+import { ComponentType, useState } from 'react';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 
 interface ParseFileExtension {
@@ -148,13 +148,13 @@ function File({
 	);
 }
 
-function Folder({ directoryEntry }: { readonly directoryEntry: DirectoryEntry }) {
-	const [open, setOpen] = useState(true);
+function Folder({ directoryEntry, depth }: { readonly directoryEntry: DirectoryEntry; readonly depth: number }) {
+	const [open, setOpen] = useState(depth <= 1);
 
 	const entries = [...(directoryEntry.entries || [])].sort(directorySortComparator);
 	const fileExtension = parseFileExtension(directoryEntry.name);
 
-	let Icon: React.ComponentType<HTMLElement>;
+	let Icon: ComponentType<HTMLElement>;
 	// top-level dir === package
 	// FolderIcon/PackageIcon is func so we can give it open args now, but instantiate it later.
 	if (directoryEntry.path && directoryEntry.path.split('/').length === 2) {
@@ -168,8 +168,7 @@ function Folder({ directoryEntry }: { readonly directoryEntry: DirectoryEntry })
 	return (
 		<>
 			{
-				// FIXME: don't hardcode 'components', get from root .name property of fileTree.
-				directoryEntry.name !== 'components' ? (
+				depth > 0 ? (
 					<li
 						key={directoryEntry.key}
 						className={`${directoryEntry.entries ? 'folder-container' : 'file-container'} ${
@@ -189,7 +188,7 @@ function Folder({ directoryEntry }: { readonly directoryEntry: DirectoryEntry })
 			{entries.map((entry) => (
 				<li key={entry.key}>
 					<ul className="pl-2">
-						<Folder directoryEntry={entry} />
+						<Folder directoryEntry={entry} depth={depth + 1} />
 					</ul>
 				</li>
 			))}
@@ -203,7 +202,7 @@ export function FileTreeExplorer({ files }: { readonly files: GetComponentsRespo
 		<div>
 			<div>
 				<ul className="text-gray-400">
-					<Folder directoryEntry={files} />
+					<Folder directoryEntry={files} depth={0} />
 				</ul>
 			</div>
 		</div>

--- a/src/features/instance/status/crawlData.ts
+++ b/src/features/instance/status/crawlData.ts
@@ -1,3 +1,4 @@
+import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { translateSecondsToAgo } from '@/lib/translateSecondsToAgo';
 
@@ -33,13 +34,16 @@ export function hasTitle(item: ItemForDisplay): item is TitleItem {
 function parseValue(name: string, value: unknown, depth: number, parentName?: string): ItemForDisplay[] {
 	if (value && Array.isArray(value)) {
 		const array = value;
-		return value.map((item, index) =>
-			parseValue(
-				array.length > 1 ? name + ' ' + (index + 1) : name,
-				item,
-				depth + 1,
-				name,
-			)).flat(1);
+		return [
+			array.length > 1 && {title: name, depth},
+			...value.map((item, index) =>
+				parseValue(
+					array.length > 1 ? String(index + 1) : name,
+					item,
+					depth + 1,
+					name,
+				)).flat(1),
+		].filter(excludeFalsy);
 	}
 	if (isObject(value)) {
 		const obj = value;


### PR DESCRIPTION
## Set Password
If you've got a new cluster in `Set Password` mode, and you try to circumvent it by going to the sign-in screen for one of its instances, you'll get properly redirected to the `Set Password` page.

## Status Nesting
We won't repeat the array name on each element anymore. Instead, we'll put it up at the top once, then count them off one by one. Note that arrays of size 1 will only show the array name, without any number.
<img width="951" height="777" alt="image" src="https://github.com/user-attachments/assets/669aa361-1f9d-45f4-9231-c122c2241001" />

## Breadcrumb Tweaks
I removed the ids from breadcrumbs, added instance names, and made the cluster breadcrumb link to the instances page _only_ when you've navigated to an instance within the cluster.
<img width="593" height="137" alt="image" src="https://github.com/user-attachments/assets/cef0804c-01b8-453c-b255-fdef345397a5" />

## Sidebar Folders
We'll track the depth of our folders for applications, and auto-collapse everything deeper than 1.
<img width="360" height="293" alt="image" src="https://github.com/user-attachments/assets/bfdf1d86-2cfb-4182-b86f-8b2d3a40e6e4" />


https://harperdb.atlassian.net/browse/STUDIO-435