### PR TITLE
fix: Strip comparator name prefixes & auto cast any types

### DIFF
--- a/src/features/instance/operations/queries/getSearchByConditions.test.ts
+++ b/src/features/instance/operations/queries/getSearchByConditions.test.ts
@@ -1,10 +1,10 @@
 import {
 	parseComparator,
-	translateBooleanValue,
 	translateColumnFilterToSearchCondition,
 	translateColumnFilterToSearchConditions,
 } from '@/features/instance/operations/queries/getSearchByConditions';
 import type { InstanceAttribute } from '@/lib/api.patch';
+import { translateKnownBooleanTypedValue } from '@/lib/boolean/translateKnownBooleanTypedValue';
 import { describe, expect, it } from 'vitest';
 
 describe('parseComparator', () => {
@@ -72,13 +72,13 @@ describe('translateBooleanValue', () => {
 	it('recognizes truthy variants (case-insensitive)', () => {
 		const truthy = ['true', 'Yes', 'OK', 'Yup', '1', 'Si', 'bet', 'TrU'];
 		for (const v of truthy) {
-			expect(translateBooleanValue(v)).toBe(true);
+			expect(translateKnownBooleanTypedValue(v)).toBe(true);
 		}
 	});
 	it('returns false for non-matching values', () => {
 		const falsy = ['false', 'no', '0', 'nah', 'maybe', 'foo', '', 'truth'];
 		for (const v of falsy) {
-			expect(translateBooleanValue(v)).toBe(false);
+			expect(translateKnownBooleanTypedValue(v)).toBe(false);
 		}
 	});
 });

--- a/src/features/instance/operations/queries/getSearchByConditions.test.ts
+++ b/src/features/instance/operations/queries/getSearchByConditions.test.ts
@@ -7,10 +7,6 @@ import {
 import type { InstanceAttribute } from '@/lib/api.patch';
 import { describe, expect, it } from 'vitest';
 
-function attr(type?: InstanceAttribute['type']): InstanceAttribute {
-	return { attribute: 'col', type };
-}
-
 describe('parseComparator', () => {
 	it('understand greater than equal', () => {
 		expect(parseComparator('>= 10')).toEqual({
@@ -170,6 +166,23 @@ describe('translateColumnFilterToSearchCondition', () => {
 		});
 	});
 
+	it('strips off redundant names', () => {
+		expect(
+			translateColumnFilterToSearchConditions('age', 'age > 1 & age < 10', attr('Int')),
+		).toEqual([
+			{
+				search_attribute: 'age',
+				search_type: 'greater_than',
+				search_value: 1,
+			},
+			{
+				search_attribute: 'age',
+				search_type: 'less_than',
+				search_value: 10,
+			},
+		]);
+	});
+
 	it('parses booleans with accepted truthy values', () => {
 		expect(
 			translateColumnFilterToSearchCondition('active', 'Yes', attr('Boolean')),
@@ -231,4 +244,9 @@ describe('translateColumnFilterToSearchCondition', () => {
 			search_value: 'value',
 		});
 	});
+
+	function attr(type?: InstanceAttribute['type']): InstanceAttribute {
+		return { attribute: 'col', type };
+	}
+
 });

--- a/src/features/instance/operations/queries/getSearchByConditions.ts
+++ b/src/features/instance/operations/queries/getSearchByConditions.ts
@@ -90,6 +90,9 @@ export function translateColumnFilterToSearchConditions(key: string, rawValues: 
 }
 
 export function translateColumnFilterToSearchCondition(key: string, rawValue: string, attribute: InstanceAttribute | undefined): SearchCondition {
+	if (rawValue.startsWith(key)) {
+		rawValue = rawValue.substring(key.length);
+	}
 	const { comparator, value } = parseComparator(rawValue);
 	switch (attribute?.type) {
 		case 'ID':
@@ -115,7 +118,6 @@ export function translateColumnFilterToSearchCondition(key: string, rawValue: st
 			};
 		}
 		case 'Date': {
-			const { comparator, value } = parseComparator(rawValue);
 			const parsed = new Date(value).toISOString();
 			return {
 				search_attribute: key,

--- a/src/features/instance/operations/queries/getSearchByConditions.ts
+++ b/src/features/instance/operations/queries/getSearchByConditions.ts
@@ -1,5 +1,7 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { InstanceAttribute } from '@/lib/api.patch';
+import { translateKnownBooleanTypedValue } from '@/lib/boolean/translateKnownBooleanTypedValue';
+import { autoCast } from '@/lib/casting/autoCast';
 import { queryOptions } from '@tanstack/react-query';
 
 interface GetSearchByConditionsParams extends InstanceClientIdConfig {
@@ -86,7 +88,7 @@ export function getSearchByConditionsOptions({
 
 export function translateColumnFilterToSearchConditions(key: string, rawValues: string, attribute: InstanceAttribute | undefined): SearchCondition[] {
 	const split = rawValues.split(/ & /);
-	return split.map(rawValue => translateColumnFilterToSearchCondition(key, rawValue, attribute))
+	return split.map(rawValue => translateColumnFilterToSearchCondition(key, rawValue, attribute));
 }
 
 export function translateColumnFilterToSearchCondition(key: string, rawValue: string, attribute: InstanceAttribute | undefined): SearchCondition {
@@ -129,17 +131,22 @@ export function translateColumnFilterToSearchCondition(key: string, rawValue: st
 			return {
 				search_attribute: key,
 				search_type: comparator,
-				search_value: translateBooleanValue(value),
+				search_value: translateKnownBooleanTypedValue(value),
 			};
 		}
-		case 'Any':
 		case 'Blob':
 		case 'Bytes':
-		default:
 			return {
 				search_attribute: key,
 				search_type: comparator,
 				search_value: value,
+			};
+		case 'Any':
+		default:
+			return {
+				search_attribute: key,
+				search_type: comparator,
+				search_value: autoCast(value),
 			};
 	}
 }
@@ -235,21 +242,4 @@ export function parseComparator(value: string): { comparator: Comparator, value:
 		comparator: 'equals',
 		value: value,
 	};
-}
-
-const acceptedOKValues = [
-	'1',
-	'bet',
-	'k',
-	'ok',
-	'si',
-	'tru',
-	'true',
-	'yes',
-	'yup',
-];
-
-export function translateBooleanValue(value: string): boolean {
-	const lowerValue = value.toLowerCase();
-	return acceptedOKValues.includes(lowerValue);
 }

--- a/src/lib/boolean/translateKnownBooleanTypedValue.test.ts
+++ b/src/lib/boolean/translateKnownBooleanTypedValue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { translateKnownBooleanTypedValue } from './translateKnownBooleanTypedValue';
+
+describe('translateKnownBooleanTypedValue', () => {
+	it('returns true for all accepted true-like strings (case-insensitive)', () => {
+		const trueLikes = [
+			'1',
+			'bet',
+			'k',
+			'ok',
+			'si',
+			'tru',
+			'true',
+			'yes',
+			'yup',
+		];
+
+		for (const val of trueLikes) {
+			// exact lower-case
+			expect(translateKnownBooleanTypedValue(val)).toBe(true);
+			// UPPER-CASE
+			expect(translateKnownBooleanTypedValue(val.toUpperCase())).toBe(true);
+			// Mixed case
+			const mixed = val[0].toUpperCase() + val.slice(1).toLowerCase();
+			expect(translateKnownBooleanTypedValue(mixed)).toBe(true);
+		}
+	});
+
+	it('returns false for common false-like or unrelated strings', () => {
+		const falseLikes = [
+			'0',
+			'false',
+			'no',
+			'n',
+			'nah',
+			'nope',
+			'off',
+			'on',
+			'',
+			'2',
+			'maybe',
+			'certainly',
+		];
+
+		for (const val of falseLikes) {
+			expect(translateKnownBooleanTypedValue(val)).toBe(false);
+			expect(translateKnownBooleanTypedValue(val.toUpperCase())).toBe(false);
+		}
+	});
+
+	it('trims whitespace', () => {
+		expect(translateKnownBooleanTypedValue(' yes')).toBe(true);
+		expect(translateKnownBooleanTypedValue('yes ')).toBe(true);
+		expect(translateKnownBooleanTypedValue('\tyes')).toBe(true);
+		expect(translateKnownBooleanTypedValue('true\n')).toBe(true);
+	});
+});

--- a/src/lib/boolean/translateKnownBooleanTypedValue.ts
+++ b/src/lib/boolean/translateKnownBooleanTypedValue.ts
@@ -1,0 +1,16 @@
+const acceptedTrueValues = [
+	'1',
+	'bet',
+	'k',
+	'ok',
+	'si',
+	'tru',
+	'true',
+	'yes',
+	'yup',
+];
+
+export function translateKnownBooleanTypedValue(value: string): boolean {
+	const lowerValue = value.toLowerCase().trim();
+	return acceptedTrueValues.includes(lowerValue);
+}

--- a/src/lib/casting/autoCast.test.ts
+++ b/src/lib/casting/autoCast.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { autoCast } from './autoCast';
+
+// This suite verifies the current behavior of autoCast:
+// - Passthrough for null/undefined/empty string and any non-string inputs
+// - Common string mappings (true/false/null/undefined/NaN with specific casing)
+// - Numeric casting via autoCasterIsNumberCheck rules
+// - ISO 8601 datetime recognition with timezone into Date objects
+// - Everything else remains the original string
+
+describe('autoCast', () => {
+	describe('passthrough values', () => {
+		it('returns null, undefined, and empty string unchanged', () => {
+			expect(autoCast(null)).toBeNull();
+			expect(autoCast(undefined)).toBeUndefined();
+			expect(autoCast('')).toBe('');
+		});
+
+		it('returns non-string inputs unchanged (by identity when applicable)', () => {
+			const num = 42;
+			expect(autoCast(num)).toBe(num);
+
+			const bool = true;
+			expect(autoCast(bool)).toBe(bool);
+
+			const obj = { a: 1 } as const;
+			expect(autoCast(obj)).toBe(obj);
+
+			const arr = [1, 2, 3] as const;
+			expect(autoCast(arr)).toBe(arr);
+
+			const d = new Date('2020-01-01T00:00:00.000Z');
+			expect(autoCast(d)).toBe(d);
+		});
+	});
+
+	describe('common string mappings', () => {
+		it('maps selected tokens to booleans/null/NaN', () => {
+			expect(autoCast('true')).toBe(true);
+			expect(autoCast('TRUE')).toBe(true);
+			expect(autoCast('false')).toBe(false);
+			expect(autoCast('FALSE')).toBe(false);
+
+			// string "undefined" maps to null (not undefined)
+			expect(autoCast('undefined')).toBeNull();
+
+			// various null casings handled as configured
+			expect(autoCast('null')).toBeNull();
+			expect(autoCast('NULL')).toBeNull();
+
+			const nanResult = autoCast('NaN');
+			expect(typeof nanResult).toBe('number');
+			expect(Number.isNaN(nanResult as number)).toBe(true);
+		});
+
+		it('does not map non-configured variants', () => {
+			// Not configured in the table: remains a string
+			expect(autoCast('True')).toBe('True');
+			expect(autoCast('False')).toBe('False');
+			expect(autoCast('UNDEFINED')).toBe('UNDEFINED');
+			expect(autoCast('nan')).toBe('nan');
+		});
+	});
+
+	describe('numeric casting via autoCasterIsNumberCheck', () => {
+		it('casts common numeric strings to numbers', () => {
+			expect(autoCast('0')).toBe(0);
+			expect(autoCast('5')).toBe(5);
+			expect(autoCast(' 1 ')).toBe(1);
+			expect(autoCast('0.5')).toBe(0.5);
+			expect(autoCast('.5')).toBe(0.5);
+			expect(autoCast('-.5')).toBe(-0.5);
+		});
+
+		it('produces Infinity for the string "Infinity"', () => {
+			expect(autoCast('Infinity')).toBe(Infinity);
+			expect(autoCast('-Infinity')).toBe(-Infinity);
+		});
+
+		it('rejects certain numeric-like forms and returns the original string', () => {
+			// leading-zero integers are rejected
+			expect(autoCast('0123')).toBe('0123');
+			expect(autoCast('00')).toBe('00');
+
+			// scientific notation rejected
+			expect(autoCast('1e3')).toBe('1e3');
+			expect(autoCast('2E6')).toBe('2E6');
+
+			// numeric prefixes rejected
+			expect(autoCast('0x10')).toBe('0x10');
+			expect(autoCast('0b10')).toBe('0b10');
+			expect(autoCast('0o10')).toBe('0o10');
+		});
+	});
+
+	describe('ISO datetime casting', () => {
+		it('casts ISO date-time strings with timezone to Date', () => {
+			const d1 = autoCast('2020-01-01T12:30Z');
+			expect(d1).toBeInstanceOf(Date);
+			expect((d1 as Date).toISOString()).toBe('2020-01-01T12:30:00.000Z');
+
+			const d2 = autoCast('2020-01-01T12:30:45Z');
+			expect(d2).toBeInstanceOf(Date);
+			expect((d2 as Date).toISOString()).toBe('2020-01-01T12:30:45.000Z');
+
+			const d3 = autoCast('2020-01-01T12:30:45.123Z');
+			expect(d3).toBeInstanceOf(Date);
+			expect((d3 as Date).toISOString()).toBe('2020-01-01T12:30:45.123Z');
+
+			const d4 = autoCast('2020-01-01T12:30+02:00');
+			expect(d4).toBeInstanceOf(Date);
+			expect((d4 as Date).toISOString()).toBe('2020-01-01T10:30:00.000Z');
+		});
+
+		it('does not cast non-ISO or timezone-less date strings', () => {
+			expect(autoCast('2020-01-01')).toBe('2020-01-01');
+			expect(autoCast('2020-01-01T12:30')).toBe('2020-01-01T12:30');
+			expect(autoCast('2020-01-01 12:30Z')).toBe('2020-01-01 12:30Z');
+		});
+	});
+
+	it('returns a value with the expected runtime type', () => {
+		const a = autoCast('true');
+		expect(typeof a).toBe('boolean');
+
+		const b = autoCast('42');
+		expect(typeof b).toBe('number');
+
+		const c = autoCast('2020-01-01T00:00Z');
+		expect(c instanceof Date).toBe(true);
+
+		const d = autoCast('not-a-special-value');
+		expect(typeof d).toBe('string');
+	});
+});

--- a/src/lib/casting/autoCast.ts
+++ b/src/lib/casting/autoCast.ts
@@ -1,0 +1,43 @@
+import { autoCasterIsNumberCheck } from '@/lib/numbers/autoCasterIsNumberCheck';
+
+const autoCastCommonStringsMap: Record<string, boolean | null | number> = {
+	true: true,
+	TRUE: true,
+	false: false,
+	FALSE: false,
+	undefined: null,
+	null: null,
+	NULL: null,
+	NaN: NaN,
+};
+const isoDateRegex =
+	/^((\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)))$/;
+
+/**
+ * Takes a raw string value and casts it to a potentially correct data type.
+ * @param data
+ * @returns
+ */
+export function autoCast(data: unknown) {
+	if (data === null || data === undefined || data === '') {
+		return data;
+	}
+
+	//if this is already typed other than string, return data
+	if (typeof data !== 'string') {
+		return data;
+	}
+
+	// Try to make it a common string
+	if (autoCastCommonStringsMap[data] !== undefined) {
+		return autoCastCommonStringsMap[data];
+	}
+
+	if (autoCasterIsNumberCheck(data)) {
+		return Number(data);
+	}
+
+	if (isoDateRegex.test(data)) return new Date(data);
+
+	return data;
+}

--- a/src/lib/numbers/autoCasterIsNumberCheck.test.ts
+++ b/src/lib/numbers/autoCasterIsNumberCheck.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { autoCasterIsNumberCheck } from './autoCasterIsNumberCheck';
+import { isNumber } from './isNumber';
+
+// This test suite documents the current behavior of autoCasterIsNumberCheck.
+// It applies additional guards on top of isNumber for our autocaster rules:
+// - Allows decimals like 0.x (fast path)
+// - Disallows scientific notation (contains 'e' or 'E')
+// - Disallows integers that start with a leading zero (except the literal '0')
+// - Still relies on isNumber for the final numeric check
+// The suite also verifies that for typical numeric forms, it yields the same
+// result as isNumber.
+
+describe('autoCasterIsNumberCheck', () => {
+	it('matches isNumber for common integers/decimals and Infinity', () => {
+		const samples = [
+			'0',
+			'5',
+			'12',
+			'-7',
+			'+3',
+			'0.5',
+			'.5',
+			'123.456',
+			'-.5',
+			'Infinity',
+			'-Infinity',
+			' 1 ',
+			'\n-2\t',
+		];
+
+		for (const s of samples) {
+			expect(autoCasterIsNumberCheck(s)).toBe(isNumber(s));
+		}
+	});
+
+	it('accepts 0.x decimals quickly and rejects other leading-zero numbers', () => {
+		// Fast-path acceptance for 0.x
+		expect(autoCasterIsNumberCheck('0.1')).toBe(true);
+		expect(autoCasterIsNumberCheck('0.0009')).toBe(true);
+
+		// Leading zero integer-like strings are rejected (even though isNumber would accept)
+		expect(isNumber('0123')).toBe(true);
+		expect(autoCasterIsNumberCheck('0123')).toBe(false);
+
+		// The literal '0' is allowed
+		expect(autoCasterIsNumberCheck('0')).toBe(true);
+
+		// Multiple zeros without decimal should be rejected by the guard
+		expect(isNumber('00')).toBe(true);
+		expect(autoCasterIsNumberCheck('00')).toBe(false);
+	});
+
+	it('rejects scientific notation even though isNumber would accept it', () => {
+		const exponents = ['1e3', '2E6', '-1e-3', '+1E+2'];
+		for (const s of exponents) {
+			expect(isNumber(s)).toBe(true);
+			expect(autoCasterIsNumberCheck(s)).toBe(false);
+		}
+	});
+
+	it('rejects 0x/0b/0o prefixes that JS Number accepts', () => {
+		const prefixed = ['0x11', '0b10', '0o10'];
+		for (const s of prefixed) {
+			expect(isNumber(s)).toBe(true);
+			expect(autoCasterIsNumberCheck(s)).toBe(false);
+		}
+	});
+
+	it('returns false for clearly non-numeric strings and empty/whitespace', () => {
+		const nons = ['', ' ', '\t\n', 'abc', '123abc', 'abc123', '--1', '1..2', '.', '-', '+', 'NaN'];
+		for (const s of nons) {
+			expect(autoCasterIsNumberCheck(s)).toBe(false);
+		}
+	});
+
+	it('returns a boolean type', () => {
+		const out = autoCasterIsNumberCheck('42');
+		expect(typeof out).toBe('boolean');
+	});
+});

--- a/src/lib/numbers/autoCasterIsNumberCheck.ts
+++ b/src/lib/numbers/autoCasterIsNumberCheck.ts
@@ -1,0 +1,14 @@
+import { isNumber } from '@/lib/numbers/isNumber';
+
+/**
+ * function to check if a string is a number based on the rules used by our autocaster
+ */
+export function autoCasterIsNumberCheck(data: string): boolean {
+	if (data.startsWith('0.') && isNumber(data)) {
+		return true;
+	}
+
+	const containsE = data.toUpperCase().includes('E');
+	const startsWithZero = data !== '0' && data.startsWith('0');
+	return !startsWithZero && !containsE && isNumber(data);
+}

--- a/src/lib/numbers/isNumber.test.ts
+++ b/src/lib/numbers/isNumber.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { isNumber } from './isNumber';
+
+// This unit test suite documents the current behavior of isNumber,
+// which relies on JavaScript's numeric coercion and parseFloat.
+// It intentionally accepts several JavaScript-recognized numeric forms
+// (including exponents, Infinity, and numeric prefixes like 0x) and
+// rejects clearly non-numeric strings or incomplete numbers.
+
+describe('isNumber', () => {
+	it('returns true for plain integers', () => {
+		expect(isNumber('0')).toBe(true);
+		expect(isNumber('5')).toBe(true);
+		expect(isNumber('12')).toBe(true);
+		expect(isNumber('-7')).toBe(true);
+		expect(isNumber('+3')).toBe(true);
+	});
+
+	it('returns true for decimals and leading-dot decimals', () => {
+		expect(isNumber('0.5')).toBe(true);
+		expect(isNumber('.5')).toBe(true);
+		expect(isNumber('123.456')).toBe(true);
+		expect(isNumber('-.5')).toBe(true);
+	});
+
+	it('returns true for scientific notation (exponents)', () => {
+		expect(isNumber('1e3')).toBe(true);
+		expect(isNumber('2E6')).toBe(true);
+		expect(isNumber('-1e-3')).toBe(true);
+		expect(isNumber('+1E+2')).toBe(true);
+	});
+
+	it('returns true for special numeric strings and prefixes recognized by JS Number', () => {
+		// Infinity forms are considered numbers by JS Number()
+		expect(isNumber('Infinity')).toBe(true);
+		expect(isNumber('-Infinity')).toBe(true);
+
+		// Hex/Binary/Octal prefixes are parsed by Number(); parseFloat reads leading 0
+		expect(isNumber('0x11')).toBe(true); // 17
+		expect(isNumber('0b10')).toBe(true); // 2
+		expect(isNumber('0o10')).toBe(true); // 8
+	});
+
+	it('ignores surrounding whitespace for valid numbers', () => {
+		expect(isNumber(' 1 ')).toBe(true);
+		expect(isNumber('\n-2\t')).toBe(true);
+	});
+
+	it('returns false for empty or whitespace-only strings', () => {
+		expect(isNumber('')).toBe(false);
+		expect(isNumber(' ')).toBe(false);
+		expect(isNumber('\t\n')).toBe(false);
+	});
+
+	it('returns false for non-numeric and malformed strings', () => {
+		expect(isNumber('abc')).toBe(false);
+		expect(isNumber('123abc')).toBe(false);
+		expect(isNumber('abc123')).toBe(false);
+		expect(isNumber('--1')).toBe(false);
+		expect(isNumber('1..2')).toBe(false);
+		expect(isNumber('.')).toBe(false);
+		expect(isNumber('-')).toBe(false);
+		expect(isNumber('+')).toBe(false);
+		expect(isNumber('NaN')).toBe(false);
+	});
+
+	it('returns a boolean type', () => {
+		const out = isNumber('42');
+		expect(typeof out).toBe('boolean');
+	});
+});

--- a/src/lib/numbers/isNumber.ts
+++ b/src/lib/numbers/isNumber.ts
@@ -1,0 +1,4 @@
+export function isNumber(str: string): boolean {
+	return !isNaN(str as unknown as number)
+		&& !isNaN(parseFloat(str));
+}


### PR DESCRIPTION
Now if someone types in something like `age > 10` it will treat it the same as the expected `> 10`. And if we have a `any` type column, or an unstructured table, we'll auto-cast the values.

https://harperdb.atlassian.net/browse/STUDIO-451