### PR TITLE
fix: Return a basic auth client if we flag for basic auth

### DIFF
--- a/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
+++ b/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
@@ -44,17 +44,19 @@ export async function onInstanceLoginSubmit({
 	}
 
 	try {
+		const auth = {
+			username,
+			password,
+		};
 		const user = await getInstanceUserInfo({
 			instanceClient,
-			auth: {
-				username,
-				password,
-			},
+			auth,
 		});
-		authStore.flagForBasicAuth(entityId, { username, password });
+		authStore.flagForBasicAuth(entityId, auth);
 		return {
 			message,
 			user,
+			instanceClient: getInstanceClient({ id: entityId }),
 		};
 	} catch (err) {
 		if (isLocalStudio) {
@@ -74,7 +76,7 @@ export async function onInstanceLoginSubmit({
 	return {
 		message,
 		user,
-		instanceClient,
+		instanceClient: fabricInstanceClient,
 	};
 }
 

--- a/src/integrations/api/instance/auth/useInstanceResetPasswordMutation.ts
+++ b/src/integrations/api/instance/auth/useInstanceResetPasswordMutation.ts
@@ -40,7 +40,7 @@ async function onInstanceResetPassword({
 		if (loginResponse.instanceClient) {
 			instanceClient = loginResponse.instanceClient;
 		}
-		// then we can either alter...
+		// if the usernames match, we need to alter the user...
 		if (desiredUsername === defaultClusterUsername) {
 			await onAlterUser({
 				username: desiredUsername,


### PR DESCRIPTION
When we were resetting the user's initial password, we were detecting we could use basic auth. But we weren't returning an updated instance client, so the old client (with cookie auth) was being used for the next request. That would error on Safari, of course. Now we'll properly utilize the basic auth for subsequent requests.

Unfortunately, we won't see the fruit of this until we get cross-origin requests, which only happens in Safari and Production.

https://harperdb.atlassian.net/browse/STUDIO-647