### PR TITLE
feat: Allow editing config safely

### DIFF
--- a/src/components/ui/alertVariants.tsx
+++ b/src/components/ui/alertVariants.tsx
@@ -8,6 +8,8 @@ export const alertVariants = cva(
 				default: 'bg-card text-card-foreground',
 				destructive:
 					'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+				warning:
+					'border-amber-500/50 text-amber-600 dark:text-amber-400 bg-amber-50/50 dark:bg-amber-950/20 [&>svg]:text-amber-600 dark:[&>svg]:text-amber-400',
 			},
 		},
 		defaultVariants: {

--- a/src/features/instance/config/overview/configRestrictions.test.ts
+++ b/src/features/instance/config/overview/configRestrictions.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { flattenConfig, getChangedFields, isRestrictedConfigPath, omitRestrictedFields } from './configRestrictions';
+
+describe('getChangedFields', () => {
+	it('should return only changed fields', () => {
+		const original = {
+			http: { cors: true, corsAccessList: ['*'] },
+			analytics: { enabled: true },
+		};
+		const edited = {
+			http: { cors: false, corsAccessList: ['*'] },
+			analytics: { enabled: true },
+		};
+		const changes = getChangedFields(original, edited);
+		expect(changes).toEqual({
+			http: { cors: false },
+		});
+	});
+
+	it('should return empty object if nothing changed', () => {
+		const config = { a: 1, b: { c: 2 } };
+		expect(getChangedFields(config, config)).toEqual({});
+	});
+
+	it('should return only deep changed fields', () => {
+		const original = {
+			http: {
+				compressionThreshold: 0,
+				cors: false,
+				corsAccessList: ['https://fabric.harper.fast'],
+				keepAliveTimeout: 301000,
+				mtls: false,
+				http2: false,
+				timeout: 120000,
+			},
+			authentication: {
+				authorizeLocal: false,
+				cacheTTL: 30000,
+				operationTokenTimeout: '1d',
+				refreshTokenTimeout: '30d',
+				cookie: {
+					domains: ['local-inference.dawson-org-2.dev.harperfabric.com'],
+				},
+			},
+		};
+		const edited = JSON.parse(JSON.stringify(original));
+		edited.http.cors = true;
+
+		const changes = getChangedFields(original, edited);
+		expect(changes).toEqual({
+			http: { cors: true },
+		});
+	});
+
+	it('should detect additions', () => {
+		const original = { a: 1 };
+		const edited = { a: 1, b: 2 };
+		expect(getChangedFields(original, edited)).toEqual({ b: 2 });
+	});
+});
+
+describe('flattenConfig', () => {
+	it('should flatten nested objects using underscores', () => {
+		const config = {
+			http: {
+				cors: true,
+				port: 9925,
+			},
+			logging: {
+				level: 'info',
+				rotation: {
+					enabled: true,
+				},
+			},
+			simple: 1,
+		};
+		const flattened = flattenConfig(config);
+		expect(flattened).toEqual({
+			http_cors: true,
+			http_port: 9925,
+			logging_level: 'info',
+			logging_rotation_enabled: true,
+			simple: 1,
+		});
+	});
+
+	it('should handle arrays as values (not flatten them)', () => {
+		const config = {
+			http: {
+				corsAccessList: ['a', 'b'],
+			},
+		};
+		const flattened = flattenConfig(config);
+		expect(flattened).toEqual({
+			http_corsAccessList: ['a', 'b'],
+		});
+	});
+
+	it('should handle empty objects', () => {
+		expect(flattenConfig({})).toEqual({});
+	});
+});
+
+describe('isRestrictedConfigPath', () => {
+	it('should return false if value has not changed', () => {
+		expect(isRestrictedConfigPath('http.port', 9925, 9925)).toBe(false);
+		expect(isRestrictedConfigPath('threads', 4, 4)).toBe(false);
+		expect(isRestrictedConfigPath('any.field', 'value', 'value')).toBe(false);
+	});
+
+	it('should return true for simple blocked fields when changed', () => {
+		expect(isRestrictedConfigPath('threads', 5, 4)).toBe(true);
+		expect(isRestrictedConfigPath('rootPath', '/new/path', '/old/path')).toBe(true);
+		expect(isRestrictedConfigPath('storage', {}, { some: 'config' })).toBe(true);
+	});
+
+	it('should return true for nested blocked fields when changed', () => {
+		expect(isRestrictedConfigPath('http.port', 9926, 9925)).toBe(true);
+		expect(isRestrictedConfigPath('http.securePort', 9927, 9926)).toBe(true);
+		expect(isRestrictedConfigPath('logging.auditLog', true, false)).toBe(true);
+		expect(isRestrictedConfigPath('logging.rotation.path', '/new/log', '/old/log')).toBe(true);
+		expect(isRestrictedConfigPath('mqtt.network.port', 1884, 1883)).toBe(true);
+	});
+
+	it('should return false for allowed fields', () => {
+		expect(isRestrictedConfigPath('http.cors', true, false)).toBe(false);
+		expect(isRestrictedConfigPath('analytics', { enabled: true }, { enabled: false })).toBe(false);
+		expect(isRestrictedConfigPath('localStudio', true, false)).toBe(false);
+		expect(isRestrictedConfigPath('logging.level', 'debug', 'info')).toBe(false);
+	});
+
+	it('should handle replication.databases specifically', () => {
+		// replication is blocked_except_databases
+		expect(isRestrictedConfigPath('replication.enabled', true, false)).toBe(true);
+		expect(isRestrictedConfigPath('replication.databases', ['db1'], [])).toBe(false);
+		// Currently replication object itself is NOT blocked because it's 'blocked_except_databases' and 'replication' !== 'databases'
+		expect(isRestrictedConfigPath('replication', { databases: ['db1'] }, { databases: [] })).toBe(false);
+	});
+
+	it('should return true if a parent field is blocked', () => {
+		// storage is blocked, so storage.anything should be blocked
+		expect(isRestrictedConfigPath('storage.type', 's3', 'hdb')).toBe(true);
+		// tls is blocked
+		expect(isRestrictedConfigPath('tls.cert', '...', '...')).toBe(false); // not changed
+		expect(isRestrictedConfigPath('tls.cert', 'new', 'old')).toBe(true);
+	});
+
+	it('should return false for unknown top-level fields', () => {
+		expect(isRestrictedConfigPath('myNewField', 1, 0)).toBe(false);
+	});
+});
+
+describe('omitRestrictedFields', () => {
+	it('should omit simple blocked fields', () => {
+		const config = {
+			threads: 4,
+			http: { port: 9925, cors: true },
+			storage: { some: 'config' },
+			analytics: { enabled: true },
+		};
+		const sanitized = omitRestrictedFields(config);
+		expect(sanitized.threads).toBeUndefined();
+		expect(sanitized.http.port).toBeUndefined();
+		expect(sanitized.http.cors).toBe(true);
+		expect(sanitized.storage).toBeUndefined();
+		expect(sanitized.analytics.enabled).toBe(true);
+	});
+
+	it('should handle replication.databases specially', () => {
+		const config = {
+			replication: {
+				enabled: true,
+				databases: ['db1'],
+				other: 'stuff',
+			},
+		};
+		const sanitized = omitRestrictedFields(config);
+		expect(sanitized.replication).toEqual({ databases: ['db1'] });
+	});
+});

--- a/src/features/instance/config/overview/configRestrictions.ts
+++ b/src/features/instance/config/overview/configRestrictions.ts
@@ -1,0 +1,140 @@
+export const RESTRICTED_CONFIG: Record<string, any> = {
+	http: {
+		port: 'blocked',
+		securePort: 'blocked',
+	},
+	threads: 'blocked',
+	authentication: {
+		enableSessions: 'blocked',
+	},
+	logging: {
+		auditLog: 'blocked',
+		root: 'blocked',
+		rotation: {
+			path: 'blocked',
+		},
+	},
+	mqtt: {
+		network: {
+			port: 'blocked',
+			securePort: 'blocked',
+		},
+	},
+	operationsApi: {
+		network: {
+			domainSocket: 'blocked',
+			port: 'blocked',
+			securePort: 'blocked',
+		},
+	},
+	rootPath: 'blocked',
+	replication: 'blocked_except_databases',
+	storage: 'blocked',
+	tls: 'blocked',
+	node: 'blocked',
+	license: 'blocked',
+	componentsRoot: 'blocked',
+	analytics: 'allowed',
+	applications: 'allowed',
+	localStudio: 'allowed',
+};
+
+export function isRestrictedConfigPath(path: string, value: any, originalValue: any): boolean {
+	// If value hasn't changed, it's not "blocked" from staying the same
+	if (JSON.stringify(value) === JSON.stringify(originalValue)) {
+		return false;
+	}
+
+	const parts = path.split('.');
+	let current: any = RESTRICTED_CONFIG;
+
+	for (let i = 0; i < parts.length; i++) {
+		const part = parts[i];
+		if (current === 'blocked') { return true; }
+		if (current === 'blocked_except_databases') {
+			return part !== 'databases';
+		}
+		if (typeof current === 'object' && current !== null && part in current) {
+			current = current[part];
+		} else {
+			// Not in RESTRICTED_CONFIG, so it's allowed
+			return false;
+		}
+	}
+
+	return current === 'blocked';
+}
+
+export function omitRestrictedFields(obj: any, schema: any = RESTRICTED_CONFIG): any {
+	if (typeof obj !== 'object' || obj === null) { return obj; }
+
+	const result = Array.isArray(obj) ? [] : {};
+
+	for (const key in obj) {
+		const value = obj[key];
+		const restriction = schema?.[key];
+
+		if (restriction === 'blocked') {
+			continue;
+		} else if (restriction === 'blocked_except_databases') {
+			if (value && typeof value === 'object' && 'databases' in value) {
+				(result as any).replication = { databases: value.databases };
+			}
+			continue;
+		} else if (typeof restriction === 'object' && restriction !== null) {
+			const sanitized = omitRestrictedFields(value, restriction);
+			if (sanitized !== undefined && (typeof sanitized !== 'object' || Object.keys(sanitized).length > 0)) {
+				(result as any)[key] = sanitized;
+			}
+		} else {
+			(result as any)[key] = value;
+		}
+	}
+
+	return result;
+}
+
+export function getChangedFields(original: any, edited: any): any {
+	if (typeof original !== 'object' || original === null || typeof edited !== 'object' || edited === null) {
+		return JSON.stringify(original) !== JSON.stringify(edited) ? edited : undefined;
+	}
+
+	const changes: any = {};
+	const allKeys = new Set([...Object.keys(original), ...Object.keys(edited)]);
+
+	for (const key of allKeys) {
+		const val1 = original[key];
+		const val2 = edited[key];
+
+		if (
+			val1 !== null && typeof val1 === 'object' && val2 !== null && typeof val2 === 'object' && !Array.isArray(val1)
+			&& !Array.isArray(val2)
+		) {
+			const nestedChanges = getChangedFields(val1, val2);
+			if (Object.keys(nestedChanges).length > 0) {
+				changes[key] = nestedChanges;
+			}
+		} else if (JSON.stringify(val1) !== JSON.stringify(val2)) {
+			changes[key] = val2;
+		}
+	}
+
+	return changes;
+}
+
+export function flattenConfig(obj: any, prefix = ''): Record<string, any> {
+	const result: Record<string, any> = {};
+
+	for (const key in obj) {
+		const value = obj[key];
+		const newKey = prefix ? `${prefix}_${key}` : key;
+
+		if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+			Object.assign(result, flattenConfig(value, newKey));
+		} else {
+			result[newKey] = value;
+		}
+	}
+
+	return result;
+}

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -1,6 +1,8 @@
 import { ApplyLicensesButton } from '@/components/ApplyLicensesButton';
 import { RestartButton } from '@/components/RestartButton';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { isLocalStudio } from '@/config/constants';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { getInstanceInfoQueryOptions } from '@/features/cluster/queries/getInstanceInfoQuery';
