### PR TITLE
[STUDIO-545] Application Editor Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"react": "^19.0.0",
 		"react-complex-tree": "^2.6.1",
 		"react-dom": "^19.0.0",
+		"react-dropzone": "^14.3.8",
 		"react-hook-form": "^7.54.2",
 		"react-markdown": "^10.1.0",
 		"recharts": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.0(react@19.2.0)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.2.0)
       react-hook-form:
         specifier: ^7.54.2
         version: 7.65.0(react@19.2.0)
@@ -2748,6 +2751,10 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   autolinker@3.16.2:
     resolution: {integrity: sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==}
 
@@ -3631,6 +3638,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -5411,6 +5422,12 @@ packages:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
     peerDependencies:
       react: ^19.2.0
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-hook-form@7.65.0:
     resolution: {integrity: sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==}
@@ -9978,6 +9995,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   autolinker@3.16.2:
     dependencies:
       tslib: 2.8.1
@@ -10915,6 +10934,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -12813,6 +12836,13 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-dropzone@14.3.8(react@19.2.0):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.2.0
 
   react-hook-form@7.65.0(react@19.2.0):
     dependencies:

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,5 +1,7 @@
-interface LoadingProps extends React.ComponentProps<'div'> {
-	text?: string;
+import { ComponentProps, ReactNode } from 'react';
+
+interface LoadingProps extends ComponentProps<'div'> {
+	text?: ReactNode;
 	centered?: boolean;
 }
 

--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -39,11 +39,11 @@ export function RestartButton({
 				onClick={targetNoun === 'Cluster' && operation === 'restart' ? onRestartClusterClick : onRestartClick}
 				disabled={disabled || isRestartPending || isRestartClusterPending}
 			>
-				<RotateCcwIcon />
-				{hideText !== true && <span className="hidden md:inline-block">Restart {targetNoun}</span>}
+				<RotateCcwIcon className="pointer-events-none" />
+				{hideText !== true && <span className="hidden md:inline-block pointer-events-none">Restart {targetNoun}</span>}
 			</Button>
 		</TooltipTrigger>
-		<TooltipContent>
+		<TooltipContent side="bottom">
 			{tooltip
 				? tooltip
 				: operation === 'restart_service'

--- a/src/components/SubNavMenu.tsx
+++ b/src/components/SubNavMenu.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 
 export function SubNavMenu({ children }: { children?: ReactNode }) {
 	return (
-		<nav className="fixed top-20 w-full md:h-12 z-39 py-2 px-4 md:px-12 bg-grey-700">
-			<div className="md:flex items-center h-full space-x-8">
+		<nav className="fixed top-20 w-full h-12 z-39 py-2 px-4 md:px-12 bg-grey-700">
+			<div className="flex items-center h-full space-x-2">
 				<Breadcrumbs />
 				{children}
 			</div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,13 +9,13 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
 			data-slot="input"
 			className={cn(
 				`border-input file:text-foreground placeholder:text-muted-foreground selection:bg-purple
-        selection:text-primary-foreground 
-        dark:aria-invalid:outline-destructive dark:aria-invalid:ring-destructive/50 ring-ring/10 
-        dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 aria-invalid:outline-destructive/60 
-        aria-invalid:ring-destructive/20 aria-invalid:border-destructive/60 dark:aria-invalid:border-destructive 
+        selection:text-primary-foreground
+        dark:aria-invalid:outline-destructive dark:aria-invalid:ring-destructive/50 ring-ring/10
+        dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 aria-invalid:outline-destructive/60
+        aria-invalid:ring-destructive/20 aria-invalid:border-destructive/60 dark:aria-invalid:border-destructive
         flex h-9 w-full min-w-0 rounded-md border bg-grey-700 px-3 py-1 text-base text-white
-        file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium 
-        focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-purple  disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 
+        file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium
+        focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-purple  disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50
         aria-invalid:focus-visible:ring-[1px] aria-invalid:focus-visible:outline-none md:text-sm dark:aria-invalid:focus-visible:ring-1`,
 				className
 			)}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -7,3 +7,6 @@ export const defaultClusterUsername = 'HDB_ADMIN';
 
 export const defaultInstanceRoute = '/';
 export const defaultInstanceRouteUpOne = '../';
+
+export const maxUploadFileSize = 1024 /* mb */ * 1024 /* kb */ * 1024 /* b */;
+export const maxFabricConnectUploadFileSize = 100 /* mb */ * 1024 /* kb */ * 1024 /* b */;

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -55,7 +55,7 @@ export function ClustersList() {
 					<div className="flex w-full justify-end gap-2">
 						<Input
 							placeholder="Filter by name"
-							className="inline-block w-48 md:w-64 bg-black border"
+							className="inline-block w-full text-xs"
 							value={filterByNameValue}
 							onChange={onFilterByNameChanged}
 						/>
@@ -64,12 +64,11 @@ export function ClustersList() {
 							<Link to="new-cluster">
 								<Button
 									variant="positive"
-									className="w-full rounded-full md:w-44"
 									accessKey="n"
 								>
 									<Plus />{' '}
-									<span>
-										<u>N</u>ew Cluster
+									<span className="hidden sm:inline-block">
+										<u>N</u>ew <span className="hidden md:inline-block">Cluster</span>
 									</span>
 								</Button>
 							</Link>
@@ -77,7 +76,7 @@ export function ClustersList() {
 					</div>
 				) : null}
 			</SubNavMenu>
-			<section className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
 					{filteredClusters.map((cluster) => (
 						<div key={cluster.id} className="col-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">

--- a/src/features/instance/InstanceLayout.tsx
+++ b/src/features/instance/InstanceLayout.tsx
@@ -4,7 +4,7 @@ import { Outlet } from '@tanstack/react-router';
 export function InstanceLayout() {
 	return (
 		<>
-			<nav className="fixed top-20 w-full z-39 md:px-12 md:py-1 bg-grey-700">
+			<nav className="fixed top-20 w-full z-39 h-12 md:px-12 bg-grey-700">
 				<InstanceNavBar />
 			</nav>
 			<div className="mt-32 min-h-[calc(100vh-theme(spacing.32))]">

--- a/src/features/instance/InstanceNavBar.tsx
+++ b/src/features/instance/InstanceNavBar.tsx
@@ -111,7 +111,7 @@ function DesktopInstanceNavBar({ links, restartRequired }: { links: Link[], rest
 function MobileInstanceNavBar({ links, restartRequired }: { links: Link[], restartRequired: boolean }) {
 	return (
 		<>
-			<div className="flex md:hidden items-center justify-between p-2 text-white">
+			<div className="flex md:hidden items-center justify-between h-full px-2 text-white">
 				<Breadcrumbs restartRequired={restartRequired} />
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>

--- a/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
@@ -1,0 +1,232 @@
+import { maxFabricConnectUploadFileSize, maxUploadFileSize } from '@/config/constants';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+import { useDraggingHook } from '@/features/instance/applications/components/ApplicationsSidebar/useDraggingHook';
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
+import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { setComponentFile } from '@/integrations/api/instance/applications/setComponentFile';
+import { humanFileSize } from '@/lib/humanFileSize';
+import { pluralize } from '@/lib/pluralize';
+import { readAsDataURL } from '@/lib/storage/readAsDataURL';
+import { useParams } from '@tanstack/react-router';
+import { cx } from 'class-variance-authority';
+import { useCallback, useState } from 'react';
+import { FileRejection, FileWithPath, useDropzone } from 'react-dropzone';
+import { toast } from 'sonner';
+
+export function DropTarget() {
+	const [uploading, setUploading] = useState('');
+	const { clusterId }: { clusterId?: string; } = useParams({ strict: false });
+	const { openedEntry, restrictPackageModification, reloadRootEntries, entryExists } = useEditorView();
+	const canUpload = !!openedEntry && !openedEntry.package && !restrictPackageModification;
+	const instanceParams = useInstanceClientIdParams();
+	const { dragging: isDraggingAnywhere, dragTarget } = useDraggingHook();
+	const dragTargetId = dragTarget?.getAttribute?.('data-rct-item-id');
+	const dragTargetDirectory = dragTargetId?.split?.('/')?.pop?.();
+
+	const currentProject = openedEntry?.project;
+	let currentPath: string | false = false;
+	let currentDirectory: string | undefined = undefined;
+	if (openedEntry?.path) {
+		const parts = openedEntry.path.split('/');
+		const currentPathIsDirectory = isDirectory(openedEntry);
+		currentPath = canUpload && ((
+			currentPathIsDirectory
+				? parts.slice(1)
+				: parts.slice(1, -1)
+		).join('/'));
+		currentDirectory = parts[parts.length - (currentPathIsDirectory ? 1 : 2)];
+	}
+
+	const onUploadDrop = useCallback(async (
+		rawAcceptedFiles: FileWithPath[],
+		rawRejectedFiles: FileRejection[],
+	) => {
+		const dragItemId = dragTarget?.getAttribute?.('data-rct-item-id')?.split?.('/');
+		const targetProject = dragItemId?.length ? dragItemId[0] : canUpload ? currentProject : false;
+		const targetPath = dragItemId?.length ? dragItemId.slice(1).join('/') : canUpload ? currentPath : false;
+		if (targetProject === false || targetProject === undefined || targetPath === false || targetPath === undefined) {
+			return;
+		}
+
+		const filesToUpload: FileWithPath[] = [];
+		const filesRejected: FileRejection[] = rawRejectedFiles.slice();
+
+		for (const file of rawAcceptedFiles) {
+			const filePath = getFilePath(targetPath, file);
+			if (file.name.startsWith('.') || file.relativePath?.includes('/.')) {
+				filesRejected.push({
+					file,
+					errors: [
+						{
+							message: 'Sensitive files and folders starting with . are skipped.',
+							code: 'dot-ignored',
+						},
+					],
+				});
+			} else if (entryExists(`${targetProject}/${filePath}`)) {
+				filesRejected.push({
+					file,
+					errors: [
+						{
+							message: `${filePath} already exists`,
+							code: 'duplicate',
+						},
+					],
+				});
+			} else {
+				filesToUpload.push(file);
+			}
+		}
+
+		let canceled = false;
+
+		const id = 'uploading-files';
+		const toastCancelAction = {
+			label: 'Cancel',
+			onClick: () => {
+				canceled = true;
+			},
+		};
+		const toastOKAction = {
+			label: 'OK',
+			onClick: () => undefined,
+		};
+
+		setUploading(`Uploading ${pluralize(filesToUpload.length, 'file', 'files')}...`);
+
+		const totalBytes = filesToUpload.reduce((sum, f) => sum + f.size, 0);
+		let uploadedBytes = 0;
+		let counter = 0;
+		for (const file of filesToUpload) {
+			counter += 1;
+
+			toast.loading(`Upload in progress...`, {
+				id,
+				descriptionClassName: 'whitespace-pre',
+				description: `${counter} of ${pluralize(filesToUpload.length, 'file', 'files')}
+${file.name}
+${humanFileSize(uploadedBytes)} of ${humanFileSize(totalBytes)}`,
+				action: toastCancelAction,
+			});
+
+			const filePath = getFilePath(targetPath, file);
+			const dataURLResponse = await readAsDataURL(file);
+			const dataURLResult = dataURLResponse.target!.result as string;
+			const demarcation = 'base64,';
+			const encodingIndex = dataURLResult.indexOf(demarcation);
+			if (!canceled) {
+				await setComponentFile({
+					...instanceParams,
+					file: filePath,
+					project: targetProject,
+					encoding: 'base64',
+					payload: dataURLResult.slice(encodingIndex + demarcation.length),
+				});
+				uploadedBytes += file.size;
+			} else {
+				filesRejected.push({
+					file,
+					errors: [
+						{
+							message: `${filePath} cancelled`,
+							code: 'cancelled',
+						},
+					],
+				});
+			}
+		}
+
+		toast.loading(`Reloading sidebar...`, {
+			id: canceled ? undefined : id,
+			action: toastOKAction,
+			description: '',
+		});
+		await reloadRootEntries();
+
+		if (filesRejected.length === 0) {
+			if (rawAcceptedFiles.length > 0) {
+				toast.success(`Uploaded ${pluralize(filesToUpload.length, 'file', 'files')}!`, {
+					id,
+					action: toastOKAction,
+					description: '',
+				});
+			}
+		} else {
+			// Note: this console.log is deliberate. It lets developers know all the files that were rejected.
+			console.log(filesRejected);
+			toast.error(canceled ? 'Cancelled uploads' : 'Rejected uploads', {
+				id: canceled ? undefined : id,
+				action: toastOKAction,
+				descriptionClassName: 'whitespace-pre overflow-y-auto',
+				description: filesRejected
+						.slice(0, 5)
+						.map(r => r.errors.map(e => e.message).join('\n'))
+						.join('\n')
+					+ (filesRejected?.length > 5 ? '\nCheck the console for the full list.' : ''),
+			});
+		}
+		setUploading('');
+	}, [dragTarget, canUpload, currentProject, currentPath, entryExists, instanceParams, reloadRootEntries]);
+
+	const isFabricConnect = !!clusterId && authStore.checkForFabricConnect(clusterId);
+	const { getRootProps, getInputProps } = useDropzone({
+		multiple: true,
+		maxSize: isFabricConnect ? maxFabricConnectUploadFileSize : maxUploadFileSize,
+		onDrop: onUploadDrop,
+	});
+
+	if (!canUpload && !dragTarget) {
+		if (!isDraggingAnywhere) {
+			return null;
+		}
+		return (
+			<div
+				className={cx(
+					'border-3 border-dashed',
+					'pointer-events-auto',
+					'cursor-copy text-sm text-center',
+					'p-2 w-full fixed bottom-0 h-16',
+					'flex flex-col items-center justify-center',
+					'bg-red-950 border-red-600',
+				)}>
+				You cannot upload into<br /><strong>{currentDirectory}</strong>
+			</div>
+		);
+	}
+
+	return (
+		<div {...getRootProps()} className={isDraggingAnywhere ? 'fixed top-0 bottom-0 w-full' +
+			' pointer-events-none' : ''}>
+			<input id="dropTarget" {...getInputProps()} />
+			<div
+				className={cx(
+					'border-3 border-dashed',
+					'pointer-events-auto',
+					'cursor-copy text-sm text-center',
+					'p-2 w-full fixed bottom-0 h-16',
+					'flex flex-col items-center justify-center',
+					isDraggingAnywhere
+						? 'animate-glow-pulse bg-green-950 border-green-600'
+						: 'bg-purple-950 border-purple-600',
+				)}>
+				{
+					uploading
+						? uploading
+						: dragTarget
+							? <>Drop to upload into<br /><strong>{dragTargetDirectory}</strong></>
+							: isDraggingAnywhere
+								? <>Drop to upload into<br /><strong>{currentDirectory}</strong></>
+								: <>Drag and drop to upload<br />or click to select files.</>
+				}
+			</div>
+		</div>
+	);
+}
+
+function getFilePath(intoPath: string, file: FileWithPath): string {
+	const relativePath = file.relativePath ?? file.name;
+	const firstSlashIndex = relativePath.indexOf('/');
+	const trimmedRelativePath = firstSlashIndex === 0 || firstSlashIndex === 1 ? relativePath.slice(firstSlashIndex + 1) : relativePath;
+	return intoPath ? `${intoPath}/${trimmedRelativePath}` : trimmedRelativePath;
+}

--- a/src/features/instance/applications/components/ApplicationsSidebar/ItemTitle.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/ItemTitle.tsx
@@ -27,7 +27,7 @@ export function ItemTitle({ title, item, context }: {
 						pkg={!!item.data?.package || item.data.path === importedApplications} />
 					: <FileTypeIcon extension={parseFileExtension(title)} />
 		}
-		<span className="text-nowrap">{title}{content ? '*' : ''}</span>
+		<span className="text-nowrap pointer-events-none">{title}{content ? '*' : ''}</span>
 		{item.data?.package && <LockedIcon />}
 	</>;
 }

--- a/src/features/instance/applications/components/ApplicationsSidebar/LockedIcon.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/LockedIcon.tsx
@@ -1,5 +1,5 @@
 import { iconSharedClassName } from './constants';
 
 export function LockedIcon() {
-	return <i className={iconSharedClassName + 'fas fa-lock text-gray-400 ml-2'} />;
+	return <i className={iconSharedClassName + 'fas fa-lock text-gray-400 ml-2 packageIsLocked'} />;
 }

--- a/src/features/instance/applications/components/ApplicationsSidebar/constants.ts
+++ b/src/features/instance/applications/components/ApplicationsSidebar/constants.ts
@@ -1,1 +1,1 @@
-export const iconSharedClassName = 'w-6 ';
+export const iconSharedClassName = 'w-6 pointer-events-none ';

--- a/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
@@ -2,6 +2,7 @@ import type { DirectoryEntry } from '@/features/instance/applications/context/di
 import type { FileEntry } from '@/features/instance/applications/context/fileEntry';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useRenameFiles } from '@/features/instance/applications/hooks/useRenameFiles';
+import { useGlobalShortcutKeys } from '@/features/instance/applications/shortcuts';
 import { extractFileNameFromPath } from '@/lib/string/paths/extractFileNameFromPath';
 import { joinPath } from '@/lib/string/paths/joinPath';
 import { renameFileInPath } from '@/lib/string/paths/renameFileInPath';
@@ -27,6 +28,8 @@ export function ApplicationsSidebar() {
 		setSelectedItems,
 	} = useEditorView();
 	const { items, rootId } = useMemo(() => buildItems(rootEntries), [rootEntries]);
+
+	useGlobalShortcutKeys();
 
 	useEffect(function setOpenedEntryFromFocusedItem() {
 		if (openedEntry?.path !== focusedItem && focusedItem) {
@@ -59,6 +62,7 @@ export function ApplicationsSidebar() {
 				break;
 		}
 	}, [items, renameFiles]);
+
 	const onRenameItem = useCallback((item: TreeItem<FileEntry | DirectoryEntry | undefined>, name: string) => {
 		if (item.data) {
 			return renameFiles([
@@ -78,6 +82,7 @@ export function ApplicationsSidebar() {
 				canDropOnNonFolder={false}
 				canReorderItems={false}
 				canSearch={true}
+				canRename={false}
 				getItemTitle={getItemTitle}
 				items={items}
 				onDrop={onDrop}

--- a/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
@@ -5,13 +5,13 @@ import { useRenameFiles } from '@/features/instance/applications/hooks/useRename
 import { useGlobalShortcutKeys } from '@/features/instance/applications/shortcuts';
 import { extractFileNameFromPath } from '@/lib/string/paths/extractFileNameFromPath';
 import { joinPath } from '@/lib/string/paths/joinPath';
-import { renameFileInPath } from '@/lib/string/paths/renameFileInPath';
 import { useCallback, useEffect, useMemo } from 'react';
 import { ControlledTreeEnvironment, Tree, TreeItem } from 'react-complex-tree';
 import './file-explorer-modern.css';
 import { DraggingPosition } from 'react-complex-tree/src/types';
 import { toast } from 'sonner';
 import { buildItems } from './buildItems';
+import { DropTarget } from './DropTarget';
 import { getItemTitle } from './getItemTitle';
 import { ItemTitle } from './ItemTitle';
 
@@ -42,7 +42,7 @@ export function ApplicationsSidebar() {
 	}, [focusedItem, items, openedEntry?.path, setOpenedEntry]);
 
 	const renameFiles = useRenameFiles();
-	const onDrop = useCallback((droppedItems: TreeItem<FileEntry | DirectoryEntry | undefined>[], target: DraggingPosition) => {
+	const onInternalDrop = useCallback((droppedItems: TreeItem<FileEntry | DirectoryEntry | undefined>[], target: DraggingPosition) => {
 		switch (target.targetType) {
 			case 'item':
 				if (items[target.targetItem]?.data?.package) {
@@ -63,19 +63,8 @@ export function ApplicationsSidebar() {
 		}
 	}, [items, renameFiles]);
 
-	const onRenameItem = useCallback((item: TreeItem<FileEntry | DirectoryEntry | undefined>, name: string) => {
-		if (item.data) {
-			return renameFiles([
-				{
-					from: item.data.path,
-					to: renameFileInPath(item.data.path, name),
-				},
-			]);
-		}
-	}, [renameFiles]);
-
 	return (
-		<div className="h-full overflow-auto pr-1.5">
+		<div className="h-full overflow-auto pr-1.5 pb-18">
 			<ControlledTreeEnvironment
 				canDragAndDrop={true}
 				canDropOnFolder={true}
@@ -85,8 +74,7 @@ export function ApplicationsSidebar() {
 				canRename={false}
 				getItemTitle={getItemTitle}
 				items={items}
-				onDrop={onDrop}
-				onRenameItem={onRenameItem}
+				onDrop={onInternalDrop}
 				renderItemTitle={ItemTitle}
 				viewState={{ applicationsTree: { focusedItem, expandedItems, selectedItems } }}
 				onFocusItem={item => setFocusedItem(item.index)}
@@ -98,6 +86,8 @@ export function ApplicationsSidebar() {
 			>
 				<Tree treeId="applicationsTree" rootItem={rootId} treeLabel="Applications file tree" />
 			</ControlledTreeEnvironment>
+
+			<DropTarget />
 		</div>
 	);
 }

--- a/src/features/instance/applications/components/ApplicationsSidebar/useDraggingHook.ts
+++ b/src/features/instance/applications/components/ApplicationsSidebar/useDraggingHook.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { importedApplications, newApplication } from './specialItems';
+
+export function useDraggingHook() {
+	const [dragging, setDragging] = useState(false);
+	const [dragTarget, setDragTarget] = useState<Element | undefined>(undefined);
+	const startDragging = useCallback((e: DragEvent) => {
+		const foundFiles = e.dataTransfer?.types?.includes('Files');
+		if (!foundFiles) {
+			return;
+		}
+		const newTarget = e.target;
+		if (newTarget instanceof Element
+			&& newTarget.classList.contains('rct-tree-item-button-isFolder')) {
+			const itemId = newTarget.getAttribute('data-rct-item-id');
+			const isLocked = newTarget.querySelector('.packageIsLocked');
+			if (!isLocked && itemId && itemId !== importedApplications && itemId !== newApplication) {
+				setDragTarget(currentTarget => {
+					if (currentTarget !== newTarget) {
+						currentTarget?.classList?.remove?.('rct-tree-item-title-container-dragging-over');
+						newTarget.classList.add('rct-tree-item-title-container-dragging-over');
+						return newTarget;
+					}
+					return currentTarget;
+				});
+			}
+		}
+		setDragging(true);
+	}, []);
+
+	const dragLeave = useCallback(() => {
+		setDragging(false);
+		setDragTarget(currentTarget => {
+			if (currentTarget) {
+				currentTarget.classList.remove('rct-tree-item-title-container-dragging-over');
+			}
+			return undefined;
+		});
+	}, []);
+
+	const dropped = useCallback((e: DragEvent) => {
+		const foundFiles = e.dataTransfer?.types?.includes('Files');
+		if (!foundFiles) {
+			return;
+		}
+		if (e.detail === 1337) {
+			// Prevent a recursive dispatch.
+			return;
+		}
+		setDragging(false);
+		if (dragTarget) {
+			dragTarget.classList.remove('rct-tree-item-title-container-dragging-over');
+			setDragTarget(undefined);
+		}
+		const dropTarget = document.getElementById('dropTarget');
+		if (dropTarget) {
+			return dropTarget.dispatchEvent(new DragEvent('drop', {
+				bubbles: true,
+				detail: 1337, // Prevent a recursive dispatch.
+				cancelable: true,
+				dataTransfer: e.dataTransfer,
+			}));
+		}
+		return false;
+	}, [dragTarget]);
+
+	useEffect(() => {
+		document.addEventListener('dragenter', startDragging);
+		document.addEventListener('dragover', startDragging);
+		document.addEventListener('dragleave', dragLeave);
+		document.addEventListener('drop', dropped);
+
+		return () => {
+			document.removeEventListener('dragenter', startDragging);
+			document.removeEventListener('dragover', startDragging);
+			document.removeEventListener('dragleave', dragLeave);
+			document.removeEventListener('drop', dropped);
+		};
+	}, [startDragging, dropped, dragLeave]);
+
+	return useMemo(() => ({ dragging, dragTarget }), [dragging, dragTarget]);
+}

--- a/src/features/instance/applications/components/ContentActions.tsx
+++ b/src/features/instance/applications/components/ContentActions.tsx
@@ -92,8 +92,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				onClick={onSaveClick}
 				disabled={fileIsClean || isSavingFile}
 			>
-				<SaveIcon />
-				<span className="hidden lg:inline-block"><u>S</u>ave</span>
+				<SaveIcon className="pointer-events-none" />
+				<span className="hidden lg:inline-block pointer-events-none"><u>S</u>ave</span>
 			</Button>}
 
 			{!isDirectory(openedEntry) && !openedEntry.package && canManageBrowseInstance && <Button
@@ -102,8 +102,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				onClick={onRenameClick}
 				disabled={!fileIsClean || isSavingFile}
 			>
-				<PencilIcon />
-				<span className="hidden lg:inline-block"><u>R</u>ename</span>
+				<PencilIcon className="pointer-events-none" />
+				<span className="hidden lg:inline-block pointer-events-none"><u>R</u>ename</span>
 			</Button>}
 
 			{!openedEntry.package && canManageBrowseInstance && <Button
@@ -111,8 +111,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				className="rounded-none"
 				onClick={onAddFileClick}
 			>
-				<FileIcon />
-				<span>
+				<FileIcon className="pointer-events-none" />
+				<span className="pointer-events-none">
 					<u>N</u>ew
 					<span className="hidden mlg:inline-block">&nbsp;File</span>
 				</span>
@@ -123,8 +123,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				className="rounded-none"
 				onClick={onAddDirectoryClick}
 			>
-				<FolderIcon />
-				<span>
+				<FolderIcon className="pointer-events-none" />
+				<span className="pointer-events-none">
 					<u>A</u>dd
 					<span className="hidden xl:inline-block">&nbsp;Directory</span>
 				</span>
@@ -135,8 +135,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				className="rounded-none"
 				onClick={onDownloadApplicationClick}
 			>
-				<DownloadIcon />
-				<span className="hidden lg:inline-block">
+				<DownloadIcon className="pointer-events-none" />
+				<span className="hidden lg:inline-block pointer-events-none">
 					Download
 					<span className="hidden xl:inline-block">&nbsp;Application</span>
 				</span>
@@ -148,8 +148,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 					className="rounded-none"
 					onClick={onRedeployClick}
 				>
-					<PackageIcon />
-					<span>Redeploy <u>P</u>ackage</span>
+					<PackageIcon className="pointer-events-none" />
+					<span className="pointer-events-none">Redeploy <u>P</u>ackage</span>
 				</Button>}
 
 			<div className="grow"></div>
@@ -169,8 +169,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				onClick={onRevertChangesClicked}
 				disabled={fileIsClean || isSavingFile}
 			>
-				<Undo2Icon />
-				<span className="hidden xl:inline-block">Revert Changes</span>
+				<Undo2Icon className="pointer-events-none" />
+				<span className="hidden xl:inline-block pointer-events-none">Revert Changes</span>
 			</Button>}
 
 			{!restrictPackageModification && canManageBrowseInstance && <Button
@@ -178,8 +178,8 @@ export function ContentActions({ toggledSidebar, toggleSidebar }: {
 				className="rounded-none"
 				onClick={onDeleteClick}
 			>
-				<TrashIcon />
-				<span className="hidden xl:inline-block"><u>D</u>elete</span>
+				<TrashIcon className="pointer-events-none" />
+				<span className="hidden xl:inline-block pointer-events-none"><u>D</u>elete</span>
 			</Button>}
 
 		</>)}

--- a/src/features/instance/applications/components/ContentViewer.tsx
+++ b/src/features/instance/applications/components/ContentViewer.tsx
@@ -1,6 +1,8 @@
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useReadMeUrlTransformer } from '@/features/instance/applications/lib/readMeUrlTransform';
+import { hasImageFileExtension } from '@/lib/string/hasImageFileExtension';
+import { parseFileExtension } from '@/lib/string/parseFileExtension';
 import Markdown from 'react-markdown';
 import { newApplication } from './ApplicationsSidebar/specialItems';
 import { NewApplication } from './NewApplication';
@@ -21,5 +23,15 @@ export function ContentViewer() {
 		</div>;
 	}
 
-	return <TextEditorView />;
+	if (hasImageFileExtension(openedEntry?.name)) {
+		return <div className="mt-9 absolute top-0 right-0 bottom-0 left-0">
+			<img
+				className="w-full h-full object-contain p-20"
+				alt={openedEntry?.name}
+				src={`data:image/${parseFileExtension(openedEntry?.name)};base64,${openedEntryContents}`}
+			/>
+		</div>;
+	} else {
+		return <TextEditorView />;
+	}
 }

--- a/src/features/instance/applications/components/NewApplication/CLIInstructions.tsx
+++ b/src/features/instance/applications/components/NewApplication/CLIInstructions.tsx
@@ -44,7 +44,7 @@ export function CLIInstructions({
 					</div>
 					<div className="ml-8">
 						<div className="bg-black rounded-lg p-4 flex items-center justify-between group">
-							<code className="text-sm whitespace-pre truncate max-w-[calc(100vw-theme(spacing.48))]">{cliStep.code}</code>
+							<code className="text-sm overflow-auto pl-8 -indent-8 wrap-anywhere">{cliStep.code}</code>
 							<Button
 								type="button"
 								variant="default"

--- a/src/features/instance/applications/components/NewApplication/index.tsx
+++ b/src/features/instance/applications/components/NewApplication/index.tsx
@@ -50,8 +50,14 @@ export function NewApplication() {
 				path: [`applicationName`],
 				message: 'Please name your application!',
 			});
+		} else if (rootEntries.find(rootEntry => rootEntry.name === data.applicationName)) {
+			ctx.addIssue({
+				code: 'custom',
+				path: [`applicationName`],
+				message: 'That application name is already in use!',
+			});
 		}
-	}, [defaultApplicationName]);
+	}, [defaultApplicationName, rootEntries]);
 
 	const methods = useForm({
 		resolver: zodResolver(NewApplicationSchema.superRefine(refineZod)),

--- a/src/features/instance/applications/components/NewApplication/index.tsx
+++ b/src/features/instance/applications/components/NewApplication/index.tsx
@@ -143,7 +143,9 @@ export function NewApplication() {
 									</TabsTrigger>
 								</TabsList>
 
-								<Separator className="bg-black mx-6 mt-1" />
+								<div className="mx-6 mt-1">
+									<Separator className="bg-black" />
+								</div>
 
 								<TabsContent value="template" className="space-y-4">
 									<TemplateInstructions

--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -1,9 +1,9 @@
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useEditorFileContent } from '@/features/instance/applications/context/editorFileContent';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { registerWithEditor } from '@/features/instance/applications/shortcuts';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
-import { curryEmitToListeners, useListener } from '@/lib/events/listener';
-import { currySetWatchedValue } from '@/lib/events/watcher';
+import { useListener } from '@/lib/events/listener';
 import { parseFileExtension } from '@/lib/string/parseFileExtension';
 import { Editor, EditorProps, OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useState } from 'react';
@@ -47,51 +47,9 @@ export function TextEditorView() {
 	}, []);
 
 	useEffect(() => {
-		if (!mounted || !canManageBrowseInstance || !!openedEntry?.package || restrictPackageModification) {
-			return;
+		if (mounted && canManageBrowseInstance && !openedEntry?.package && !restrictPackageModification) {
+			return registerWithEditor(mounted);
 		}
-		const [editor, monaco] = mounted;
-		const disposables = [
-			editor.addAction({
-				id: 'new-file',
-				label: 'New File',
-				keybindings: [monaco.KeyMod.WinCtrl | monaco.KeyMod.Alt | monaco.KeyCode.KeyN],
-				run: currySetWatchedValue('ShowAddDirectoryOrFileModalType', 'file'),
-			}),
-			editor.addAction({
-				id: 'rename-file',
-				label: 'Rename File',
-				keybindings: [monaco.KeyMod.WinCtrl | monaco.KeyMod.Alt | monaco.KeyCode.KeyR],
-				run: currySetWatchedValue('ShowRenameFileModal', true),
-			}),
-			editor.addAction({
-				id: 'new-directory',
-				label: 'New Directory',
-				keybindings: [monaco.KeyMod.WinCtrl | monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyN],
-				run: currySetWatchedValue('ShowAddDirectoryOrFileModalType', 'directory'),
-			}),
-			editor.addAction({
-				id: 'save-file',
-				label: 'Save Changes',
-				keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
-				run: curryEmitToListeners('SaveFile', true),
-			}),
-			editor.addAction({
-				id: 'revert-file',
-				label: 'Revert File',
-				run: curryEmitToListeners('RevertChanges', true),
-			}),
-			editor.addAction({
-				id: 'delete-file',
-				label: 'Delete File',
-				run: currySetWatchedValue('ShowDeleteDirectoryOrFileModal', true),
-			}),
-		];
-		return () => {
-			for (const disposable of disposables) {
-				disposable?.dispose();
-			}
-		};
 	}, [mounted, canManageBrowseInstance, openedEntry, restrictPackageModification]);
 
 	useListener(

--- a/src/features/instance/applications/context/EditorViewContext.tsx
+++ b/src/features/instance/applications/context/EditorViewContext.tsx
@@ -8,6 +8,7 @@ import { FileEntry } from './fileEntry';
 export type EditorViewContextValue = {
 	rootEntries: Array<DirectoryEntry | FileEntry>;
 	reloadRootEntries: () => Promise<APIDirectoryEntry>;
+	entryExists: (path: string) => boolean;
 
 	openedEntry: DirectoryEntry | FileEntry | undefined;
 	setOpenedEntry: (entry: DirectoryEntry | FileEntry | undefined) => void;

--- a/src/features/instance/applications/context/EditorViewProvider.tsx
+++ b/src/features/instance/applications/context/EditorViewProvider.tsx
@@ -38,28 +38,25 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 	const queryClient = useQueryClient();
 	const { open }: { open?: string } = useSearch({ strict: false });
 
-	const reloadRootEntries = useCallback(async () =>
-		queryClient.fetchQuery<APIDirectoryEntry>({
-			queryKey: [instanceParams.entityId, 'get_components'],
-			networkMode: 'online',
-		}), [queryClient, instanceParams]);
-
 	/*
 	 Create our structured view from the relational API data.
 	 */
 	const { data: apiComponents } = useSuspenseQuery(getComponentsQueryOptions(instanceParams));
-	const rootEntries: Array<DirectoryEntry | FileEntry> = useMemo(() => {
-		if (!apiComponents) {
-			return [];
-		}
-		return transformNodes(
-			apiComponents.entries,
+	const mappedData: {
+		rootEntries: Array<DirectoryEntry | FileEntry>,
+		pathsRegistry: Set<string>,
+	} = useMemo(() => {
+		const pathsRegistry = new Set<string>();
+		const rootEntries = transformNodes(
+			apiComponents.entries || [],
 			'entries',
 			(node: APIFileEntry | APIDirectoryEntry, parents: APIDirectoryEntry[]) => {
 				const readMeAPIFile = isDirectory(node) && node.entries.find(e => e.name.toLowerCase() === 'readme.md');
+				const path = [...parents.map(p => p.name), node.name].join('/');
+				pathsRegistry.add(path);
 				return {
 					name: node.name,
-					path: [...parents.map(p => p.name), node.name].join('/'),
+					path,
 					project: (parents[0] || node)?.name,
 					package: (parents[0] || node)?.package,
 					overviewEntry: readMeAPIFile && !isDirectory(readMeAPIFile) && {
@@ -71,9 +68,23 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 				} satisfies DirectoryEntry | FileEntry;
 			},
 		);
+		return {
+			rootEntries,
+			pathsRegistry,
+		};
 	}, [apiComponents]);
 
-	const defaultFolderExpansions = rootEntries.filter(rootEntry => !rootEntry.package && rootEntry.path !== newApplication).map<TreeItemIndex>(rootEntry => rootEntry.name);
+	const reloadRootEntries = useCallback(async () =>
+		queryClient.fetchQuery<APIDirectoryEntry>({
+			queryKey: [instanceParams.entityId, 'get_components'],
+			networkMode: 'online',
+		}), [queryClient, instanceParams]);
+
+	const entryExists = useCallback((path: string) => {
+		return mappedData.pathsRegistry.has(path);
+	}, [mappedData.pathsRegistry]);
+
+	const defaultFolderExpansions = mappedData.rootEntries.filter(rootEntry => !rootEntry.package && rootEntry.path !== newApplication).map<TreeItemIndex>(rootEntry => rootEntry.name);
 	let defaultFocusedItem = defaultFolderExpansions[0];
 	let defaultSelectedItem = defaultFolderExpansions.slice(0, 1);
 	if (!defaultFocusedItem) {
@@ -181,8 +192,9 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 	const value = useMemo<EditorViewContextValue>(() => {
 		return {
 
-			rootEntries,
+			rootEntries: mappedData.rootEntries,
 			reloadRootEntries,
+			entryExists,
 
 			focusedItem,
 			setFocusedItem,
@@ -203,8 +215,9 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 
 		};
 	}, [
-		rootEntries,
+		mappedData.rootEntries,
 		reloadRootEntries,
+		entryExists,
 
 		focusedItem,
 		setFocusedItem,

--- a/src/features/instance/applications/hooks/useRenameFiles.tsx
+++ b/src/features/instance/applications/hooks/useRenameFiles.tsx
@@ -67,6 +67,7 @@ export function useRenameFiles() {
 				...instanceParams,
 				file: oldFile,
 				project: oldProject,
+				encoding: 'base64',
 			});
 			if (canceled) {
 				break;
@@ -77,6 +78,7 @@ export function useRenameFiles() {
 				...instanceParams,
 				file: newFile,
 				project: newProject,
+				encoding: 'base64',
 				payload: fileContents.message,
 			});
 			if (canceled) {
@@ -101,7 +103,7 @@ export function useRenameFiles() {
 				description: 'All done!',
 				duration: 3000,
 				action: {
-					label: 'OK!',
+					label: 'OK',
 					onClick: () => {
 						// ;D
 					},
@@ -113,7 +115,7 @@ export function useRenameFiles() {
 				description: `${currentStep} of ${totalSteps} steps completed.`,
 				duration: 10000,
 				action: {
-					label: 'Gotcha',
+					label: 'OK',
 					onClick: () => {
 						// >_<
 					},
@@ -126,7 +128,7 @@ export function useRenameFiles() {
 		setSelectedItems(selectedItems => {
 			const updatedSelectedItems = selectedItems.slice();
 			for (const change of actualChanges) {
-				const existingIndex = selectedItems.indexOf(change.from);
+				const existingIndex = updatedSelectedItems.indexOf(change.from);
 				if (existingIndex >= 0) {
 					updatedSelectedItems.splice(existingIndex, 1, change.to);
 				} else {

--- a/src/features/instance/applications/index.tsx
+++ b/src/features/instance/applications/index.tsx
@@ -1,14 +1,14 @@
-import { ContentActions } from '@/features/instance/applications/components/ContentActions';
-import { ContentViewer } from '@/features/instance/applications/components/ContentViewer';
-import { AddDirectoryOrFileModal } from '@/features/instance/applications/modals/AddDirectoryOrFileModal';
-import { DeleteDirectoryOrFileModal } from '@/features/instance/applications/modals/DeleteDirectoryOrFileModal';
-import { DownloadApplicationModal } from '@/features/instance/applications/modals/DownloadApplicationModal';
-import { RedeployApplicationModal } from '@/features/instance/applications/modals/RedeployApplicationModal';
-import { RenameFileModal } from '@/features/instance/applications/modals/RenameFileModal';
 import { useSessionToggler } from '@/hooks/useSessionToggler';
 import { cx } from 'class-variance-authority';
 import { ApplicationsSidebar } from './components/ApplicationsSidebar';
+import { ContentActions } from './components/ContentActions';
+import { ContentViewer } from './components/ContentViewer';
 import { EditorViewProvider } from './context/EditorViewProvider';
+import { AddDirectoryOrFileModal } from './modals/AddDirectoryOrFileModal';
+import { DeleteDirectoryOrFileModal } from './modals/DeleteDirectoryOrFileModal';
+import { DownloadApplicationModal } from './modals/DownloadApplicationModal';
+import { RedeployApplicationModal } from './modals/RedeployApplicationModal';
+import { RenameFileModal } from './modals/RenameFileModal';
 
 export function ApplicationsEditor() {
 	const { toggle, toggled } = useSessionToggler('ApplicationsSidebarOpened', true);

--- a/src/features/instance/applications/index.tsx
+++ b/src/features/instance/applications/index.tsx
@@ -24,10 +24,14 @@ export function ApplicationsEditor() {
 				<ApplicationsSidebar />
 			</aside>
 
-			<div className={cx('applications-content overflow-y-auto overflow-x-hidden fixed bottom-0 right-0 left-0' +
-				' md:left-56' +
-				' transition-[left]' +
-				' h-[calc(100vh-theme(spacing.32))]', toggled && 'sm:left-56')}>
+			<div className={cx(
+				'applications-content',
+				'overflow-y-auto overflow-x-hidden',
+				'fixed top-32 right-0 bottom-0 left-0',
+				'transition-[left]',
+				'md:left-56',
+				toggled && 'sm:left-56',
+			)}>
 				<ContentViewer />
 				<ContentActions toggledSidebar={toggled} toggleSidebar={toggle} />
 			</div>

--- a/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
@@ -19,7 +19,8 @@ import { isDirectory } from '@/features/instance/applications/context/isDirector
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useSetComponentFile } from '@/integrations/api/instance/applications/setComponentFile';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
-import { useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
 import { useCallback } from 'react';
@@ -27,8 +28,12 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 export function AddDirectoryOrFileModal() {
-	const type = useWatchedValue('ShowAddDirectoryOrFileModalType', false);
-	const hideModal = useSetWatchedValue('ShowAddDirectoryOrFileModalType', false);
+	const { value: type, trigger } = useWatchedValue('ShowAddDirectoryOrFileModalType', false);
+
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowAddDirectoryOrFileModalType', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
 
 	const { openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems, setExpandedItems } = useEditorView();
 	const instanceParams = useInstanceClientIdParams();
@@ -71,7 +76,7 @@ export function AddDirectoryOrFileModal() {
 			{
 				onSuccess: () => {
 					void reloadRootEntries();
-					hideModal();
+					closeModal();
 					form.reset();
 					const treeId = [openedEntry.project, filePath, data.name].filter(excludeFalsy).join('/');
 					setFocusedItem(treeId);
@@ -82,15 +87,15 @@ export function AddDirectoryOrFileModal() {
 				},
 			},
 		);
-	}, [addFolderFile, form, hideModal, instanceParams, openedEntry, reloadRootEntries, setExpandedItems, setFocusedItem, setSelectedItems, type]);
+	}, [addFolderFile, form, closeModal, instanceParams, openedEntry, reloadRootEntries, setExpandedItems, setFocusedItem, setSelectedItems, type]);
 
 	const onCancelClick = useCallback(() => {
-		hideModal();
+		closeModal();
 		form.reset();
-	}, [hideModal, form]);
+	}, [closeModal, form]);
 
 	return (
-		<Dialog onOpenChange={hideModal} open={!!type}>
+		<Dialog onOpenChange={closeModal} open={!!type}>
 			<DialogContent aria-describedby={undefined} className="text-white">
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(submitForm)}>

--- a/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
@@ -21,10 +21,12 @@ import { useSetComponentFile } from '@/integrations/api/instance/applications/se
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import z from 'zod';
 
 export function AddDirectoryOrFileModal() {
@@ -35,7 +37,14 @@ export function AddDirectoryOrFileModal() {
 		attemptToRestoreFocus(trigger);
 	}, [trigger]);
 
-	const { openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems, setExpandedItems } = useEditorView();
+	const {
+		openedEntry,
+		entryExists,
+		reloadRootEntries,
+		setFocusedItem,
+		setSelectedItems,
+		setExpandedItems,
+	} = useEditorView();
 	const instanceParams = useInstanceClientIdParams();
 	const { mutate: addFolderFile, isPending } = useSetComponentFile();
 	const NewFileFolderSchema = z.object({
@@ -57,7 +66,7 @@ export function AddDirectoryOrFileModal() {
 	});
 
 	const submitForm = useCallback((data: z.infer<typeof NewFileFolderSchema>) => {
-		if (!openedEntry) {
+		if (!openedEntry || !type) {
 			return;
 		}
 		const splitPath = openedEntry.path.split('/');
@@ -66,9 +75,16 @@ export function AddDirectoryOrFileModal() {
 				? splitPath.slice(1)
 				: splitPath.slice(1, -1)
 		).join('/');
+		const file = filePath ? `${filePath}/${data.name}` : data.name;
+		if (entryExists(openedEntry.project + '/' + file)) {
+			toast.error(`${capitalizeWords(type)} already exists!`, {
+				description: file,
+			});
+			return;
+		}
 		addFolderFile(
 			{
-				file: `${filePath}/${data.name}`,
+				file,
 				project: openedEntry.project,
 				payload: type === 'directory' ? undefined : '',
 				...instanceParams,
@@ -87,7 +103,7 @@ export function AddDirectoryOrFileModal() {
 				},
 			},
 		);
-	}, [addFolderFile, form, closeModal, instanceParams, openedEntry, reloadRootEntries, setExpandedItems, setFocusedItem, setSelectedItems, type]);
+	}, [addFolderFile, form, closeModal, instanceParams, openedEntry, entryExists, reloadRootEntries, setExpandedItems, setFocusedItem, setSelectedItems, type]);
 
 	const onCancelClick = useCallback(() => {
 		closeModal();

--- a/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
@@ -3,17 +3,21 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
-import { useDropComponent } from '@/integrations/api/instance/applications/dropComponent';
+import { dropComponent } from '@/integrations/api/instance/applications/dropComponent';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { pluralize } from '@/lib/pluralize';
 import { Trash } from 'lucide-react';
 import { MouseEvent, useCallback } from 'react';
+import { toast } from 'sonner';
 
 export function DeleteDirectoryOrFileModal() {
 	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteDirectoryOrFileModal', false);
 
 	const instanceParams = useInstanceClientIdParams();
-	const { openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems } = useEditorView();
+	const { openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems, selectedItems } = useEditorView();
+
+	const multipleSelected = selectedItems.length > 1;
 	const isDirectorySelected = isDirectory(openedEntry);
 	const isApplicationSelected = isDirectorySelected && openedEntry.path === openedEntry.project;
 	const isPackageSelected = !!openedEntry?.package;
@@ -25,41 +29,70 @@ export function DeleteDirectoryOrFileModal() {
 			: isDirectorySelected
 				? 'Directory'
 				: 'File';
-	const { mutate: deleteFolderFile, isPending, isSuccess } = useDropComponent();
-	const actionStatus = isSuccess ? `${action}d` : isPending ? `${action.slice(0, -1)}ing` : action;
 
 	const closeModal = useCallback(() => {
 		setWatchedValue('ShowDeleteDirectoryOrFileModal', false);
 		attemptToRestoreFocus(trigger);
 	}, [trigger]);
 
-	const handleDeleteFolderOrFile = useCallback(() => {
-		if (!openedEntry) {
-			return;
-		}
-		deleteFolderFile(
-			{
-				file: openedEntry.package
-					? undefined
-					: `${openedEntry.path.split('/').slice(1).join('/')}`,
-				project: openedEntry.project,
+	const handleDeleteFolderOrFile = useCallback(async () => {
+		closeModal();
+
+		let split: string[] = [];
+		let count = 0;
+		let canceled = false;
+
+		const toastCancelAction = {
+			label: 'Cancel',
+			onClick: () => {
+				canceled = true;
+			},
+		};
+		const toastOKAction = {
+			label: 'OK',
+			onClick: () => undefined,
+		};
+
+		const id = 'deleting-files';
+
+		for (const selectedItem of selectedItems.reverse()) {
+			split = (selectedItem as string).split('/');
+			const project = split[0];
+			const file = split.length > 1 ? split.slice(1).join('/') : undefined;
+
+			toast.loading(`${action} in progress...`, {
+				id,
+				description: `${count} of ${pluralize(selectedItems.length, 'item', 'items')}`,
+				action: toastCancelAction,
+			});
+			await dropComponent({
+				file,
+				project,
 				...instanceParams,
-			},
-			{
-				onSuccess: () => {
-					closeModal();
-					const itemToFocus = !openedEntry.package && openedEntry.path.split('/').slice(0, -1).join('/');
-					setFocusedItem(itemToFocus || undefined);
-					setSelectedItems(itemToFocus ? [itemToFocus] : []);
-					void reloadRootEntries();
-				},
-			},
-		);
-	}, [deleteFolderFile, instanceParams, openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems, closeModal]);
+			});
+			if (canceled) {
+				break;
+			}
+			count += 1;
+		}
+
+		if (canceled) {
+			toast.warning(`${action} canceled!`, { id, description: '', action: toastOKAction });
+		} else {
+			toast.success(`${action} completed!`, { id, description: '', action: toastOKAction });
+		}
+
+		if (split.length) {
+			const itemToFocus = split.slice(0, -1).join('/');
+			setFocusedItem(itemToFocus || undefined);
+			setSelectedItems(itemToFocus ? [itemToFocus] : []);
+			void reloadRootEntries();
+		}
+	}, [action, closeModal, instanceParams, reloadRootEntries, selectedItems, setFocusedItem, setSelectedItems]);
 
 	const onClickYes = useCallback((e: MouseEvent) => {
 		e.preventDefault();
-		handleDeleteFolderOrFile();
+		void handleDeleteFolderOrFile();
 	}, [handleDeleteFolderOrFile]);
 
 	return (
@@ -68,11 +101,11 @@ export function DeleteDirectoryOrFileModal() {
 				<DialogHeader>
 					<DialogTitle>{action} {thing}</DialogTitle>
 					<DialogDescription>
-						Are you sure you want to {action.toLowerCase()} this {thing.toLowerCase()}?
+						Are you sure you want
+						to {action.toLowerCase()} {multipleSelected ? `these ${selectedItems.length} items` : `this ${thing.toLowerCase()}`}?
 					</DialogDescription>
-					{!isPackageSelected && <DialogDescription>
-						{openedEntry?.path}
-					</DialogDescription>}
+					{!isPackageSelected &&
+						<DialogDescription className="whitespace-pre">{multipleSelected ? selectedItems.join('\n') : openedEntry?.path}</DialogDescription>}
 				</DialogHeader>
 
 				<div className="flex w-full gap-4">
@@ -83,11 +116,10 @@ export function DeleteDirectoryOrFileModal() {
 						variant="destructiveOutline"
 						type="button"
 						className="w-full rounded-full"
-						disabled={isPending}
 						autoFocus={true}
 						onClick={onClickYes}
 					>
-						<Trash /> {actionStatus} {thing}{isPending ? '...' : ''}
+						<Trash /> {action} {multipleSelected ? 'items' : thing}
 					</Button>
 				</div>
 			</DialogContent>

--- a/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
@@ -4,21 +4,34 @@ import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useDropComponent } from '@/integrations/api/instance/applications/dropComponent';
-import { setWatchedValue, useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { Trash } from 'lucide-react';
 import { MouseEvent, useCallback } from 'react';
 
 export function DeleteDirectoryOrFileModal() {
-	const isModalOpen = useWatchedValue('ShowDeleteDirectoryOrFileModal', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteDirectoryOrFileModal', false);
 
 	const instanceParams = useInstanceClientIdParams();
 	const { openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems } = useEditorView();
 	const isDirectorySelected = isDirectory(openedEntry);
+	const isApplicationSelected = isDirectorySelected && openedEntry.path === openedEntry.project;
 	const isPackageSelected = !!openedEntry?.package;
 	const action = isPackageSelected ? 'Remove' : 'Delete';
-	const thing = isPackageSelected ? 'Imported Application' : isDirectorySelected ? 'Directory' : 'File';
+	const thing = isPackageSelected
+		? 'Imported Application'
+		: isApplicationSelected
+			? 'Application'
+			: isDirectorySelected
+				? 'Directory'
+				: 'File';
 	const { mutate: deleteFolderFile, isPending, isSuccess } = useDropComponent();
 	const actionStatus = isSuccess ? `${action}d` : isPending ? `${action.slice(0, -1)}ing` : action;
+
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowDeleteDirectoryOrFileModal', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
 
 	const handleDeleteFolderOrFile = useCallback(() => {
 		if (!openedEntry) {
@@ -34,7 +47,7 @@ export function DeleteDirectoryOrFileModal() {
 			},
 			{
 				onSuccess: () => {
-					setWatchedValue('ShowDeleteDirectoryOrFileModal', false);
+					closeModal();
 					const itemToFocus = !openedEntry.package && openedEntry.path.split('/').slice(0, -1).join('/');
 					setFocusedItem(itemToFocus || undefined);
 					setSelectedItems(itemToFocus ? [itemToFocus] : []);
@@ -42,14 +55,12 @@ export function DeleteDirectoryOrFileModal() {
 				},
 			},
 		);
-	}, [deleteFolderFile, instanceParams, openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems]);
+	}, [deleteFolderFile, instanceParams, openedEntry, reloadRootEntries, setFocusedItem, setSelectedItems, closeModal]);
 
 	const onClickYes = useCallback((e: MouseEvent) => {
 		e.preventDefault();
 		handleDeleteFolderOrFile();
 	}, [handleDeleteFolderOrFile]);
-
-	const closeModal = useSetWatchedValue('ShowDeleteDirectoryOrFileModal', false);
 
 	return (
 		<Dialog onOpenChange={closeModal} open={isModalOpen}>

--- a/src/features/instance/applications/modals/DownloadApplicationModal.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.tsx
@@ -5,13 +5,14 @@ import { Label } from '@/components/ui/label';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { usePackageComponentMutation } from '@/integrations/api/instance/applications/packageComponent';
-import { setWatchedValue, useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { DownloadIcon } from 'lucide-react';
 import { ChangeEvent, MouseEvent, useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
 export function DownloadApplicationModal() {
-	const isModalOpen = useWatchedValue('ShowDownloadApplicationModal', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowDownloadApplicationModal', false);
 
 	const instanceParams = useInstanceClientIdParams();
 	const { openedEntry } = useEditorView();
@@ -24,13 +25,16 @@ export function DownloadApplicationModal() {
 		setIncludeNodeModules(e.target.checked);
 	}, []);
 
-	const closeModal = useSetWatchedValue('ShowDownloadApplicationModal', false);
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowDownloadApplicationModal', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
 	const onClickYes = useCallback((e: MouseEvent) => {
 		e.preventDefault();
 		if (!openedEntry) {
 			return;
 		}
-		setWatchedValue('ShowDownloadApplicationModal', false);
+		closeModal();
 		const toastId = toast.loading('Packaging...');
 		packageComponent(
 			{
@@ -55,7 +59,7 @@ export function DownloadApplicationModal() {
 				},
 			},
 		);
-	}, [openedEntry, packageComponent, includeNodeModules, instanceParams]);
+	}, [openedEntry, packageComponent, includeNodeModules, instanceParams, closeModal]);
 
 
 	return (

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useDeployComponentMutation } from '@/integrations/api/instance/applications/deployComponent';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { RefreshCwIcon } from 'lucide-react';
@@ -18,7 +19,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
 export function RedeployApplicationModal() {
-	const isModalOpen = useWatchedValue('ShowRedeployApplicationModal', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowRedeployApplicationModal', false);
 
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();
@@ -41,11 +42,17 @@ export function RedeployApplicationModal() {
 		reset({ applicationUrl: packageUrl });
 	}, [reset, packageUrl]);
 
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowRedeployApplicationModal', false);
+		attemptToRestoreFocus(trigger);
+		reset({ applicationUrl: packageUrl });
+	}, [reset, packageUrl, trigger]);
+
 	const redeployPackage = useCallback((applicationUrl: string, installCommand: string | undefined) => {
 		if (!openedEntry) {
 			return;
 		}
-		setWatchedValue('ShowRedeployApplicationModal', false);
+		closeModal();
 
 		const toastId = toast.loading('Redeploying...');
 		reDeployApplication({
@@ -70,7 +77,7 @@ export function RedeployApplicationModal() {
 				toast.dismiss(toastId);
 			},
 		});
-	}, [reDeployApplication, openedEntry, instanceParams, queryClient]);
+	}, [reDeployApplication, openedEntry, instanceParams, queryClient, closeModal]);
 
 	const submitForm = ({ applicationUrl, installCommand }: {
 		applicationUrl: string | undefined,
@@ -81,14 +88,9 @@ export function RedeployApplicationModal() {
 		}
 	};
 
-	const modalClosed = useCallback(() => {
-		setWatchedValue('ShowRedeployApplicationModal', false);
-		reset({ applicationUrl: packageUrl });
-	}, [reset, packageUrl]);
-
 	return (
 		<Dialog
-			onOpenChange={modalClosed}
+			onOpenChange={closeModal}
 			open={isModalOpen}
 		>
 			<DialogContent aria-describedby={undefined} className="text-white">
@@ -146,7 +148,7 @@ export function RedeployApplicationModal() {
 								type="button"
 								variant="ghostOutline"
 								className="w-full rounded-full"
-								onClick={modalClosed}
+								onClick={closeModal}
 								disabled={isPending}
 							>
 								Cancel

--- a/src/features/instance/applications/modals/RenameFileModal.tsx
+++ b/src/features/instance/applications/modals/RenameFileModal.tsx
@@ -16,7 +16,8 @@ import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useRenameFiles } from '@/features/instance/applications/hooks/useRenameFiles';
-import { useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { renameFileInPath } from '@/lib/string/paths/renameFileInPath';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PencilIcon } from 'lucide-react';
@@ -25,8 +26,12 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 export function RenameFileModal() {
-	const isModalOpen = useWatchedValue('ShowRenameFileModal', false);
-	const hideModal = useSetWatchedValue('ShowRenameFileModal', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowRenameFileModal', false);
+
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowRenameFileModal', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
 
 	const { openedEntry } = useEditorView();
 	const RenameFileSchema = z.object({
@@ -68,18 +73,18 @@ export function RenameFileModal() {
 				to: renameFileInPath(openedEntry.path, data.name),
 			},
 		]);
-		hideModal();
+		closeModal();
 		form.reset();
 		setIsPending(false);
-	}, [form, hideModal, openedEntry, renameFiles, setIsPending]);
+	}, [form, closeModal, openedEntry, renameFiles, setIsPending]);
 
 	const onCancelClick = useCallback(() => {
-		hideModal();
+		closeModal();
 		form.reset();
-	}, [hideModal, form]);
+	}, [closeModal, form]);
 
 	return (
-		<Dialog onOpenChange={hideModal} open={isModalOpen}>
+		<Dialog onOpenChange={closeModal} open={isModalOpen}>
 			<DialogContent aria-describedby={undefined} className="text-white">
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(submitForm)}>

--- a/src/features/instance/applications/modals/RenameFileModal.tsx
+++ b/src/features/instance/applications/modals/RenameFileModal.tsx
@@ -14,6 +14,7 @@ import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useRenameFiles } from '@/features/instance/applications/hooks/useRenameFiles';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
@@ -23,6 +24,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { PencilIcon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import z from 'zod';
 
 export function RenameFileModal() {
@@ -33,7 +35,7 @@ export function RenameFileModal() {
 		attemptToRestoreFocus(trigger);
 	}, [trigger]);
 
-	const { openedEntry } = useEditorView();
+	const { openedEntry, entryExists } = useEditorView();
 	const RenameFileSchema = z.object({
 		name: z
 			.string()
@@ -45,7 +47,6 @@ export function RenameFileModal() {
 			.trim()
 			.refine((name) => name !== openedEntry?.name, {
 				error: 'Please enter a new name.',
-				path: ['name'],
 			}),
 	});
 	const [isPending, setIsPending] = useState(false);
@@ -65,18 +66,20 @@ export function RenameFileModal() {
 		if (!openedEntry) {
 			return;
 		}
+		const to = renameFileInPath(openedEntry.path, data.name);
+		if (entryExists(to)) {
+			toast.error(`${isDirectory(openedEntry) ? 'Directory' : 'File'} already exists!`, {
+				description: to,
+			});
+			return;
+		}
 
 		setIsPending(true);
-		await renameFiles([
-			{
-				from: openedEntry.path,
-				to: renameFileInPath(openedEntry.path, data.name),
-			},
-		]);
+		await renameFiles([{ from: openedEntry.path, to }]);
 		closeModal();
 		form.reset();
 		setIsPending(false);
-	}, [form, closeModal, openedEntry, renameFiles, setIsPending]);
+	}, [closeModal, entryExists, form, openedEntry, renameFiles, setIsPending]);
 
 	const onCancelClick = useCallback(() => {
 		closeModal();

--- a/src/features/instance/applications/shortcuts/contract.ts
+++ b/src/features/instance/applications/shortcuts/contract.ts
@@ -1,0 +1,17 @@
+import { OnMount } from '@monaco-editor/react';
+
+export interface Contract {
+	handleGlobal?(
+		key: string,
+		modifierState: {
+			cmd: boolean;
+			alt: boolean;
+			shift: boolean;
+			ctrl: boolean;
+		},
+	): true | undefined;
+
+	addEditorAction?(
+		monaco: Parameters<OnMount>[1],
+	): Parameters<Parameters<OnMount>[0]['addAction']>[0];
+}

--- a/src/features/instance/applications/shortcuts/deleteShortcut.ts
+++ b/src/features/instance/applications/shortcuts/deleteShortcut.ts
@@ -1,0 +1,19 @@
+import { currySetWatchedValue, setWatchedValue } from '@/lib/events/watcher';
+import { Contract } from './contract';
+
+export const deleteShortcut = {
+	handleGlobal(key) {
+		if (key === 'Backspace') {
+			setWatchedValue('ShowDeleteDirectoryOrFileModal', true);
+			return true;
+		}
+	},
+	addEditorAction(monaco) {
+		return {
+			id: 'delete-file',
+			label: 'Delete File',
+			keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Delete],
+			run: currySetWatchedValue('ShowDeleteDirectoryOrFileModal', true),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/applications/shortcuts/deleteShortcut.ts
+++ b/src/features/instance/applications/shortcuts/deleteShortcut.ts
@@ -2,8 +2,8 @@ import { currySetWatchedValue, setWatchedValue } from '@/lib/events/watcher';
 import { Contract } from './contract';
 
 export const deleteShortcut = {
-	handleGlobal(key) {
-		if (key === 'Backspace') {
+	handleGlobal(key, modifiers) {
+		if ((modifiers.cmd || modifiers.ctrl) && key === 'Delete') {
 			setWatchedValue('ShowDeleteDirectoryOrFileModal', true);
 			return true;
 		}

--- a/src/features/instance/applications/shortcuts/index.ts
+++ b/src/features/instance/applications/shortcuts/index.ts
@@ -55,5 +55,5 @@ function keyDownHandler(e: KeyboardEvent) {
 			return;
 		}
 	}
-	console.log('unhandled key press', e.key, modifiers);
+	// console.log('unhandled key press', e.key, modifiers);
 }

--- a/src/features/instance/applications/shortcuts/index.ts
+++ b/src/features/instance/applications/shortcuts/index.ts
@@ -1,0 +1,59 @@
+import { excludePropertyFalsy } from '@/lib/arrays/excludePropertyFalsy';
+import { OnMount } from '@monaco-editor/react';
+import { useEffect } from 'react';
+import { Contract } from './contract';
+import { deleteShortcut } from './deleteShortcut';
+import { newDirectoryShortcut } from './newDirectoryShortcut';
+import { newFileShortcut } from './newFileShortcut';
+import { renameFileShortcut } from './renameFileShortcut';
+import { revertFileShortcut } from './revertFileShortcut';
+import { saveChangesShortcut } from './saveChangesShortcut';
+
+const shortcuts: Contract[] = [
+	deleteShortcut,
+	newDirectoryShortcut,
+	newFileShortcut,
+	renameFileShortcut,
+	revertFileShortcut,
+	saveChangesShortcut,
+];
+
+const editorShortcuts = shortcuts.filter(excludePropertyFalsy('addEditorAction'));
+const globalShortcuts = shortcuts.filter(excludePropertyFalsy('handleGlobal'));
+
+export function registerWithEditor(mounted: Parameters<OnMount>) {
+	const [editor, monaco] = mounted;
+	const disposables = editorShortcuts
+		.map(shortcut => editor.addAction(shortcut.addEditorAction(monaco)));
+	return () => {
+		for (const disposable of disposables) {
+			disposable?.dispose();
+		}
+	};
+}
+
+export function useGlobalShortcutKeys() {
+	useEffect(() => {
+		document.addEventListener('keydown', keyDownHandler);
+
+		return () => {
+			document.removeEventListener('keydown', keyDownHandler);
+		};
+	}, []);
+}
+
+function keyDownHandler(e: KeyboardEvent) {
+	const cmd = e.getModifierState('Meta');
+	const alt = e.getModifierState('Alt');
+	const shift = e.getModifierState('Shift');
+	const ctrl = e.getModifierState('Control');
+	const modifiers = { cmd, alt, shift, ctrl };
+
+	for (const globalShortcut of globalShortcuts) {
+		if (globalShortcut.handleGlobal(e.key, modifiers)) {
+			e.preventDefault();
+			return;
+		}
+	}
+	console.log('unhandled key press', e.key, modifiers);
+}

--- a/src/features/instance/applications/shortcuts/newDirectoryShortcut.ts
+++ b/src/features/instance/applications/shortcuts/newDirectoryShortcut.ts
@@ -1,0 +1,19 @@
+import { currySetWatchedValue, setWatchedValue } from '@/lib/events/watcher';
+import { Contract } from './contract';
+
+export const newDirectoryShortcut = {
+	handleGlobal(key, modifiers) {
+		if (modifiers.ctrl && modifiers.alt && modifiers.shift && key === '˜' /*n*/) {
+			setWatchedValue('ShowAddDirectoryOrFileModalType', 'directory');
+			return true;
+		}
+	},
+	addEditorAction(monaco) {
+		return {
+			id: 'new-directory',
+			label: 'New Directory',
+			keybindings: [monaco.KeyMod.WinCtrl | monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyN],
+			run: currySetWatchedValue('ShowAddDirectoryOrFileModalType', 'directory'),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/applications/shortcuts/newFileShortcut.ts
+++ b/src/features/instance/applications/shortcuts/newFileShortcut.ts
@@ -1,0 +1,19 @@
+import { currySetWatchedValue, setWatchedValue } from '@/lib/events/watcher';
+import { Contract } from './contract';
+
+export const newFileShortcut = {
+	handleGlobal(key, modifiers) {
+		if (modifiers.ctrl && key === 'n') {
+			setWatchedValue('ShowAddDirectoryOrFileModalType', 'file');
+			return true;
+		}
+	},
+	addEditorAction(monaco) {
+		return {
+			id: 'new-file',
+			label: 'New File',
+			keybindings: [monaco.KeyMod.WinCtrl | monaco.KeyCode.KeyN],
+			run: currySetWatchedValue('ShowAddDirectoryOrFileModalType', 'file'),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/applications/shortcuts/renameFileShortcut.ts
+++ b/src/features/instance/applications/shortcuts/renameFileShortcut.ts
@@ -1,0 +1,22 @@
+import { currySetWatchedValue, setWatchedValue } from '@/lib/events/watcher';
+import { Contract } from './contract';
+
+export const renameFileShortcut = {
+	handleGlobal(key) {
+		if (key === 'F2') {
+			setWatchedValue('ShowRenameFileModal', 'file');
+			return true;
+		}
+	},
+	addEditorAction(monaco) {
+		return {
+			id: 'rename-file',
+			label: 'Rename File',
+			keybindings: [
+				monaco.KeyMod.WinCtrl | monaco.KeyMod.Alt | monaco.KeyCode.KeyR,
+				monaco.KeyCode.F2,
+			],
+			run: currySetWatchedValue('ShowRenameFileModal', true),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/applications/shortcuts/revertFileShortcut.ts
+++ b/src/features/instance/applications/shortcuts/revertFileShortcut.ts
@@ -1,0 +1,12 @@
+import { curryEmitToListeners } from '@/lib/events/listener';
+import { Contract } from './contract';
+
+export const revertFileShortcut = {
+	addEditorAction() {
+		return {
+			id: 'revert-file',
+			label: 'Revert File',
+			run: curryEmitToListeners('RevertChanges', true),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/applications/shortcuts/saveChangesShortcut.ts
+++ b/src/features/instance/applications/shortcuts/saveChangesShortcut.ts
@@ -1,0 +1,19 @@
+import { curryEmitToListeners, emitToListeners } from '@/lib/events/listener';
+import { Contract } from './contract';
+
+export const saveChangesShortcut = {
+	handleGlobal(key, modifiers) {
+		if (modifiers.cmd && key === 's') {
+			emitToListeners('SaveFile', true);
+			return true;
+		}
+	},
+	addEditorAction(monaco) {
+		return {
+			id: 'save-file',
+			label: 'Save Changes',
+			keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
+			run: curryEmitToListeners('SaveFile', true),
+		};
+	},
+} satisfies Contract;

--- a/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
+++ b/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
@@ -2,7 +2,8 @@ import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { useDeleteDatabaseMutation } from '@/integrations/api/instance/database/deleteDatabase';
-import { useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { useCallback } from 'react';
@@ -12,8 +13,12 @@ export function DeleteDatabaseModal({ databaseName, onDeleted }: {
 	readonly databaseName: string;
 	readonly onDeleted: (deleted: 'table' | 'database') => void;
 }) {
-	const isModalOpen = useWatchedValue('ShowDeleteDatabase', false);
-	const closeModal = useSetWatchedValue('ShowDeleteDatabase', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteDatabase', false);
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowDeleteDatabase', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
+
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();

--- a/src/features/instance/databases/modals/DeleteTableModal.tsx
+++ b/src/features/instance/databases/modals/DeleteTableModal.tsx
@@ -2,7 +2,8 @@ import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { useDeleteTableMutation } from '@/integrations/api/instance/database/deleteTable';
-import { useSetWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { useCallback } from 'react';
@@ -13,8 +14,12 @@ export function DeleteTableModal({ databaseName, tableName, onDeleted }: {
 	readonly tableName: string;
 	readonly onDeleted: (deleted: 'table' | 'database') => void;
 }) {
-	const isModalOpen = useWatchedValue('ShowDeleteTable', false);
-	const closeModal = useSetWatchedValue('ShowDeleteTable', false);
+	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteTable', false);
+	const closeModal = useCallback(() => {
+		setWatchedValue('ShowDeleteTable', false);
+		attemptToRestoreFocus(trigger);
+	}, [trigger]);
+
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();

--- a/src/features/organization/billing/index.tsx
+++ b/src/features/organization/billing/index.tsx
@@ -14,7 +14,7 @@ export function OrgBillingIndex() {
 
 	if (!update) {
 		return (
-			<div className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				You don't have access to manage payments for this organization. Please contact your administrator.
 			</div>
 		);
@@ -23,7 +23,7 @@ export function OrgBillingIndex() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<div className="md:grid gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))] mb-12">
 					<section className="col-span-1 text-white md:col-span-4 lg:col-span-3 md:border-r-1 border-b md:border-b-0 md:pr-4 border-gray-700">
 						<DesktopBillingNavBar />

--- a/src/features/organizations/NewOrg.tsx
+++ b/src/features/organizations/NewOrg.tsx
@@ -5,7 +5,7 @@ export function NewOrg() {
 	return (
 		<>
 			<SubNavMenu />
-			<section className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<NewOrgForm />
 			</section>
 		</>

--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -90,18 +90,19 @@ export function OrganizationsIndex() {
 				<div className="flex w-full justify-end gap-2">
 					<Input
 						placeholder="Filter by name"
-						className="inline-block w-48 md:w-64 bg-black border"
+						className="inline-block w-full text-xs"
 						value={filterByNameValue}
 						onChange={onFilterByNameChanged}
 					/>
 					<Link to="/new-org">
-						<Button variant="positive" className="rounded-full w-44" accessKey="n">
-							<PlusIcon /> <span><u>N</u>ew Organization</span>
+						<Button variant="positive" accessKey="n">
+							<PlusIcon />
+							<span className="hidden sm:inline-block"><u>N</u>ew <span className="hidden md:inline-block">Organization</span></span>
 						</Button>
 					</Link>
 				</div>
 			</SubNavMenu>
-			<section className="mt-40 md:mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-12">
 					{organizationRoles.map((organizationRole) => (
 						<div

--- a/src/integrations/api/instance/applications/getComponentFile.ts
+++ b/src/integrations/api/instance/applications/getComponentFile.ts
@@ -1,9 +1,11 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { hasImageFileExtension } from '@/lib/string/hasImageFileExtension';
 import { queryOptions } from '@tanstack/react-query';
 
 interface GetComponentFileRequest extends InstanceClientIdConfig {
 	file: string | undefined;
 	project: string | undefined;
+	encoding?: 'utf8' | 'ASCII' | 'binary' | 'hex' | 'base64' | 'utf16le' | 'latin1' | 'ucs2';
 }
 
 export interface GetComponentFileResponse {
@@ -19,11 +21,13 @@ export async function getComponentFile({
 	instanceClient,
 	file,
 	project,
+	encoding,
 }: GetComponentFileRequest): Promise<GetComponentFileResponse> {
 	const { data } = await instanceClient.post('/', {
 		operation: 'get_component_file',
 		file,
 		project,
+		encoding: encoding ?? (hasImageFileExtension(file) ? 'base64' : 'utf8'),
 	});
 	return {
 		file,
@@ -47,5 +51,6 @@ export function getComponentFileQueryKey(params: GetComponentFileRequest) {
 		"get_component_file",
 		params.file,
 		params.project,
+		params.encoding,
 	] as const;
 }

--- a/src/integrations/api/instance/applications/setComponentFile.ts
+++ b/src/integrations/api/instance/applications/setComponentFile.ts
@@ -5,16 +5,25 @@ export interface SetComponentFileRequest extends InstanceClientConfig, InstanceT
 	file: string;
 	payload?: string;
 	project: string;
+	encoding?: 'utf8' | 'ASCII' | 'binary' | 'hex' | 'base64' | 'utf16le' | 'latin1' | 'ucs2';
 }
 
-export async function setComponentFile({ file, payload, project, entityType, instanceClient }: SetComponentFileRequest) {
+export async function setComponentFile({
+	file,
+	payload,
+	project,
+	entityType,
+	instanceClient,
+	encoding,
+}: SetComponentFileRequest) {
 	const { data } = await instanceClient.post('/', {
 		operation: 'set_component_file',
 		file,
 		payload,
 		project,
+		encoding,
 		replicated: entityType === 'cluster',
-	});
+	}, { timeout: 300_000 });
 	return data;
 }
 

--- a/src/lib/arrays/excludePropertyFalsy.ts
+++ b/src/lib/arrays/excludePropertyFalsy.ts
@@ -1,0 +1,5 @@
+import { itemKeyIsDefined } from '@/lib/types/itemKeyIsDefined';
+
+export function excludePropertyFalsy<T, K extends keyof T>(key: K) {
+	return (item: T) => itemKeyIsDefined(item, key);
+}

--- a/src/lib/attemptToRestoreFocus.ts
+++ b/src/lib/attemptToRestoreFocus.ts
@@ -1,0 +1,27 @@
+import { sleep } from '@/lib/sleep';
+
+interface IFocusable {
+	focus?: () => void;
+}
+
+interface ITargetFocusable {
+	target?: IFocusable;
+}
+
+export function attemptToRestoreFocus(trigger?: unknown) {
+	const focusableTrigger = trigger as IFocusable;
+	if (focusableTrigger?.focus) {
+		focusElement(focusableTrigger);
+	} else {
+		const triggerTargetFocusable = trigger as ITargetFocusable;
+		if (triggerTargetFocusable?.target?.focus) {
+			focusElement(triggerTargetFocusable.target);
+		}
+	}
+}
+
+function focusElement(element: IFocusable) {
+	sleep(1).then(() => {
+		element.focus?.();
+	});
+}

--- a/src/lib/events/listener.ts
+++ b/src/lib/events/listener.ts
@@ -1,19 +1,19 @@
 import { WatchedValueKeys, WatchedValuesTypeMap } from '@/lib/storage/watchedValueKeys';
 import { useCallback, useEffect } from 'react';
 
-const listenersMap: Record<string, Array<(newValue: unknown) => void>> = {};
+const listenersMap: Record<string, Array<(newValue: unknown, trigger?: unknown) => void>> = {};
 
-export function useListener<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, listener: (newValue: T) => void, deps: unknown) {
+export function useListener<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, listener: (newValue: T, trigger?: unknown) => void, deps: unknown) {
 	// eslint-disable-next-line react-hooks/preserve-manual-memoization,react-hooks/exhaustive-deps
-	const callback = useCallback((newValue: T) => listener(newValue), [deps]);
+	const callback = useCallback((newValue: T, trigger?: unknown) => listener(newValue, trigger), [deps]);
 	useEffect(() => {
 		if (!listenersMap[name]) {
 			listenersMap[name] = [];
 		}
-		listenersMap[name].push(callback as (newValue: unknown) => void);
+		listenersMap[name].push(callback as (newValue: unknown, trigger?: unknown) => void);
 
 		return function cleanUp() {
-			const index = listenersMap[name].indexOf(callback as (newValue: unknown) => void);
+			const index = listenersMap[name].indexOf(callback as (newValue: unknown, trigger?: unknown) => void);
 			if (index >= 0) {
 				listenersMap[name].splice(index, 1);
 			}
@@ -21,19 +21,19 @@ export function useListener<K extends keyof WatchedValuesTypeMap, T extends Watc
 	}, [name, listener, callback]);
 }
 
-export function emitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, value: T): void {
-	const listeners = listenersMap[name] as Array<(newValue: T) => void>;
+export function emitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, value: T, trigger?: unknown): void {
+	const listeners = listenersMap[name];
 	if (listeners) {
 		for (const listener of listeners) {
-			listener(value);
+			listener(value, trigger);
 		}
 	}
 }
 
-export function curryEmitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, value: T): () => void {
-	return () => emitToListeners(name, value);
+export function curryEmitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K, value: T, trigger?: unknown): (e?: unknown) => void {
+	return (e?: unknown) => emitToListeners(name, value, trigger ?? e);
 }
 
-export function useEmitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T): () => void {
-	return useCallback(() => emitToListeners(name, value), [name, value]);
+export function useEmitToListeners<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T, trigger?: unknown): () => void {
+	return useCallback((e?: unknown) => emitToListeners(name, value, trigger ?? e), [name, value, trigger]);
 }

--- a/src/lib/events/watcher.ts
+++ b/src/lib/events/watcher.ts
@@ -2,26 +2,31 @@ import { emitToListeners, useListener } from '@/lib/events/listener';
 import { WatchedValueKeys, WatchedValuesTypeMap } from '@/lib/storage/watchedValueKeys';
 import { useCallback, useState } from 'react';
 
-export function useWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: K): T | undefined
-export function useWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K], D extends T>(name: K, defaultValue: D): T
-export function useWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K], D extends T>(name: K, defaultValue?: D): T | undefined {
-	const [value, setValue] = useState<T | undefined>(defaultValue);
+interface ValueWrapper<T> {
+	value: T,
+	trigger?: unknown
+}
+
+export function useWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K], D extends T>(name: K, defaultValue: D): ValueWrapper<T> {
+	const [value, setValue] = useState<{ value: T, trigger?: unknown }>({ value: defaultValue });
 	useListener(
 		name,
-		(newValue: T) => setValue(newValue),
+		(newValue: T, trigger) => setValue({ value: newValue, trigger }),
 		[setValue],
 	);
 	return value;
 }
 
-export function setWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T): void {
-	emitToListeners(name, value);
+export function setWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T, trigger?: unknown): void {
+	emitToListeners(name, value, trigger);
 }
 
-export function currySetWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T): () => void {
-	return () => setWatchedValue(name, value);
+export function currySetWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T, trigger?: unknown): (e?: unknown) => void {
+	return (e) => setWatchedValue(name, value, trigger ?? e);
 }
 
-export function useSetWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T): () => void {
-	return useCallback(() => setWatchedValue(name, value), [name, value]);
+export function useSetWatchedValue<K extends keyof WatchedValuesTypeMap, T extends WatchedValuesTypeMap[K]>(name: WatchedValueKeys, value: T, trigger?: unknown): () => void {
+	return useCallback((e?: unknown) => {
+		setWatchedValue(name, value, trigger ?? e);
+	}, [name, value, trigger]);
 }

--- a/src/lib/storage/readAsDataURL.ts
+++ b/src/lib/storage/readAsDataURL.ts
@@ -1,0 +1,9 @@
+export function readAsDataURL(file: File): Promise<ProgressEvent<FileReader>> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onabort = reject;
+		reader.onerror = reject;
+		reader.onload = resolve;
+		reader.readAsDataURL(file);
+	});
+}

--- a/src/lib/string/hasImageFileExtension.ts
+++ b/src/lib/string/hasImageFileExtension.ts
@@ -1,0 +1,16 @@
+import { parseFileExtension } from '@/lib/string/parseFileExtension';
+
+export function hasImageFileExtension(filename: string | undefined): boolean {
+	const extension = parseFileExtension(filename).toLowerCase();
+	switch (extension) {
+		case 'jpg':
+		case 'jpeg':
+		case 'gif':
+		case 'png':
+		case 'pneg':
+		case 'webp':
+			return true;
+		default:
+			return false;
+	}
+}

--- a/src/lib/types/itemKeyIsDefined.ts
+++ b/src/lib/types/itemKeyIsDefined.ts
@@ -1,0 +1,3 @@
+export function itemKeyIsDefined<T, K extends keyof T>(item: T, key: K): item is T & Required<Pick<T, K>> {
+	return item[key] !== undefined;
+}


### PR DESCRIPTION
I added a few quality of life improvements:
https://harperdb.atlassian.net/browse/STUDIO-545

## Global shortcut keys on the Applications tab:

1. if (modifiers.cmd && key === 's') { Save File }
2. if (modifiers.ctrl && key === 'n') { Show New File Modal }
3. if (modifiers.ctrl && modifiers.alt && modifiers.shift && key === '˜' /*n*/) { Show New Directory Modal }
4. if (key === 'Backspace') { Show Delete File Modal } (uses Ctrl/Cmd + Delete when editor is focused)
5. if (key === 'F2') { Show Rename Modal }

## Mostly Restore Focus on Modal Closing

For stuff like tapping "Add Directory", and then closing the modal, the triggering button will regain focus after the modal closes. We have more complex modal triggers from multiple places, so we can't rely on the built-in functionality from radix.

## Drag and Drop or Click to Upload

You can drag-and-drop files and folders or click the lower left area to upload to your currently selected folder in the Applications bar, or onto particular folders in your sidebar. Dropping anywhere else on the page will upload into the current directory, if one is selected. The lower left will make it clear where you're uploading files, if anywhere.

## Renaming Binary Files

If you rename a binary file (like an image), its contents won't get corrupted anymore.

## File Improvements

We'll preview images instead of showing their binary content in the editor.

## Delete Multiple Files

You can select multiple folders and/or files and delete them all in one go.


