### PR TITLE
fix: Tweak domain binding for usability

### DIFF
--- a/src/features/cluster/domains/AssociateDomainWithCluster.tsx
+++ b/src/features/cluster/domains/AssociateDomainWithCluster.tsx
@@ -1,22 +1,15 @@
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
-import { useCheckboxCallback } from '@/hooks/useCheckboxCallback';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { Cluster, SchemaOrganizationDomain } from '@/integrations/api/api.patch';
 import { extractDomainFromTLD } from '@/lib/string/extractDomainFromTLD';
-import { CopyIcon, Save } from 'lucide-react';
-import { useCallback } from 'react';
+import { CopyIcon } from 'lucide-react';
 
-export function AssociateDomainWithCluster({ cluster: { fqdn }, disabled, domain: { domain, id }, bindDomain }: {
+export function AssociateDomainWithCluster({ cluster: { fqdn }, domain: { domain, id } }: {
 	cluster: Cluster;
 	domain: SchemaOrganizationDomain;
-	bindDomain: (generateDomainCerts: boolean) => void;
-	disabled: any;
 }) {
-	const [generateDomainCerts, onGenerateDomainCerts] = useCheckboxCallback(true);
 	const recordName = extractDomainFromTLD(domain);
-	const [onCopyName, onCopyTarget] = useCopyToClipboard(recordName, fqdn || '');
-	const onClick = useCallback(() => bindDomain(generateDomainCerts), [bindDomain, generateDomainCerts]);
+	const [onCopyName, onCopyTarget, onCopyId] = useCopyToClipboard(recordName, fqdn || '', id);
 
 	return (
 		<div className="grid gap-4 grid-cols-1 md:grid-cols-[80px_1fr] pb-6">
@@ -28,74 +21,62 @@ export function AssociateDomainWithCluster({ cluster: { fqdn }, disabled, domain
 			<div className="col-span-1">CNAME</div>
 
 			<div className="col-span-1">Name:</div>
-			<div className="col-span-1 flex gap-2">
-				<input
-					className="py-1 px-3 bg-gray-700 rounded-md w-full"
-					type="text"
-					readOnly={true}
-					name="recordName"
-					value={recordName}
-					onClick={onCopyName}
-				/>
-				<Button type="button" size="sm" onClick={onCopyName}>
-					<CopyIcon className="w-4 h-4" />
-				</Button>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="recordName"
+						value={recordName}
+						onClick={onCopyName}
+					/>
+					<Button type="button" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyName}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
 			</div>
 
 			<div className="col-span-1">TTL:</div>
 			<div className="col-span-1">Auto</div>
 
 			<div className="col-span-1">Target:</div>
-			<div className="col-span-1 flex gap-2">
-				<input
-					className="py-1 px-3 bg-gray-700 rounded-md w-full"
-					type="text"
-					readOnly={true}
-					name="recordTarget"
-					value={fqdn}
-					onClick={onCopyTarget}
-				/>
-				<Button type="button" size="sm" onClick={onCopyTarget}>
-					<CopyIcon className="w-4 h-4" />
-				</Button>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="recordTarget"
+						value={fqdn}
+						onClick={onCopyTarget}
+					/>
+					<Button type="button" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyTarget}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
 			</div>
 
-			<div className="text-muted-foreground md:col-span-2 text-wrap">
-				Once you've completed the above steps, you are ready to bind the domain to this cluster. A domain can only be
-				bound to a single cluster.
+			<div className="col-span-1 text-xs">Domain ID:</div>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-800 rounded-md px-3 py-0.5 text-xs text-muted-foreground italic flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="domainId"
+						value={id}
+						onClick={onCopyId}
+					/>
+					<Button type="button" variant="ghost" className="h-5 w-5 p-0 shrink-0" onClick={onCopyId}>
+						<CopyIcon className="w-3 h-3" />
+					</Button>
+				</div>
 			</div>
 
-			<div className="col-span-1">
-				<label htmlFor="generateDomainCerts">
-					Certs:
-				</label>
-			</div>
-			<div className="col-span-1">
-				<label htmlFor="generateDomainCerts" className="-m-2 p-2">
-					Should we generate SSL certificates with LetsEncrypt?
-					<div className="flex mt-2">
-						<Switch
-							id="generateDomainCerts"
-							checked={generateDomainCerts}
-							className="mr-2"
-							onCheckedChange={onGenerateDomainCerts}
-						/>
-						{generateDomainCerts ? 'Yes' : 'No, I will add my own certificates, thank you very much.'}
-					</div>
-				</label>
-			</div>
-
-			<div className="col-span-1"></div>
-			<div className="col-span-1">
-				<Button
-					type="button"
-					variant="submit"
-					data-id={id}
-					onClick={onClick}
-					disabled={disabled}
-				>
-					<Save /> Bind to This Cluster
-				</Button>
+			<div className="text-muted-foreground md:col-span-2 text-wrap italic text-sm">
+				Select this domain using the checkbox to the left, then click "Bind" in the top right to finish associating it
+				with this cluster.
 			</div>
 		</div>
 	);

--- a/src/features/cluster/domains/Management.tsx
+++ b/src/features/cluster/domains/Management.tsx
@@ -7,8 +7,10 @@ import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
+import { isRunning } from '@/components/ui/utils/badgeStatus';
 import { useDataTableColumns } from '@/features/cluster/domains/constants/tableDefinition';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { useSetDomainIdsOnCluster } from '@/features/clusters/mutations/setDomainIdsOnCluster';
 import {
 	AddOrganizationDomainSchema,
 	useAddDomainToOrganization,
@@ -18,11 +20,13 @@ import { getOrganizationDomainsQueryOptions } from '@/features/organization/quer
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
 import { SchemaOrganizationDomain } from '@/integrations/api/api.patch';
+import { unique } from '@/lib/arrays/unique';
 import { pluralize } from '@/lib/pluralize';
+import { queryClient } from '@/react-query/queryClient';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { ListTodoIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { ListTodoIcon, PlusIcon, RefreshCwIcon, Save } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -63,7 +67,35 @@ export function DomainsManagement() {
 
 	const onRefreshClick = useRefreshClick(refetch);
 
-	const { mutate: addDomain, isPending: isAddPending } = useAddDomainToOrganization();
+	const [selectedDomainIds, setSelectedDomainIds] = useState<string[]>([]);
+	const onToggleDomainSelection = useCallback((domainId: string) => {
+		setSelectedDomainIds((prev) =>
+			prev.includes(domainId) ? prev.filter((id) => id !== domainId) : [...prev, domainId]
+		);
+	}, []);
+
+	const { mutate: setDomainIds, isPending: isBindPending } = useSetDomainIdsOnCluster();
+
+	const onBindClick = useCallback(() => {
+		if (!isRunning(cluster.status)) {
+			toast.error('Cluster is currently ' + cluster.status, { description: 'To bind a domain, it must be running.' });
+			return;
+		}
+
+		setDomainIds({
+			clusterId: cluster.id,
+			domainIds: unique((cluster.domainIds?.slice() || []).concat(selectedDomainIds)),
+			generateDomainCerts: true,
+		}, {
+			onSuccess: () => {
+				void queryClient.invalidateQueries({ queryKey: [cluster.organizationId], refetchType: 'active' });
+				toast.success('Domain(s) bound! Certificates are being generated in the background now.');
+				setSelectedDomainIds([]);
+			},
+		});
+	}, [cluster, selectedDomainIds, setDomainIds]);
+
+	const { mutateAsync: addDomain, isPending: isAddPending } = useAddDomainToOrganization();
 	const form = useForm({
 		resolver: zodResolver(AddOrganizationDomainSchema),
 		defaultValues: {
@@ -75,13 +107,17 @@ export function DomainsManagement() {
 	const onSubmitClick = useCallback(
 		async (formData: z.infer<typeof AddOrganizationDomainSchema>) => {
 			if (formData) {
-				addDomain(formData, {
-					onSuccess: () => {
-						form.reset();
-						refetch();
-						toast.success('Domain added! Please add the txt record above to your domain registrar.');
-					},
-				});
+				const domains = formData.domain.split(/[,\s]+/).map((d: string) => d.trim()).filter(Boolean);
+				for (const domain of domains) {
+					await addDomain({ ...formData, domain });
+				}
+				form.reset();
+				await refetch();
+				toast.success(
+					`${
+						pluralize(domains.length, 'Domain', 'Domains')
+					} added! Please add the txt record above to your domain registrar.`,
+				);
 			}
 		},
 		[addDomain, form, refetch],
@@ -118,7 +154,20 @@ export function DomainsManagement() {
 		}
 	}, [pendingDomains]);
 
-	const dataTableColumns = useDataTableColumns(cluster);
+	const dataTableColumns = useDataTableColumns(cluster, selectedDomainIds, onToggleDomainSelection);
+
+	const domainValue = form.watch('domain');
+	const isApex = useMemo(() => {
+		if (typeof domainValue !== 'string') { return false; }
+		const parts = domainValue.trim().split('.');
+		return parts.length === 2;
+	}, [domainValue]);
+
+	const suggestWww = useCallback(() => {
+		if (typeof domainValue === 'string') {
+			form.setValue('domain', `${domainValue.trim()}, www.${domainValue.trim()}`);
+		}
+	}, [domainValue, form]);
 
 	return (
 		<SimpleBrowseDataTable<SchemaOrganizationDomain, unknown>
@@ -127,7 +176,7 @@ export function DomainsManagement() {
 			columns={dataTableColumns}
 			sortingState={sortingState}
 		>
-			<div className="w-full flex flex-col md:flex-row justify-between md:items-center md:space-x-2 space-y-2 md:space-y-0">
+			<div className="w-full flex flex-col md:flex-row items-center md:justify-between md:space-x-2 space-y-2 md:space-y-0">
 				{update && (
 					<Form {...form}>
 						<form
@@ -145,6 +194,14 @@ export function DomainsManagement() {
 										<FormControl>
 											<Input type="text" enterKeyHint="done" autoComplete="off" {...field} />
 										</FormControl>
+										{isApex && (
+											<div className="mt-1 flex gap-4">
+												Adding an apex domain?
+												<Button variant="positiveOutline" type="button" onClick={suggestWww}>
+													Add www as well
+												</Button>
+											</div>
+										)}
 										<FormMessage>
 											<span className="text-muted-foreground italic">
 												Type in a domain like example.com or your.example.com, and you'll be guided through validating
@@ -154,7 +211,7 @@ export function DomainsManagement() {
 									</FormItem>
 								)}
 							/>
-							<div className="flex-0 self-start md:pt-6.5">
+							<div className="flex-0 self-start flex gap-1 md:pt-6.5">
 								<Button
 									type="submit"
 									variant="submit"
@@ -162,35 +219,49 @@ export function DomainsManagement() {
 								>
 									<PlusIcon /> Add
 								</Button>
+
+								{pendingDomains.length > 0 && (
+									<Button
+										variant="positiveOutline"
+										onClick={onValidateClick}
+										accessKey="r"
+										type="button"
+										disabled={isFetching || isRefetching}
+									>
+										<ListTodoIcon />{' '}
+										<span>
+											<u>V</u>alidate
+										</span>
+									</Button>
+								)}
+								<Button
+									variant="defaultOutline"
+									onClick={onRefreshClick}
+									accessKey="r"
+									type="button"
+									disabled={isFetching || isRefetching}
+								>
+									<RefreshCwIcon />{' '}
+									<span className="hidden lg:inline-block">
+										<u>R</u>efresh
+									</span>
+								</Button>
 							</div>
 						</form>
 					</Form>
 				)}
 
-				{pendingDomains.length > 0 && (
-					<Button
-						variant="positiveOutline"
-						onClick={onValidateClick}
-						accessKey="r"
-						disabled={isFetching || isRefetching}
-					>
-						<ListTodoIcon />{' '}
-						<span>
-							<u>V</u>alidate
-						</span>
-					</Button>
+				{selectedDomainIds.length > 0 && (
+					<div className="flex-0 self-start md:pt-6.5">
+						<Button
+							variant="submit"
+							onClick={onBindClick}
+							disabled={isBindPending}
+						>
+							<Save /> Bind {pluralize(selectedDomainIds.length, 'Domain', 'Domains')}
+						</Button>
+					</div>
 				)}
-				<Button
-					variant="defaultOutline"
-					onClick={onRefreshClick}
-					accessKey="r"
-					disabled={isFetching || isRefetching}
-				>
-					<RefreshCwIcon />{' '}
-					<span className="hidden lg:inline-block">
-						<u>R</u>efresh
-					</span>
-				</Button>
 			</div>
 		</SimpleBrowseDataTable>
 	);

--- a/src/features/cluster/domains/VerifyDomainOwnership.tsx
+++ b/src/features/cluster/domains/VerifyDomainOwnership.tsx
@@ -1,12 +1,23 @@
 import { Button } from '@/components/ui/button';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
-import { SchemaOrganizationDomain } from '@/integrations/api/api.patch';
+import { Cluster, SchemaOrganizationDomain } from '@/integrations/api/api.patch';
+import { extractDomainFromTLD } from '@/lib/string/extractDomainFromTLD';
 import { CopyIcon } from 'lucide-react';
 
 export function VerifyDomainOwnership(
-	{ domain: { challengeToken, challengeTxtRecord } }: { domain: SchemaOrganizationDomain },
+	{ domain: { challengeToken, challengeTxtRecord, domain, id }, cluster: { fqdn } }: {
+		domain: SchemaOrganizationDomain;
+		cluster: Cluster;
+	},
 ) {
-	const [onCopyTxtRecord, onCopyToken] = useCopyToClipboard(challengeTxtRecord, challengeToken);
+	const recordName = extractDomainFromTLD(domain);
+	const [onCopyTxtRecord, onCopyToken, onCopyName, onCopyTarget, onCopyId] = useCopyToClipboard(
+		challengeTxtRecord,
+		challengeToken,
+		recordName,
+		fqdn || '',
+		id,
+	);
 
 	return (
 		<div className="grid gap-2 grid-cols-1 md:grid-cols-[80px_1fr] pb-6">
@@ -18,39 +29,104 @@ export function VerifyDomainOwnership(
 			<div className="col-span-1">TXT</div>
 
 			<div className="col-span-1">Name:</div>
-			<div className="col-span-1 flex gap-2">
-				<input
-					className="py-1 px-3 bg-gray-700 rounded-md w-full"
-					type="text"
-					readOnly={true}
-					name="challengeName"
-					value={challengeTxtRecord}
-					onClick={onCopyTxtRecord}
-				/>
-				<Button type="button" size="sm" onClick={onCopyTxtRecord}>
-					<CopyIcon className="w-4 h-4" />
-				</Button>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="challengeName"
+						value={challengeTxtRecord}
+						onClick={onCopyTxtRecord}
+					/>
+					<Button type="button" size="sm" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyTxtRecord}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
 			</div>
 
 			<div className="col-span-1">TTL:</div>
 			<div className="col-span-1">Auto</div>
 
 			<div className="col-span-1">Content:</div>
-			<div className="col-span-1 flex gap-2">
-				<input
-					className="py-1 px-3 bg-gray-700 rounded-md w-full"
-					type="text"
-					readOnly={true}
-					name="challengeToken"
-					value={challengeToken}
-					onClick={onCopyToken}
-				/>
-				<Button type="button" size="sm" onClick={onCopyToken}>
-					<CopyIcon className="w-4 h-4" />
-				</Button>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="challengeToken"
+						value={challengeToken}
+						onClick={onCopyToken}
+					/>
+					<Button type="button" size="sm" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyToken}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
 			</div>
 
-			<div className="text-muted-foreground md:col-span-2 text-wrap">
+			<div className="text-muted-foreground md:col-span-2 text-wrap mt-4">
+				While you're at it, you should also add the CNAME record to point to this cluster:
+			</div>
+
+			<div className="col-span-1">Type:</div>
+			<div className="col-span-1">CNAME</div>
+
+			<div className="col-span-1">Name:</div>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="recordName"
+						value={recordName}
+						onClick={onCopyName}
+					/>
+					<Button type="button" size="sm" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyName}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
+			</div>
+
+			<div className="col-span-1">TTL:</div>
+			<div className="col-span-1">Auto</div>
+
+			<div className="col-span-1">Target:</div>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-700 rounded-md px-3 py-1 flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="recordTarget"
+						value={fqdn}
+						onClick={onCopyTarget}
+					/>
+					<Button type="button" size="sm" variant="ghost" className="h-6 w-6 p-0 shrink-0" onClick={onCopyTarget}>
+						<CopyIcon className="w-3.5 h-3.5" />
+					</Button>
+				</div>
+			</div>
+
+			<div className="col-span-1 text-xs">Domain ID:</div>
+			<div className="col-span-1 flex gap-2 items-center">
+				<div className="flex items-center gap-1 bg-gray-800 rounded-md px-3 py-0.5 text-xs text-muted-foreground italic flex-1 overflow-hidden">
+					<input
+						className="bg-transparent border-none outline-none w-full cursor-text truncate"
+						type="text"
+						readOnly={true}
+						name="domainId"
+						value={id}
+						onClick={onCopyId}
+					/>
+					<Button type="button" size="sm" variant="ghost" className="h-5 w-5 p-0 shrink-0" onClick={onCopyId}>
+						<CopyIcon className="w-3 h-3" />
+					</Button>
+				</div>
+			</div>
+
+			<div className="text-muted-foreground md:col-span-2 text-wrap mt-2">
 				Then after your DNS TTL elapses, click the "Validate" button above.
 			</div>
 		</div>

--- a/src/features/cluster/domains/components/CertificateProgress.tsx
+++ b/src/features/cluster/domains/components/CertificateProgress.tsx
@@ -1,0 +1,131 @@
+import { Button } from '@/components/ui/button';
+import { ChallengeCertificate } from '@/features/cluster/domains/queries/getChallengeCertificates';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { Cluster, SchemaOrganizationDomain } from '@/integrations/api/api.patch';
+import { extractDomainFromTLD } from '@/lib/string/extractDomainFromTLD';
+import { CopyIcon } from 'lucide-react';
+import { useMemo } from 'react';
+
+export function CertificateProgress({
+	certificate,
+	domain,
+	cluster,
+}: {
+	certificate: ChallengeCertificate;
+	domain: SchemaOrganizationDomain;
+	cluster: Cluster;
+}) {
+	const recordName = extractDomainFromTLD(domain.domain);
+	const [onCopyName, onCopyTarget, onCopyId] = useCopyToClipboard(
+		recordName,
+		cluster.fqdn || '',
+		domain.id,
+	);
+
+	const progress = useMemo(() => {
+		if (certificate.issueDate && !certificate.inProgress) {
+			return {
+				width: '100%',
+				color: 'bg-green/80',
+				pulse: false,
+				text: 'Certificate Issued',
+			};
+		}
+		if (certificate.inProgress) {
+			return {
+				width: '100%',
+				color: 'bg-yellow/80',
+				pulse: true,
+				text: 'Generating Certificate...',
+			};
+		}
+		// If neither issueDate nor inProgress, it's pending
+		return {
+			width: '100%',
+			color: 'bg-gray-600',
+			pulse: false,
+			text: 'Pending Certificate Generation...',
+		};
+	}, [certificate]);
+
+	return (
+		<div className="w-full max-w-2xl border border-border/50 rounded-md p-4 bg-gray-900/20">
+			<div className="mb-4">
+				<div className="w-full h-1.5 rounded-full overflow-clip flex shadow-sm bg-gray-800">
+					<div
+						style={{ width: progress.width }}
+						className={`grow transition-[width] duration-1000 ease-in-out motion-reduce:transition-none ${progress.color} ${
+							progress.pulse ? 'animate-pulse' : ''
+						}`}
+					>
+					</div>
+				</div>
+				<div className="text-[10px] text-muted-foreground font-light mt-1 italic">{progress.text}</div>
+			</div>
+
+			<div className="grid gap-2 grid-cols-1 md:grid-cols-[80px_1fr] text-sm">
+				<div className="col-span-1 text-xs text-muted-foreground">CNAME:</div>
+				<div className="col-span-1 flex gap-2 items-center flex-wrap">
+					<div className="flex items-center gap-1 bg-gray-800 px-2 py-0.5 rounded text-xs">
+						<span className="truncate max-w-[150px]" title={recordName}>
+							{recordName}
+						</span>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-4 w-4 p-0"
+							onClick={onCopyName}
+							title="Copy Name"
+						>
+							<CopyIcon className="w-3 h-3" />
+						</Button>
+					</div>
+					<ArrowIcon />
+					<div className="flex items-center gap-1 bg-gray-800 px-2 py-0.5 rounded text-xs">
+						<span className="truncate max-w-[200px]" title={cluster.fqdn || ''}>
+							{cluster.fqdn}
+						</span>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-4 w-4 p-0"
+							onClick={onCopyTarget}
+							title="Copy Target"
+						>
+							<CopyIcon className="w-3 h-3" />
+						</Button>
+					</div>
+				</div>
+
+				<div className="col-span-1 text-[10px] text-muted-foreground">Domain ID:</div>
+				<div className="col-span-1 flex gap-2 items-center">
+					<div className="flex items-center gap-1 bg-gray-800/50 px-2 py-0.5 rounded text-[10px] text-muted-foreground italic">
+						<span className="truncate max-w-[200px]">{domain.id}</span>
+						<Button type="button" variant="ghost" size="sm" className="h-3 w-3 p-0" onClick={onCopyId} title="Copy ID">
+							<CopyIcon className="w-2.5 h-2.5" />
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ArrowIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className="w-3 h-3 text-muted-foreground"
+		>
+			<path d="M5 12h14" />
+			<path d="m12 5 7 7-7 7" />
+		</svg>
+	);
+}

--- a/src/features/cluster/domains/constants/tableDefinition.tsx
+++ b/src/features/cluster/domains/constants/tableDefinition.tsx
@@ -2,6 +2,8 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { isRunning } from '@/components/ui/utils/badgeStatus';
 import { AssociateDomainWithCluster } from '@/features/cluster/domains/AssociateDomainWithCluster';
+import { CertificateProgress } from '@/features/cluster/domains/components/CertificateProgress';
+import { useChallengeCertificates } from '@/features/cluster/domains/queries/getChallengeCertificates';
 import { VerifyDomainOwnership } from '@/features/cluster/domains/VerifyDomainOwnership';
 import { useSetDomainIdsOnCluster } from '@/features/clusters/mutations/setDomainIdsOnCluster';
 import { useDeleteDomain } from '@/features/organization/mutations/deleteDomain';
@@ -15,7 +17,17 @@ import { toast } from 'sonner';
 
 const columnHelper = createColumnHelper<SchemaOrganizationDomain>();
 
-export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrganizationDomain>> {
+export function useDataTableColumns(
+	cluster: Cluster,
+	selectedDomainIds: string[],
+	onToggleDomainSelection: (domainId: string) => void,
+): Array<ColumnDef<SchemaOrganizationDomain>> {
+	const { data: challengeCertificates } = useChallengeCertificates(cluster.id);
+	const isGeneratingCert = useMemo(
+		() => !!challengeCertificates?.some((cert) => !cert.issueDate || cert.inProgress),
+		[challengeCertificates],
+	);
+
 	const { mutate: setDomainIds, isPending: addPending } = useSetDomainIdsOnCluster();
 	const { mutate: deleteDomain, isPending: deletePending } = useDeleteDomain();
 	const isPending = addPending || deletePending;
@@ -67,6 +79,28 @@ export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrg
 
 	return useMemo(() => [
 		columnHelper.display({
+			id: 'select',
+			header: 'Bind',
+			size: 50,
+			cell: (props) => {
+				const domain = props.row.original;
+				const canBind = domain.status === 'ACTIVE' && !domain.clusterId && !clusterIsSelfManaged(cluster);
+				if (!canBind) {
+					return null;
+				}
+				return (
+					<label className="p-10 -m-10">
+						<input
+							type="checkbox"
+							checked={selectedDomainIds.includes(domain.id)}
+							onChange={() => onToggleDomainSelection(domain.id)}
+							disabled={isPending || isGeneratingCert}
+						/>
+					</label>
+				);
+			},
+		}),
+		columnHelper.display({
 			header: 'Domains',
 			id: 'domain',
 			enableSorting: false,
@@ -108,11 +142,18 @@ export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrg
 			cell: (props) => {
 				const domain = props.row.original;
 
+				const certForDomain = challengeCertificates?.find((c) => c.domain === domain.domain);
+
 				if (domain.status === 'ACTIVE' && domain.clusterId) {
 					if (cluster.id === domain.clusterId) {
 						return (
 							<>
 								<div>Bound to this cluster</div>
+								{certForDomain && (!certForDomain.issueDate || certForDomain.inProgress) && (
+									<div className="py-2">
+										<CertificateProgress certificate={certForDomain} domain={domain} cluster={cluster} />
+									</div>
+								)}
 								<Button
 									variant="destructiveGhost"
 									className="text-muted-foreground text-xs"
@@ -129,7 +170,7 @@ export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrg
 				}
 
 				if (domain.status === 'PENDING_VALIDATION') {
-					return <VerifyDomainOwnership domain={domain} />;
+					return <VerifyDomainOwnership domain={domain} cluster={cluster} />;
 				}
 
 				if (clusterIsSelfManaged(cluster)) {
@@ -141,8 +182,6 @@ export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrg
 						<AssociateDomainWithCluster
 							cluster={cluster}
 							domain={domain}
-							bindDomain={(generateDomainCerts) => bindDomainToThisCluster(domain.id, generateDomainCerts)}
-							disabled={isPending}
 						/>
 					);
 				}
@@ -151,5 +190,13 @@ export function useDataTableColumns(cluster: Cluster): Array<ColumnDef<SchemaOrg
 				return domain.status;
 			},
 		}),
-	], [cluster, bindDomainToThisCluster, isPending]);
+	], [
+		cluster,
+		bindDomainToThisCluster,
+		isPending,
+		challengeCertificates,
+		isGeneratingCert,
+		selectedDomainIds,
+		onToggleDomainSelection,
+	]);
 }

--- a/src/features/cluster/domains/queries/getChallengeCertificates.ts
+++ b/src/features/cluster/domains/queries/getChallengeCertificates.ts
@@ -1,0 +1,41 @@
+import { getInstanceClient } from '@/config/getInstanceClient';
+import { getSearchByValue } from '@/integrations/api/instance/database/getSearchByValue';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+
+export interface ChallengeCertificate {
+	domain: string;
+	issueDate: string | null;
+	renewalDate: string | null;
+	challengeToken: string;
+	challengeContent: string;
+	inProgress: boolean;
+}
+
+export function getChallengeCertificatesQueryOptions(clusterId?: string) {
+	return queryOptions({
+		queryKey: [clusterId, 'ChallengeCertificate'],
+		queryFn: async () => {
+			if (!clusterId) { return []; }
+			const instanceClient = getInstanceClient({ id: clusterId, forceFabricConnect: true });
+			const { data } = await getSearchByValue<ChallengeCertificate>({
+				searchAttribute: 'domain',
+				entityId: clusterId,
+				databaseName: 'data',
+				tableName: 'ChallengeCertificate',
+				sort: { attribute: 'domain', descending: true },
+				enabled: true,
+				instanceClient,
+				onlyIfCached: false,
+				pageIndex: 0,
+				pageSize: 100,
+			});
+			return data;
+		},
+		enabled: !!clusterId,
+		refetchInterval: 5000,
+	});
+}
+
+export function useChallengeCertificates(clusterId?: string) {
+	return useQuery(getChallengeCertificatesQueryOptions(clusterId));
+}

--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -53,18 +53,6 @@ export function ConfigIndex() {
 					<HandshakeIcon className="hidden md:inline-block" /> <span className="ms-3">Roles</span>
 				</Link>
 			</li>
-			{!isLocalStudio && !isSelfManaged && (
-				<li>
-					<Link
-						to={buildAbsoluteLinkToPage(params, 'config/domains')}
-						className={sharedClasses}
-						inactiveProps={inactiveProps}
-						activeProps={activeProps}
-					>
-						<GlobeIcon className="hidden md:inline-block" /> <span className="ms-3">Domains</span>
-					</Link>
-				</li>
-			)}
 			{certsAvailable && (
 				<li>
 					<Link
@@ -74,6 +62,18 @@ export function ConfigIndex() {
 						activeProps={activeProps}
 					>
 						<ShieldCheckIcon className="hidden md:inline-block" /> <span className="ms-3">Certificates</span>
+					</Link>
+				</li>
+			)}
+			{!isLocalStudio && !isSelfManaged && (
+				<li>
+					<Link
+						to={buildAbsoluteLinkToPage(params, 'config/domains')}
+						className={sharedClasses}
+						inactiveProps={inactiveProps}
+						activeProps={activeProps}
+					>
+						<GlobeIcon className="hidden md:inline-block" /> <span className="ms-3">Domains</span>
 					</Link>
 				</li>
 			)}

--- a/src/integrations/api/instance/database/getSearchByConditions.ts
+++ b/src/integrations/api/instance/database/getSearchByConditions.ts
@@ -83,7 +83,7 @@ export function getSearchByConditionsOptions(params: GetSearchByConditionsParams
 	});
 }
 
-export function getSearchByConditions({
+export function getSearchByConditions<T = Record<string, unknown>>({
 	instanceClient,
 	databaseName,
 	tableName,
@@ -94,7 +94,7 @@ export function getSearchByConditions({
 	onlyIfCached,
 	headers,
 }: GetSearchByConditionsParams) {
-	return instanceClient.post<Record<string, unknown>[]>(
+	return instanceClient.post<T[]>(
 		'/',
 		{
 			operation: 'search_by_conditions',

--- a/src/integrations/api/instance/database/getSearchByValue.ts
+++ b/src/integrations/api/instance/database/getSearchByValue.ts
@@ -60,7 +60,7 @@ export function getSearchByValueOptions(params: GetSearchByValueParams) {
 	});
 }
 
-export function getSearchByValue({
+export function getSearchByValue<T = Record<string, unknown>>({
 	instanceClient,
 	databaseName,
 	tableName,
@@ -72,7 +72,7 @@ export function getSearchByValue({
 	headers,
 }: GetSearchByValueParams) {
 	const customizedSort = sort.attribute.length && !(sort.attribute === searchAttribute && !sort.descending);
-	return instanceClient.post<Record<string, unknown>[]>(
+	return instanceClient.post<T[]>(
 		'/',
 		{
 			operation: 'search_by_value',


### PR DESCRIPTION
1. Always generate certs with LetsEncrypt (take away the checkbox) to simplify things for people.
2. Give them a way to bind multiple domains at once so they don't submit overlapping requests.
3. If they add an apex domain, suggest adding www as well.
4. Show the progress visually of the certification generation (by using fabric connect to look at the ChallengeCertificate table)

https://harperdb.atlassian.net/browse/STUDIO-666
https://harperdb.atlassian.net/browse/STUDIO-667
https://harperdb.atlassian.net/browse/STUDIO-668