### PR TITLE
fix: Always describe plans as auto-renewing

### DIFF
--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -115,8 +115,7 @@ export function ClusterCard({
 									<DropdownMenuLabel key={plan.planId}>
 										{plan.planId} / {plan.regionId}
 										<br />
-										Auto Renewal{' '}
-										{plan.autoRenew ? <Badge variant="success">ON</Badge> : <Badge variant="warning">OFF</Badge>}
+										Auto Renewal <Badge variant="success">ON</Badge>
 									</DropdownMenuLabel>
 								))}
 								{menuItems.length > 0 && (


### PR DESCRIPTION
The only spot we show auto-renew: on or off was in the cluster card menu. Let's always describe it as on. (Terminated clusters are the only ones that won't auto-renew, and they won't have a menu.)