### PR TITLE
Cluster Progress Improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @HarperDB/front-end
+* @HarperFast/front-end

--- a/src/components/ui/utils/badgeStatus.tsx
+++ b/src/components/ui/utils/badgeStatus.tsx
@@ -16,7 +16,7 @@ export type BadgeStatusVariant =
 export type BadgeStatusVariantValues = 'warning' | 'success' | 'secondary' | 'destructive' | 'outline' | 'default';
 
 export function renderBadgeStatusVariant(value: BadgeStatusVariant): BadgeStatusVariantValues {
-	if (isBeingUpdated(value)) {
+	if (isPendingUpdate(value) || isBeingUpdated(value)) {
 		return 'warning';
 	}
 	if (isRunning(value)) {
@@ -45,10 +45,18 @@ export function isRunning(value: string | undefined): boolean {
 	}
 }
 
+export function isPendingUpdate(value: string | undefined): boolean {
+	switch (value) {
+		case 'CLONE_PENDING':
+			return true;
+		default:
+			return false;
+	}
+}
+
 export function isBeingUpdated(value: string | undefined): boolean {
 	switch (value) {
 		case 'PROVISIONING':
-		case 'CLONE_PENDING':
 		case 'CLONING':
 		case 'CLONE_READY':
 		case 'UPDATING_HDB_NODES':

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -1,15 +1,11 @@
 import { SubNavMenu } from '@/components/SubNavMenu';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { ClusterCard } from '@/features/clusters/components/ClusterCard';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { byClusterStatusThenName } from '@/lib/arrays/sort/byClusterStatusThenName';
-import { groupBy } from '@/lib/groupBy';
-import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { curryFilterByFuzzySearch } from '@/lib/string/filterByFuzzySearch';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
@@ -27,29 +23,21 @@ export function ClustersList() {
 		setFilterByNameValue(e.currentTarget.value?.toLowerCase() || '');
 	}, []);
 
-	const clustersData = useMemo(() => {
-		const groups = groupBy(
-			orgInfo?.clusters
-				?.slice()
-				.filter(cluster => cluster.status !== 'TERMINATED')
-				.filter(curryFilterByFuzzySearch<Cluster>(['id', 'name'], filterByNameValue))
-				.sort(byClusterStatusThenName) || [],
-			'status'
-		);
-		return {
-			keys: Object.keys(groups),
-			groups,
-		};
-	}, [filterByNameValue, orgInfo?.clusters]);
+	const clusters = useMemo(() =>
+		orgInfo?.clusters
+			?.slice()
+			.filter(cluster => cluster.status !== 'TERMINATED')
+			.filter(curryFilterByFuzzySearch<Cluster>(['id', 'name'], filterByNameValue))
+			.sort(byClusterStatusThenName) || [], [filterByNameValue, orgInfo?.clusters]);
 
 	return (
 		<>
 			<SubNavMenu>
-				{isSuccess && orgInfo?.clusters?.length ? (
-					<div className="flex w-full justify-between">
+				{isSuccess ? (
+					<div className="flex w-full justify-end gap-2">
 						<Input
 							placeholder="Filter by name"
-							className="inline-block w-full md:w-64 bg-black border"
+							className="inline-block w-48 md:w-64 bg-black border"
 							onChange={onFilterByNameChanged}
 						/>
 
@@ -71,26 +59,19 @@ export function ClustersList() {
 				) : null}
 			</SubNavMenu>
 			<section className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
-				{clustersData.keys.length ? (
-					clustersData.keys.map((clusterStatus) => (
-						<div key={clusterStatus}>
-							<h2 className="mb-2">
-								<Badge variant={renderBadgeStatusVariant(clusterStatus)}>{capitalizeWords(clusterStatus)}</Badge>
-							</h2>
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
-								{clustersData.groups[clusterStatus].map((cluster) => (
-									<div key={cluster.id} className="cols-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">
-										<ClusterCard cluster={cluster} />
-									</div>
-								))}
+				{clusters.length ? (
+					<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
+						{clusters.map((cluster) => (
+							<div key={cluster.id} className="cols-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">
+								<ClusterCard cluster={cluster} />
 							</div>
-						</div>
-					))
+						))}
+					</div>
 				) : (
 					<div className="flex-col space-y-5 items-center justify-center text-center">
 						<h2 className="text-2xl text-center text-white">
 							No clusters found.
-							{create && ' Create a new cluster.'}
+							{create && ' Want to create a new cluster?'}
 						</h2>
 
 						{create && (

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -1,5 +1,4 @@
 import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
-import { ProgressBar } from '@/components/ProgressBar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -10,10 +9,10 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
-import { isBeingUpdated, isRunning } from '@/components/ui/utils/badgeStatus';
 import { useInstanceClient } from '@/config/useInstanceClient';
-import { getClusterInfo, getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { getClusterInfo } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterCardAction } from '@/features/clusters/components/ClusterCardAction';
+import { ClusterProgress } from '@/features/clusters/components/ClusterProgress';
 import { useTerminateClusterMutation } from '@/features/clusters/mutations/terminateCluster';
 import { onInstanceLogoutSubmit } from '@/features/instance/operations/mutations/onInstanceLogoutSubmit';
 import { useInstanceAuth } from '@/hooks/useAuth';
@@ -21,10 +20,9 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { authStore } from '@/lib/authStore';
-import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { queryKeys } from '@/react-query/constants';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { CopyIcon, Ellipsis } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -51,27 +49,6 @@ export function ClusterCard({ cluster }: { cluster: Cluster; }) {
 		() => cluster.status && deletedClusterStatuses.includes(cluster.status),
 		[cluster.status],
 	);
-
-	const isUpdating = isBeingUpdated(cluster.status);
-	const { data: clusterById } = useQuery(
-		getClusterInfoQueryOptions(isUpdating && cluster.id, 2000),
-	);
-	const updating = useMemo(() => {
-		if (isUpdating && clusterById?.instances) {
-			const updating = clusterById.instances.reduce((total, instance) =>
-				total + (isBeingUpdated(instance.status) ? 1 : 0), 0);
-			const running = clusterById.instances.reduce((total, instance) =>
-				total + (isRunning(instance.status) ? 1 : 0), 0);
-			const current = running;
-			const total = updating + running;
-			return {
-				width: `${current === 0 ? 0 : (current / total * 100)}%`,
-				text: total > 0
-					? `${current} / ${total}`
-					: `${capitalizeWords(cluster.status ?? 'Updating')}...`,
-			};
-		}
-	}, [cluster.status, clusterById?.instances, isUpdating]);
 
 	const onSignOutClick = useCallback(async () => {
 		setSigningOut(true);
@@ -190,7 +167,7 @@ export function ClusterCard({ cluster }: { cluster: Cluster; }) {
 							<DropdownMenuContent>
 								<DropdownMenuLabel className="text-gray-600 text-xs">Plans</DropdownMenuLabel>
 								{cluster.plans?.map((plan) => (
-									<DropdownMenuLabel key={plan.planId}>
+									<DropdownMenuLabel key={plan.planId + plan.regionId}>
 										{plan.planId} / {plan.regionId}
 										<br />
 										Auto Renewal <Badge variant="success">ON</Badge>
@@ -210,15 +187,8 @@ export function ClusterCard({ cluster }: { cluster: Cluster; }) {
 					<h2>{cluster.name}</h2>
 				</CardTitle>
 			</CardHeader>
-			<CardContent className="flex justify-between">
-				{updating && cluster.status && (
-					<ProgressBar
-						animated={true}
-						className="bg-yellow-800/60"
-						width={updating.width}
-						placeholder={updating.text}
-					/>
-				)}
+			<CardContent className="flex items-center justify-between gap-2">
+				<ClusterProgress cluster={cluster} showProgressBarWhenFullyReady={true} />
 				{isActive && view && <ClusterCardAction cluster={cluster} />}
 			</CardContent>
 

--- a/src/features/clusters/components/ClusterCardAction.tsx
+++ b/src/features/clusters/components/ClusterCardAction.tsx
@@ -15,7 +15,7 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 	}
 
 	if (!cluster.fqdn) {
-		return <Link to={`${cluster.id}/instances`} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
+		return <Link to={`${cluster.id}/instances`} className="text-sm text-nowrap" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
 			<span className="py-2 hover:border-b-2">
 				Instances <ArrowRight className="inline-block" />
 			</span>
@@ -24,13 +24,13 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 
 	if (isPendingResetPassword) {
 		if (update) {
-			return <Link to={`${cluster.id}/set-password`} className="text-sm" aria-label={`Set Password on ${cluster.name}`} title={`Set Password on ${cluster.name}`}>
+			return <Link to={`${cluster.id}/set-password`} className="text-sm text-nowrap" aria-label={`Set Password on ${cluster.name}`} title={`Set Password on ${cluster.name}`}>
 				<span className="py-2 hover:border-b-2">
 					Set Password <ArrowRight className="inline-block" />
 				</span>
 			</Link>;
 		}
-		return <span className="py-2">
+		return <span className="py-2 text-nowrap">
 			Pending Owner Setup
 		</span>;
 	}
@@ -39,13 +39,13 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		return undefined;
 	}
 	if (auth.user) {
-		return <Link to={`${cluster.id}${defaultInstanceRoute}`} className="text-sm" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
+		return <Link to={`${cluster.id}${defaultInstanceRoute}`} className="text-sm text-nowrap" aria-label={`View ${cluster.name}`} title={`View ${cluster.name}`}>
 			<span className="py-2 hover:border-b-2">
 				View <ArrowRight className="inline-block" />
 			</span>
 		</Link>;
 	}
-	return <Link to={`${cluster.id}/sign-in`} className="text-sm" aria-label={`Sign In to ${cluster.name}`} title={`Sign In to ${cluster.name}`}>
+	return <Link to={`${cluster.id}/sign-in`} className="text-sm text-nowrap" aria-label={`Sign In to ${cluster.name}`} title={`Sign In to ${cluster.name}`}>
 		<span className="py-2 hover:border-b-2">
 			Sign In <ArrowRight className="inline-block" />
 		</span>

--- a/src/features/clusters/components/ClusterProgress.tsx
+++ b/src/features/clusters/components/ClusterProgress.tsx
@@ -1,0 +1,86 @@
+import { isBeingUpdated, isPendingUpdate, isRunning } from '@/components/ui/utils/badgeStatus';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { Cluster } from '@/lib/api.patch';
+import { countBy } from '@/lib/countBy';
+import { sleep } from '@/lib/sleep';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+
+/**
+ * Displays a triple segment progress bar to the user which will let them watch their instance(s) progress through:
+ * 	1. Pending (Clone Pending or Clone Ready)
+ * 	2. Updating (Provisioning or Cloning)
+ * 	3. Running (Running or Updated)
+ */
+export function ClusterProgress({ cluster, showProgressBarWhenFullyReady }: {
+	cluster: Pick<Cluster, 'status' | 'id'>,
+	showProgressBarWhenFullyReady: boolean
+}) {
+	const [showProgress, setShowProgress] = useState(false);
+
+	const { data: clusterById } = useQuery(
+		getClusterInfoQueryOptions(showProgress && cluster.id, 2000),
+	);
+
+	useEffect(() => {
+		if (isPendingUpdate(cluster.status) || isBeingUpdated(cluster.status)) {
+			setShowProgress(true);
+		} else if (showProgress && !showProgressBarWhenFullyReady) {
+			const waitingForInstances = clusterById?.instances?.some(instance => isPendingUpdate(instance.status) || isBeingUpdated(instance.status));
+			if (!waitingForInstances) {
+				sleep(10_000).then(() => setShowProgress(false));
+			}
+		}
+	}, [showProgress, cluster.status, clusterById?.instances, showProgressBarWhenFullyReady]);
+
+	const updating = useMemo(() => {
+		const instances = clusterById?.instances ?? [];
+		const counts = countBy(instances, 'status');
+		let pending = 0;
+		const pendingTexts: string[] = [];
+		let updating = 0;
+		const updatingTexts: string[] = [];
+		let running = 0;
+		const runningTexts: string[] = [];
+		for (const status in counts) {
+			if (isPendingUpdate(status)) {
+				pending += counts[status];
+				pendingTexts.push(counts[status] + ' ' + capitalizeWords(status));
+			} else if (isBeingUpdated(status)) {
+				updating += counts[status];
+				updatingTexts.push(counts[status] + ' ' + capitalizeWords(status));
+			} else if (isRunning(status)) {
+				running += counts[status];
+				runningTexts.push(counts[status] + ' ' + capitalizeWords(status));
+			}
+			// We'll ignore terminated or non-updated instances from the totals.
+		}
+		const total = pending + updating + running;
+		return {
+			pendingWidth: `${total === 0 ? 100 : pending === 0 ? 0 : (pending / total * 100)}%`,
+			updatingWidth: `${updating === 0 ? 0 : (updating / total * 100)}%`,
+			runningWidth: `${running === 0 ? 0 : (running / total * 100)}%`,
+			text: [
+				...runningTexts.sort(),
+				...updatingTexts.sort(),
+				...pendingTexts.sort(),
+			].join(' · '),
+		};
+	}, [clusterById?.instances]);
+
+	if (!showProgress) {
+		return null;
+	}
+	return (<div className="w-full text-center">
+		<div className="w-full h-2.5 rounded-full overflow-clip flex shadow">
+			{/*Running*/}
+			<div style={{ width: updating.runningWidth }} className="grow bg-green/80 transition-[width] duration-1000 ease-in-out motion-reduce:transition-none"></div>
+			{/*Updating*/}
+			<div style={{ width: updating.updatingWidth }} className="grow animate-pulse bg-yellow/80 transition-[width] duration-1000 ease-in-out motion-reduce:transition-none"></div>
+			{/*Pending*/}
+			<div style={{ width: updating.pendingWidth }} className="grow bg-gray-600 transition-[width] duration-1000 ease-in-out motion-reduce:transition-none"></div>
+		</div>
+		{updating.text && (<div className="text-xs text-muted-foreground font-light mt-2">{updating.text}</div>)}
+	</div>);
+}

--- a/src/features/clusters/mutations/terminateCluster.ts
+++ b/src/features/clusters/mutations/terminateCluster.ts
@@ -2,7 +2,7 @@ import { apiClient } from '@/config/apiClient';
 import { useMutation } from '@tanstack/react-query';
 
 async function onTerminateCluster(clusterId: string) {
-	const { data } = await apiClient.delete(`/Cluster/${clusterId}` as '/Cluster/{id}');
+	const { data } = await apiClient.delete(`/Cluster/${clusterId}` as '/Cluster/{id}', { timeout: 120_000 },);
 	return data;
 }
 

--- a/src/features/instance/applications/new/ImportApplicationForm.tsx
+++ b/src/features/instance/applications/new/ImportApplicationForm.tsx
@@ -109,7 +109,7 @@ export function ImportApplicationForm({
 								<FormControl>
 									<Input
 										type="url"
-										placeholder="https://github.com/HarperDB/nextjs-example"
+										placeholder="https://github.com/HarperFast/status-check"
 										{...field}
 										onChange={(e: FormEvent<HTMLInputElement>) => {
 											field.onChange(e.currentTarget.value);

--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -74,10 +74,10 @@ export function OrganizationsIndex() {
 	return (
 		<>
 			<SubNavMenu>
-				<div className="flex w-full justify-between">
+				<div className="flex w-full justify-end gap-2">
 					<Input
 						placeholder="Filter by name"
-						className="inline-block w-full md:w-64 bg-black border"
+						className="inline-block w-48 md:w-64 bg-black border"
 						onChange={onFilterByNameChanged}
 					/>
 					<NewOrganizationModal />

--- a/src/features/organizations/modals/NewOrganizationModal.tsx
+++ b/src/features/organizations/modals/NewOrganizationModal.tsx
@@ -70,7 +70,7 @@ export function NewOrganizationModal() {
 	return (
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
 			<DialogTrigger asChild>
-				<Button variant="positive" className="rounded-full md:w-44 w-full" accessKey="n">
+				<Button variant="positive" className="rounded-full w-44" accessKey="n">
 					<Plus /> <span><u>N</u>ew Organization</span>
 				</Button>
 			</DialogTrigger>

--- a/src/lib/countBy.ts
+++ b/src/lib/countBy.ts
@@ -1,0 +1,26 @@
+export function countBy<T extends object>(items: T[], property: keyof T): Record<string, number> {
+	const retVal: Record<string, number> = {};
+
+	for (const item of items) {
+		const key = item[property] as string;
+		if (key === undefined) {
+			continue;
+		}
+
+		if (Array.isArray(key)) {
+			for (const k of key) {
+				if (!retVal[k]) {
+					retVal[k] = 0;
+				}
+				retVal[k] += 1;
+			}
+		} else {
+			if (!retVal[key]) {
+				retVal[key] = 0;
+			}
+			retVal[key] += 1;
+		}
+	}
+
+	return retVal;
+}


### PR DESCRIPTION
I fixed a few things:
1. Renamed our GH org references to HarperFast
2. The instance statuses in the progress bar will be more accurate, and the actual status text will show up too.
3. Tweaked the filter bars for orgs and clusters to take up a bit less space on mobile. Now they don't run into the breadcrumbs as easily.
4. I was terminating a lot of instances while testing this... and bigger ones can take longer than 15 seconds to terminate successfully. So I raised the timeout on the front-end to 2 minutes.

https://harperdb.atlassian.net/browse/STUDIO-455

https://harperdb.atlassian.net/browse/STUDIO-462