### PR TITLE
fix: Allow multiple updates to profile

### DIFF
--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -7,10 +7,10 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { logoutOnSuccess } from '@/features/auth/handlers/logoutOnSuccess';
-import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
 import { useUpdateUserMutation } from '@/features/profile/mutations/updateUserMutation';
 import { UpdateUserSchema } from '@/features/profile/mutations/updateUserSchema';
 import { useCloudAuth } from '@/hooks/useAuth';
+import { authStore, OverallAppSignIn } from '@/lib/authStore';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate, useRouter } from '@tanstack/react-router';
 import { Save } from 'lucide-react';
@@ -23,17 +23,15 @@ export function ProfileIndex() {
 	const router = useRouter();
 	const navigate = useNavigate();
 	const { user } = useCloudAuth();
+
 	const form = useForm({
 		resolver: zodResolver(UpdateUserSchema),
-		defaultValues: async () => {
-			const user = await getCurrentUser();
-			return {
-				confirmNewPassword: '',
-				firstname: user.firstname,
-				id: user.id,
-				lastname: user.lastname,
-				newPassword: '',
-			};
+		defaultValues: {
+			confirmNewPassword: '',
+			firstname: user?.firstname || '',
+			id: user?.id || '',
+			lastname: user?.lastname || '',
+			newPassword: '',
 		},
 	});
 	const { mutate: updateUser, isPending: isUpdatePending } = useUpdateUserMutation();
@@ -43,7 +41,11 @@ export function ProfileIndex() {
 			if (formData) {
 				updateUser(formData, {
 					onSuccess: (data) => {
-						form.reset(data);
+						form.reset({
+							...form.formState.defaultValues,
+							...data,
+						});
+						authStore.updateUserForEntity(OverallAppSignIn, data);
 						if (formData.newPassword) {
 							toast.success('Profile updated successfully!', {
 								description: 'Please sign in with your new password.',
@@ -157,7 +159,6 @@ export function ProfileIndex() {
 							</FormItem>
 						)}
 					/>
-
 
 					<div className="flex justify-between w-full">
 						<Button

--- a/src/features/profile/mutations/updateUserMutation.ts
+++ b/src/features/profile/mutations/updateUserMutation.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/config/apiClient';
 import { UpdateUserSchema } from '@/features/profile/mutations/updateUserSchema';
 import { SchemaUser } from '@/lib/api.gen';
+import { User } from '@/lib/api.patch';
 import { useMutation } from '@tanstack/react-query';
 import z from 'zod';
 
@@ -13,7 +14,7 @@ async function onUpdateUser(formData: z.infer<typeof UpdateUserSchema>) {
 		userData.password = newPassword;
 	}
 	const { data } = await apiClient.patch(`/User/${id}` as '/User/{id}', userData);
-	return data;
+	return data as Partial<User>;
 }
 
 export function useUpdateUserMutation() {

--- a/src/lib/authStore.ts
+++ b/src/lib/authStore.ts
@@ -120,6 +120,22 @@ class AuthStore {
 		this.updateConnectionIfChanged(id, false, user);
 	}
 
+	public updateUserForEntity(entity: EntityTypes, changes: Partial<AuthenticatedConnection['user']>): void {
+		const id = this.calculateIdFromEntity(entity);
+		const key = this.calculateKeyFromEntity(entity);
+		if (!id || !key) {
+			return;
+		}
+		const connection = this.getConnectionById(id);
+		if (!connection.user) {
+			return;
+		}
+		this.updateConnectionIfChanged(id, false, {
+			...connection.user,
+			...changes,
+		});
+	}
+
 	public calculateIdFromEntity(entity: EntityTypes | EntityIds | undefined): EntityIds | undefined {
 		if (isLocalStudio || entity === OverallAppSignIn) {
 			return OverallAppSignIn;


### PR DESCRIPTION
When we were resetting the form, we weren't setting _all_ of the fields again properly. This resulted in invalid values (non-strings) in other fields, which prevented the form from submitting again. Now you can change your name multiple times, and save it as many times as you like. Neat.

https://harperdb.atlassian.net/browse/STUDIO-489