### PR TITLE
feat: Link to releases when possible

### DIFF
--- a/src/components/Version.tsx
+++ b/src/components/Version.tsx
@@ -2,10 +2,14 @@ import { badgeVariants } from '@/components/ui/badgeVariants';
 import { cn } from '@/lib/cn';
 
 export function Version() {
+	let studioVersion = import.meta.env.VITE_STUDIO_VERSION;
+	const link = studioVersion?.startsWith('v')
+		? `https://github.com/HarperFast/studio/releases/tag/${studioVersion}`
+		: 'https://github.com/HarperFast/studio/releases';
 	return (
-		<a href="https://github.com/HarperFast/studio/releases" target="_blank" rel="noopener noreferrer">
+		<a href={link} target="_blank" rel="noopener noreferrer">
 			<span className={cn(badgeVariants({ variant: 'default' }), 'text-xs inline-block ml-2 align-text-top')}>
-				{import.meta.env.VITE_STUDIO_VERSION} BETA
+				{studioVersion} BETA
 			</span>
 		</a>
 	);

--- a/src/features/instance/config/overview/components/HarperVersion.tsx
+++ b/src/features/instance/config/overview/components/HarperVersion.tsx
@@ -8,11 +8,22 @@ export const HarperVersion = ({
 	loadingRegistration?: boolean;
 	registrationInfo?: RegistrationInfoResponse;
 }) => {
+	const link = !!registrationInfo?.version
+		&& parseInt(registrationInfo.version[0], 10) >= 5
+		&& `https://github.com/HarperFast/harper/releases/tag/v${registrationInfo.version}`;
 	return (
 		<>
 			<dt className="font-bold text-sm/6">Harper Version</dt>
 			<dd className="text-sm/6 sm:mt-2">
-				{loadingRegistration ? <TextLoadingSkeleton className="w-10" /> : registrationInfo?.version || 'Unknown'}
+				{loadingRegistration
+					? <TextLoadingSkeleton className="w-10" />
+					: link
+					? (
+						<a href={link} target="_blank" className="underline hover:text-blue-300" rel="noopener noreferrer">
+							{registrationInfo.version}
+						</a>
+					)
+					: registrationInfo?.version || 'Unknown'}
 			</dd>
 		</>
 	);


### PR DESCRIPTION
When we’re using v5 of Harper, or when we have a Studio release, we can link to the corresponding GitHub release. The config page has been linkified accordingly, and the link already in the header has been made more specific.

https://github.com/HarperFast/studio/issues/1175