### PR TITLE
[STUDIO-584] Sort self-managed instances consistently

### DIFF
--- a/src/features/cluster/Instances.tsx
+++ b/src/features/cluster/Instances.tsx
@@ -9,6 +9,7 @@ import { calculateInstanceFQDN } from '@/features/clusters/upsert/lib/calculateI
 import { Instance } from '@/lib/api.patch';
 import { clusterIsSelfManaged } from '@/lib/api/clusterIsSelfManaged';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
+import { byInstanceFqdnThenPort } from '@/lib/arrays/sort/byInstanceFqdnThenPort';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { useQuery } from '@tanstack/react-query';
@@ -102,8 +103,14 @@ export function Instances() {
 		[isSelfManaged],
 	);
 	const instances = useMemo(
-		() =>
-			cluster?.instances?.filter(instance => instance.status && !deletedClusterStatuses.includes(instance.status)) ?? [],
+		() => {
+			if (!cluster?.instances) {
+				return [];
+			}
+			return cluster.instances
+				.filter(instance => instance.status && !deletedClusterStatuses.includes(instance.status))
+				.sort(byInstanceFqdnThenPort);
+		},
 		[cluster],
 	);
 	return (

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -3,6 +3,7 @@ import { ErrorComponent } from '@/components/ErrorComponent';
 import { Loading } from '@/components/Loading';
 import { SubNavSimpleLayout } from '@/components/SubNavSimpleLayout';
 import { isFailed, isTerminated } from '@/components/ui/utils/badgeStatus';
+import { deletedClusterStatuses } from '@/config/clusterStatuses';
 import { getPlanTypesOptions } from '@/features/cluster/queries/getPlanTypesQuery';
 import { getRegionLocationsOptions } from '@/features/clusters/queries/getRegionLocationsQuery';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -10,6 +11,7 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { SchemaPlan } from '@/lib/api.gen';
 import { Cluster, Organization } from '@/lib/api.patch';
 import { sortByField } from '@/lib/arrays/sort/byField';
+import { byInstanceFqdnThenPort } from '@/lib/arrays/sort/byInstanceFqdnThenPort';
 import { groupThenKeyBy } from '@/lib/groupThenKeyBy';
 import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
 import { useQuery } from '@tanstack/react-query';
@@ -111,15 +113,16 @@ export function UpsertCluster() {
 				}
 			}
 			if (!regionPlans.length && clusterToLoad.instances) {
-				for (const instance of clusterToLoad.instances) {
-					if (instance.status !== 'REMOVED') {
-						isSelfManaged = true;
-						instances.push({
-							fqdn: instance.instanceFqdn,
-							port: instance.operationsApiPort,
-							secure: instance.operationsApiSecure ? 'true' : 'false',
-						});
-					}
+				const clusterInstances = clusterToLoad.instances
+					.filter(instance => instance.status && !deletedClusterStatuses.includes(instance.status))
+					.sort(byInstanceFqdnThenPort);
+				for (const instance of clusterInstances) {
+					isSelfManaged = true;
+					instances.push({
+						fqdn: instance.instanceFqdn,
+						port: instance.operationsApiPort,
+						secure: instance.operationsApiSecure ? 'true' : 'false',
+					});
 				}
 			}
 		} else if (defaults) {

--- a/src/features/clusters/upsert/lib/calculateInstanceFQDN.test.ts
+++ b/src/features/clusters/upsert/lib/calculateInstanceFQDN.test.ts
@@ -32,11 +32,6 @@ describe('calculateInstanceFQDN', () => {
 		expect(calculateInstanceFQDN(instance)).toBe(`http://example.com:${defaultOperationsApiPort}`);
 	});
 
-	it('maps 127.0.0.1 to localhost', () => {
-		const instance = buildInstance({ fqdn: '127.0.0.1', port: 80 });
-		expect(calculateInstanceFQDN(instance)).toBe(`http://localhost`);
-	});
-
 	it('handles conflicts between port and secure', () => {
 		const instance = buildInstance({ secure: 'true', port: 80 });
 		expect(calculateInstanceFQDN(instance)).toBe('http://example.com');

--- a/src/features/clusters/upsert/lib/calculateInstanceFQDN.ts
+++ b/src/features/clusters/upsert/lib/calculateInstanceFQDN.ts
@@ -3,12 +3,10 @@ import { UpsertClusterSchema } from '@/features/clusters/upsert/upsertClusterSch
 import { z } from 'zod';
 
 export function calculateInstanceFQDN(instance: z.infer<typeof UpsertClusterSchema.shape.instances.element>) {
-	let { secure, fqdn, port } = instance;
+	const { fqdn } = instance;
+	let { secure, port } = instance;
 	if (!port) {
 		port = defaultOperationsApiPort;
-	}
-	if (fqdn === '127.0.0.1') {
-		fqdn = 'localhost';
 	}
 	if (port === 443 && secure === 'false') {
 		secure = 'true';

--- a/src/lib/arrays/sort/byInstanceFqdnThenPort.test.ts
+++ b/src/lib/arrays/sort/byInstanceFqdnThenPort.test.ts
@@ -1,0 +1,43 @@
+import { SchemaHdbInstance } from '@/lib/api.gen';
+import { describe, expect, it } from 'vitest';
+import { byInstanceFqdnThenPort } from './byInstanceFqdnThenPort';
+
+type Item = Pick<SchemaHdbInstance, 'instanceFqdn' | 'operationsApiPort'>;
+
+describe('byInstanceFqdnThenPort', () => {
+	it('sorts by instanceFqdn ascending when FQDNs differ', () => {
+		const items: Item[] = [
+			{ instanceFqdn: 'z.example.com', operationsApiPort: 9000 },
+			{ instanceFqdn: 'a.example.com', operationsApiPort: 8000 },
+			{ instanceFqdn: 'm.example.com', operationsApiPort: 7000 },
+		];
+
+		const sorted = [...items].sort(byInstanceFqdnThenPort);
+
+		expect(sorted.map((i) => i.instanceFqdn)).toEqual([
+			'a.example.com',
+			'm.example.com',
+			'z.example.com',
+		]);
+	});
+
+	it('when instanceFqdn is equal, sorts by operationsApiPort ascending', () => {
+		const items: Item[] = [
+			{ instanceFqdn: 'a.example.com', operationsApiPort: 9000 },
+			{ instanceFqdn: 'a.example.com', operationsApiPort: 8000 },
+			{ instanceFqdn: 'a.example.com', operationsApiPort: 7000 },
+		];
+
+		const sorted = [...items].sort(byInstanceFqdnThenPort);
+
+		expect(sorted.map((i) => i.operationsApiPort)).toEqual([7000, 8000, 9000]);
+	});
+
+	it('returns 0 when both instanceFqdn and operationsApiPort are equal', () => {
+		const a: Item = { instanceFqdn: 'same.example.com', operationsApiPort: 1234 };
+		const b: Item = { instanceFqdn: 'same.example.com', operationsApiPort: 1234 };
+
+		expect(byInstanceFqdnThenPort(a, b)).toBe(0);
+		expect(byInstanceFqdnThenPort(b, a)).toBe(0);
+	});
+});

--- a/src/lib/arrays/sort/byInstanceFqdnThenPort.ts
+++ b/src/lib/arrays/sort/byInstanceFqdnThenPort.ts
@@ -1,0 +1,16 @@
+import { SchemaHdbInstance } from '@/lib/api.gen';
+import { ipAddressToNumber } from '@/lib/numbers/ipAddressToNumber';
+import { isIpAddress } from '@/lib/string/isIpAddress';
+
+export function byInstanceFqdnThenPort(
+	a: Pick<SchemaHdbInstance, 'instanceFqdn' | 'operationsApiPort'>,
+	b: Pick<SchemaHdbInstance, 'instanceFqdn' | 'operationsApiPort'>,
+) {
+	if (a.instanceFqdn === b.instanceFqdn) {
+		return a.operationsApiPort - b.operationsApiPort;
+	}
+	if (isIpAddress(a.instanceFqdn) && isIpAddress(b.instanceFqdn)) {
+		return ipAddressToNumber(a.instanceFqdn) - ipAddressToNumber(b.instanceFqdn);
+	}
+	return a.instanceFqdn > b.instanceFqdn ? 1 : -1;
+}

--- a/src/lib/numbers/ipAddressToNumber.test.ts
+++ b/src/lib/numbers/ipAddressToNumber.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { ipAddressToNumber } from './ipAddressToNumber';
+
+describe('ipAddressToNumber', () => {
+  it('maps common IPv4 addresses to their unsigned 32-bit numbers', () => {
+    const cases: Array<[string, number]> = [
+      ['0.0.0.0', 0],
+      ['0.0.0.1', 1],
+      ['0.0.1.0', 256],
+      ['0.1.0.0', 65536],
+      ['1.0.0.0', 16777216],
+      ['127.0.0.1', 2130706433],
+      ['127.255.255.255', 2147483647],
+      ['128.0.0.0', 2147483648],
+      ['255.255.255.255', 4294967295],
+    ];
+
+    for (const [ip, expected] of cases) {
+      expect(ipAddressToNumber(ip), ip).toBe(expected);
+    }
+  });
+
+  it('is monotonically increasing across the 127.x.x.x → 128.0.0.0 boundary', () => {
+    const a = ipAddressToNumber('127.255.255.255');
+    const b = ipAddressToNumber('128.0.0.0');
+    expect(a).toBeLessThan(b);
+  });
+});

--- a/src/lib/numbers/ipAddressToNumber.ts
+++ b/src/lib/numbers/ipAddressToNumber.ts
@@ -1,0 +1,5 @@
+export function ipAddressToNumber(ipAddress: string): number {
+	const parts = ipAddress.split('.').map(Number);
+	// Coerce result to an unsigned 32-bit integer to avoid negative values for >= 128.0.0.0
+	return (((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0);
+}

--- a/src/lib/string/isIpAddress.test.ts
+++ b/src/lib/string/isIpAddress.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isIpAddress } from './isIpAddress';
+
+describe('isIpAddress', () => {
+	it('returns true for valid IPv4 addresses', () => {
+		const cases = ['127.0.0.1', '0.0.0.0', '255.255.255.255', '1.2.3.4', '10.0.0.254'];
+		for (const value of cases) {
+			expect(isIpAddress(value), value).toBe(true);
+		}
+	});
+
+	it('returns false for hostnames/domains', () => {
+		const cases = ['example.com', 'sub.domain.local', 'localhost'];
+		for (const value of cases) {
+			expect(isIpAddress(value), value).toBe(false);
+		}
+	});
+
+	it('returns false for invalid IPv4 formats', () => {
+		const cases = [
+			'',
+			'1',
+			'1.2',
+			'1.2.3',
+			'1.2.3.4.5',
+			'256.0.0.1',
+			'1.2.3.256',
+			'123.456.78.90',
+			'01a.2.3.4',
+			'1.2.3.4 ',
+			' 1.2.3.4',
+			'1.2.3.4abc',
+			'::1',
+		];
+		for (const value of cases) {
+			expect(isIpAddress(value), value).toBe(false);
+		}
+	});
+});

--- a/src/lib/string/isIpAddress.ts
+++ b/src/lib/string/isIpAddress.ts
@@ -1,0 +1,8 @@
+export function isIpAddress(value: string | unknown): boolean {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	// Strict IPv4 check: exactly four octets, each 0–255; no extra chars
+	const ipv4 = /^(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+	return ipv4.test(value);
+}


### PR DESCRIPTION
When looking at the list of instances, either when editing a self-managed cluster or on the instances list, make sure we’re sorting appropriately.

- [x] If it’s an ip address, sort them numerically. So 127.0.0.1, 127.0.0.2, 127.0.0.20, etc, in that order.
- [x] If it’s a hostname, then sort alphabetically. a.example.com, b.example.com, etc. Numbers within the hostname will sort lexicographically. So a-2.example.com would appear after a-10.example.com. That’s OK.


https://harperdb.atlassian.net/browse/STUDIO-584