### PR TITLE
feat: Add coupon management for organizations in admin mode

### DIFF
--- a/src/features/organization/modals/AddCouponModal.tsx
+++ b/src/features/organization/modals/AddCouponModal.tsx
@@ -1,0 +1,134 @@
+import { Button } from '@/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Form } from '@/components/ui/form/Form';
+import { FormControl } from '@/components/ui/form/FormControl';
+import { FormField } from '@/components/ui/form/FormField';
+import { FormItem } from '@/components/ui/form/FormItem';
+import { FormLabel } from '@/components/ui/form/FormLabel';
+import { FormMessage } from '@/components/ui/form/FormMessage';
+import { Input } from '@/components/ui/input';
+import { AddCouponSchema, AddCouponType } from '@/features/organization/mutations/AddCouponSchema';
+import { useAddCouponToOrganization } from '@/features/organization/mutations/addCouponToOrganization';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+export function AddCouponModal({
+	organizationId,
+	organizationName,
+	isOpen,
+	onClose,
+}: {
+	organizationId: string;
+	organizationName?: string;
+	isOpen: boolean;
+	onClose: () => void;
+}) {
+	const { mutate, isPending } = useAddCouponToOrganization();
+
+	const form = useForm<AddCouponType>({
+		resolver: zodResolver(AddCouponSchema),
+		defaultValues: {
+			couponId: '',
+		},
+	});
+
+	const { handleSubmit, control, reset } = form;
+
+	useEffect(() => {
+		if (isOpen) {
+			reset({ couponId: '' });
+		}
+	}, [isOpen, reset]);
+
+	const onSubmit = useCallback(
+		(values: AddCouponType) => {
+			mutate(
+				{ organizationId, couponId: values.couponId },
+				{
+					onSuccess: (error?: string) => {
+						if (!error) {
+							toast.success('Success', {
+								description: `Coupon "${values.couponId}" added to ${organizationName || organizationId}.`,
+							});
+							onClose();
+						} else {
+							toast.error('Error', {
+								description: error || 'Failed to add coupon.',
+							});
+						}
+					},
+				},
+			);
+		},
+		[mutate, organizationId, organizationName, onClose],
+	);
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Add Coupon</DialogTitle>
+					<DialogDescription>
+						Add a coupon code to{' '}
+						{organizationName || organizationId}. This coupon will be applied to the next billing cycle.
+						<br />
+						Coupons can be created in our{' '}
+						<a
+							href="https://dashboard.stripe.com/"
+							target="_blank"
+							rel="noreferrer"
+							className="text-purple hover:underline"
+						>
+							Stripe Dashboard
+						</a>.
+					</DialogDescription>
+				</DialogHeader>
+				<Form {...form}>
+					<form onSubmit={handleSubmit(onSubmit)}>
+						<div className="grid gap-4 py-4">
+							<FormField
+								control={control}
+								name="couponId"
+								render={({ field }) => (
+									<FormItem className="grid items-center gap-4">
+										<FormLabel>Coupon ID</FormLabel>
+										<FormControl>
+											<Input
+												{...field}
+												placeholder="e.g. 100OFF"
+												disabled={isPending}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={onClose}
+								disabled={isPending}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isPending}>
+								{isPending ? 'Adding...' : 'Add Coupon'}
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/organization/mutations/AddCouponSchema.ts
+++ b/src/features/organization/mutations/AddCouponSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const AddCouponSchema = z.object({
+	couponId: z
+		.string()
+		.nonempty({
+			message: 'Please enter a coupon ID.',
+		})
+		.trim(),
+});
+
+export type AddCouponType = z.infer<typeof AddCouponSchema>;

--- a/src/features/organization/mutations/addCouponToOrganization.ts
+++ b/src/features/organization/mutations/addCouponToOrganization.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '@/config/apiClient';
+import { useMutation } from '@tanstack/react-query';
+
+export async function onAddCouponToOrganizationSubmit(
+	{ organizationId, couponId }: { organizationId: string; couponId: string },
+) {
+	const { data } = await apiClient.post(
+		'/Coupon' as any,
+		{
+			organizationId,
+			couponId,
+		},
+		{
+			validateStatus: (status) => status >= 200 && status < 400 || status === 400 || status === 409,
+		},
+	);
+	return data;
+}
+
+export function useAddCouponToOrganization() {
+	return useMutation({
+		mutationFn: onAddCouponToOrganizationSubmit,
+	});
+}

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -8,11 +8,22 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
+import { AddCouponModal } from '@/features/organization/modals/AddCouponModal';
+import { useAdminMode } from '@/hooks/useAuth';
 import { useOrganizationPermissions, useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { Link } from '@tanstack/react-router';
-import { ArrowRight, Ellipsis } from 'lucide-react';
-import { useCallback } from 'react';
+import {
+	ArrowRight,
+	CreditCardIcon,
+	Ellipsis,
+	ServerIcon,
+	ShieldCheckIcon,
+	TicketIcon,
+	Trash2Icon,
+	UsersIcon,
+} from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 export function OrgCard({
 	organizationRole,
@@ -25,6 +36,9 @@ export function OrgCard({
 	const { remove, update: canUpdateOrganization } = useOrganizationPermissions(organizationId);
 	const showBilling = canUpdateOrganization;
 	const { view: showOrgUsersAndRoles } = useOrganizationRolePermissions(organizationId);
+	const isAdminMode = useAdminMode();
+
+	const [isCouponModalOpen, setIsCouponModalOpen] = useState(false);
 
 	const onDeleteClick = useCallback(() => {
 		onDeleteOrgModal(organizationRole);
@@ -44,22 +58,40 @@ export function OrgCard({
 								<DropdownMenuLabel className="text-gray-600 text-xs">Options</DropdownMenuLabel>
 								<DropdownMenuSeparator />
 								<Link to={`${organizationId}`}>
-									<DropdownMenuItem>Clusters</DropdownMenuItem>
+									<DropdownMenuItem>
+										<ServerIcon className="size-4 mr-2 text-blue-500" />
+										Clusters
+									</DropdownMenuItem>
 								</Link>
 								{showOrgUsersAndRoles && (
 									<Link to={`${organizationId}/roles`}>
-										<DropdownMenuItem>Roles</DropdownMenuItem>
+										<DropdownMenuItem>
+											<ShieldCheckIcon className="size-4 mr-2 text-purple" />
+											Roles
+										</DropdownMenuItem>
 									</Link>
 								)}
 								{showOrgUsersAndRoles && (
 									<Link to={`${organizationId}/users`}>
-										<DropdownMenuItem>Users</DropdownMenuItem>
+										<DropdownMenuItem>
+											<UsersIcon className="size-4 mr-2 text-orange-500" />
+											Users
+										</DropdownMenuItem>
 									</Link>
 								)}
 								{showBilling && (
 									<Link to={`${organizationId}/billing`}>
-										<DropdownMenuItem>Billing</DropdownMenuItem>
+										<DropdownMenuItem>
+											<CreditCardIcon className="size-4 mr-2 text-green-500" />
+											Billing
+										</DropdownMenuItem>
 									</Link>
+								)}
+								{isAdminMode && (
+									<DropdownMenuItem onClick={() => setIsCouponModalOpen(true)}>
+										<TicketIcon className="size-4 mr-2 text-pink-500" />
+										Add Coupon
+									</DropdownMenuItem>
 								)}
 								<DropdownMenuSeparator />
 								{remove && (
@@ -67,6 +99,7 @@ export function OrgCard({
 										className="focus:bg-red/70 focus:text-white"
 										onClick={onDeleteClick}
 									>
+										<Trash2Icon className="size-4 mr-2 text-red-500" />
 										Delete
 									</DropdownMenuItem>
 								)}
@@ -91,6 +124,12 @@ export function OrgCard({
 					</span>
 				</Link>
 			</CardContent>
+			<AddCouponModal
+				organizationId={organizationId}
+				organizationName={organizationName}
+				isOpen={isCouponModalOpen}
+				onClose={() => setIsCouponModalOpen(false)}
+			/>
 		</Card>
 	);
 }


### PR DESCRIPTION
Introduces an "Add Coupon" action on OrgCard (visible only in admin mode) backed by a new modal, Zod schema, and React Query mutation that posts to the /Coupon endpoint. Also adds icons to all OrgCard dropdown menu items for visual consistency.

https://harperdb.atlassian.net/browse/STUDIO-607