### PR TITLE
feat: Consistent auth placeholders and focus

### DIFF
--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -21,7 +21,7 @@ import { queryKeys } from '@/react-query/constants';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Navigate, useNavigate, useParams, useRouter, useSearch } from '@tanstack/react-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -57,13 +57,18 @@ export function ClusterInstanceSignIn() {
 		[operationsUrl],
 	);
 
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(SignInSchema),
 		defaultValues: {
 			username: '',
 			password: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
+
+	useEffect(() => {
+		setFocus('username');
+	}, [setFocus]);
 
 	const { mutate: submitInstanceLogin, isPending } = useInstanceLoginMutation();
 
@@ -115,10 +120,10 @@ export function ClusterInstanceSignIn() {
 				<div className="text-white w-xs">
 					<h2 className="text-2xl font-light">
 						Sign in to Harper {noun}</h2>
-					<Form {...form}>
-						<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
+					<Form {...methods}>
+						<form onSubmit={handleSubmit(submitForm)} className="my-4">
 							<FormField
-								control={form.control}
+								control={control}
 								name="username"
 								render={({ field }) => (
 									<FormItem className="my-4">
@@ -127,7 +132,6 @@ export function ClusterInstanceSignIn() {
 											<Input
 												autoComplete="username"
 												type="text"
-												placeholder="harpersys"
 												{...field}
 											/>
 										</FormControl>
@@ -136,7 +140,7 @@ export function ClusterInstanceSignIn() {
 								)}
 							/>
 							<FormField
-								control={form.control}
+								control={control}
 								name="password"
 								render={({ field }) => (
 									<FormItem className="my-4">
@@ -144,7 +148,6 @@ export function ClusterInstanceSignIn() {
 										<FormControl>
 											<Input
 												type="password"
-												placeholder="password"
 												{...field}
 											/>
 										</FormControl>

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -6,6 +6,7 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useForgotPasswordMutation } from '@/features/auth/hooks/useForgotPassword';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -23,12 +24,17 @@ const ForgotPasswordSchema = z.object({
 
 export function ForgotPassword() {
 	const navigate = useNavigate();
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(ForgotPasswordSchema),
 		defaultValues: {
 			email: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
+
+	useEffect(() => {
+		setFocus('email');
+	}, [setFocus]);
 
 	const { mutate: submitForgotPasswordData, isPending } = useForgotPasswordMutation();
 
@@ -51,10 +57,10 @@ export function ForgotPassword() {
 		<div className="text-white w-xs">
 			<h2 className="text-2xl font-light">Enter your account email</h2>
 			<p className="text-sm pt-1">If a matching account exists, we'll send you a password reset link.</p>
-			<Form {...form}>
-				<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
+			<Form {...methods}>
+				<form onSubmit={handleSubmit(submitForm)} className="my-4">
 					<FormField
-						control={form.control}
+						control={control}
 						name="email"
 						render={({ field }) => (
 							<FormItem className="my-2">
@@ -63,7 +69,6 @@ export function ForgotPassword() {
 									<Input
 										disabled={isPending}
 										type="email"
-										placeholder="jane.smith@harperdb.io"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>

--- a/src/features/auth/ResetPassword.tsx
+++ b/src/features/auth/ResetPassword.tsx
@@ -8,7 +8,7 @@ import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -37,17 +37,22 @@ export function RestPassword() {
 		}
 	}, [token, navigate]);
 
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(ResetPasswordSchema),
 		defaultValues: {
 			password: '',
 			confirmPassword: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
+
+	useEffect(() => {
+		setFocus('password');
+	}, [setFocus]);
 
 	const { mutate: submitResetPasswordData, isPending } = useResetPasswordMutation();
 
-	const submitForm = async (formData: { password: string; confirmPassword: string }) => {
+	const submitForm = useCallback(async (formData: { password: string; confirmPassword: string }) => {
 		submitResetPasswordData(
 			{ token: token as string, password: formData.password },
 			{
@@ -63,15 +68,15 @@ export function RestPassword() {
 				},
 			}
 		);
-	};
+	}, [navigate, submitResetPasswordData, token]);
 
 	return (
 		<div className="text-white w-xs">
 			<h2 className="text-2xl font-light">Reset Password</h2>
-			<Form {...form}>
-				<form className="my-4" onSubmit={form.handleSubmit(submitForm)}>
+			<Form {...methods}>
+				<form className="my-4" onSubmit={handleSubmit(submitForm)}>
 					<FormField
-						control={form.control}
+						control={control}
 						name="password"
 						render={({ field }) => (
 							<FormItem className="my-2">
@@ -80,7 +85,6 @@ export function RestPassword() {
 									<Input
 										disabled={isPending}
 										type="password"
-										placeholder="enter new password"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>
@@ -90,7 +94,7 @@ export function RestPassword() {
 						)}
 					/>
 					<FormField
-						control={form.control}
+						control={control}
 						name="confirmPassword"
 						render={({ field }) => (
 							<FormItem className="my-2">
@@ -99,7 +103,6 @@ export function RestPassword() {
 									<Input
 										disabled={isPending}
 										type="password"
-										placeholder="confirm new password"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -15,6 +15,7 @@ import { queryKeys } from '@/react-query/constants';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useRouter, useSearch } from '@tanstack/react-router';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -34,13 +35,18 @@ export function SignIn() {
 	const queryClient = useQueryClient();
 	const { redirect } = useSearch({ strict: false });
 
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(SignInSchema),
 		defaultValues: {
 			email: '',
 			password: '',
 		},
 	});
+	const { handleSubmit, control, setFocus } = methods;
+
+	useEffect(() => {
+		setFocus('email');
+	}, [setFocus]);
 
 	const { mutate: submitLoginData, isPending } = useLoginMutation();
 
@@ -59,7 +65,7 @@ export function SignIn() {
 					});
 				}
 				await queryClient.invalidateQueries({ queryKey: [queryKeys.user], refetchType: 'none' });
-				router.invalidate();
+				void router.invalidate();
 				await navigate({ to: redirect?.startsWith('/') ? redirect : defaultCloudRoute });
 			},
 		});
@@ -68,10 +74,10 @@ export function SignIn() {
 	return (
 		<div className="text-white w-xs">
 			<h2 className="text-2xl font-light">Sign in to Harper Fabric</h2>
-			<Form {...form}>
-				<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
+			<Form {...methods}>
+				<form onSubmit={handleSubmit(submitForm)} className="my-4">
 					<FormField
-						control={form.control}
+						control={control}
 						name="email"
 						render={({ field }) => (
 							<FormItem className="my-4">
@@ -79,7 +85,6 @@ export function SignIn() {
 								<FormControl>
 									<Input
 										type="email"
-										placeholder="jane.smith@harperdb.io"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>
@@ -89,7 +94,7 @@ export function SignIn() {
 						)}
 					/>
 					<FormField
-						control={form.control}
+						control={control}
 						name="password"
 						render={({ field }) => (
 							<FormItem className="my-4">
@@ -97,7 +102,6 @@ export function SignIn() {
 								<FormControl>
 									<Input
 										type="password"
-										placeholder="password"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { useSignUpMutation } from '@/features/auth/hooks/useSignUp';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate, useSearch } from '@tanstack/react-router';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -34,27 +35,41 @@ const SignInSchema = z.object({
 	password: z
 		.string()
 		.min(8, { error: 'Password must be at least 8 characters long.' }),
-});
+	confirmPassword: z.string(),
+})
+	.refine((data) => data.password === data.confirmPassword, {
+		error: 'Passwords do not match.',
+		path: ['confirmPassword'],
+	});
 
 export function SignUp() {
 	const navigate = useNavigate();
 	const { email } = useSearch({ strict: false });
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(SignInSchema),
 		defaultValues: {
 			firstname: '',
 			lastname: '',
 			email: email || '',
 			password: '',
+			confirmPassword: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
+
+	useEffect(() => {
+		setFocus('firstname');
+	}, [setFocus]);
 
 	const { mutate: submitSignUpData } = useSignUpMutation();
 
 	const submitForm = async (formData: z.infer<typeof SignInSchema>) => {
-		submitSignUpData(formData, {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { confirmPassword, ...userData } = formData;
+		submitSignUpData(userData, {
 			onSuccess: () => {
 				toast.success('Success', {
+					duration: 60_000,
 					description: 'Your account has been created! Please check your email to finish activating your' +
 						' account.',
 					action: {
@@ -70,10 +85,10 @@ export function SignUp() {
 	return (
 		<div className="text-white w-xs">
 			<h2 className="text-2xl font-light">Sign up for Harper Studio</h2>
-			<Form {...form}>
-				<form onSubmit={form.handleSubmit(submitForm)} className="grid gap-4 my-4">
+			<Form {...methods}>
+				<form onSubmit={handleSubmit(submitForm)} className="grid gap-4 my-4">
 					<FormField
-						control={form.control}
+						control={control}
 						name="firstname"
 						render={({ field }) => (
 							<FormItem>
@@ -81,7 +96,6 @@ export function SignUp() {
 								<FormControl>
 									<Input
 										type="text"
-										placeholder="Jane"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										autoCapitalize="words"
 										{...field}
@@ -92,7 +106,7 @@ export function SignUp() {
 						)}
 					/>
 					<FormField
-						control={form.control}
+						control={control}
 						name="lastname"
 						render={({ field }) => (
 							<FormItem>
@@ -100,7 +114,6 @@ export function SignUp() {
 								<FormControl>
 									<Input
 										type="text"
-										placeholder="Doe"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										autoCapitalize="words"
 										{...field}
@@ -111,7 +124,7 @@ export function SignUp() {
 						)}
 					/>
 					<FormField
-						control={form.control}
+						control={control}
 						name="email"
 						render={({ field }) => (
 							<FormItem>
@@ -121,7 +134,6 @@ export function SignUp() {
 										type="email"
 										readOnly={!!email}
 										disabled={!!email}
-										placeholder="jane.doe@harpersystems.dev"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										autoComplete="email"
 										autoCapitalize="none"
@@ -133,7 +145,7 @@ export function SignUp() {
 						)}
 					/>
 					<FormField
-						control={form.control}
+						control={control}
 						name="password"
 						render={({ field }) => (
 							<FormItem>
@@ -141,7 +153,23 @@ export function SignUp() {
 								<FormControl>
 									<Input
 										type="password"
-										placeholder="password"
+										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name="confirmPassword"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel className="pb-1">Confirm Password</FormLabel>
+								<FormControl>
+									<Input
+										type="password"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										{...field}
 									/>

--- a/src/features/auth/VerifyEmail.tsx
+++ b/src/features/auth/VerifyEmail.tsx
@@ -26,14 +26,19 @@ const VerifyEmailSchema = z.object({
 function SendEmailVerification() {
 	const navigate = useNavigate();
 	const { mutate: submitResendEmailVerification, isPending } = useResendEmailVerification();
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(VerifyEmailSchema),
 		defaultValues: {
 			email: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
 
-	const submitForm = async (formData: z.infer<typeof VerifyEmailSchema>) => {
+	useEffect(() => {
+		setFocus('email');
+	}, [setFocus]);
+
+	const submitForm = useCallback(async (formData: z.infer<typeof VerifyEmailSchema>) => {
 		submitResendEmailVerification(formData, {
 			onSuccess: (message) => {
 				toast.success('Success', {
@@ -46,14 +51,14 @@ function SendEmailVerification() {
 				navigate({ to: '/sign-in' });
 			},
 		});
-	};
+	}, [navigate, submitResendEmailVerification]);
 
 	return (
-		<Form {...form}>
+		<Form {...methods}>
 			<p className="text-sm py-2">Please Enter an Email</p>
-			<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
+			<form onSubmit={handleSubmit(submitForm)} className="my-4">
 				<FormField
-					control={form.control}
+					control={control}
 					name="email"
 					render={({ field }) => (
 						<FormItem className="my-2">
@@ -62,7 +67,6 @@ function SendEmailVerification() {
 								<Input
 									disabled={isPending}
 									type="email"
-									placeholder="jane.doe@harperdb.io"
 									className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 									{...field}
 								/>

--- a/src/features/cluster/ClusterSetPassword.tsx
+++ b/src/features/cluster/ClusterSetPassword.tsx
@@ -20,7 +20,7 @@ import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluste
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { Navigate, useNavigate, useParams, useRouter, useSearch } from '@tanstack/react-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -38,7 +38,7 @@ export function ClusterSetPassword() {
 	const { redirect } = useSearch({ strict: false });
 	const router = useRouter();
 
-	const form = useForm({
+	const methods = useForm({
 		resolver: zodResolver(AddUserFormSchema),
 		defaultValues: {
 			confirmPassword: '',
@@ -47,6 +47,12 @@ export function ClusterSetPassword() {
 			username: '',
 		},
 	});
+	const { setFocus, control, handleSubmit } = methods;
+
+	useEffect(() => {
+		setFocus('password');
+	}, [setFocus]);
+
 	const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;
 
 	const { mutate: submitInstanceResetPassword, isPending } = useInstanceResetPasswordMutation();
@@ -86,10 +92,10 @@ export function ClusterSetPassword() {
 			<div className="h-screen items-center justify-center flex">
 				<div className="text-white w-xs">
 					<h2 className="text-2xl font-light">Create Admin User</h2>
-					<Form {...form}>
-						<form onSubmit={form.handleSubmit(submitForm)} className="my-4">
+					<Form {...methods}>
+						<form onSubmit={handleSubmit(submitForm)} className="my-4">
 							<FormField
-								control={form.control}
+								control={control}
 								name="username"
 								render={({ field }) => (
 									<FormItem className="my-4">
@@ -106,7 +112,7 @@ export function ClusterSetPassword() {
 								)}
 							/>
 							<FormField
-								control={form.control}
+								control={control}
 								name="password"
 								render={({ field }) => (
 									<FormItem className="my-4">
@@ -122,7 +128,7 @@ export function ClusterSetPassword() {
 								)}
 							/>
 							<FormField
-								control={form.control}
+								control={control}
 								name="confirmPassword"
 								render={({ field }) => (
 									<FormItem className="my-4">

--- a/src/features/instance/operations/schemas/addUserFormSchema.ts
+++ b/src/features/instance/operations/schemas/addUserFormSchema.ts
@@ -19,5 +19,5 @@ export const AddUserFormSchema = z
 	})
 	.refine((data) => data.password === data.confirmPassword, {
 		error: 'Passwords do not match.',
-		path: ['confirmPassword'], // This specifies where the error message should be attached
+		path: ['confirmPassword'],
 	});

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -75,7 +75,6 @@ export function ProfileIndex() {
 								<FormControl>
 									<Input
 										type="text"
-										placeholder="Jane"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										autoCapitalize="words"
 										{...field}
@@ -95,7 +94,6 @@ export function ProfileIndex() {
 								<FormControl>
 									<Input
 										type="text"
-										placeholder="Doe"
 										className="bg-purple-400 border-purple-400 dark:bg-black dark:border-black"
 										autoCapitalize="words"
 										{...field}


### PR DESCRIPTION
Here is what is changing for the auth forms:

1. Don’t use placeholders except to communicate a default value, or to communicate that a field is optional (such as when editing your profile, the password is optional).
2. On every auth form, focus the first field. Except for the cluster “Create Admin User” form, where we should focus the “password” because we’ll set a default value for the username (to their email address).
3. When signing up, confirm your password, just like we do everywhere else the password is created.
4. After sign up submitted, make the “plz verify” toast stay up for a minute, instead of the default of 4 seconds so users don’t miss it.


https://harperdb.atlassian.net/browse/STUDIO-437