### PR TITLE
fix: Handle abbreviated name under self-managed properly

### DIFF
--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -226,7 +226,7 @@ export function ClusterDetails({
 									<Input
 										{...field}
 										type="text"
-										maxLength={UpsertClusterSchema.shape.abbreviatedName.maxLength!}
+										maxLength={UpsertClusterSchema.shape.abbreviatedName.unwrap().maxLength!}
 										autoCapitalize="none"
 										autoComplete="off"
 										autoCorrect="off"

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -190,7 +190,7 @@ export function ClusterForm({
 	const calculatedNames = useMemo(() => {
 		const suggestedAbbreviatedName = collapseKebabsToMaxLength(
 			toKebabCase(systemName),
-			UpsertClusterSchema.shape.abbreviatedName.maxLength!,
+			UpsertClusterSchema.shape.abbreviatedName.unwrap().maxLength!,
 		);
 		return {
 			suggestedAbbreviatedName,
@@ -317,7 +317,9 @@ export function ClusterForm({
 			});
 		} else {
 			submitNewClusterData({
-				abbreviatedName: isSelfManaged ? undefined : (formData.abbreviatedName || calculatedNames.suggestedAbbreviatedName),
+				abbreviatedName: isSelfManaged
+					? undefined
+					: (formData.abbreviatedName || calculatedNames.suggestedAbbreviatedName),
 				autoRenew: true,
 				fqdn: isSelfManaged && formData.fqdn || undefined,
 				name: formData.systemName,

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -112,7 +112,7 @@ export function UpsertCluster() {
 		return {
 			autoRenew: cluster?.plans?.[0]?.autoRenew ?? true,
 			systemName: cluster?.name ?? '',
-			abbreviatedName: cluster?.abbreviatedName || '',
+			abbreviatedName: cluster?.abbreviatedName ?? '',
 			deploymentDescription: selectedPlan?.deploymentDescription ?? defaults?.deploymentDescription ?? '',
 			performanceDescription: selectedPlan?.performanceDescription ?? defaults?.performanceDescription ?? '',
 			fqdn: isSelfManaged ? cluster?.fqdn ?? '' : '',

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -112,7 +112,7 @@ export function UpsertCluster() {
 		return {
 			autoRenew: cluster?.plans?.[0]?.autoRenew ?? true,
 			systemName: cluster?.name ?? '',
-			abbreviatedName: cluster?.abbreviatedName ?? '',
+			abbreviatedName: cluster?.abbreviatedName || '',
 			deploymentDescription: selectedPlan?.deploymentDescription ?? defaults?.deploymentDescription ?? '',
 			performanceDescription: selectedPlan?.performanceDescription ?? defaults?.performanceDescription ?? '',
 			fqdn: isSelfManaged ? cluster?.fqdn ?? '' : '',

--- a/src/features/clusters/upsert/upsertClusterSchema.tsx
+++ b/src/features/clusters/upsert/upsertClusterSchema.tsx
@@ -9,7 +9,8 @@ export const UpsertClusterSchema = z.object({
 	abbreviatedName: z
 		.string()
 		.max(20, 'Must be at most 20 characters long.')
-		.regex(/^[a-zA-Z0-9-]*$/, 'Can only contain letters, numbers and dashes'),
+		.regex(/^[a-zA-Z0-9-]*$/, 'Can only contain letters, numbers and dashes')
+		.optional(),
 	fqdn: z
 		.string()
 		.regex(hostNameRegex, 'Please enter a valid host name without the port or any path.')


### PR DESCRIPTION
There were inconsistencies based on what you’d type, and when you’d switch, that could prevent Zod from passing validation. Or we’d accidentally pass an empty string to the server, causing a validation error there. This will avoid those odd cases, and make sure we pass along the abbreviated name when appropriate.