### PR TITLE
fix: Protect against large files

### DIFF
--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -2,7 +2,10 @@ import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { ALL_EDITOR_COMMAND_IDS } from '@/features/instance/applications/components/editorMenuCommands';
 import { setEditorShortcutLabels } from '@/features/instance/applications/components/editorShortcutLabels';
 import { useEditorFileContent } from '@/features/instance/applications/context/editorFileContent';
-import { useApplicationTypeIntelligence } from '@/features/instance/applications/hooks/useApplicationTypeIntelligence';
+import {
+	MAX_WORKER_MODEL_CHARS,
+	useApplicationTypeIntelligence,
+} from '@/features/instance/applications/hooks/useApplicationTypeIntelligence';
 import { useCodeNavigation } from '@/features/instance/applications/hooks/useCodeNavigation';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { registerWithEditor } from '@/features/instance/applications/shortcuts';
@@ -76,7 +79,13 @@ export function TextEditorView() {
 	useCodeNavigation(mounted?.[0]);
 
 	const extension = parseFileExtension(openedEntry?.path);
-	const language = extensionToLanguageMap[extension] || 'plaintext';
+	const fileContent = updatedFileContent ?? openedEntryContents;
+	// A huge open file would feed its full text to the language worker the same
+	// way sibling models do, overflowing the structured-clone buffer
+	// ("DataCloneError: ... out of memory."). Render it as plaintext so no
+	// language service runs against it.
+	const oversized = (fileContent?.length ?? 0) > MAX_WORKER_MODEL_CHARS;
+	const language = oversized ? 'plaintext' : extensionToLanguageMap[extension] || 'plaintext';
 
 	const handleEditorWillMount: EditorProps['beforeMount'] = useCallback((monaco) => {
 		configureHarperLanguageSupport(monaco);
@@ -151,7 +160,7 @@ export function TextEditorView() {
 			path={openedEntry.path}
 			language={language}
 			theme={monacoTheme}
-			value={updatedFileContent ?? openedEntryContents}
+			value={fileContent}
 			keepCurrentModel
 			beforeMount={handleEditorWillMount}
 			onMount={handleEditorDidMount}

--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -225,8 +225,10 @@ export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined
 			// Acquire npm @types for the packages these files import. Scan scripts
 			// only — declaration and JSON files don't introduce new dependencies.
 			const scriptSources = loaded
-				.filter(file => /\.(tsx?|jsx?|mjs|cjs|mts|cts)$/i.test(file.appPath) && !/\.d\.ts$/i.test(file.appPath))
-				.filter(file => file.content.length <= MAX_WORKER_MODEL_CHARS)
+				.filter(file =>
+					/\.(tsx?|jsx?|mjs|cjs|mts|cts)$/i.test(file.appPath) && !/\.d\.ts$/i.test(file.appPath)
+					&& file.content.length <= MAX_WORKER_MODEL_CHARS
+				)
 				.map(file => file.content);
 			void acquireApplicationTypes(scriptSources);
 		})();

--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -41,6 +41,17 @@ const IGNORED_DIR = /^(node_modules|dist|build|out|coverage|\.git|\.next|\.turbo
 const IGNORED_FILE = /^(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$/i;
 /** Cap simultaneous file fetches so large projects don't flood the connection pool. */
 const FETCH_CONCURRENCY = 5;
+/**
+ * Skip files larger than this when feeding the language worker. Monaco clones a
+ * model's full text to its worker over `postMessage` (structured clone), and
+ * `setEagerModelSync(true)` does so for every model we create here. A large
+ * file — a checked-in bundle, generated data, a minified vendor script — can
+ * overflow the clone buffer and crash the worker with "DataCloneError: Data
+ * cannot be cloned, out of memory.", and even short of that it bloats worker
+ * memory and slows the language service. Real source never approaches this, and
+ * such files add nothing to IntelliSense.
+ */
+export const MAX_WORKER_MODEL_CHARS = 512 * 1024;
 
 type AnyEntry = DirectoryEntry | FileEntry;
 
@@ -196,6 +207,11 @@ export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined
 				if (file.appPath === openPathRef.current) {
 					continue;
 				}
+				// Don't register oversized files: their full text would be cloned to
+				// the language worker (see MAX_WORKER_MODEL_CHARS) and can crash it.
+				if (file.content.length > MAX_WORKER_MODEL_CHARS) {
+					continue;
+				}
 				const uri = monaco.Uri.parse(`file:///${file.appPath}`);
 				if (monaco.editor.getModel(uri)) {
 					continue;
@@ -210,6 +226,7 @@ export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined
 			// only — declaration and JSON files don't introduce new dependencies.
 			const scriptSources = loaded
 				.filter(file => /\.(tsx?|jsx?|mjs|cjs|mts|cts)$/i.test(file.appPath) && !/\.d\.ts$/i.test(file.appPath))
+				.filter(file => file.content.length <= MAX_WORKER_MODEL_CHARS)
 				.map(file => file.content);
 			void acquireApplicationTypes(scriptSources);
 		})();


### PR DESCRIPTION
```
Failed to execute 'postMessage' on 'Worker': Data cannot be cloned, out of memory. DataCloneError: Failed to execute 'postMessage' on 'Worker': Data cannot be cloned, out of memory.
```