### PR TITLE
Updated Cluster Card and Cluster Card Dropdown

### DIFF
--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -116,7 +116,8 @@ export function ClusterCard({
 					{cluster.fqdn ? (
 						<>
 							<span className="truncate max-w-48">{cluster.fqdn}</span>
-							<CopyIcon onClick={onCopyFQDNClick} size={16} />
+							<CopyIcon onClick={onCopyFQDNClick} size={16} className="cursor-pointer" />
+							<span className="grow"></span>
 						</>
 					) : (
 						<span>Self-Hosted</span>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -37,6 +37,7 @@ export function ClusterCard({
 }) {
 	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
 	const auth = useInstanceAuth(cluster.id);
+	const isSelfManaged = useMemo(() => !!cluster?.plans?.[0]?.planId?.startsWith('self-hosted'), [cluster]);
 
 	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
 	const isTerminated = useMemo(
@@ -71,6 +72,11 @@ export function ClusterCard({
 		toast.info('FQDN url copied to clipboard');
 	}, [cluster.fqdn]);
 
+	const onCopyAPIClick = useCallback(() => {
+		navigator.clipboard.writeText(`https://${cluster.fqdn}`);
+		toast.info('API url copied to clipboard');
+	}, [cluster.fqdn]);
+
 	const menuItems = [
 		isActive && update && (
 			<Link to={`${cluster.id}/edit`} disabled={signingOut}>
@@ -85,6 +91,11 @@ export function ClusterCard({
 		isActive && view && (
 			<DropdownMenuItem onClick={onCopyFQDNClick} disabled={signingOut}>
 				Copy FQDN Url
+			</DropdownMenuItem>
+		),
+		isActive && view && !isSelfManaged && (
+			<DropdownMenuItem onClick={onCopyAPIClick} disabled={signingOut}>
+				Copy API Url
 			</DropdownMenuItem>
 		),
 		isActive && view && !!operationsUrl && !auth.isLoading && auth.user && (
@@ -103,7 +114,7 @@ export function ClusterCard({
 		<Card className="relative h-full justify-between">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
-					<span className="truncate">{cluster.id}</span>
+					<span className="truncate">{cluster?.fqdn}</span>
 					{!isTerminated && (
 						<DropdownMenu>
 							<DropdownMenuTrigger>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -88,7 +88,7 @@ export function ClusterCard({
 				<DropdownMenuItem>Instances</DropdownMenuItem>
 			</Link>
 		),
-		isActive && view && (
+		isActive && view && !isSelfManaged && (
 			<DropdownMenuItem onClick={onCopyFQDNClick} disabled={signingOut}>
 				Copy FQDN Url
 			</DropdownMenuItem>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -88,12 +88,12 @@ export function ClusterCard({
 				<DropdownMenuItem>Instances</DropdownMenuItem>
 			</Link>
 		),
-		isActive && view && !isSelfManaged && (
+		isActive && view && cluster.fqdn && (
 			<DropdownMenuItem onClick={onCopyFQDNClick} disabled={signingOut}>
 				Copy FQDN Url
 			</DropdownMenuItem>
 		),
-		isActive && view && !isSelfManaged && (
+		isActive && view && cluster.fqdn && (
 			<DropdownMenuItem onClick={onCopyAPIClick} disabled={signingOut}>
 				Copy API Url
 			</DropdownMenuItem>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -21,7 +21,7 @@ import { authStore } from '@/lib/authStore';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { Link } from '@tanstack/react-router';
-import { Ellipsis } from 'lucide-react';
+import { CopyIcon, Ellipsis } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -114,7 +114,14 @@ export function ClusterCard({
 		<Card className="relative h-full justify-between">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
-					<span className="truncate">{cluster?.fqdn}</span>
+					{!isSelfManaged ? (
+						<>
+							<span className="truncate max-w-48">{cluster?.fqdn}</span>
+							<CopyIcon onClick={onCopyFQDNClick} size={16} />
+						</>
+					) : (
+						<span>Self-Hosted</span>
+					)}
 					{!isTerminated && (
 						<DropdownMenu>
 							<DropdownMenuTrigger>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -68,7 +68,7 @@ export function ClusterCard({
 
 	const onCopyFQDNClick = useCallback(() => {
 		navigator.clipboard.writeText(cluster.fqdn || '');
-		toast.info('FQDN url copied to clipboard');
+		toast.info('FQDN copied to clipboard');
 	}, [cluster.fqdn]);
 
 	const onCopyAPIClick = useCallback(() => {

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -37,7 +37,6 @@ export function ClusterCard({
 }) {
 	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
 	const auth = useInstanceAuth(cluster.id);
-	const isSelfManaged = useMemo(() => !!cluster?.plans?.[0]?.planId?.startsWith('self-hosted'), [cluster]);
 
 	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
 	const isTerminated = useMemo(
@@ -114,9 +113,9 @@ export function ClusterCard({
 		<Card className="relative h-full justify-between">
 			<CardHeader>
 				<CardDescription className="flex items-center justify-between">
-					{!isSelfManaged ? (
+					{cluster.fqdn ? (
 						<>
-							<span className="truncate max-w-48">{cluster?.fqdn}</span>
+							<span className="truncate max-w-48">{cluster.fqdn}</span>
 							<CopyIcon onClick={onCopyFQDNClick} size={16} />
 						</>
 					) : (


### PR DESCRIPTION
Ticket:
[STUDIO-438](https://harperdb.atlassian.net/browse/STUDIO-438)

Overview:
- Replaced cluster id for fqdn url on cluster card with copy icon
- Added copy api url in cluster card dropdown for non-self-managed clusters
- Display "Self-Hosted" if the cluster is self-hosted in replacement of the fqdn url
- Removed copy fqdn url on cluster card dropdown if cluster is self-hosted

<img width="785" height="232" alt="Screenshot 2025-09-22 at 2 17 23 PM" src="https://github.com/user-attachments/assets/959e3e49-62fe-4248-b91d-eb4a9d221f65" />

<img width="788" height="337" alt="Screenshot 2025-09-22 at 2 19 38 PM" src="https://github.com/user-attachments/assets/7100401c-edc3-4378-a9a2-75f8c20b82f8" />

<img width="929" height="433" alt="Screenshot 2025-09-22 at 2 19 49 PM" src="https://github.com/user-attachments/assets/e90c3342-d03a-47cc-b605-cbbd4af8e69e" />


[STUDIO-438]: https://harperdb.atlassian.net/browse/STUDIO-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