### PR TITLE
fix: Lock down status check and file instance actions a bit more

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/FileMenuActionButtons.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeExplorer/FileMenuActionButtons.tsx
@@ -9,7 +9,7 @@ import { useUpdateComponentFile } from '@/features/instance/operations/mutations
 import { getComponentsQueryOptions } from '@/features/instance/operations/queries/getComponents';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { Minus, Plus, RefreshCwIcon } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { RedeployApplicationModal } from '@/features/instance/applications/modals/RedeployApplicationModal';
 
@@ -98,6 +98,11 @@ export function FileMenuActionButtons() {
 			}
 		});
 	}, [reDeployApplication, selectedFolderFile, instanceParams, queryClient]);
+	const restrictPackageModification = useMemo(() => {
+		return selectedFolderFile.pkg?.includes('github.com/HarperDB/status-check-fabric')
+			|| selectedFolderFile.pkg?.includes('github.com/HarperFast/status-check-fabric');
+	}, [selectedFolderFile.pkg]);
+
 
 	const toggleDeleting = useCallback(() => {
 		setIsDeleteFolderOrFileClicked(!isDeleteFolderOrFileClicked);
@@ -106,7 +111,7 @@ export function FileMenuActionButtons() {
 	return (
 		<div className="p-2 border-b border-gray-700 mb-2 min-h-12">
 			<div className='flex flex-wrap gap-2'>
-				{selectedFolderFile.pkg && (
+				{selectedFolderFile.pkg && !restrictPackageModification && (
 					<Button
 						onClick={() => setIsRedeployApplicationClicked(true)}
 						disabled={isDeployComponentPending}
@@ -151,7 +156,7 @@ export function FileMenuActionButtons() {
 				) : (
 					''
 				)}
-				{selectedFolderFile.filePath ? (
+				{selectedFolderFile.filePath && !restrictPackageModification ? (
 					<Button
 						onClick={toggleDeleting}
 						disabled={isDeployComponentPending}

--- a/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
@@ -1,11 +1,13 @@
 import { GetComponentsResponse } from '@/features/instance/operations/queries/getComponents';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { FileTreeExplorer } from './FileTreeExplorer';
 import { FileMenuActionButtons } from './FileTreeExplorer/FileMenuActionButtons';
 
 export function ApplicationsSidebar({ fileTreeQueryData }: { fileTreeQueryData: GetComponentsResponse }) {
+	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	return (
 		<>
-			<FileMenuActionButtons />
+			{canManageBrowseInstance && (<FileMenuActionButtons />)}
 			<FileTreeExplorer files={fileTreeQueryData} />
 		</>
 	);

--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
 import { useEffectedState } from '@/hooks/useEffectedState';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { Editor } from '@monaco-editor/react';
 import { useParams } from '@tanstack/react-router';
 import { ImportIcon, PlusIcon, Save } from 'lucide-react';
@@ -51,11 +52,13 @@ export function TextEditorView() {
 		setLanguage(updatedLanguage);
 	}, [selectedFolderFile]);
 
+	const canManageBrowseInstance = useInstanceBrowseManagePermission();
+
 	return (
 		<div className="h-[calc(100vh-theme(spacing.52))]">
 			<div className="flex items-center justify-between py-1 border-b border-gray-700">
 				<span className="p-2">{selectedFolderFile.filePath ? crumbPath : 'Select a file'}</span>
-				{!selectedFolderFile.pkg && (
+				{!selectedFolderFile.pkg && canManageBrowseInstance && (
 					<div className="flex flex-col justify-end space-y-2 md:justify-normal md:flex-row">
 						<Button
 							variant="positiveOutline"
@@ -98,20 +101,22 @@ export function TextEditorView() {
 			{!selectedFolderFile.filePath || isFolder(selectedFolderFile.entries) ? (
 				<div className="flex flex-col items-center justify-center h-full space-y-4">
 					<span className="text-white">No file selected</span>
-					<div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
-						<Button variant="positiveOutline" className="ms-4" size="lg" onClick={() => {
-							setIsNewApplicationModalOpen(true);
-							setAppType('create');
+					{canManageBrowseInstance && (
+						<div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4">
+							<Button variant="positiveOutline" className="ms-4" size="lg" onClick={() => {
+								setIsNewApplicationModalOpen(true);
+								setAppType('create');
 							}}>
-							<PlusIcon /> Create New Application
-						</Button>
-						<Button variant="defaultOutline" className="ms-4" size="lg" onClick={() => {
-							setIsNewApplicationModalOpen(true);
-							setAppType('import');
-						}}>
-							<ImportIcon /> Import Application
-						</Button>
-					</div>
+								<PlusIcon /> Create New Application
+							</Button>
+							<Button variant="defaultOutline" className="ms-4" size="lg" onClick={() => {
+								setIsNewApplicationModalOpen(true);
+								setAppType('import');
+							}}>
+								<ImportIcon /> Import Application
+							</Button>
+						</div>
+					)}
 				</div>
 			) : (
 				<Editor


### PR DESCRIPTION
Implement a restriction in the user interface to prevent users from deleting the status-check application on the Applications tab of an instance or cluster. Although users can delete it on their own, doing so will disrupt their load balancing. Ensure that the UI does not provide an option to delete the status-check to avoid accidental disruptions.

Don’t let users redeploy this application either (easily, from the UI, that is).

https://harperdb.atlassian.net/browse/STUDIO-467