### PR TITLE
fix: table list scroll, make result set header sticky

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -66,6 +66,7 @@ export function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
 export function TableHeadSortable<TData extends RowData>({
 	header,
 	onColumnClick,
+	className,
 	...props
 }: React.ComponentProps<'th'> & {
 	header: Header<TData, unknown>;
@@ -87,7 +88,7 @@ export function TableHeadSortable<TData extends RowData>({
 		<TableHead
 			{...props}
 			style={{ width: `${header.getSize()}px` }}
-			className={enableSorting ? 'px-0' : 'px-2'}
+			className={cn(enableSorting ? 'px-0' : 'px-2', className)}
 		>
 			<div className="flex items-center justify-between">
 				{enableSorting

--- a/src/features/instance/databases/components/ColumnFilters.tsx
+++ b/src/features/instance/databases/components/ColumnFilters.tsx
@@ -5,6 +5,7 @@ import { FormItem } from '@/components/ui/form/FormItem';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { TableCell, TableHeader, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/cn';
 import { HeaderGroup } from '@tanstack/react-table';
 import { KeyboardEvent, useCallback } from 'react';
 import { UseFormReturn } from 'react-hook-form';
@@ -34,7 +35,14 @@ export function ColumnFilters<TData>({
 				{headerGroups.map((headerGroup) => (
 					<TableRow key={headerGroup.id} className="border-none">
 						{headerGroup.headers.map((header) => (
-							<TableCell key={header.id} style={{ width: `${header.column.getSize()}px` }}>
+							<TableCell
+								key={header.id}
+								style={{ width: `${header.column.getSize()}px` }}
+								className={cn(
+									'sticky z-10 bg-card dark:bg-black-dark border-b border-border',
+									'top-[calc(var(--spacing(32))+var(--spacing(10)))]',
+								)}
+							>
 								{header.column.columnDef.enableColumnFilter && (
 									<FormField
 										control={columnFiltersForm.control}

--- a/src/features/instance/databases/components/ColumnFilters.tsx
+++ b/src/features/instance/databases/components/ColumnFilters.tsx
@@ -48,7 +48,7 @@ export function ColumnFilters<TData>({
 										control={columnFiltersForm.control}
 										name={header.id}
 										render={({ field }) => (
-											<FormItem className="border-r-1 border-r-black">
+											<FormItem className="border-r border-r-black">
 												<FormControl>
 													<Input
 														{...field}

--- a/src/features/instance/databases/components/DatabasesSidebar.tsx
+++ b/src/features/instance/databases/components/DatabasesSidebar.tsx
@@ -54,12 +54,12 @@ export function DatabasesSidebar({ instanceDatabaseMap }: { instanceDatabaseMap?
 	}, [navigate, params]);
 
 	return (
-		<div className="pl-3">
-			<h1 className="pt-3 pb-3 text-3xl">Databases</h1>
+		<div className="pl-3 flex flex-col h-full min-h-0">
+			<h1 className="pt-3 pb-3 text-3xl shrink-0">Databases</h1>
 			{loading
-				? <TextLoadingSkeleton className="w-full h-9 m-0 rounded-md" />
+				? <TextLoadingSkeleton className="w-full h-9 m-0 rounded-md shrink-0" />
 				: (
-					<div className="flex space-x-2">
+					<div className="flex space-x-2 shrink-0">
 						<Select
 							name="databaseSelect"
 							value={params.databaseName || ''}
@@ -82,9 +82,9 @@ export function DatabasesSidebar({ instanceDatabaseMap }: { instanceDatabaseMap?
 					</div>
 				)}
 			{loading
-				? <TextLoadingSkeleton className="w-full min-h-80 rounded-md mb-0" />
+				? <TextLoadingSkeleton className="w-full flex-1 min-h-0 rounded-md mb-0 mt-4" />
 				: (
-					<ScrollArea className="border rounded-md min-h-80 border-grey-700 mt-4">
+					<ScrollArea type="auto" className="flex-1 min-h-0 border rounded-md border-grey-700 mt-4">
 						{tableNames.length === 0 && params.databaseName?.length
 							? (
 								<div className="w-full h-full text-center">
@@ -133,10 +133,12 @@ export function DatabasesSidebar({ instanceDatabaseMap }: { instanceDatabaseMap?
 					</ScrollArea>
 				)}
 			{canManageBrowseInstance && (
-				<CreateNewTableModal
-					databaseName={params.databaseName}
-					onSelectTable={onSelectTable}
-				/>
+				<div className="shrink-0">
+					<CreateNewTableModal
+						databaseName={params.databaseName}
+						onSelectTable={onSelectTable}
+					/>
+				</div>
 			)}
 		</div>
 	);

--- a/src/features/instance/databases/components/TableView.tsx
+++ b/src/features/instance/databases/components/TableView.tsx
@@ -87,12 +87,17 @@ export function TableView<TData, TValue>({
 
 	return (
 		<>
-			<Table containerClassName="rounded-md bg-card dark:bg-black-dark grow max-h-[calc(100vh-128px-16px-112px-80px)]">
+			<Table containerClassName="rounded-md bg-card dark:bg-black-dark grow overflow-visible">
 				<TableHeader>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<TableRow key={headerGroup.id} className="border-none">
 							{headerGroup.headers.map((header) => (
-								<TableHeadSortable key={header.id} header={header} onColumnClick={onColumnClick} />
+								<TableHeadSortable
+									key={header.id}
+									header={header}
+									onColumnClick={onColumnClick}
+									className="sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
+								/>
 							))}
 						</TableRow>
 					))}

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -42,11 +42,11 @@ export function Databases() {
 	}
 
 	return (
-		<main className="grid grid-cols-1 gap-4 md:grid-cols-12 min-h-[calc(100vh-(--spacing(36)))]">
-			<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3">
+		<main className="grid grid-cols-1 gap-4 md:grid-cols-12 md:items-start">
+			<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden">
 				<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
 			</section>
-			<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9 flex flex-col">
+			<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9 flex flex-col min-h-0">
 				{params.databaseName && params.tableName && (
 					<DatabaseTableView
 						instanceDatabaseMap={instanceDatabaseMap}

--- a/src/features/instance/databases/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/databases/modals/CreateNewTableModal.tsx
@@ -88,7 +88,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 	return (
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
 			<DialogTrigger asChild>
-				<div className="sticky bottom-0 py-4 bg-background/80 backdrop-blur-xs dark:bg-black/70">
+				<div className="shrink-0 py-4">
 					<Button variant="positiveOutline" className="w-full rounded-full" size="lg" accessKey="t">
 						<Plus />
 						<span>


### PR DESCRIPTION
If you have many tables, you need to scroll the entire browser window to scroll the list of tables. This PR restricts the height of the sidebar to the browser window's height and will automatically show the scrollbar if the list of tables exceeds the height of the browser window.

A nice side effect of this, it fixes the mismatched background color behind the "Create a Table" button.

It also makes the result set table header sticky so you can see the column names as you scroll.

This does not make the Add new Record, Import CSV, etc elements sticky. It also doesn't make the pagination in the footer sticky. Only the table header.