### PR TITLE
feat: Pass credentials

### DIFF
--- a/src/features/instance/apis/APIDocs.tsx
+++ b/src/features/instance/apis/APIDocs.tsx
@@ -96,7 +96,9 @@ export function APIDocs() {
 		<SwaggerUI
 			spec={spec}
 			persistAuthorization={true}
+			withCredentials={true}
 			requestSnippetsEnabled={true}
+			defaultModelRendering="model"
 			requestSnippets={requestSnippets}
 			plugins={plugins}
 			tryItOutEnabled={true}


### PR DESCRIPTION
We can pass the cookie authorization along to the requests we make. This makes it easier to see your results without having to set up the authorization, but you don't end up seeing how to set up authorization in the code snippets now.

https://harperdb.atlassian.net/browse/STUDIO-591