### PR TITLE
Show CPU/Memory and cloud instance type on plan details

### DIFF
--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -8,7 +8,7 @@ import { ClusterName } from '@/features/clusters/upsert/fields/ClusterName';
 import { ClusterPerformanceDescription } from '@/features/clusters/upsert/fields/ClusterPerformanceDescription';
 import { ClusterSkipGtmWait } from '@/features/clusters/upsert/fields/ClusterSkipGtmWait';
 import { ClusterVersion } from '@/features/clusters/upsert/fields/ClusterVersion';
-import { SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
+import { SchemaCloudInstanceTypes, SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
 import { ArrowRight } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { UseFormReturn, useFormState } from 'react-hook-form';
@@ -23,7 +23,7 @@ interface ClusterDetailsProps {
 	form: UseFormReturn<UpsertClusterSchemaType>;
 	harperVersions: HarperVersionsResponse | undefined;
 	isEnterprise: boolean;
-	isAkamai: boolean;
+	cloudProvider: keyof SchemaCloudInstanceTypes;
 	isPending: boolean;
 	mode: 'version' | undefined;
 	regionLocations: SchemaRegion[] | undefined;
@@ -41,7 +41,7 @@ export function ClusterDetails({
 	form,
 	harperVersions,
 	isEnterprise,
-	isAkamai,
+	cloudProvider,
 	isPending,
 	mode,
 	regionLocations,
@@ -169,7 +169,7 @@ export function ClusterDetails({
 							selectedPlan={selectedPlan}
 							totalPrice={totalPrice}
 							isEnterprise={isEnterprise}
-							isAkamai={isAkamai}
+							cloudProvider={cloudProvider}
 						/>
 					)}
 				{clusterId && !isSelfManaged && <ClusterSkipGtmWait className="col-span-3 md:col-span-6" form={form} />}

--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -23,7 +23,7 @@ interface ClusterDetailsProps {
 	form: UseFormReturn<UpsertClusterSchemaType>;
 	harperVersions: HarperVersionsResponse | undefined;
 	isEnterprise: boolean;
-	cloudProvider: keyof SchemaCloudInstanceTypes;
+	cloudProvider: keyof SchemaCloudInstanceTypes | undefined;
 	isPending: boolean;
 	mode: 'version' | undefined;
 	regionLocations: SchemaRegion[] | undefined;

--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -23,6 +23,7 @@ interface ClusterDetailsProps {
 	form: UseFormReturn<UpsertClusterSchemaType>;
 	harperVersions: HarperVersionsResponse | undefined;
 	isEnterprise: boolean;
+	isAkamai: boolean;
 	isPending: boolean;
 	mode: 'version' | undefined;
 	regionLocations: SchemaRegion[] | undefined;
@@ -40,6 +41,7 @@ export function ClusterDetails({
 	form,
 	harperVersions,
 	isEnterprise,
+	isAkamai,
 	isPending,
 	mode,
 	regionLocations,
@@ -167,6 +169,7 @@ export function ClusterDetails({
 							selectedPlan={selectedPlan}
 							totalPrice={totalPrice}
 							isEnterprise={isEnterprise}
+							isAkamai={isAkamai}
 						/>
 					)}
 				{clusterId && !isSelfManaged && <ClusterSkipGtmWait className="col-span-3 md:col-span-6" form={form} />}

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -64,7 +64,7 @@ export function ClusterForm({
 	const navigate = useNavigate();
 	const router = useRouter();
 	const isEnterprise = organization?.type === ENTERPRISE;
-	const cloudProvider = organization?.channel === 'Akamai' ? 'linode' : 'gcp';
+	const cloudProvider = organization?.channel === 'Akamai' ? 'linode' : undefined;
 
 	const queryClient = useQueryClient();
 	const { mutate: submitNewClusterData, isPending: isCreatePending } = useCreateNewClusterMutation();

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -64,6 +64,7 @@ export function ClusterForm({
 	const navigate = useNavigate();
 	const router = useRouter();
 	const isEnterprise = organization?.type === ENTERPRISE;
+	const isAkamai = organization?.channel === 'Akamai';
 
 	const queryClient = useQueryClient();
 	const { mutate: submitNewClusterData, isPending: isCreatePending } = useCreateNewClusterMutation();
@@ -491,6 +492,7 @@ export function ClusterForm({
 									selectedPlan={selectedPlan}
 									totalPrice={totalPrice}
 									isEnterprise={isEnterprise}
+									isAkamai={isAkamai}
 								/>
 							</form>
 						</>

--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -64,7 +64,7 @@ export function ClusterForm({
 	const navigate = useNavigate();
 	const router = useRouter();
 	const isEnterprise = organization?.type === ENTERPRISE;
-	const isAkamai = organization?.channel === 'Akamai';
+	const cloudProvider = organization?.channel === 'Akamai' ? 'linode' : 'gcp';
 
 	const queryClient = useQueryClient();
 	const { mutate: submitNewClusterData, isPending: isCreatePending } = useCreateNewClusterMutation();
@@ -492,7 +492,7 @@ export function ClusterForm({
 									selectedPlan={selectedPlan}
 									totalPrice={totalPrice}
 									isEnterprise={isEnterprise}
-									isAkamai={isAkamai}
+									cloudProvider={cloudProvider}
 								/>
 							</form>
 						</>

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -1,7 +1,7 @@
 import { ContactUs } from '@/components/ContactUs';
 import { ErrorComponent } from '@/components/ErrorComponent';
 import { Button } from '@/components/ui/button';
-import { SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
+import { SchemaCloudInstanceTypes, SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
 import { PlusIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useFieldArray, UseFormReturn } from 'react-hook-form';
@@ -15,7 +15,7 @@ interface ClusterRegionsProps {
 	selectedPlan: SchemaPlan | undefined;
 	totalPrice: number | undefined;
 	isEnterprise: boolean;
-	isAkamai: boolean;
+	cloudProvider: keyof SchemaCloudInstanceTypes;
 }
 
 export function ClusterRegions({
@@ -25,7 +25,7 @@ export function ClusterRegions({
 	selectedPlan,
 	totalPrice,
 	isEnterprise,
-	isAkamai,
+	cloudProvider,
 }: ClusterRegionsProps) {
 	const selectedRegionPlans = form.watch('regionPlans');
 
@@ -87,7 +87,7 @@ export function ClusterRegions({
 					regionNameToLatencyToRegion={regionNameToLatencyToRegion}
 					selectedPlan={selectedPlan}
 					isEnterprise={isEnterprise}
-					isAkamai={isAkamai}
+					cloudProvider={cloudProvider}
 				/>
 			))}
 

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -15,6 +15,7 @@ interface ClusterRegionsProps {
 	selectedPlan: SchemaPlan | undefined;
 	totalPrice: number | undefined;
 	isEnterprise: boolean;
+	isAkamai: boolean;
 }
 
 export function ClusterRegions({
@@ -24,6 +25,7 @@ export function ClusterRegions({
 	selectedPlan,
 	totalPrice,
 	isEnterprise,
+	isAkamai,
 }: ClusterRegionsProps) {
 	const selectedRegionPlans = form.watch('regionPlans');
 
@@ -85,6 +87,7 @@ export function ClusterRegions({
 					regionNameToLatencyToRegion={regionNameToLatencyToRegion}
 					selectedPlan={selectedPlan}
 					isEnterprise={isEnterprise}
+					isAkamai={isAkamai}
 				/>
 			))}
 

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -15,7 +15,7 @@ interface ClusterRegionsProps {
 	selectedPlan: SchemaPlan | undefined;
 	totalPrice: number | undefined;
 	isEnterprise: boolean;
-	cloudProvider: keyof SchemaCloudInstanceTypes;
+	cloudProvider: keyof SchemaCloudInstanceTypes | undefined;
 }
 
 export function ClusterRegions({

--- a/src/features/clusters/upsert/components/RegionFormInputs.tsx
+++ b/src/features/clusters/upsert/components/RegionFormInputs.tsx
@@ -6,7 +6,7 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { UpsertClusterSchemaType } from '@/features/clusters/upsert/upsertClusterSchema';
-import { SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
+import { SchemaCloudInstanceTypes, SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
 import { sortByNumberPrefix } from '@/lib/arrays/sort/byNumberPrefix';
 import { TrashIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -21,7 +21,7 @@ type RegionFormInputsProps = {
 	regionNameToLatencyToRegion: Record<string, Record<string, SchemaRegion>>;
 	selectedPlan: SchemaPlan | undefined;
 	isEnterprise: boolean;
-	isAkamai: boolean;
+	cloudProvider: keyof SchemaCloudInstanceTypes;
 };
 
 export function RegionFormInputs({
@@ -32,7 +32,7 @@ export function RegionFormInputs({
 	regionNameToLatencyToRegion,
 	selectedPlan,
 	isEnterprise,
-	isAkamai,
+	cloudProvider,
 }: RegionFormInputsProps) {
 	const availableRegionNames = useMemo(() => Object.keys(regionNameToLatencyToRegion).sort(), [
 		regionNameToLatencyToRegion,
@@ -145,7 +145,7 @@ export function RegionFormInputs({
 				selectedPlan={selectedPlan}
 				selectedRegion={regionNameToLatencyToRegion[selectedRegionName]?.[selectedLatencyDescription]}
 				isEnterprise={isEnterprise}
-				isAkamai={isAkamai}
+				cloudProvider={cloudProvider}
 			/>
 		</div>
 	);

--- a/src/features/clusters/upsert/components/RegionFormInputs.tsx
+++ b/src/features/clusters/upsert/components/RegionFormInputs.tsx
@@ -21,6 +21,7 @@ type RegionFormInputsProps = {
 	regionNameToLatencyToRegion: Record<string, Record<string, SchemaRegion>>;
 	selectedPlan: SchemaPlan | undefined;
 	isEnterprise: boolean;
+	isAkamai: boolean;
 };
 
 export function RegionFormInputs({
@@ -31,6 +32,7 @@ export function RegionFormInputs({
 	regionNameToLatencyToRegion,
 	selectedPlan,
 	isEnterprise,
+	isAkamai,
 }: RegionFormInputsProps) {
 	const availableRegionNames = useMemo(() => Object.keys(regionNameToLatencyToRegion).sort(), [
 		regionNameToLatencyToRegion,
@@ -143,6 +145,7 @@ export function RegionFormInputs({
 				selectedPlan={selectedPlan}
 				selectedRegion={regionNameToLatencyToRegion[selectedRegionName]?.[selectedLatencyDescription]}
 				isEnterprise={isEnterprise}
+				isAkamai={isAkamai}
 			/>
 		</div>
 	);

--- a/src/features/clusters/upsert/components/RegionFormInputs.tsx
+++ b/src/features/clusters/upsert/components/RegionFormInputs.tsx
@@ -21,7 +21,7 @@ type RegionFormInputsProps = {
 	regionNameToLatencyToRegion: Record<string, Record<string, SchemaRegion>>;
 	selectedPlan: SchemaPlan | undefined;
 	isEnterprise: boolean;
-	cloudProvider: keyof SchemaCloudInstanceTypes;
+	cloudProvider: keyof SchemaCloudInstanceTypes | undefined;
 };
 
 export function RegionFormInputs({

--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -98,12 +98,8 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 				value: `${humanFileSize(resourcesPerInstance.storageGb * 1000_000_000)}`,
 			},
 			!!resourcesPerInstance && isPositive(resourcesPerInstance.cpuCores) && {
-				label: 'CPU Cores',
+				label: 'Maximum CPU Cores',
 				value: `${humanNumber(resourcesPerInstance.cpuCores)}`,
-			},
-			!!resourcesPerInstance && isPositive(resourcesPerInstance.threads) && {
-				label: 'Threads',
-				value: `${humanNumber(resourcesPerInstance.threads)}`,
 			},
 			!!resourcesPerInstance && isPositive(resourcesPerInstance.memoryMb) && {
 				label: 'Memory',

--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -17,7 +17,7 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 	readonly selectedPlan: SchemaPlan | undefined;
 	readonly selectedRegion: SchemaRegion | undefined;
 	readonly isEnterprise: boolean;
-	readonly cloudProvider: keyof SchemaCloudInstanceTypes;
+	readonly cloudProvider: keyof SchemaCloudInstanceTypes | undefined;
 }) {
 	const [toggled, setToggled] = useState(false);
 	const onUsageLimitsClick = useCallback(() => {
@@ -25,7 +25,7 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 	}, [toggled, setToggled]);
 	const planLimits = selectedPlan?.planLimits;
 	const resourcesPerInstance = selectedPlan?.resourcesPerInstance;
-	const cloudInstanceType = selectedPlan?.cloudInstanceTypes?.[cloudProvider];
+	const cloudInstanceType = cloudProvider && selectedPlan?.cloudInstanceTypes?.[cloudProvider];
 
 	const expirationMonths = isPositive(planLimits?.expirationMonths) && planLimits.expirationMonths < 1000
 		&& planLimits.expirationMonths;

--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -13,10 +13,11 @@ import { isPositive } from '@/lib/types/isPositive';
 import { ArrowDownIcon, ArrowRightIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
-export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterprise }: {
+export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterprise, isAkamai }: {
 	readonly selectedPlan: SchemaPlan | undefined;
 	readonly selectedRegion: SchemaRegion | undefined;
 	readonly isEnterprise: boolean;
+	readonly isAkamai: boolean;
 }) {
 	const [toggled, setToggled] = useState(false);
 	const onUsageLimitsClick = useCallback(() => {
@@ -24,6 +25,9 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 	}, [toggled, setToggled]);
 	const planLimits = selectedPlan?.planLimits;
 	const resourcesPerInstance = selectedPlan?.resourcesPerInstance;
+	const cloudInstanceType = isAkamai
+		? selectedPlan?.cloudInstanceTypes?.linode
+		: selectedPlan?.cloudInstanceTypes?.gcp;
 
 	const expirationMonths = isPositive(planLimits?.expirationMonths) && planLimits.expirationMonths < 1000
 		&& planLimits.expirationMonths;
@@ -92,6 +96,22 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 			!!resourcesPerInstance && isPositive(resourcesPerInstance.storageGb) && {
 				label: 'Storage',
 				value: `${humanFileSize(resourcesPerInstance.storageGb * 1000_000_000)}`,
+			},
+			!!resourcesPerInstance && isPositive(resourcesPerInstance.cpuCores) && {
+				label: 'CPU Cores',
+				value: `${humanNumber(resourcesPerInstance.cpuCores)}`,
+			},
+			!!resourcesPerInstance && isPositive(resourcesPerInstance.threads) && {
+				label: 'Threads',
+				value: `${humanNumber(resourcesPerInstance.threads)}`,
+			},
+			!!resourcesPerInstance && isPositive(resourcesPerInstance.memoryMb) && {
+				label: 'Memory',
+				value: `${resourcesPerInstance.memoryMb / 1024} GB`,
+			},
+			!!cloudInstanceType && {
+				label: 'Cloud Instance Type',
+				value: cloudInstanceType,
 			},
 			!!expirationMonths && {
 				label: 'Expiration',

--- a/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
+++ b/src/features/clusters/upsert/components/ResourcesPerInstance.tsx
@@ -3,7 +3,7 @@ import { FormControl } from '@/components/ui/form/FormControl';
 import { FormItem } from '@/components/ui/form/FormItem';
 import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
-import { SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
+import { SchemaCloudInstanceTypes, SchemaPlan, SchemaRegion } from '@/integrations/api/api.gen';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { cn } from '@/lib/cn';
 import { humanFileSize } from '@/lib/humanFileSize';
@@ -13,11 +13,11 @@ import { isPositive } from '@/lib/types/isPositive';
 import { ArrowDownIcon, ArrowRightIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
-export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterprise, isAkamai }: {
+export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterprise, cloudProvider }: {
 	readonly selectedPlan: SchemaPlan | undefined;
 	readonly selectedRegion: SchemaRegion | undefined;
 	readonly isEnterprise: boolean;
-	readonly isAkamai: boolean;
+	readonly cloudProvider: keyof SchemaCloudInstanceTypes;
 }) {
 	const [toggled, setToggled] = useState(false);
 	const onUsageLimitsClick = useCallback(() => {
@@ -25,9 +25,7 @@ export function ResourcesPerInstance({ selectedPlan, selectedRegion, isEnterpris
 	}, [toggled, setToggled]);
 	const planLimits = selectedPlan?.planLimits;
 	const resourcesPerInstance = selectedPlan?.resourcesPerInstance;
-	const cloudInstanceType = isAkamai
-		? selectedPlan?.cloudInstanceTypes?.linode
-		: selectedPlan?.cloudInstanceTypes?.gcp;
+	const cloudInstanceType = selectedPlan?.cloudInstanceTypes?.[cloudProvider];
 
 	const expirationMonths = isPositive(planLimits?.expirationMonths) && planLimits.expirationMonths < 1000
 		&& planLimits.expirationMonths;


### PR DESCRIPTION
## Summary
- Adds **Maximum CPU Cores** and **Memory** rows to the "Learn More" plan-details table on the cluster creation page (sourced from `selectedPlan.resourcesPerInstance`).
- For **dedicated plans** only, adds a **Cloud Instance Type** row showing either the Linode (e.g. `g6-dedicated-16`) or GCP (e.g. `n2d-standard-16`) instance type from `selectedPlan.cloudInstanceTypes`.
- Linode is shown when the org's `channel` is `"Akamai"`; GCP is shown otherwise.

## Purpose
The plan details dropdown on cluster creation already exposed Storage and usage limits, but customers/SEs couldn't see the underlying instance shape (CPU/RAM) or which cloud SKU a dedicated plan would provision. This adds that visibility without changing pricing or any other behavior.

## Where to focus review
- `ClusterForm.tsx` — `isAkamai` is computed from `organization?.channel === 'Akamai'`. The channel string itself is never rendered; only the boolean is threaded through.
- `ResourcesPerInstance.tsx` — Cloud Instance Type row is gated on `!!cloudInstanceType`, which is only truthy when `selectedPlan.cloudInstanceTypes` is present (i.e. dedicated plans). Confirm that's the intended gate vs. checking `deploymentDescription.startsWith('Dedicated')`.
- Memory display: `memoryMb / 1024` + `" GB"` — assumes `memoryMb` is base-2 (MiB), per the data model.
- The `isAkamai` prop is threaded `ClusterForm → ClusterDetails → ClusterRegions → RegionFormInputs → ResourcesPerInstance`, mirroring the existing `isEnterprise` plumbing.

## Test plan
- [ ] Open the cluster creation page on a non-Akamai org with a dedicated plan selected → "Cloud Instance Type" row shows the GCP SKU.
- [ ] Open with an Akamai-channel org → "Cloud Instance Type" row shows the Linode SKU.
- [ ] Select a non-dedicated plan → "Cloud Instance Type" row is absent; CPU/Memory still appear when the plan provides them.
- [ ] Confirm no other content in the plan-details table or surrounding form changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)