### PR TITLE
fix: Make the whole resources block clickable

### DIFF
--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -107,7 +107,7 @@ export function ResourcesPerInstance({ planLimits, resourcesPerInstance, selecte
 	}
 
 	return <FormItem className="basis-full">
-		<FormLabel>
+		<FormLabel onClick={onUsageLimitsClick}>
 			Purchasing usage block for {isPositive(planLimits.readsPerMinuteCount) ? `${humanNumber(planLimits.readsPerMinuteCount * multiplier)} reads/min & ` : ''}
 			{humanNumber(planLimits.totalReadCount * multiplier)} total reads {isPositive(planLimits.readsPerMinuteCount) ? 'in ' + (selectedRegion?.region ?? '') + ' region' : 'per server'},<br className="hidden sm:block" />
 			{isPositive(planLimits.writesPerMinuteCount) ? ` ${humanNumber(planLimits.writesPerMinuteCount)} writes/min & ` : ' '}
@@ -117,7 +117,6 @@ export function ResourcesPerInstance({ planLimits, resourcesPerInstance, selecte
 				type="button"
 				variant="link"
 				className="text-white"
-				onClick={onUsageLimitsClick}
 			>
 				Learn More {toggled ? <ArrowDownIcon /> : <ArrowRightIcon />}
 			</Button>


### PR DESCRIPTION
The mouse was changing to a pointer for the whole label, but you had to click on the button to actually trigger the expansion. Now you can click anywhere on the label, and it'll toggle!

https://harperdb.atlassian.net/browse/STUDIO-461