### PR TITLE
Fix Computed Cluster URLs in Docs

### DIFF
--- a/src/config/useEntityRestURL.ts
+++ b/src/config/useEntityRestURL.ts
@@ -1,0 +1,23 @@
+import { useInstanceClient } from '@/config/useInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { getRestUrlForCluster } from '@/lib/urls/getRestUrlForCluster';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+
+export function useEntityRestURL(): string | null {
+	const { clusterId, instanceId }: { clusterId?: string; instanceId?: string } = useParams({ strict: false });
+	const instanceClient = useInstanceClient();
+	const { data: cluster } = useQuery(
+		getClusterInfoQueryOptions(clusterId),
+	);
+
+	const isFabricConnect = (!!clusterId && authStore.checkForFabricConnect(clusterId))
+		|| !!instanceId && authStore.checkForFabricConnect(instanceId);
+	if (isFabricConnect) {
+		return getRestUrlForCluster(cluster);
+	} else if (instanceClient.defaults.baseURL) {
+		return instanceClient.defaults.baseURL.replace(/:9925\/?/, '');
+	}
+	return null;
+}

--- a/src/features/cluster/Scaling.tsx
+++ b/src/features/cluster/Scaling.tsx
@@ -11,7 +11,7 @@ import { getClusterInfoQueryOptions } from './queries/getClusterInfoQuery';
 export function Scaling() {
 	const { clusterId }: { organizationId: string; clusterId: string } = useParams({ strict: false });
 	const { data: cluster, isLoading: clusterIsLoading } = useQuery(
-		getClusterInfoQueryOptions(clusterId, 2000),
+		getClusterInfoQueryOptions(clusterId, 2_000),
 	);
 	const status = cluster?.status;
 	const clusterIsActive = useMemo(() => {

--- a/src/features/cluster/StartingUp.tsx
+++ b/src/features/cluster/StartingUp.tsx
@@ -18,7 +18,7 @@ export function StartingUp() {
 	const router = useRouter();
 	const { clusterId }: { organizationId: string; clusterId: string } = useParams({ strict: false });
 	const { data: cluster, isLoading: clusterIsLoading } = useQuery(
-		getClusterInfoQueryOptions(clusterId, 2000),
+		getClusterInfoQueryOptions(clusterId, 2_000),
 	);
 
 	const status = cluster?.status;

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -12,10 +12,11 @@ export function getClusterInfoQueryOptions(clusterId?: string | false, refetch?:
 		queryKey: [clusterId],
 		queryFn: () => getClusterInfo(clusterId as string),
 		retry: false,
+		staleTime: 1_900,
 		enabled: !!clusterId,
 		refetchInterval: refetch
 			? refetch === true
-				? 10000
+				? 10_000
 				: refetch
 			: undefined,
 	});

--- a/src/features/clusters/components/ClusterProgress.tsx
+++ b/src/features/clusters/components/ClusterProgress.tsx
@@ -19,7 +19,7 @@ export function ClusterProgress({ cluster, forceProgressBarVisible }: {
 	const [showProgress, setShowProgress] = useState(forceProgressBarVisible || false);
 
 	const { data: clusterById } = useQuery(
-		getClusterInfoQueryOptions(showProgress && cluster.id, 2000),
+		getClusterInfoQueryOptions(showProgress && cluster.id, 2_000),
 	);
 
 	useEffect(function showProgressIfPendingOrUpdating() {

--- a/src/features/instance/apis/APIDocs.tsx
+++ b/src/features/instance/apis/APIDocs.tsx
@@ -1,6 +1,7 @@
 import { ErrorComponent } from '@/components/ErrorComponent';
 import { Loading } from '@/components/Loading';
 import { Button } from '@/components/ui/button';
+import { useEntityRestURL } from '@/config/useEntityRestURL';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { plugins } from '@/features/instance/apis/plugins';
 import { requestSnippets } from '@/features/instance/apis/requestSnippets';
@@ -27,11 +28,15 @@ export function APIDocs() {
 	const { data: registrationInfo, isLoading: isLoadingRegistration } = useQuery(
 		getRegistrationInfoQueryOptions(operationsParams),
 	);
+	const baseURL = useEntityRestURL();
 	const {
 		data: spec,
 		isLoading: isLoadingDocs,
 		error,
 	} = useQuery(getOpenAPIQueryOptions(operationsParams));
+	if (spec?.servers?.length) {
+		spec.servers[0].url = baseURL;
+	}
 	const http = configurationInfo?.http;
 
 	let apiInaccessibleWarning: string = '';

--- a/src/features/instance/applications/context/EditorViewProvider.tsx
+++ b/src/features/instance/applications/context/EditorViewProvider.tsx
@@ -1,3 +1,4 @@
+import { useEntityRestURL } from '@/config/useEntityRestURL';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import {
 	importedApplications,
@@ -35,6 +36,7 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 	const [openedEntryContents, setOpenedEntryContents] = useState<string | undefined>(undefined);
 	const { setContent: setUpdatedEntryContents } = useEditorFileContent(openedEntry?.path);
 	const instanceParams = useInstanceClientIdParams();
+	const baseURL = useEntityRestURL();
 	const queryClient = useQueryClient();
 	const { open }: { open?: string } = useSearch({ strict: false });
 
@@ -157,7 +159,6 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 		if (
 			loadedPath === pathToLoad && contents !== undefined
 		) {
-			const baseURL = instanceParams.instanceClient.defaults.baseURL;
 			if (loadedOverviewEntry && baseURL && getComponentFileQueryData) {
 				contents = parseReadMe(contents, baseURL, getComponentFileQueryData);
 			}

--- a/src/lib/urls/getRestUrlForCluster.ts
+++ b/src/lib/urls/getRestUrlForCluster.ts
@@ -1,0 +1,12 @@
+import { Cluster } from '@/integrations/api/api.patch';
+
+export function getRestUrlForCluster(cluster: undefined | Pick<Cluster, 'fqdn'>): string | null {
+	let fqdn = cluster?.fqdn;
+	if (!fqdn) {
+		return null;
+	}
+	if (!fqdn.match(/^https?:\/\//i)) {
+		fqdn = `https://${fqdn}`;
+	}
+	return new URL(fqdn).toString();
+}


### PR DESCRIPTION
When viewing the parsed README and the API Docs, the URL was wrong under certain auth scenarios (namely, when using Fabric Connect).

<img width="1334" height="401" alt="Screenshot 2025-12-12 at 10 35 02 AM" src="https://github.com/user-attachments/assets/e29f1eac-ffa0-4fd0-94c4-4ed61b298772" />
<img width="1349" height="665" alt="Screenshot 2025-12-12 at 10 35 12 AM" src="https://github.com/user-attachments/assets/89def85a-cec7-461c-a1be-d06a2861ff55" />


https://harperdb.atlassian.net/browse/STUDIO-624