### PR TITLE
Fix analytics aggregation

### DIFF
--- a/src/features/instance/operations/queries/getAnalytics.ts
+++ b/src/features/instance/operations/queries/getAnalytics.ts
@@ -9,6 +9,7 @@ export interface MetricConfig {
 	name: string;
 	label?: string;
 	dataKey: MetricDataKey;
+	aggregator: (accumulator: number, current: number) => number;
 	units: MetricUnits;
 	path?: string;
 }

--- a/src/features/instance/status/components/Monitoring.tsx
+++ b/src/features/instance/status/components/Monitoring.tsx
@@ -7,14 +7,67 @@ import type { Metric, MetricConfig } from '@/features/instance/operations/querie
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.tsx';
 
 const metrics: MetricConfig[] = [
-	{id: 'db-read', name: 'db-read', dataKey: 'count', units: 'reads'},
-	{id: 'db-read-bytes', label: 'db-read-bytes', name: 'db-read', dataKey: metricSum, units: 'bytes'},
-	{id: 'db-write', name: 'db-write', dataKey: 'count', units: 'writes'},
-	{id: 'db-write-bytes', label: 'db-write-bytes', name: 'db-write', dataKey: metricSum, units: 'bytes'},
-	{id: 'db-message', name: 'db-message', dataKey: 'count', units: 'messages'},
-	{id: 'db-message-bytes', label: 'db-message-bytes', name: 'db-message', dataKey: metricSum, units: 'bytes'},
-	{id: 'cpu-usage-user', name: 'cpu-usage', path: 'user', dataKey: metricSum, units: 'secs'},
-	{id: 'cpu-usage-harper', name: 'cpu-usage', path: 'harper', dataKey: metricSum, units: 'secs'},
+	{
+		id: 'db-read',
+		name: 'db-read',
+		dataKey: 'count',
+		aggregator: aggregateSum,
+		units: 'reads'
+	},
+	{
+		id: 'db-read-bytes',
+		label: 'db-read-bytes',
+		name: 'db-read',
+		dataKey: metricSum,
+		aggregator: aggregateSum,
+		units: 'bytes',
+	},
+	{
+		id: 'db-write',
+		name: 'db-write',
+		dataKey: 'count',
+		aggregator: aggregateSum,
+		units: 'writes',
+	},
+	{
+		id: 'db-write-bytes',
+		label: 'db-write-bytes',
+		name: 'db-write',
+		dataKey: metricSum,
+		aggregator: aggregateSum,
+		units: 'bytes',
+	},
+	{
+		id: 'db-message',
+		name: 'db-message',
+		dataKey: 'count',
+		aggregator: aggregateSum,
+		units: 'messages',
+	},
+	{
+		id: 'db-message-bytes',
+		label: 'db-message-bytes',
+		name: 'db-message',
+		dataKey: metricSum,
+		aggregator: aggregateSum,
+		units: 'bytes',
+	},
+	{
+		id: 'cpu-usage-user',
+		name: 'cpu-usage',
+		path: 'user',
+		dataKey: metricSum,
+		aggregator: aggregateSum,
+		units: 'secs',
+	},
+	{
+		id: 'cpu-usage-harper',
+		name: 'cpu-usage',
+		path: 'harper',
+		dataKey: metricSum,
+		aggregator: aggregateSum,
+		units: 'secs',
+	},
 ];
 
 function metricSum(metric: Metric) {
@@ -130,7 +183,7 @@ export function Monitoring({instanceParams}: MonitoringParams) {
 				</div>
 			</div>
 			<MetricVisualization
-			  metricConfig={selectedMetric}
+				metricConfig={selectedMetric}
 				startTime={startTime}
 				endTime={endTime}
 				instanceParams={instanceParams} />

--- a/src/features/instance/status/components/Monitoring.tsx
+++ b/src/features/instance/status/components/Monitoring.tsx
@@ -77,6 +77,10 @@ function metricSum(metric: Metric) {
 	return 0;
 }
 
+function aggregateSum(accumulator: number, current: number) {
+	return accumulator + current;
+}
+
 interface TimeSelectOption {
 	label: string;
 	value: number;

--- a/src/features/instance/status/components/monitoring/MetricVisualization.tsx
+++ b/src/features/instance/status/components/monitoring/MetricVisualization.tsx
@@ -103,7 +103,7 @@ export function MetricVisualization({ metricConfig, startTime, endTime, instance
 					})
 					}
 					<XAxis dataKey={(item) => formatTime(item.id)} />
-					<YAxis unit={` ${yAxisUnits}`} width={80} />
+					<YAxis unit={` ${yAxisUnits}`} width={100} />
 					<Legend />
 					<Tooltip />
 				</LineChart>

--- a/src/features/instance/status/components/monitoring/MetricVisualization.tsx
+++ b/src/features/instance/status/components/monitoring/MetricVisualization.tsx
@@ -9,7 +9,9 @@ import { harperPalette } from '@/lib/colorPalette.ts';
 type MetricValue = string | number | boolean;
 type NullableMetricValue = MetricValue | null;
 type NullableMetric = {[key: string]: NullableMetricValue};
-type CoalescedMetrics = {[id: string]: {[node: string]: MetricValue}};
+type NodeMetric = {[node: string]: number};
+type CoalescedMetrics = {[id: string]: NodeMetric};
+type FormattedMetric = {[node: string]: string};
 
 interface MetricVisualizationParams {
 	metricConfig: MetricConfig;
@@ -52,7 +54,7 @@ export function MetricVisualization({ metricConfig, startTime, endTime, instance
 
 	const nodeMetrics = useMemo(() => {
 		const coalescedMetrics: CoalescedMetrics = {};
-		const { dataKey, units } = metricConfig;
+		const { dataKey, aggregator, units } = metricConfig;
 		let conversionUnits = units as string;
 
 		if (metrics && metrics.length > 0) {
@@ -65,17 +67,27 @@ export function MetricVisualization({ metricConfig, startTime, endTime, instance
 
 			for (const metric of metrics) {
 				const coalescedTime = Math.floor(metric.id / metric.period) * metric.period;
-				const resolvedMetric = resolveMetricDataKey(metric, dataKey, units, conversionUnits).toFixed(2);
+				const resolvedMetric = resolveMetricDataKey(metric, dataKey, units, conversionUnits);
 
 				if (coalescedMetrics[coalescedTime]) {
-					coalescedMetrics[coalescedTime][metric.node] = resolvedMetric;
+					if (metric.node in coalescedMetrics[coalescedTime]) {
+						coalescedMetrics[coalescedTime][metric.node] = aggregator(coalescedMetrics[coalescedTime][metric.node], resolvedMetric);
+					} else {
+						coalescedMetrics[coalescedTime][metric.node] = resolvedMetric;
+					}
 				} else {
 					coalescedMetrics[coalescedTime] = { [metric.node]: resolvedMetric };
 				}
 			}
 
 			return Object.keys(coalescedMetrics).map((id: string) => {
-				return { id: Number.parseInt(id), ...coalescedMetrics[id] };
+				const numericalId = Number.parseInt(id);
+				const coalescedMetric = coalescedMetrics[id];
+				const formattedMetrics = Object.keys(coalescedMetrics[id]).reduce((metric, node) => {
+					metric[node] = coalescedMetric[node].toFixed(2);
+					return metric;
+				}, {} as FormattedMetric);
+				return { id: numericalId, ...formattedMetrics };
 			});
 		}
 	}, [metrics, metricConfig]);


### PR DESCRIPTION
Fixes STUDIO-542

Prior to this change I wasn’t aggregating analytics across all tables in the results. So these charts would only show metrics for the last table in the get_analytics response.

Now they sum across all returned metrics for the same node and coalesced time window.