### PR TITLE
[STUDIO-455] Display Progress of Cluster Updates

### DIFF
--- a/src/components/EstimatedProgressBar.tsx
+++ b/src/components/EstimatedProgressBar.tsx
@@ -1,11 +1,16 @@
+import { ProgressBar } from '@/components/ProgressBar';
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
-export function EstimatedProgressBar({ duration, message, lateMessage }: { duration: number, message: ReactNode, lateMessage: ReactNode }) {
+export function EstimatedProgressBar({ duration, message, lateMessage }: {
+	duration: number,
+	message: ReactNode,
+	lateMessage: ReactNode
+}) {
 	const animationFrameId = useRef<number>(0);
 	const previousTimeRef = useRef<number>(0);
 	const [finished, setFinished] = useState(false);
 	const minPercentage = 5;
-	const [style, setStyle] = useState({ width: `${minPercentage}%` });
+	const [width, setWidth] = useState(`${minPercentage}%`);
 
 	const animate = useCallback((time: number) => {
 		if (!previousTimeRef.current) {
@@ -13,7 +18,7 @@ export function EstimatedProgressBar({ duration, message, lateMessage }: { durat
 		}
 		const timeElapsed = time - previousTimeRef.current;
 		const percentage = Math.min(timeElapsed / duration, 1);
-		setStyle({ width: Math.max(minPercentage, percentage * 100) + '%' });
+		setWidth(Math.max(minPercentage, percentage * 100) + '%');
 
 		if (percentage < 1) {
 			animationFrameId.current = requestAnimationFrame(animate);
@@ -29,11 +34,6 @@ export function EstimatedProgressBar({ duration, message, lateMessage }: { durat
 
 	return (<>
 		{!finished ? message : lateMessage}
-		<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
-			<div
-				className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500 mt-2"
-				style={style}
-			></div>
-		</div>
+		<ProgressBar width={width} animated={false}></ProgressBar>
 	</>);
 }

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,27 @@
+import { cx } from 'class-variance-authority';
+
+export function ProgressBar({ width, className, animated, placeholder }: {
+	width: string | undefined;
+	className?: string;
+	animated?: boolean;
+	placeholder?: string;
+}) {
+	return (
+		<div className={cx('w-full bg-gray-200 rounded-full relative', placeholder ? 'h-6' : 'h-2.5')}>
+			{placeholder && (
+				<div className="absolute top-0 h-full w-full font-bold text-xs flex flex-col items-center justify-center text-black/60 text-shadow-2xs">{placeholder}</div>)}
+			<div
+				className={cx(
+					'rounded-full',
+					placeholder ? 'h-6' : 'h-2.5',
+					!className?.includes('bg-') && 'bg-purple/40',
+					animated && 'transition-[width] duration-1000 ease-in-out motion-reduce:transition-none',
+					className,
+				)}
+				style={{
+					width,
+				}}
+			></div>
+		</div>
+	);
+}

--- a/src/components/ui/utils/badgeStatus.tsx
+++ b/src/components/ui/utils/badgeStatus.tsx
@@ -16,17 +16,13 @@ export type BadgeStatusVariant =
 export type BadgeStatusVariantValues = 'warning' | 'success' | 'secondary' | 'destructive' | 'outline' | 'default';
 
 export function renderBadgeStatusVariant(value: BadgeStatusVariant): BadgeStatusVariantValues {
+	if (isBeingUpdated(value)) {
+		return 'warning';
+	}
+	if (isRunning(value)) {
+		return 'success';
+	}
 	switch (value) {
-		case 'PROVISIONING':
-		case 'CLONE_PENDING':
-		case 'CLONING':
-		case 'CLONE_READY':
-		case 'UPDATING_HDB_NODES':
-		case 'UPDATING':
-			return 'warning';
-		case 'RUNNING':
-		case 'UPDATED':
-			return 'success';
 		case 'STOPPED':
 			return 'secondary';
 		case 'TERMINATING':
@@ -36,5 +32,29 @@ export function renderBadgeStatusVariant(value: BadgeStatusVariant): BadgeStatus
 			return 'destructive';
 		default:
 			return 'default';
+	}
+}
+
+export function isRunning(value: string | undefined): boolean {
+	switch (value) {
+		case 'RUNNING':
+		case 'UPDATED':
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function isBeingUpdated(value: string | undefined): boolean {
+	switch (value) {
+		case 'PROVISIONING':
+		case 'CLONE_PENDING':
+		case 'CLONING':
+		case 'CLONE_READY':
+		case 'UPDATING_HDB_NODES':
+		case 'UPDATING':
+			return true;
+		default:
+			return false;
 	}
 }

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -8,12 +8,16 @@ export async function getClusterInfo(clusterId: string) {
 	return data as Cluster;
 }
 
-export function getClusterInfoQueryOptions(clusterId?: string, refetch?: boolean) {
+export function getClusterInfoQueryOptions(clusterId?: string | false, refetch?: boolean | number) {
 	return queryOptions({
 		queryKey: [queryKeys.cluster, clusterId],
-		queryFn: () => getClusterInfo(clusterId!),
+		queryFn: () => getClusterInfo(clusterId as string),
 		retry: false,
 		enabled: !!clusterId,
-		refetchInterval: refetch ? 10000 : undefined,
+		refetchInterval: refetch
+			? refetch === true
+				? 10000
+				: refetch
+			: undefined,
 	});
 }

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@/components/ProgressBar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -8,9 +9,9 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
-import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
+import { isBeingUpdated, isRunning } from '@/components/ui/utils/badgeStatus';
 import { useInstanceClient } from '@/config/useInstanceClient';
-import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
+import { getClusterInfo, getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterCardAction } from '@/features/clusters/components/ClusterCardAction';
 import { onInstanceLogoutSubmit } from '@/features/instance/operations/mutations/onInstanceLogoutSubmit';
 import { useInstanceAuth } from '@/hooks/useAuth';
@@ -18,8 +19,8 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { authStore } from '@/lib/authStore';
-import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { CopyIcon, Ellipsis } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -37,12 +38,28 @@ export function ClusterCard({
 }) {
 	const { view, update, remove } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
 	const auth = useInstanceAuth(cluster.id);
+	const isUpdating = isBeingUpdated(cluster.status);
+	const { data: clusterById } = useQuery(
+		getClusterInfoQueryOptions(isUpdating && cluster.id, 2000),
+	);
 
 	const isActive = useMemo(() => cluster.status && activeClusterStatuses.includes(cluster.status), [cluster.status]);
 	const isTerminated = useMemo(
 		() => cluster.status && deletedClusterStatuses.includes(cluster.status),
-		[cluster.status]
+		[cluster.status],
 	);
+	const updating = useMemo(() => {
+		if (isUpdating && clusterById?.instances) {
+			const updating = clusterById.instances.reduce((total, instance) =>
+				total + (isBeingUpdated(instance.status) ? 1 : 0), 0);
+			const running = clusterById.instances.reduce((total, instance) =>
+				total + (isRunning(instance.status) ? 1 : 0), 0);
+			return {
+				current: running,
+				total: updating + running,
+			};
+		}
+	}, [clusterById, isUpdating]);
 	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
 	const instanceClient = useInstanceClient(operationsUrl);
 	const [signingOut, setSigningOut] = useState(false);
@@ -151,8 +168,13 @@ export function ClusterCard({
 				</CardTitle>
 			</CardHeader>
 			<CardContent className="flex justify-between">
-				{cluster.status && (
-					<Badge variant={renderBadgeStatusVariant(cluster.status)}>{capitalizeWords(cluster.status)}</Badge>
+				{updating && (
+					<ProgressBar
+						animated={true}
+						className="bg-yellow-800/60"
+						width={(updating.current === 0 ? 0 : (updating.current / updating.total * 100)) + '%'}
+						placeholder="updating..."
+					/>
 				)}
 				{isActive && view && <ClusterCardAction cluster={cluster} />}
 			</CardContent>

--- a/src/hooks/useApplyLicensesClick.tsx
+++ b/src/hooks/useApplyLicensesClick.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@/components/ProgressBar';
 import { useInstanceClient } from '@/config/useInstanceClient';
 import { installUsageLicense } from '@/features/instance/operations/mutations/installUsageLicense';
 import { getInstanceUserInfo } from '@/features/instance/operations/queries/getInstanceUserInfo';
@@ -23,7 +24,7 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 	const instanceClient = useInstanceClient();
 	const { instanceId }: { instanceId?: string; } = useParams({ strict: false });
 	const queryClient = useQueryClient();
-	const {isRestartPending, onRestartClick } = useRestartInstanceClick({
+	const { isRestartPending, onRestartClick } = useRestartInstanceClick({
 		operation: 'restart_service',
 		instanceClient,
 	});
@@ -46,7 +47,10 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 
 		const toastId = toast.loading('Applying Licenses', {
 			...toastConfig,
-			description: renderProgressUpdate(),
+			description: <ProgressBar
+				animated={true}
+				width="0%"
+			/>,
 		});
 
 		let licensesApplied = 0;
@@ -59,7 +63,10 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 					: `Applying License ${i + 1} of ${licenses.length}`, {
 					...toastConfig,
 					id: toastId,
-					description: renderProgressUpdate(i, licenses.length),
+					description: <ProgressBar
+						animated={true}
+						width={(i === 0 ? 0 : (i / licenses.length * 100)) + '%'}
+					/>,
 				});
 				try {
 					// Make sure the instance is responding.
@@ -135,14 +142,4 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 		onApplyLicensesClick,
 		isApplyLicensesPending: isApplyLicensesPending || isRestartPending,
 	};
-}
-
-function renderProgressUpdate(current?: number, total?: number) {
-	return (<>
-		{current !== undefined && total !== undefined && total > 0 && (
-			<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
-				<div className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500" style={{ width: (current === 0 ? 0 : (current / total * 100)) + '%' }}></div>
-			</div>)}
-		<div className="text-xs mt-2">Please don't close your browser or navigate away. This may take a bit.</div>
-	</>);
 }

--- a/src/hooks/useRestartClusterClick.tsx
+++ b/src/hooks/useRestartClusterClick.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@/components/ProgressBar';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
 import { restartInstance } from '@/features/instance/operations/mutations/restartInstance';
@@ -41,7 +42,10 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 
 		const toastId = toast.loading('Restarting', {
 			...toastConfig,
-			description: renderProgressUpdate(),
+			description: <ProgressBar
+				animated={true}
+				width="0%"
+			/>,
 		});
 
 		const cluster = await getClusterInfo(clusterId);
@@ -62,7 +66,10 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 					toast.loading(`Restarting Instance ${i + 1} of ${instanceClients.length}`, {
 						...toastConfig,
 						id: toastId,
-						description: renderProgressUpdate(i, instanceClients.length),
+						description: <ProgressBar
+							animated={true}
+							width={(i === 0 ? 0 : (i / instanceClients.length * 100)) + '%'}
+						/>,
 					});
 					try {
 						// Make sure the instance is responding.
@@ -76,8 +83,7 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 							instanceClient,
 						});
 						instancesRestarted += 1;
-					}
-					catch {
+					} catch {
 						if (i + 1 !== instanceClients.length) {
 							// If it fails to restart, or wasn't available, warn for a bit then move on.
 							toast.loading(`Failed Restarting Instance ${i + 1} of ${instanceClients.length}`, {
@@ -144,14 +150,4 @@ export function useRestartClusterClick({ onRestartedSuccessfully }: RestartClust
 		onRestartClick,
 		isRestartPending,
 	};
-}
-
-function renderProgressUpdate(current?: number, total?: number) {
-	return (<>
-		{current !== undefined && total !== undefined && total > 0 && (
-			<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
-				<div className="bg-purple-600 h-2.5 rounded-full dark:bg-purple-500" style={{ width: (current === 0 ? 0 : (current / total * 100)) + '%' }}></div>
-			</div>)}
-			<div className="text-xs mt-2">Please don't close your browser or navigate away. This may take a bit.</div>
-	</>);
 }


### PR DESCRIPTION
# [chore: Extract shared ProgressBar component](https://github.com/HarperDB/hdbms/commit/67967c93f1bdc3d09a0cc9f4ac9450983bdb557d) 

This one is simpler than estimated progress bar. That one utilizes this new progress bar, but animates it over a given period of time to fill up.

# [feat: Watch cluster instances when updating them](https://github.com/HarperDB/hdbms/commit/2d664178ebc154d8d2ce11202dcc7c8077c17791) 
We'll estimate how far through the update they are based on the statuses of the instances in the cluster.

https://harperdb.atlassian.net/browse/STUDIO-455