### PR TITLE
fix: disabling 'create' button upon creating a new application

### DIFF
--- a/src/features/instance/applications/new/CreateNewApplicationForm.tsx
+++ b/src/features/instance/applications/new/CreateNewApplicationForm.tsx
@@ -42,7 +42,7 @@ export function CreateNewApplicationForm({
 		},
 	});
 
-	const { mutate: createNewApplication } = useCreateComponentMutation();
+	const { mutate: createNewApplication, isPending: isCreateNewApplicationPending } = useCreateComponentMutation();
 	const submitForm = (formData: CreateComponentFormData) => {
 		createNewApplication({ ...formData, ...instanceParams }, {
 			onSuccess: () => {
@@ -72,7 +72,7 @@ export function CreateNewApplicationForm({
 						className="w-full"
 						variant="submit"
 						type="submit"
-						disabled={!form.formState.isDirty || isRestartPending}
+						disabled={!form.formState.isDirty || isCreateNewApplicationPending || isRestartPending}
 					>
 						Create <ArrowRight />
 					</Button>


### PR DESCRIPTION
Overview:
Create button should now be disabled upon immediate trigging a create application call.

https://harperdb.atlassian.net/browse/STUDIO-506
