### PR TITLE
fix: Use correct copyright notice template in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 HarperDB, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This update might seem backwards, but this is what we want. It's actually a template for the copyright notice you can use in your source files rather than an actual copyright notice.