### PR TITLE
feat: RUM custom retention metrics

### DIFF
--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -77,11 +77,20 @@ export function useOnRouteLoadTracker() {
 			return;
 		}
 		if (user && !isLocalUser(user)) {
-			datadogRum.setUser({
-				id: user.id,
-				name: [user.firstname, user.lastname].filter(excludeFalsy).join(' ') || undefined,
-				email: user.email,
-			});
+	       datadogRum.setUser({
+		       id: user.id,
+		       name: [user.firstname, user.lastname].filter(excludeFalsy).join(' ') || undefined,
+		       email: user.email,
+	       });
+
+		   // First time vs return visit action
+	       if (localStorage.getItem('hasVisitedBefore')) {
+		       datadogRum.addAction('return_visit');
+	       } else {
+		       datadogRum.addAction('first_time_visit');
+		       localStorage.setItem('hasVisitedBefore', 'true');
+	       }
+
 		} else {
 			datadogRum.clearUser();
 		}
@@ -90,6 +99,19 @@ export function useOnRouteLoadTracker() {
 
 export function loginSuccessDatadogAction(data: { id: string; email: string; firstname: string; lastname: string }) {
 	if (!enabled) return;
+
+	// Time between logins
+	const lastLogin = localStorage.getItem('lastLoginTimestamp');
+	const now = Date.now();
+	
+	if (lastLogin) {
+		const seconds = Math.floor((now - Number(lastLogin)) / 1000);
+		if (!Number.isNaN(seconds) && seconds >= 0) {
+			datadogRum.addAction('login_time_gap', { seconds });
+		}
+	}
+
+	localStorage.setItem('lastLoginTimestamp', String(now));
 
 	datadogRum.setUser({
 		id: data.id,


### PR DESCRIPTION
Use localStorage to persist and track user visit and login timestamps. Curious if there's a better way to do this

+ Log `first_time_visit` and `return_visit` actions to distinguish new vs. returning users.
+ Log `login_time_gap` (in seconds) to capture time between logins.

These metrics provide deeper insight into user engagement, retention patterns, and the percentage of users who return after their first login. This will enable more effective tracking and analysis of user behavior in Datadog dashboards.