### PR TITLE
fix: Show and properly apply licenses

### DIFF
--- a/src/components/ApplyLicensesButton.tsx
+++ b/src/components/ApplyLicensesButton.tsx
@@ -30,7 +30,7 @@ export function ApplyLicensesButton({
 				</Button>
 			</TooltipTrigger>
 			<TooltipContent>
-				{countNewLicensesAre} available for this instance. After applying, you will want to restart the instance.
+				{countNewLicensesAre} available for this instance.
 			</TooltipContent>
 		</Tooltip>
 	);

--- a/src/features/cluster/queries/getInstanceInfoQuery.ts
+++ b/src/features/cluster/queries/getInstanceInfoQuery.ts
@@ -29,6 +29,7 @@ export function getInstanceInfoQueryOptions(params: GetInstanceInfoParams) {
 	return queryOptions({
 		queryKey: [params.clusterId, params.instanceId] as const,
 		queryFn: () => getInstanceInfo(params),
+		enabled: !!params.clusterId && !!params.instanceId,
 		retry: false,
 	});
 }

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -8,7 +8,6 @@ import { ApplicationURL } from '@/features/instance/config/overview/components/A
 import { HarperVersion } from '@/features/instance/config/overview/components/HarperVersion';
 import { InstanceNodeName } from '@/features/instance/config/overview/components/InstanceNodeName';
 import { InstanceURL } from '@/features/instance/config/overview/components/InstanceURL';
-import { Instance } from '@/integrations/api/api.patch';
 import { getConfigurationQueryOptions } from '@/integrations/api/instance/status/getConfiguration';
 import {
 	getRegistrationInfoQueryOptions,
@@ -19,7 +18,7 @@ import { keyBy } from '@/lib/keyBy';
 import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import Editor from '@monaco-editor/react';
 import { useQuery } from '@tanstack/react-query';
-import { useLoaderData, useParams, useRouteContext } from '@tanstack/react-router';
+import { useLoaderData, useParams } from '@tanstack/react-router';
 import { ReactNode, useMemo } from 'react';
 
 const LocalStudioOverview = ({ children }: { children: ReactNode }) => {
@@ -31,8 +30,10 @@ const CloudStudioOverview = ({ children }: { children: ReactNode }) => {
 };
 
 export function ConfigOverviewIndex() {
-	const { clusterId, instanceId }: { instanceId?: string; clusterId: string } = useParams({ strict: false });
-	const { instance: cloudInstance }: { instance?: Instance } = useRouteContext({ strict: false });
+	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
+	const { data: cloudInstance } = useQuery(
+		getInstanceInfoQueryOptions({ clusterId, instanceId }),
+	);
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
 	const instanceParams = useInstanceClientIdParams();
 
@@ -55,13 +56,13 @@ export function ConfigOverviewIndex() {
 	);
 
 	const newLicenses = useMemo(() => {
-		if (clusterId && !instanceId) {
-			// We won't check the licenses when running through a load balancer.
+		if (isLocalStudio) {
 			return [];
 		}
-		if (appliedLicenses && cloudInstance?.licenses) {
+		const cloudLicenses = cloudInstance?.instance?.licenses;
+		if (appliedLicenses && cloudLicenses) {
 			const appliedLicensesById = keyBy(appliedLicenses, 'id');
-			return cloudInstance.licenses.filter(cloudLicense => !appliedLicensesById[cloudLicense.id]);
+			return cloudLicenses.filter(cloudLicense => !appliedLicensesById[cloudLicense.id]);
 		}
 		return [];
 	}, [clusterId, instanceId, appliedLicenses, cloudInstance]);

--- a/src/hooks/useApplyLicensesClick.tsx
+++ b/src/hooks/useApplyLicensesClick.tsx
@@ -1,13 +1,11 @@
 import { ProgressBar } from '@/components/ProgressBar';
-import { useInstanceClient } from '@/config/useInstanceClient';
-import { useRestartInstanceClick } from '@/hooks/useRestartInstanceClick';
+import { useInstanceClient, useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { SchemaLicense } from '@/integrations/api/api.gen';
 import { installUsageLicense } from '@/integrations/api/instance/auth/installUsageLicense';
 import { getInstanceUserInfo } from '@/integrations/api/instance/status/getInstanceUserInfo';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { sleep } from '@/lib/sleep';
 import { useQueryClient } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -21,13 +19,9 @@ interface ApplyLicensesClickResponse {
 }
 
 export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): ApplyLicensesClickResponse {
+	const instanceParams = useInstanceClientIdParams();
 	const instanceClient = useInstanceClient();
-	const { instanceId }: { instanceId?: string } = useParams({ strict: false });
 	const queryClient = useQueryClient();
-	const { isRestartPending, onRestartClick } = useRestartInstanceClick({
-		operation: 'restart_service',
-		instanceClient,
-	});
 
 	const [isApplyLicensesPending, setIsApplyLicensesPending] = useState(false);
 
@@ -100,9 +94,11 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 			}
 		}
 
+		await queryClient.invalidateQueries({
+			queryKey: [instanceParams.entityId, 'get_usage_licenses'],
+			refetchType: 'active',
+		});
 		setIsApplyLicensesPending(false);
-
-		void queryClient.invalidateQueries({ queryKey: [instanceId, 'get_configuration'], refetchType: 'active' });
 
 		const licenseWord = licenses.length === 1 ? 'License' : 'Licenses';
 		if (canceled) {
@@ -118,13 +114,12 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 		} else if (licenses.length === licensesApplied) {
 			toast.success('Success', {
 				id: toastId,
-				description: `${licenseWord} applied!\nPlease restart your instance.`,
+				description: `${licenseWord} applied!`,
 				duration: 0,
 				action: {
-					label: 'Restart',
+					label: 'OK',
 					onClick: () => {
 						toast.dismiss(toastId);
-						onRestartClick();
 					},
 				},
 			});
@@ -143,10 +138,10 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 				},
 			});
 		}
-	}, [instanceClient, instanceId, licenses, onRestartClick, queryClient]);
+	}, [instanceClient, instanceParams.entityId, licenses, queryClient]);
 
 	return {
 		onApplyLicensesClick,
-		isApplyLicensesPending: isApplyLicensesPending || isRestartPending,
+		isApplyLicensesPending,
 	};
 }


### PR DESCRIPTION
We weren't loading up the context data properly, causing the button to not show up. I fixed that, and I tweaked it so that we'll show it for clusters too. We won't request a restart after applying, either, since I fixed the query invalidation to bust the right cache to show the new license.

https://harperdb.atlassian.net/browse/STUDIO-650