### PR TITLE
feat: Change the default from global to us

### DIFF
--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -208,7 +208,7 @@ export function ClusterForm({
 			const firstSelectedRegion = regionNameToLatencyToRegion?.[firstRegion.regionName]?.[firstRegion.latencyDescription];
 			if (!allowedRegionIds.includes(firstSelectedRegion?.id)) {
 				const possibleRegions = regionLocations?.filter(r => allowedRegionIds.includes(r.id));
-				const regionToSelect = possibleRegions?.find(r => r.region === 'Global') || possibleRegions?.[0];
+				const regionToSelect = possibleRegions?.find(r => r.region === 'US') || possibleRegions?.[0];
 				if (regionToSelect) {
 					form.setValue('regionPlans.0.regionName', regionToSelect.region);
 					form.setValue('regionPlans.0.latencyDescription', regionToSelect.latencyDescription);

--- a/src/features/clusters/upsert/lib/calculateDefaultDeploymentPerformanceAndRegionPlans.ts
+++ b/src/features/clusters/upsert/lib/calculateDefaultDeploymentPerformanceAndRegionPlans.ts
@@ -13,7 +13,7 @@ export function calculateDefaultDeploymentPerformanceAndRegionPlans(
 	const allowedRegionIds = planToSelect?.allowedRegionIds;
 	if (planToSelect) {
 		const allowedRegions = allowedRegionIds ? regionLocations.filter(regionLocation => allowedRegionIds.includes(regionLocation.id)) : regionLocations;
-		const regionToSelect = allowedRegions.find(regionLocation => regionLocation.region === 'Global') || allowedRegions[0];
+		const regionToSelect = allowedRegions.find(regionLocation => regionLocation.region === 'US') || allowedRegions[0];
 		if (regionToSelect) {
 			return {
 				deploymentDescription: planToSelect.deploymentDescription,


### PR DESCRIPTION
When picking the free cluster default region, use `US` instead of `Global`. They can still change their selection, of course.

https://harperdb.atlassian.net/browse/STUDIO-500