### PR TITLE
fix: Scroll warning when lots of skipped hashes

### DIFF
--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -113,7 +113,7 @@ export function AddTableRowModal({
 				<AlertTitle>
 					Skipped {skippedHashes.length === 1 ? 'Hash' : 'Hashes'} Detected
 				</AlertTitle>
-				<AlertDescription>
+				<AlertDescription className="max-h-36 overflow-auto">
 					<ol>
 						{skippedHashes.map(hash => <li key={hash}>{hash}</li>)}
 					</ol>


### PR DESCRIPTION
If there are more than a handful of skipped hashes, scroll the list vertically. Otherwise, the modal goes off the screen.

https://harperdb.atlassian.net/browse/STUDIO-599