### PR TITLE
Redeploy app tweaks

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -9,5 +9,9 @@ module.exports = {
 			0,
 			'never',
 		],
+		'footer-max-line-length': [
+			0,
+			'never',
+		],
 	},
 };

--- a/src/features/instance/applications/lib/parseReadMe.test.ts
+++ b/src/features/instance/applications/lib/parseReadMe.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseReadMe } from './parseReadMe';
+
+
+describe('parseReadMe', () => {
+	const resp = (project: string = 'Example') => ({ project });
+	const baseURL = 'https://example.com:9925';
+
+	it('replaces localhost:9926 links with base host derived from 9925 URL (no trailing slash)', () => {
+		const input = [
+			'Visit http://localhost:9926',
+			'API: http://localhost:9926/api',
+			'Secure: https://localhost:9926/docs',
+		].join('\n');
+
+		const output = parseReadMe(input, baseURL, resp());
+
+		expect(output).toContain('Visit https://example.com');
+		expect(output).toContain('API: https://example.com/api');
+		expect(output).toContain('Secure: https://example.com/docs');
+	});
+
+	it('replaces localhost:9926 links when base 9925 URL ends with a trailing slash', () => {
+		const input = 'Go to http://localhost:9926/path';
+
+		const output = parseReadMe(input, baseURL, resp());
+
+		expect(output).toBe('Go to https://example.com/path');
+	});
+
+	it('replaces the project placeholder when response.project is provided', () => {
+		const input = 'Welcome to Your New Harper Fabric App!';
+
+		const output = parseReadMe(input, baseURL, resp('My App'));
+
+		expect(output).toBe('Welcome to My App!');
+	});
+
+	it('does not alter unrelated hosts or content', () => {
+		const input = [
+			'External link: https://example.com/page',
+			'No placeholder here.',
+		].join('\n');
+
+		const output = parseReadMe(input, baseURL, resp());
+
+		expect(output).toBe(input);
+	});
+
+	it('is idempotent when run multiple times with same inputs', () => {
+		const input = 'http://localhost:9926/a and Your New Harper Fabric App';
+
+		const once = parseReadMe(input, baseURL, resp('Proj'));
+		const twice = parseReadMe(once, baseURL, resp('Proj'));
+
+		expect(twice).toBe(once);
+	});
+});

--- a/src/features/instance/applications/lib/parseReadMe.ts
+++ b/src/features/instance/applications/lib/parseReadMe.ts
@@ -1,10 +1,10 @@
 import { GetComponentFileResponse } from '@/features/instance/operations/queries/getComponentFile';
 
-export function parseReadMe(contents: string, baseURL: string, response: GetComponentFileResponse): string {
+export function parseReadMe(contents: string, baseURL: string, response: Pick<GetComponentFileResponse, 'project'>): string {
 	const operations9925URL = baseURL;
-	const rest9926URL = baseURL.replace(':9925', '');
+	const rest9926URL = baseURL.replace(/:9925\/?/, '');
 	if (operations9925URL) {
-		contents = contents.replaceAll('http://localhost:9926', rest9926URL);
+		contents = contents.replaceAll(/https?:\/\/localhost:9926/g, rest9926URL);
 	}
 	if (response.project) {
 		contents = contents.replaceAll('Your New Harper Fabric App', response.project);

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -45,7 +45,8 @@ export function RedeployApplicationModal() {
 		if (!openedEntry) {
 			return;
 		}
-		const originalPackageUrl = openedEntry.package;
+		setWatchedValue('ShowRedeployApplicationModal', false);
+
 		const toastId = toast.loading('Redeploying...');
 		reDeployApplication({
 			applicationName: openedEntry.project,
@@ -64,10 +65,8 @@ export function RedeployApplicationModal() {
 					queryKey: [instanceParams.entityId, 'get_components'],
 					refetchType: 'active',
 				});
-				setWatchedValue('ShowRedeployApplicationModal', false);
 			},
 			onError: () => {
-				openedEntry.package = originalPackageUrl;
 				toast.dismiss(toastId);
 			},
 		});

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -13,7 +13,7 @@ import { useDeployComponentMutation } from '@/features/instance/operations/mutat
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { Ban, RefreshCwIcon } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -27,6 +27,19 @@ export function RedeployApplicationModal() {
 	const packageUrl = openedEntry?.package;
 
 	const { mutate: reDeployApplication, isPending } = useDeployComponentMutation();
+
+	const methods = useForm({
+		defaultValues: {
+			applicationUrl: packageUrl,
+			installCommand: '',
+		},
+	});
+
+	const { control, handleSubmit, reset } = methods;
+
+	useEffect(() => {
+		reset({ applicationUrl: packageUrl });
+	}, [reset, packageUrl]);
 
 	const redeployPackage = useCallback((applicationUrl: string, installCommand: string | undefined) => {
 		if (!openedEntry) {
@@ -59,15 +72,6 @@ export function RedeployApplicationModal() {
 			},
 		});
 	}, [reDeployApplication, openedEntry, instanceParams, queryClient]);
-
-	const methods = useForm({
-		defaultValues: {
-			applicationUrl: packageUrl,
-			installCommand: '',
-		},
-	});
-
-	const { control, handleSubmit, reset } = methods;
 
 	const submitForm = ({ applicationUrl, installCommand }: {
 		applicationUrl: string | undefined,


### PR DESCRIPTION
This fixes the bug preventing the package reference from being restored when opening the redeploy app modal, closing issue #897.

When deploying an application with this, I noticed some of the README links weren't parsing quite right for display, leaving double slashes in some cases. I fixed those as well, and covered that with unit tests.

And then commitlint got mad at me for typing a human sentence, so I got mad right back at it. And I won.

https://harperdb.atlassian.net/browse/STUDIO-513