### PR TITLE
fix: Only allow 1 free colocated cluster

### DIFF
--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -44,7 +44,7 @@ export function UpsertCluster() {
 				&& orgCluster.plans) {
 				for (const clusterPlan of orgCluster.plans) {
 					const foundPlan = planTypes.find(p => p.id === clusterPlan.planId);
-					if (foundPlan?.priceUsd === 0) {
+					if (foundPlan?.priceUsd === 0 && !foundPlan.id.startsWith('self-hosted')) {
 						return true;
 					}
 				}


### PR DESCRIPTION
The API only enforces a single colocated free cluster. They let you make as many self-managed free clusters as you want! So we should too.

https://harperdb.atlassian.net/browse/STUDIO-454