### PR TITLE
fix: Use the word Remove with Self-Managed

### DIFF
--- a/src/components/ConfirmDeletionModal.tsx
+++ b/src/components/ConfirmDeletionModal.tsx
@@ -15,6 +15,7 @@ export function ConfirmDeletionModal({
 	typeOfThingBeingDeleted,
 	nameOfThingBeingDeleted,
 	isModalOpen,
+	hideDataLossWarning,
 	setIsModalOpen,
 	deletionConfirmed,
 	deletionPending,
@@ -25,6 +26,7 @@ export function ConfirmDeletionModal({
 	typeOfThingBeingDeleted: string;
 	nameOfThingBeingDeleted?: string;
 	isModalOpen: boolean;
+	hideDataLossWarning?: boolean;
 	setIsModalOpen: (isOpen: boolean) => void;
 	deletionConfirmed: () => void;
 	deletionPending: boolean;
@@ -41,18 +43,22 @@ export function ConfirmDeletionModal({
 			)}
 			<DialogContent className="sm:max-w-[750px]">
 				<DialogHeader>
-					<DialogTitle>Are you sure you want to {transitiveVerb.toLowerCase()} this {typeOfThingBeingDeleted}?</DialogTitle>
+					<DialogTitle>
+						Are you sure you want
+						to {transitiveVerb.toLowerCase()} this {typeOfThingBeingDeleted}?
+					</DialogTitle>
 					<DialogDescription>This action cannot be undone.</DialogDescription>
 				</DialogHeader>
-				<div className="p-3 my-5 text-white rounded-md bg-amber-600">
+				{!hideDataLossWarning && (<div className="p-3 my-5 text-white rounded-md bg-amber-600">
 					<p className="flex space-x-1 font-semibold align-baseline">
 						<TriangleAlert className="inline-block size-5" /> <span>Warning</span>
 					</p>
 					<p className="pt-2 text-base">
-						By {presentParticiple.toLowerCase()} {typeOfThingBeingDeleted} <span className="font-semibold">{nameOfThingBeingDeleted} </span>
+						By {presentParticiple.toLowerCase()} {typeOfThingBeingDeleted}
+						<span className="font-semibold">{nameOfThingBeingDeleted} </span>
 						you will lose the data stored in it permanently.
 					</p>
-				</div>
+				</div>)}
 				<DialogFooter>
 					<div className="flex justify-center space-x-5">
 						<Button className="rounded-full" onClick={() => setIsModalOpen(false)}>

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -1,11 +1,9 @@
-import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { ClusterCard } from '@/features/clusters/components/ClusterCard';
-import { useTerminateClusterMutation } from '@/features/clusters/mutations/terminateCluster';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
@@ -13,25 +11,16 @@ import { byClusterStatusThenName } from '@/lib/arrays/sort/byClusterStatusThenNa
 import { groupBy } from '@/lib/groupBy';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { curryFilterByFuzzySearch } from '@/lib/string/filterByFuzzySearch';
-import { queryKeys } from '@/react-query/constants';
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
 import { Plus } from 'lucide-react';
 import { FormEvent, useCallback, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 export function ClustersList() {
-	const queryClient = useQueryClient();
 	const { organizationId }: { organizationId: string } = useParams({ strict: false });
 	const { create } = useOrganizationClusterPermissions(organizationId);
 	const { data: orgInfo, isSuccess } = useSuspenseQuery(getOrganizationQueryOptions(organizationId));
-	const { mutate: terminateCluster, isPending: isTerminateClusterPending } = useTerminateClusterMutation();
 
-	const [isTerminateClusterModalOpen, setIsTerminateClusterModalOpen] = useState(false);
-	const [terminateClusterInfo, setTerminateClusterInfo] = useState({
-		id: '',
-		name: '',
-	});
 	const [filterByNameValue, setFilterByNameValue] = useState('');
 
 	const onFilterByNameChanged = useCallback((e: FormEvent<HTMLInputElement>) => {
@@ -52,47 +41,6 @@ export function ClustersList() {
 			groups,
 		};
 	}, [filterByNameValue, orgInfo?.clusters]);
-
-	const handleTerminatedCluster = useCallback(
-		(clusterInfo: { id: string; name: string }) => {
-			if (clusterInfo) {
-				terminateCluster(clusterInfo.id, {
-					onSuccess: () => {
-						toast.success('Success', {
-							description: `Cluster successfully terminated.`,
-							duration: 5000,
-							action: {
-								label: 'Dismiss',
-								onClick: () => toast.dismiss(),
-							},
-						});
-						void queryClient.invalidateQueries({ queryKey: [queryKeys.organization], refetchType: 'active' });
-						setIsTerminateClusterModalOpen(false);
-					},
-					onError: () => {
-						toast.error('Error', {
-							description: `Failed to terminate cluster: ${clusterInfo.name}.`,
-							duration: 5000,
-							action: {
-								label: 'Dismiss',
-								onClick: () => toast.dismiss(),
-							},
-						});
-						setIsTerminateClusterModalOpen(false);
-					},
-				});
-			}
-		},
-		[terminateCluster, queryClient, setIsTerminateClusterModalOpen]
-	);
-
-	const onTerminateClusterModal = useCallback((cluster: Cluster) => {
-		setTerminateClusterInfo({
-			id: cluster.id,
-			name: cluster.name,
-		});
-		setIsTerminateClusterModalOpen(true);
-	}, []);
 
 	return (
 		<>
@@ -132,7 +80,7 @@ export function ClustersList() {
 							<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
 								{clustersData.groups[clusterStatus].map((cluster) => (
 									<div key={cluster.id} className="cols-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">
-										<ClusterCard cluster={cluster} onTerminateClusterModal={onTerminateClusterModal} />
+										<ClusterCard cluster={cluster} />
 									</div>
 								))}
 							</div>
@@ -162,16 +110,6 @@ export function ClustersList() {
 					</div>
 				)}
 			</section>
-			<ConfirmDeletionModal
-				typeOfThingBeingDeleted="cluster"
-				transitiveVerb="Terminate"
-				presentParticiple="Terminating"
-				nameOfThingBeingDeleted={terminateClusterInfo.name}
-				isModalOpen={isTerminateClusterModalOpen}
-				setIsModalOpen={(isOpen: boolean) => setIsTerminateClusterModalOpen(isOpen)}
-				deletionConfirmed={() => handleTerminatedCluster(terminateClusterInfo)}
-				deletionPending={isTerminateClusterPending}
-			/>
 		</>
 	);
 }

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -1,3 +1,4 @@
+import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { ProgressBar } from '@/components/ProgressBar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -13,14 +14,17 @@ import { isBeingUpdated, isRunning } from '@/components/ui/utils/badgeStatus';
 import { useInstanceClient } from '@/config/useInstanceClient';
 import { getClusterInfo, getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterCardAction } from '@/features/clusters/components/ClusterCardAction';
+import { useTerminateClusterMutation } from '@/features/clusters/mutations/terminateCluster';
 import { onInstanceLogoutSubmit } from '@/features/instance/operations/mutations/onInstanceLogoutSubmit';
 import { useInstanceAuth } from '@/hooks/useAuth';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { authStore } from '@/lib/authStore';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
-import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/react-query/constants';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { CopyIcon, Ellipsis } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -29,24 +33,28 @@ import { toast } from 'sonner';
 const activeClusterStatuses = ['RUNNING'];
 const deletedClusterStatuses = ['TERMINATING', 'TERMINATED', 'REMOVED'];
 
-export function ClusterCard({
-	cluster,
-	onTerminateClusterModal,
-}: {
-	cluster: Cluster;
-	onTerminateClusterModal: (cluster: Cluster) => void;
-}) {
-	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
+export function ClusterCard({ cluster }: { cluster: Cluster; }) {
+	const queryClient = useQueryClient();
+	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
+	const instanceClient = useInstanceClient(operationsUrl);
 	const auth = useInstanceAuth(cluster.id);
-	const isUpdating = isBeingUpdated(cluster.status);
-	const { data: clusterById } = useQuery(
-		getClusterInfoQueryOptions(isUpdating && cluster.id, 2000),
-	);
+
+	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
+	const { mutate: terminateCluster, isPending: isTerminateClusterPending } = useTerminateClusterMutation();
+
+	const [signingOut, setSigningOut] = useState(false);
+	const [isTerminateClusterModalOpen, setIsTerminateClusterModalOpen] = useState(false);
 
 	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
+	const isSelfManaged = useMemo(() => !!cluster?.plans?.[0]?.planId?.startsWith('self-hosted'), [cluster]);
 	const isTerminated = useMemo(
 		() => cluster.status && deletedClusterStatuses.includes(cluster.status),
 		[cluster.status],
+	);
+
+	const isUpdating = isBeingUpdated(cluster.status);
+	const { data: clusterById } = useQuery(
+		getClusterInfoQueryOptions(isUpdating && cluster.id, 2000),
 	);
 	const updating = useMemo(() => {
 		if (isUpdating && clusterById?.instances) {
@@ -54,15 +62,16 @@ export function ClusterCard({
 				total + (isBeingUpdated(instance.status) ? 1 : 0), 0);
 			const running = clusterById.instances.reduce((total, instance) =>
 				total + (isRunning(instance.status) ? 1 : 0), 0);
+			const current = running;
+			const total = updating + running;
 			return {
-				current: running,
-				total: updating + running,
+				width: `${current === 0 ? 0 : (current / total * 100)}%`,
+				text: total > 0
+					? `${current} / ${total}`
+					: `${capitalizeWords(cluster.status ?? 'Updating')}...`,
 			};
 		}
-	}, [clusterById, isUpdating]);
-	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
-	const instanceClient = useInstanceClient(operationsUrl);
-	const [signingOut, setSigningOut] = useState(false);
+	}, [cluster.status, clusterById?.instances, isUpdating]);
 
 	const onSignOutClick = useCallback(async () => {
 		setSigningOut(true);
@@ -79,9 +88,43 @@ export function ClusterCard({
 		}
 		authStore.setUserForEntity(cluster, null);
 	}, [cluster, instanceClient]);
-	const onTerminateClick = useCallback(() => {
-		onTerminateClusterModal(cluster);
-	}, [cluster, onTerminateClusterModal]);
+
+	const onTerminateClick = useCallback(() => setIsTerminateClusterModalOpen(true), []);
+
+	const handleTerminatedCluster = useCallback(() => {
+		terminateCluster(cluster.id, {
+			onSuccess: () => {
+				toast.success('Success', {
+					description: isSelfManaged
+						? `Cluster successfully removed.`
+						: `Cluster successfully terminated.`,
+					duration: 5000,
+					action: {
+						label: 'Dismiss',
+						onClick: () => toast.dismiss(),
+					},
+				});
+				void queryClient.invalidateQueries({
+					queryKey: [queryKeys.organization],
+					refetchType: 'active',
+				});
+				setIsTerminateClusterModalOpen(false);
+			},
+			onError: () => {
+				toast.error('Error', {
+					description: isSelfManaged
+						? `Failed to remove cluster: ${cluster.name}`
+						: `Failed to terminate cluster: ${cluster.name}.`,
+					duration: 5000,
+					action: {
+						label: 'Dismiss',
+						onClick: () => toast.dismiss(),
+					},
+				});
+				setIsTerminateClusterModalOpen(false);
+			},
+		});
+	}, [terminateCluster, cluster.id, cluster.name, isSelfManaged, queryClient]);
 
 	const onCopyFQDNClick = useCallback(() => {
 		navigator.clipboard.writeText(cluster.fqdn || '');
@@ -121,7 +164,7 @@ export function ClusterCard({
 		),
 		!isTerminated && remove && (
 			<DropdownMenuItem className="focus:bg-red/70 focus:text-white" onClick={onTerminateClick}>
-				Terminate
+				{isSelfManaged ? 'Remove' : 'Terminate'}
 			</DropdownMenuItem>
 		),
 	].filter(excludeFalsy);
@@ -168,16 +211,28 @@ export function ClusterCard({
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="flex justify-between">
-				{updating && (
+				{updating && cluster.status && (
 					<ProgressBar
 						animated={true}
 						className="bg-yellow-800/60"
-						width={(updating.current === 0 ? 0 : (updating.current / updating.total * 100)) + '%'}
-						placeholder="updating..."
+						width={updating.width}
+						placeholder={updating.text}
 					/>
 				)}
 				{isActive && view && <ClusterCardAction cluster={cluster} />}
 			</CardContent>
+
+			<ConfirmDeletionModal
+				typeOfThingBeingDeleted="cluster"
+				transitiveVerb={isSelfManaged ? 'Remove' : 'Terminate'}
+				presentParticiple={isSelfManaged ? 'Removing' : 'Terminating'}
+				nameOfThingBeingDeleted={cluster.name}
+				isModalOpen={isTerminateClusterModalOpen}
+				hideDataLossWarning={isSelfManaged}
+				setIsModalOpen={(isOpen: boolean) => setIsTerminateClusterModalOpen(isOpen)}
+				deletionConfirmed={handleTerminatedCluster}
+				deletionPending={isTerminateClusterPending}
+			/>
 		</Card>
 	);
 }


### PR DESCRIPTION
I brought the logic closer to the card, and adjusted the wording for self-managed to "Remove", otherwise "Terminate", etc. Plus, we'll hide the warning about data loss when you're self-managed.

Note that I based this off of @BboyAkers 's PR for the card tweaks, to avoid conflicts! 🥳 

https://harperdb.atlassian.net/browse/STUDIO-450