### PR TITLE
feat: Default cluster username to user’s email in the form

### DIFF
--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/features/instance/operations/mutations/useInstanceResetPasswordMutation';
 import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
 import { AddUserFormSchema } from '@/features/instance/operations/schemas/addUserFormSchema';
+import { useCloudAuth } from '@/hooks/useAuth';
 import { authStore } from '@/lib/authStore';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -26,6 +27,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 export function ClusterSetPassword() {
+	const { user } = useCloudAuth();
 	const { clusterId }: { clusterId: string; } = useParams({ strict: false });
 	const { data: cluster } = useQuery(
 		getClusterInfoQueryOptions(clusterId, true),
@@ -44,7 +46,7 @@ export function ClusterSetPassword() {
 			confirmPassword: '',
 			password: '',
 			role: 'super_user',
-			username: '',
+			username: user?.email ?? '',
 		},
 	});
 	const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;


### PR DESCRIPTION
When creating the first admin user for a cluster (the forced "Set Password" flow), we'll default the username to the logged in user's email address, so they have less to type.

<img width="409" height="370" alt="image" src="https://github.com/user-attachments/assets/e3ec7179-5af7-4be8-9251-49f2313204fd" />

https://harperdb.atlassian.net/browse/STUDIO-436