@@ -9,6 +11,7 @@ import { ClusterDomainsList } from '@/features/instance/config/overview/componen
 import { HarperVersion } from '@/features/instance/config/overview/components/HarperVersion';
 import { InstanceNodeName } from '@/features/instance/config/overview/components/InstanceNodeName';
 import { InstanceURL } from '@/features/instance/config/overview/components/InstanceURL';
+import { useRollingConfigUpdate } from '@/hooks/useRollingConfigUpdate';
 import { getConfigurationQueryOptions } from '@/integrations/api/instance/status/getConfiguration';
 import {
 	getRegistrationInfoQueryOptions,
@@ -20,7 +23,9 @@ import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import Editor from '@monaco-editor/react';
 import { useQuery } from '@tanstack/react-query';
 import { useLoaderData, useParams } from '@tanstack/react-router';
-import { ReactNode, useMemo } from 'react';
+import { AlertCircleIcon, EditIcon, SaveIcon, XIcon } from 'lucide-react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { flattenConfig, getChangedFields, isRestrictedConfigPath, omitRestrictedFields } from './configRestrictions';
 
 const LocalStudioOverview = ({ children }: { children: ReactNode }) => {
 	return <>{children}</>;
@@ -53,6 +58,82 @@ export function ConfigOverviewIndex() {
 		getConfigurationQueryOptions(instanceParams),
 	);
 
+	const sanitizedConfigInfo = useMemo(() => {
+		if (!configurationInfo) { return null; }
+		return omitRestrictedFields(configurationInfo);
+	}, [configurationInfo]);
+
+	const [isEditing, setIsEditing] = useState(false);
+	const [editedConfig, setEditedConfig] = useState<string>('');
+	const [jsonError, setJsonError] = useState<string | null>(null);
+	const [restrictedError, setRestrictedError] = useState<string[]>([]);
+
+	const { onConfigUpdate, isPending: isSaving } = useRollingConfigUpdate();
+
+	useEffect(() => {
+		if (sanitizedConfigInfo && !isEditing) {
+			setEditedConfig(JSON.stringify(sanitizedConfigInfo, null, 4));
+			setJsonError(null);
+			setRestrictedError([]);
+		}
+	}, [sanitizedConfigInfo, isEditing]);
+
+	const handleEditorChange = useCallback((value: string | undefined) => {
+		setEditedConfig(value || '');
+		if (value) {
+			try {
+				const parsed = JSON.parse(value);
+				setJsonError(null);
+
+				const blockedFields: string[] = [];
+				const checkBlocked = (obj: any, orig: any, path = '') => {
+					for (const key in obj) {
+						const currentPath = path ? `${path}.${key}` : key;
+						const val = obj[key];
+						const origVal = orig?.[key];
+
+						if (isRestrictedConfigPath(currentPath, val, origVal)) {
+							blockedFields.push(currentPath);
+						} else if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+							checkBlocked(val, origVal, currentPath);
+						}
+					}
+					// Also check for deleted keys if they were blocked
+					for (const key in orig) {
+						const currentPath = path ? `${path}.${key}` : key;
+						if (!(key in obj)) {
+							if (isRestrictedConfigPath(currentPath, undefined, orig[key])) {
+								blockedFields.push(currentPath);
+							}
+						}
+					}
+				};
+
+				if (sanitizedConfigInfo) {
+					checkBlocked(parsed, sanitizedConfigInfo);
+				}
+				setRestrictedError(blockedFields);
+			} catch (e: any) {
+				setJsonError(e.message);
+				setRestrictedError([]);
+			}
+		}
+	}, [configurationInfo]);
+
+	const handleSave = useCallback(() => {
+		if (jsonError || restrictedError.length > 0) { return; }
+		try {
+			const parsed = JSON.parse(editedConfig);
+			const changedFields = getChangedFields(sanitizedConfigInfo, parsed);
+			const flattened = flattenConfig(changedFields);
+
+			onConfigUpdate(flattened);
+			setIsEditing(false);
+		} catch (e: any) {
+			setJsonError(e.message);
+		}
+	}, [editedConfig, jsonError, onConfigUpdate, sanitizedConfigInfo, restrictedError.length]);
+
 	const newLicenses = useMemo(() => {
 		if (isLocalStudio) {
 			return [];
@@ -63,7 +144,7 @@ export function ConfigOverviewIndex() {
 			return cloudLicenses.filter(cloudLicense => !appliedLicensesById[cloudLicense.id]);
 		}
 		return [];
-	}, [clusterId, instanceId, appliedLicenses, instanceInfo]);
+	}, [appliedLicenses, instanceInfo]);
 
 	return (
 		<div className="h-full flex flex-col">
@@ -116,12 +197,65 @@ export function ConfigOverviewIndex() {
 					</CloudStudioOverview>
 				)}
 
