### PR TITLE
fix: Don’t let people delete or edit their own role

### DIFF
--- a/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
@@ -246,7 +246,7 @@ export function EditOrganizationRoleModal({
 										defaultValue={updatedPermissions}
 									/>
 								</div>
-								{(remove || update) && (<DialogFooter className="col-span-2">
+								{(!isSelf && (remove || update)) && (<DialogFooter className="col-span-2">
 									<div className="flex justify-between w-full">
 										{remove && (<Button
 											type="button"


### PR DESCRIPTION
For safety, users should not be able to edit or delete their own role. The API enforces this, I believe, but the UI needs to as well. Notably, we make the editor read-only already. We were just incorrectly showing the buttons too!