### PR TITLE
fix: Wait longer before timing out during application import

### DIFF
--- a/src/features/instance/applications/new/ImportProjectForm.tsx
+++ b/src/features/instance/applications/new/ImportProjectForm.tsx
@@ -49,11 +49,22 @@ export function ImportProjectForm({
 
 	const { mutate: deployNewApplication, isPending: isDeployComponentPending } = useDeployComponentMutation();
 	const submitForm = async (formData: DeployComponentFormData) => {
+		const toastId = toast.loading(`Importing application...`, {
+			description: 'This may take a bit.',
+			duration: 300_000,
+		});
 		deployNewApplication({ ...formData, ...instanceParams }, {
 			onSuccess: () => {
-				toast.success(`Application ${formData.applicationName} imported successfully`);
+				toast.success(`Application imported successfully`, {
+					description: `${formData.applicationName} is now available!`,
+					id: toastId,
+					duration: 5_000,
+				});
 				onRestartedSuccessfully();
 			},
+			onError: () => {
+				toast.dismiss(toastId);
+			}
 		});
 	};
 	const handleFetchApplication = async (url: string) => {

--- a/src/features/instance/operations/mutations/deployComponent.ts
+++ b/src/features/instance/operations/mutations/deployComponent.ts
@@ -22,7 +22,7 @@ async function onDeployComponentSubmit({
 			replicated,
 			restart: 'rolling',
 		},
-		{ timeout: 60000 },
+		{ timeout: 300_000 },
 	);
 	return data;
 }


### PR DESCRIPTION
We'll show a toast, and we'll wait up to 5 minutes before timing out. Some of the imported applications can be really big.

https://harperdb.atlassian.net/browse/STUDIO-439