-			<h3 className="flex-none font-bold text-sm/6">Instance Config (read only)</h3>
-			{!instanceId && (
-				<p className="text-muted-foreground italic text-sm mb-2">
-					You are viewing the config for one instance in your cluster, based on what the load balancer selected for you.
-				</p>
+			<div className="flex-none flex items-center justify-between mb-2">
+				<div>
+					<h3 className="font-bold text-sm/6">Instance Config {isEditing ? '(editing)' : '(read only)'}</h3>
+					{!instanceId && !isLocalStudio && (
+						<p className="text-muted-foreground italic text-sm">
+							You are viewing the config for one instance in your cluster, based on what the load balancer selected for
+							you.
+						</p>
+					)}
+				</div>
+				<div className="flex items-center gap-2 pr-4">
+					{!isEditing
+						? (
+							<Button size="sm" onClick={() => setIsEditing(true)}>
+								<EditIcon className="w-4 h-4 mr-1" /> Edit
+							</Button>
+						)
+						: (
+							<>
+								<Button size="sm" variant="ghost" onClick={() => setIsEditing(false)}>
+									<XIcon className="w-4 h-4 mr-1" /> Cancel
+								</Button>
+								<Button
+									size="sm"
+									disabled={!!jsonError || restrictedError.length > 0 || isSaving}
+									onClick={handleSave}
+								>
+									<SaveIcon className="w-4 h-4 mr-1" /> {isSaving ? 'Saving...' : 'Save & Restart'}
+								</Button>
+							</>
+						)}
+				</div>
+			</div>
+
+			{jsonError && (
+				<Alert variant="destructive" className="mb-4">
+					<AlertCircleIcon className="h-4 w-4" />
+					<AlertTitle>Invalid JSON</AlertTitle>
+					<AlertDescription>{jsonError}</AlertDescription>
+				</Alert>
 			)}
+
+			{restrictedError.length > 0 && (
+				<Alert variant="destructive" className="mb-4">
+					<AlertCircleIcon className="h-4 w-4" />
+					<AlertTitle>Restricted Configuration</AlertTitle>
+					<AlertDescription>
+						The following fields cannot be modified via Studio:
+						<ul className="list-disc ml-4 mt-2">
+							{restrictedError.map(field => (
+								<li key={field}>
+									<code>{field}</code>
+								</li>
+							))}
+						</ul>
+					</AlertDescription>
+				</Alert>
+			)}
+
 			<div className="grow">
 				{!loadingConfig
 					? (
@@ -129,8 +263,9 @@ export function ConfigOverviewIndex() {
 							className="w-full min-h-full h-96"
 							language="json"
 							theme="vs-dark"
-							options={{ readOnly: true, scrollBeyondLastLine: false }}
-							value={JSON.stringify(configurationInfo, null, 4)}
+							options={{ readOnly: !isEditing, scrollBeyondLastLine: false }}
+							value={isEditing ? editedConfig : JSON.stringify(sanitizedConfigInfo, null, 4)}
+							onChange={handleEditorChange}
 						/>
 					)
 					: (


### PR DESCRIPTION
The button is a bit subtle, but this gives you a safe way to make edits. It will only send changed fields, and I've pruned out the non-safe fields from being displayed.

https://harperdb.atlassian.net/browse/STUDIO-56