### PR TITLE
fix: Add consistent clipboard copy toasting

### DIFF
--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -17,6 +17,7 @@ import { ClusterProgress } from '@/features/clusters/components/ClusterProgress'
 import { useTerminateClusterMutation } from '@/features/clusters/mutations/terminateCluster';
 import { onInstanceLogoutSubmit } from '@/features/instance/operations/mutations/onInstanceLogoutSubmit';
 import { useInstanceAuth } from '@/hooks/useAuth';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/lib/api.patch';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
@@ -101,15 +102,10 @@ export function ClusterCard({ cluster }: { cluster: Cluster; }) {
 		});
 	}, [terminateCluster, cluster.id, cluster.name, isSelfManaged, queryClient]);
 
-	const onCopyFQDNClick = useCallback(() => {
-		void navigator.clipboard.writeText(cluster.fqdn!);
-		toast.info('Host name copied to clipboard!');
-	}, [cluster.fqdn]);
-
-	const onCopyAPIClick = useCallback(() => {
-		void navigator.clipboard.writeText(`https://${cluster.fqdn}`);
-		toast.info('API URL copied to clipboard!');
-	}, [cluster.fqdn]);
+	const [onCopyFQDNClick, onCopyAPIClick] = useCopyToClipboard(
+		`${cluster.fqdn}`,
+		`https://${cluster.fqdn}`,
+	);
 
 	const menuItems = [
 		isActive && update && (

--- a/src/features/instance/applications/components/NewApplication/CLIInstructions.tsx
+++ b/src/features/instance/applications/components/NewApplication/CLIInstructions.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { useInstanceClientParams } from '@/config/useInstanceClient';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { CheckIcon, CopyIcon, TerminalIcon } from 'lucide-react';
 import { FormState, UseFormWatch } from 'react-hook-form';
 import { z } from 'zod';
@@ -21,6 +22,9 @@ export function CLIInstructions({
 	const instanceParams = useInstanceClientParams();
 	const applicationName = watch('applicationName') || defaultApplicationName;
 	const cliSteps = useCLISteps(applicationName, instanceParams.instanceClient.defaults.baseURL);
+	const cliCopyClicks = useCopyToClipboard(
+		...cliSteps.map(step => step.code),
+	);
 
 	return <>
 
@@ -47,7 +51,7 @@ export function CLIInstructions({
 								type="button"
 								variant="default"
 								size="sm"
-								onClick={() => void navigator.clipboard.writeText(cliStep.code)}
+								onClick={cliCopyClicks[index]}
 							>
 								<CopyIcon className="w-4 h-4" />
 							</Button>

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -1,0 +1,18 @@
+import { ClipboardCheckIcon } from 'lucide-react';
+import { useMemo } from 'react';
+import { toast } from 'sonner';
+
+export function useCopyToClipboard(...texts: string[]): Array<() => void> {
+	return useMemo(() => {
+		return texts.map(text => (() => {
+			void navigator.clipboard.writeText(text);
+			toast.info('Copied to clipboard!', {
+				icon: <ClipboardCheckIcon />,
+				duration: 1000,
+			});
+		}));
+		// We can override the linting here because we know we're providing an accurate list of dependencies that will only
+		// change and trigger a re-render of the memo when the text contents change.
+		// eslint-disable-next-line react-hooks/use-memo,react-hooks/exhaustive-deps
+	}, texts);
+}


### PR DESCRIPTION
I extracted a hook that returns callbacks for using the clipboard. It does it in a way where it's easy for us to have multiple, which works great for the code snippet copies. I added a fun little clipboard check icon too.

https://harperdb.atlassian.net/browse/STUDIO-559