### PR TITLE
fix: ensure SDK ready before startView and add login_success for retention tracking

### DIFF
--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -20,7 +20,7 @@ import { Link, useNavigate, useRouter, useSearch } from '@tanstack/react-router'
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { datadogRum } from '@datadog/browser-rum';
+import { loginSuccessDatadogAction } from '@/integrations/datadog/datadog';
 
 const SignInSchema = z.object({
 	email: zodRequireEmail,
@@ -57,13 +57,7 @@ export function SignIn() {
 				authStore.setUserForEntity(OverallAppSignIn, data);
 				const defaultCloudRoute = getDefaultSignedInCloudRouteForUser(data);
 
-				datadogRum.setUser({
-					id: data.id,
-					email: data.email,
-					name: [data.firstname, data.lastname].filter(Boolean).join(' ') || undefined,
-				});
-				
-				datadogRum.addAction('login_success', { userId: data.id });
+				loginSuccessDatadogAction(data);
 
 				const company = parseCompanyFromEmail(data.email);
 				reoClient?.identify?.({

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -20,6 +20,7 @@ import { Link, useNavigate, useRouter, useSearch } from '@tanstack/react-router'
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { datadogRum } from '@datadog/browser-rum';
 
 const SignInSchema = z.object({
 	email: zodRequireEmail,
@@ -55,6 +56,14 @@ export function SignIn() {
 			onSuccess: async (data) => {
 				authStore.setUserForEntity(OverallAppSignIn, data);
 				const defaultCloudRoute = getDefaultSignedInCloudRouteForUser(data);
+
+				datadogRum.setUser({
+					id: data.id,
+					email: data.email,
+					name: [data.firstname, data.lastname].filter(Boolean).join(' ') || undefined,
+				});
+				
+				datadogRum.addAction('login_success', { userId: data.id });
 
 				const company = parseCompanyFromEmail(data.email);
 				reoClient?.identify?.({

--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -28,12 +28,21 @@ export function useDatadog() {
 				version: import.meta.env.VITE_STUDIO_VERSION,
 
 				trackViewsManually: true,
+				trackUserInteractions: true,
 
 				sessionSampleRate: 100,
 				sessionReplaySampleRate: 0,
 				defaultPrivacyLevel: 'mask',
 
 				plugins: [reactPlugin()],
+			});
+
+			datadogRum.onReady(() => {
+				datadogRum.startView({
+					service: 'studio',
+					version: import.meta.env.VITE_STUDIO_VERSION,
+					name: window.location.pathname || 'initial',
+				});
 			});
 		}
 	}, []);
@@ -46,14 +55,20 @@ export function useOnRouteLoadTracker() {
 
 	useEffect(() => {
 		const currentMatches = router.matchRoutes(router.state.location);
-		const name = translateUrlForDatadog(location.href, currentMatches.map(m => m.params));
+		const name = translateUrlForDatadog(
+			location.href,
+			currentMatches.map((m) => m.params)
+		);
 		if (!enabled) {
 			return;
 		}
-		datadogRum.startView({
-			service: 'studio',
-			version: import.meta.env.VITE_STUDIO_VERSION,
-			name,
+
+		datadogRum.onReady(() => {
+			datadogRum.startView({
+				service: 'studio',
+				version: import.meta.env.VITE_STUDIO_VERSION,
+				name,
+			});
 		});
 	}, [location.href, router]);
 

--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -87,3 +87,15 @@ export function useOnRouteLoadTracker() {
 		}
 	}, [user]);
 }
+
+export function loginSuccessDatadogAction(data: { id: string; email: string; firstname: string; lastname: string }) {
+	if (!enabled) return;
+
+	datadogRum.setUser({
+		id: data.id,
+		email: data.email,
+		name: [data.firstname, data.lastname].filter(Boolean).join(' ') || undefined,
+	});
+
+	datadogRum.addAction('login_success', { userId: data.id });
+}


### PR DESCRIPTION
Made a few small tweaks to fix missing retention data in Datadog. Wrapped our `startView()` calls in `datadogRum.onReady()` so the SDK doesn’t drop the first view before it’s initialized, and added a `login_success` action after sign-in (right after `setUser()`) so Datadog has a clear cohort anchor for retention. Engagement metrics like session duration were already working. This just makes sure retention and post-login tracking show up correctly in Product Analytics.