### PR TITLE
Improved Free Validations

### DIFF
--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -255,6 +255,7 @@ export function ClusterDetails({
 					regionLocations={regionLocations}
 					regionNameToLatencyToRegion={regionNameToLatencyToRegion}
 					selectedPlan={selectedPlan}
+					totalPrice={totalPrice}
 				/>)
 			}
 

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -26,6 +26,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 interface ClusterFormProps {
+	alreadyUsingFree: boolean;
 	clusterId?: string;
 	defaultValues: z.infer<typeof UpsertClusterSchema>;
 	deploymentToPerformanceToPlan: Record<string, Record<string, SchemaPlan>>;
@@ -40,6 +41,7 @@ interface ClusterFormProps {
 }
 
 export function ClusterForm({
+	alreadyUsingFree,
 	clusterId,
 	defaultValues,
 	deploymentToPerformanceToPlan,
@@ -78,6 +80,13 @@ export function ClusterForm({
 				}
 			}
 		} else {
+			if (selectedPlan?.priceUsd === 0 && alreadyUsingFree) {
+				ctx.addIssue({
+					code: 'custom',
+					path: [`performanceDescription`],
+					message: 'Only one free cluster is allowed per organization.',
+				});
+			}
 			for (let i = 0; i < data.regionPlans.length; i++) {
 				const regionPlan = data.regionPlans[i];
 				const region = regionNameToLatencyToRegion[regionPlan.regionName]?.[regionPlan.latencyDescription];
@@ -90,25 +99,33 @@ export function ClusterForm({
 						message: 'You can only select a region once!',
 					});
 				}
-				if (selectedPlan?.allowedRegionIds?.length && region?.id && !selectedPlan.allowedRegionIds.includes(region.id)) {
-					const prefixMatches = stringsShareAPrefix(selectedPlan.allowedRegionIds, region.id);
-					if (!prefixMatches) {
+				if (selectedPlan?.allowedRegionIds?.length && region?.id) {
+					if (!selectedPlan.allowedRegionIds.includes(region.id)) {
+						const prefixMatches = stringsShareAPrefix(selectedPlan.allowedRegionIds, region.id);
+						if (!prefixMatches) {
+							ctx.addIssue({
+								code: 'custom',
+								path: [`regionPlans.${i}.regionName`],
+								message: `This region is not available with the selected performance tier!`,
+							});
+						} else {
+							ctx.addIssue({
+								code: 'custom',
+								path: [`regionPlans.${i}.latencyDescription`],
+								message: `This latency is not available with the selected performance tier!`,
+							});
+						}
+					} else if (i >= 1) {
 						ctx.addIssue({
 							code: 'custom',
 							path: [`regionPlans.${i}.regionName`],
-							message: `This region is not available with the selected performance tier!`,
-						});
-					} else {
-						ctx.addIssue({
-							code: 'custom',
-							path: [`regionPlans.${i}.latencyDescription`],
-							message: `This latency is not available with the selected performance tier!`,
+							message: `You can only select one region with this performance tier!`,
 						});
 					}
 				}
 			}
 		}
-	}, [deploymentToPerformanceToPlan, regionNameToLatencyToRegion]);
+	}, [alreadyUsingFree, deploymentToPerformanceToPlan, regionNameToLatencyToRegion]);
 
 	const form = useForm({
 		mode: 'onChange',

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -14,6 +14,7 @@ interface ClusterRegionsProps {
 	regionLocations: SchemaRegion[] | undefined;
 	regionNameToLatencyToRegion: Record<string, Record<string, SchemaRegion>>;
 	selectedPlan: SchemaPlan | undefined;
+	totalPrice: number | undefined;
 }
 
 export function ClusterRegions({
@@ -21,6 +22,7 @@ export function ClusterRegions({
 	regionLocations,
 	regionNameToLatencyToRegion,
 	selectedPlan,
+	totalPrice,
 }: ClusterRegionsProps) {
 	const selectedRegionPlans = form.watch('regionPlans');
 
@@ -31,8 +33,12 @@ export function ClusterRegions({
 
 	const nextAvailableRegionToAdd = useMemo(() => {
 		const selectedRegionNames = selectedRegionPlans.map(region => regionNameToLatencyToRegion?.[region.regionName!]?.[region.latencyDescription!]?.region);
+		if (!totalPrice) {
+			// Free plans can only add a single region.
+			return null;
+		}
 		return regionLocations?.find(r => !selectedRegionNames.includes(r.region));
-	}, [regionLocations, regionNameToLatencyToRegion, selectedRegionPlans]);
+	}, [regionLocations, regionNameToLatencyToRegion, selectedRegionPlans, totalPrice]);
 
 	const onAddARegionClick = useCallback(() => {
 		if (nextAvailableRegionToAdd) {

--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -106,7 +106,7 @@ export function ResourcesPerInstance({ planLimits, resourcesPerInstance, selecte
 		return 'This plan has no usage limits.';
 	}
 
-	return <FormItem className="col-span-3 md:col-span-6">
+	return <FormItem className="basis-full">
 		<FormLabel>
 			Purchasing usage block for {isPositive(planLimits.readsPerMinuteCount) ? `${humanNumber(planLimits.readsPerMinuteCount * multiplier)} reads/min & ` : ''}
 			{humanNumber(planLimits.totalReadCount * multiplier)} total reads {isPositive(planLimits.readsPerMinuteCount) ? 'in ' + (selectedRegion?.region ?? '') + ' region' : 'per server'},<br className="hidden sm:block" />

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -2,7 +2,6 @@ import { ContactUs } from '@/components/ContactUs';
 import { ErrorComponent } from '@/components/ErrorComponent';
 import { Loading } from '@/components/Loading';
 import { SubNavSimpleLayout } from '@/components/SubNavSimpleLayout';
-import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { getPlanTypesOptions } from '@/features/cluster/queries/getPlanTypesQuery';
 import { getRegionLocationsOptions } from '@/features/clusters/queries/getRegionLocationsQuery';
 import { ClusterForm } from '@/features/clusters/upsert/ClusterForm';
@@ -10,25 +9,24 @@ import {
 	calculateDefaultDeploymentPerformanceAndRegionPlans,
 } from '@/features/clusters/upsert/lib/calculateDefaultDeploymentPerformanceAndRegionPlans';
 import { UpsertClusterSchema } from '@/features/clusters/upsert/upsertClusterSchema';
-import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { LocalStorageKeys, useLocalStorage } from '@/hooks/useLocalStorage';
 import { SchemaPlan, SchemaRegion } from '@/lib/api.gen';
+import { Cluster, Organization } from '@/lib/api.patch';
 import { sortByField } from '@/lib/arrays/sort/byField';
 import { groupThenKeyBy } from '@/lib/groupThenKeyBy';
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
+import { useParams, useRouteContext } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
 import { z } from 'zod';
 
 export function UpsertCluster() {
 	const { organizationId, clusterId }: { organizationId: string; clusterId?: string } = useParams({ strict: false });
 	const [onlyShowAvailableHosts, setOnlyShowAvailableHosts] = useState(true);
+	const { organization, cluster }: { organization: Organization; cluster?: Cluster } = useRouteContext({ strict: false });
 	const [savedClusterState, setSavedClusterState] = useLocalStorage<null | ({
 		clusterId?: string
 	} & z.infer<typeof UpsertClusterSchema>)>(LocalStorageKeys.SavedClusterState, null);
 
-	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId));
-	const { data: organization } = useQuery(getOrganizationQueryOptions(organizationId));
 	const { data: planTypes } = useQuery(getPlanTypesOptions(organizationId));
 	const { data: regionLocationsAvailableHosts } = useQuery(getRegionLocationsOptions({
 		availableHosts: true,
@@ -36,6 +34,23 @@ export function UpsertCluster() {
 	}));
 	const { data: regionLocationsAll } = useQuery(getRegionLocationsOptions({ organizationId }));
 	const regionLocations = onlyShowAvailableHosts ? regionLocationsAvailableHosts : regionLocationsAll;
+
+	const alreadyUsingFree = useMemo(() => {
+		for (const orgCluster of organization?.clusters ?? []) {
+			if (orgCluster.id !== cluster?.id
+				&& planTypes
+				&& orgCluster.status !== 'TERMINATED'
+				&& orgCluster.plans) {
+				for (const clusterPlan of orgCluster.plans) {
+					const foundPlan = planTypes.find(p => p.id === clusterPlan.planId);
+					if (foundPlan?.priceUsd === 0) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}, [cluster?.id, organization?.clusters, planTypes]);
 
 	const deploymentToPerformanceToPlan = useMemo<Record<string, Record<string, SchemaPlan>>>(() =>
 		groupThenKeyBy(planTypes?.sort(sortByField('priceUsd')) || [], 'deploymentDescription', 'performanceDescription'), [planTypes]);
@@ -55,7 +70,7 @@ export function UpsertCluster() {
 		const regionPlans: z.infer<typeof UpsertClusterSchema.shape.regionPlans> = [];
 		const instances: z.infer<typeof UpsertClusterSchema.shape.instances> = [];
 		const regionLocations = onlyShowAvailableHosts ? regionLocationsAvailableHosts : regionLocationsAll;
-		const defaults = calculateDefaultDeploymentPerformanceAndRegionPlans(planTypes, regionLocations);
+		const defaults = calculateDefaultDeploymentPerformanceAndRegionPlans(planTypes, regionLocations, alreadyUsingFree);
 
 		let isSelfManaged = false;
 		if (planTypes && regionLocations) {
@@ -101,7 +116,7 @@ export function UpsertCluster() {
 			instances,
 			regionPlans,
 		};
-	}, [cluster, clusterId, onlyShowAvailableHosts, planTypes, regionLocationsAll, regionLocationsAvailableHosts, savedClusterState]);
+	}, [alreadyUsingFree, cluster, clusterId, onlyShowAvailableHosts, planTypes, regionLocationsAll, regionLocationsAvailableHosts, savedClusterState]);
 
 	const isLoading = !defaultValues || !organization || !planTypes || !regionLocations;
 	if (isLoading) {
@@ -141,6 +156,7 @@ export function UpsertCluster() {
 				setOnlyShowAvailableHosts={setOnlyShowAvailableHosts}
 				setSavedClusterState={setSavedClusterState}
 				startOffOnBilling={!!savedClusterState}
+				alreadyUsingFree={alreadyUsingFree}
 			/>
 		</SubNavSimpleLayout>
 	);

--- a/src/features/clusters/upsert/lib/calculateDefaultDeploymentPerformanceAndRegionPlans.ts
+++ b/src/features/clusters/upsert/lib/calculateDefaultDeploymentPerformanceAndRegionPlans.ts
@@ -5,8 +5,9 @@ import { z } from 'zod';
 export function calculateDefaultDeploymentPerformanceAndRegionPlans(
 	planTypes: SchemaPlan[],
 	regionLocations: SchemaRegion[],
+	alreadyUsingFree?: boolean,
 ): null | Pick<z.infer<typeof UpsertClusterSchema>, 'deploymentDescription' | 'performanceDescription' | 'regionPlans'> {
-	const planToSelect = planTypes.find(planType => !planType.priceUsd && planType.deploymentType === 'colocated')
+	const planToSelect = planTypes.find(planType => (alreadyUsingFree ? !!planType.priceUsd : !planType.priceUsd) && planType.deploymentType === 'colocated')
 		|| planTypes.find(planType => planType.deploymentType === 'colocated')
 		|| planTypes[0];
 	const allowedRegionIds = planToSelect?.allowedRegionIds;


### PR DESCRIPTION
We'll do a few things better now:
1. The resources usage block will wrap properly now. When we moved it, we didn't update the classes.
2. If you select a free performance tier, we won't show the "add region" button.
3. If you add multiple regions on a paid tier, then select the free tier, it will warn you on the 2nd+ region.
4. If your org has already created a free cluster, we'll auto-pick a paid tier when opening the new cluster form.
5. If you try to pick the free tier in that org, we'll show a validation error on the performance tier dropdown.

https://harperdb.atlassian.net/browse/STUDIO-441