### PR TITLE
fix: Auto-pick http when entering localhost

### DIFF
--- a/src/features/clusters/upsert/components/InstanceFormInputs.tsx
+++ b/src/features/clusters/upsert/components/InstanceFormInputs.tsx
@@ -75,6 +75,16 @@ export function InstanceFormInputs({
 								autoCapitalize="none"
 								autoComplete="off"
 								autoCorrect="off"
+								onChange={e => {
+									field.onChange(e);
+									const value = e.target.value;
+									const isLocalhost = value === 'localhost' || value === '127.0.0.1';
+									const secureFieldState = form.getFieldState(`instances.${index}.secure`);
+
+									if (isLocalhost && !secureFieldState.isDirty) {
+										form.setValue(`instances.${index}.secure`, 'false');
+									}
+								}}
 							/>
 						</FormControl>
 						<FormMessage />


### PR DESCRIPTION
If you’re self-managing a localhost or 127.0.0.1 instance, we can auto-pick http:// for you to make things easier.

https://harperdb.atlassian.net/browse/STUDIO-575