### PR TITLE
fix: Consider instance status before attempting to restart it

### DIFF
--- a/src/hooks/useRestartClusterClick.tsx
+++ b/src/hooks/useRestartClusterClick.tsx
@@ -1,6 +1,10 @@
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
 import { restartInstance } from '@/features/instance/operations/mutations/restartInstance';
+import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
+import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
+import { pluralize } from '@/lib/pluralize';
+import { sleep } from '@/lib/sleep';
 import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
 import { useParams } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
@@ -41,28 +45,50 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 		});
 
 		const cluster = await getClusterInfo(clusterId);
-		let succeeded = false;
-		if (cluster) {
-			const instanceClients = cluster.instances?.map(instance => {
-				return getInstanceClient({ id: instance.id, operationsUrl: getOperationsUrlForInstance(instance) });
-			});
-			if (instanceClients?.length) {
-				for (let i = 0; i < instanceClients.length; i++) {
-					const instanceClient = instanceClients[i];
-					if (!canceled) {
-						toast.loading('Restarting', {
-							...toastConfig,
-							id: toastId,
-							description: renderProgressUpdate(i, instanceClients.length),
+		const allInstances = cluster?.instances ?? [];
+		const instanceClients = allInstances
+			.filter(instance => instance.status === 'RUNNING')
+			.map(instance => getInstanceClient({
+				id: instance.id,
+				operationsUrl: getOperationsUrlForInstance(instance),
+			}))
+			.reverse();
+		let instancesRestarted = 0;
+
+		if (instanceClients.length) {
+			for (let i = 0; i < instanceClients.length; i++) {
+				const instanceClient = instanceClients[i];
+				if (!canceled) {
+					toast.loading(`Restarting Instance ${i + 1} of ${instanceClients.length}`, {
+						...toastConfig,
+						id: toastId,
+						description: renderProgressUpdate(i, instanceClients.length),
+					});
+					try {
+						// Make sure the instance is responding.
+						await getInstanceUserInfo({
+							instanceClient,
 						});
+						// Then restart it.
 						await restartInstance({
 							operation: 'restart',
 							replicated: false,
 							instanceClient,
 						});
+						instancesRestarted += 1;
+					}
+					catch {
+						if (i !== instanceClients.length) {
+							// If it fails to restart, or wasn't available, warn for a bit then move on.
+							toast.loading(`Failed Restarting Instance ${i + 1} of ${instanceClients.length}`, {
+								...toastConfig,
+								id: toastId,
+								description: 'We will carry on momentarily.',
+							});
+							await sleep(3000);
+						}
 					}
 				}
-				succeeded = true;
 			}
 		}
 
@@ -72,25 +98,39 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 			toast.error('Cancelled', {
 				id: toastId,
 				description: `The restart was partially cancelled.`,
+				duration: 10_000,
 				action: {
 					label: 'Dismiss',
 					onClick: () => toast.dismiss(),
 				},
 			});
-		} else if (succeeded) {
+		} else if (allInstances.length === instancesRestarted) {
 			onRestartedSuccessfully?.();
 			toast.success('Success', {
 				id: toastId,
-				description: `Cluster restarted!`,
+				description: `Cluster fully restarted!`,
+				duration: 10_000,
 				action: {
 					label: 'Dismiss',
 					onClick: () => toast.dismiss(),
 				},
 			});
 		} else {
+			const allTheInstances = pluralize(allInstances.length, 'instance', 'instances');
+			const someRunningInstancesWere = pluralize(
+				instancesRestarted,
+				'"RUNNING" instance was',
+				'"RUNNING" instances were',
+			);
 			toast.error('Error', {
 				id: toastId,
-				description: `Failed to restart cluster.`,
+				description: `Failed to fully restart cluster.\n`
+					+ [
+						allInstances.length === 0 && 'No instances were found within the cluster to restart.',
+						instancesRestarted === 0 && `No instances were in a "RUNNING" state of ${allTheInstances}.`,
+						allInstances.length !== instancesRestarted && `Only ${someRunningInstancesWere} restarted of ${allTheInstances}.`,
+					].filter(excludeFalsy)[0],
+				duration: 10_000,
 				action: {
 					label: 'Dismiss',
 					onClick: () => toast.dismiss(),
@@ -108,10 +148,10 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 
 function renderProgressUpdate(current?: number, total?: number) {
 	return (<>
-		Restarting cluster instances.
 		{current !== undefined && total !== undefined && total > 0 && (
 			<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
 				<div className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500" style={{ width: (current === 0 ? 0 : (current / total * 100)) + '%' }}></div>
 			</div>)}
+			<div className="text-xs mt-2">Please don't close your browser or navigate away. This may take a bit.</div>
 	</>);
 }


### PR DESCRIPTION
When we restart, we'll consider the reported status of the instances to filter down to only running instances. Then, before restarting an instance, we'll ping it first to make sure it'll actually respond. We'll handle errors and partial restarts accordingly, and let the user know how it's going along the way.

We'll also restart the instances in reverse order so the first one stays up the longest, since it appears that we usually "load balance" to the first instance. 🤷 

We'll let them know which instance we're working on:
<img width="401" height="153" alt="Screenshot 2025-09-17 at 12 25 23 PM" src="https://github.com/user-attachments/assets/1d3a2268-bd6a-4742-924d-f71781bd02ae" />

If one fails, we'll pause for a few seconds to let them know. They can cancel the restart if they want:
<img width="429" height="145" alt="Screenshot 2025-09-17 at 12 25 28 PM" src="https://github.com/user-attachments/assets/81d2409c-bffb-4b42-9a16-7a095b60b573" />

We'll continue on to the next instance:
<img width="405" height="151" alt="Screenshot 2025-09-17 at 12 25 31 PM" src="https://github.com/user-attachments/assets/37608d01-7724-4bc4-9675-e8bea9263947" />

Once we're done restarting whatever we can, we'll show an error to the user with the details:
<img width="404" height="163" alt="Screenshot 2025-09-17 at 12 25 12 PM" src="https://github.com/user-attachments/assets/39680472-fe89-4e47-81af-12fb1e9e8427" />

https://harperdb.atlassian.net/browse/STUDIO-406