### PR TITLE
feat: Resizable, draggable log and record modals

### DIFF
--- a/.claude/hooks/copy-env-local.sh
+++ b/.claude/hooks/copy-env-local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SessionStart hook: when working in a linked git worktree, copy .env.local from the main
+# worktree so the dev server (which loads it via `dotenv -e .env.local`) is configured without
+# any manual setup.
+#
+# Safe by design: it only ever *creates* .env.local when it is missing, never overwrites an
+# existing one, and never touches the main checkout. It always exits 0 so it can't fail a session.
+
+# Operate from the project root regardless of where the hook was invoked.
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
+
+# Only act inside a git working tree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Already configured — nothing to do.
+if [ -f .env.local ]; then
+	exit 0
+fi
+
+# The main worktree is always the first entry of `git worktree list`.
+main=$(git worktree list --porcelain 2>/dev/null | sed -n '1s/^worktree //p')
+if [ -z "$main" ] || [ "$main" = "$PWD" ]; then
+	# No worktrees, or we *are* the main checkout — leave .env.local management to the user.
+	exit 0
+fi
+
+src="$main/.env.local"
+if [ -f "$src" ] && cp "$src" .env.local 2>/dev/null; then
+	echo "[claude] Copied .env.local from the main worktree so the dev server is configured." >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
 	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/copy-env-local.sh\"",
+						"statusMessage": "Syncing .env.local for this worktree..."
+					}
+				]
+			}
+		],
 		"Stop": [
 			{
 				"hooks": [

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,5 +1,5 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { GripHorizontal, XIcon } from 'lucide-react';
+import { GripHorizontal, Maximize, Minimize, XIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/cn';
@@ -70,7 +70,11 @@ const RESIZE_HANDLES: { dir: ResizeDirection; className: string }[] = [
 function ResizableDialogContent(
 	{ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>,
 ) {
-	const { size, position, isDragging, isResizing, contentRef, startDrag, startResize } = useResizableDialog();
+	const { size, position, isDragging, isResizing, isMaximized, contentRef, startDrag, startResize, toggleMaximize } =
+		useResizableDialog();
+
+	const headerButtonClass =
+		'ring-offset-background focus:ring-ring text-popover-foreground flex size-8 items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none';
 
 	return (
 		<DialogPortal data-slot="dialog-portal">
@@ -111,7 +115,24 @@ function ResizableDialogContent(
 						<GripHorizontal className="mt-1 size-4 text-muted-foreground/40" />
 					</div>
 					{children}
-					<DialogCloseButton className="z-20" />
+					{
+						/* Header actions — maximize/restore and close — vertically centered on the title row
+					    (top-6 matches the body's p-6, and the row's height matches the text-lg title line). */
+					}
+					<div className="absolute top-6 right-4 z-20 flex h-[1.125rem] items-center gap-1">
+						<button
+							type="button"
+							onClick={toggleMaximize}
+							aria-label={isMaximized ? 'Restore modal size' : 'Maximize modal'}
+							className={headerButtonClass}
+						>
+							{isMaximized ? <Minimize className="size-4" /> : <Maximize className="size-4" />}
+						</button>
+						<DialogPrimitive.Close aria-label="Close" className={headerButtonClass}>
+							<XIcon className="size-4" />
+							<span className="sr-only">Close</span>
+						</DialogPrimitive.Close>
+					</div>
 				</div>
 				{/* Resize handles sit outside the clipped body so their hit area can extend past the edges. */}
 				{RESIZE_HANDLES.map(({ dir, className: handleClassName }) => (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,8 +37,10 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<typeof Dial
 function DialogCloseButton({ className }: { className?: string }) {
 	return (
 		<DialogPrimitive.Close
+			// Anchored to the very corner with padding so the whole top-right corner is a click target,
+			// not just the X glyph. The icon still sits ~16px in (matching its old position).
 			className={cn(
-				"ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-0 right-0 flex items-start justify-end rounded-bl-md p-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 		>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -49,18 +49,20 @@ function DialogCloseButton({ className }: { className?: string }) {
 }
 
 /**
- * Resize handles, one per edge and corner. Edges are inset so the corner handles own the very
- * corners (where both axes resize). Edges sit at z-30, corners above them at z-40.
+ * Resize handles, one per edge and corner. Each straddles the modal border and extends ~8px
+ * outward (negative insets) for a generous, forgiving hit area — only possible because the
+ * content shell below does not clip its overflow. Edges are inset from the corners so the corner
+ * handles own the very corners (where both axes resize); edges sit at z-30, corners above at z-40.
  */
 const RESIZE_HANDLES: { dir: ResizeDirection; className: string }[] = [
-	{ dir: 'n', className: 'top-0 inset-x-3 h-1.5 cursor-ns-resize z-30' },
-	{ dir: 's', className: 'bottom-0 inset-x-3 h-1.5 cursor-ns-resize z-30' },
-	{ dir: 'e', className: 'right-0 inset-y-3 w-1.5 cursor-ew-resize z-30' },
-	{ dir: 'w', className: 'left-0 inset-y-3 w-1.5 cursor-ew-resize z-30' },
-	{ dir: 'nw', className: 'top-0 left-0 size-3 cursor-nwse-resize z-40' },
-	{ dir: 'ne', className: 'top-0 right-0 size-3 cursor-nesw-resize z-40' },
-	{ dir: 'sw', className: 'bottom-0 left-0 size-3 cursor-nesw-resize z-40' },
-	{ dir: 'se', className: 'bottom-0 right-0 size-3 cursor-nwse-resize z-40' },
+	{ dir: 'n', className: '-top-2 inset-x-5 h-4 cursor-ns-resize z-30' },
+	{ dir: 's', className: '-bottom-2 inset-x-5 h-4 cursor-ns-resize z-30' },
+	{ dir: 'e', className: '-right-2 inset-y-5 w-4 cursor-ew-resize z-30' },
+	{ dir: 'w', className: '-left-2 inset-y-5 w-4 cursor-ew-resize z-30' },
+	{ dir: 'nw', className: '-top-2 -left-2 size-6 cursor-nwse-resize z-40' },
+	{ dir: 'ne', className: '-top-2 -right-2 size-6 cursor-nesw-resize z-40' },
+	{ dir: 'sw', className: '-bottom-2 -left-2 size-6 cursor-nesw-resize z-40' },
+	{ dir: 'se', className: '-bottom-2 -right-2 size-6 cursor-nwse-resize z-40' },
 ];
 
 function ResizableDialogContent(
@@ -79,31 +81,41 @@ function ResizableDialogContent(
 				className={cn(
 					'bg-popover '
 						+ 'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 '
-						+ 'fixed z-50 flex flex-col '
-						+ 'overflow-hidden '
-						+ 'gap-4 rounded-md border p-6 shadow-2xl '
-						// No transition: dragging/resizing move the modal imperatively every frame, and an
-						// implicit `transition: all` would make it lag behind the cursor. (Open/close still animate.)
+						+ 'fixed z-50 '
+						+ 'rounded-md border shadow-2xl '
+						// Deliberately NOT clipped here: the resize handles below extend past the modal edges,
+						// so the inner body does the clipping instead. No transition either — dragging/resizing
+						// move the modal imperatively every frame and an implicit `transition: all` would make
+						// it lag behind the cursor. (Open/close still animate.)
 						+ 'transition-none',
-					(isDragging || isResizing) && 'select-none',
 					isDragging && 'will-change-transform',
 					className,
 				)}
 				{...props}
 			>
-				{/* Title-bar strip: grab anywhere across the top to drag the modal around. */}
+				{/* Inner body holds the actual UI and clips it to the rounded rect. */}
 				<div
-					onMouseDown={startDrag}
-					className="absolute inset-x-0 top-0 z-10 flex h-12 cursor-move items-start justify-center"
-					aria-hidden
+					className={cn(
+						'flex h-full w-full flex-col gap-4 overflow-hidden rounded-md p-6',
+						(isDragging || isResizing) && 'select-none',
+					)}
 				>
-					<GripHorizontal className="mt-1 size-4 text-muted-foreground/40" />
+					{/* Title-bar strip: grab anywhere across the top to drag the modal around. */}
+					<div
+						onMouseDown={startDrag}
+						className="absolute inset-x-0 top-0 z-10 flex h-12 cursor-move items-start justify-center"
+						aria-hidden
+					>
+						<GripHorizontal className="mt-1 size-4 text-muted-foreground/40" />
+					</div>
+					{children}
+					<DialogCloseButton className="z-20" />
 				</div>
-				{children}
-				<DialogCloseButton className="z-20" />
+				{/* Resize handles sit outside the clipped body so their hit area can extend past the edges. */}
 				{RESIZE_HANDLES.map(({ dir, className: handleClassName }) => (
 					<div
 						key={dir}
+						data-resize-handle={dir}
 						onMouseDown={startResize(dir)}
 						className={cn('absolute', handleClassName)}
 						aria-hidden

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -82,8 +82,11 @@ function ResizableDialogContent(
 						+ 'fixed z-50 flex flex-col '
 						+ 'overflow-hidden '
 						+ 'gap-4 rounded-md border p-6 shadow-2xl '
-						+ 'duration-200',
+						// No transition: dragging/resizing move the modal imperatively every frame, and an
+						// implicit `transition: all` would make it lag behind the cursor. (Open/close still animate.)
+						+ 'transition-none',
 					(isDragging || isResizing) && 'select-none',
+					isDragging && 'will-change-transform',
 					className,
 				)}
 				{...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,9 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { XIcon } from 'lucide-react';
+import { GripHorizontal, XIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/cn';
+import { type ResizeDirection, useResizableDialog } from './useResizableDialog';
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
 	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -33,7 +34,96 @@ function DialogOverlay({ className, ...props }: React.ComponentProps<typeof Dial
 	);
 }
 
-function DialogContent({ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>) {
+function DialogCloseButton({ className }: { className?: string }) {
+	return (
+		<DialogPrimitive.Close
+			className={cn(
+				"ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+		>
+			<XIcon className="text-popover-foreground" />
+			<span className="sr-only">Close</span>
+		</DialogPrimitive.Close>
+	);
+}
+
+/**
+ * Resize handles, one per edge and corner. Edges are inset so the corner handles own the very
+ * corners (where both axes resize). Edges sit at z-30, corners above them at z-40.
+ */
+const RESIZE_HANDLES: { dir: ResizeDirection; className: string }[] = [
+	{ dir: 'n', className: 'top-0 inset-x-3 h-1.5 cursor-ns-resize z-30' },
+	{ dir: 's', className: 'bottom-0 inset-x-3 h-1.5 cursor-ns-resize z-30' },
+	{ dir: 'e', className: 'right-0 inset-y-3 w-1.5 cursor-ew-resize z-30' },
+	{ dir: 'w', className: 'left-0 inset-y-3 w-1.5 cursor-ew-resize z-30' },
+	{ dir: 'nw', className: 'top-0 left-0 size-3 cursor-nwse-resize z-40' },
+	{ dir: 'ne', className: 'top-0 right-0 size-3 cursor-nesw-resize z-40' },
+	{ dir: 'sw', className: 'bottom-0 left-0 size-3 cursor-nesw-resize z-40' },
+	{ dir: 'se', className: 'bottom-0 right-0 size-3 cursor-nwse-resize z-40' },
+];
+
+function ResizableDialogContent(
+	{ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>,
+) {
+	const { size, position, isDragging, isResizing, contentRef, startDrag, startResize } = useResizableDialog();
+
+	return (
+		<DialogPortal data-slot="dialog-portal">
+			{/* Drop the backdrop to fully transparent while dragging so the user can see what's behind the modal. */}
+			<DialogOverlay className={cn('transition-opacity duration-200', isDragging && 'opacity-0')} />
+			<DialogPrimitive.Content
+				ref={contentRef}
+				data-slot="dialog-content"
+				style={{ left: position.x, top: position.y, width: size.width, height: size.height }}
+				className={cn(
+					'bg-popover '
+						+ 'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 '
+						+ 'fixed z-50 flex flex-col '
+						+ 'overflow-hidden '
+						+ 'gap-4 rounded-md border p-6 shadow-2xl '
+						+ 'duration-200',
+					(isDragging || isResizing) && 'select-none',
+					className,
+				)}
+				{...props}
+			>
+				{/* Title-bar strip: grab anywhere across the top to drag the modal around. */}
+				<div
+					onMouseDown={startDrag}
+					className="absolute inset-x-0 top-0 z-10 flex h-12 cursor-move items-start justify-center"
+					aria-hidden
+				>
+					<GripHorizontal className="mt-1 size-4 text-muted-foreground/40" />
+				</div>
+				{children}
+				<DialogCloseButton className="z-20" />
+				{RESIZE_HANDLES.map(({ dir, className: handleClassName }) => (
+					<div
+						key={dir}
+						onMouseDown={startResize(dir)}
+						className={cn('absolute', handleClassName)}
+						aria-hidden
+					/>
+				))}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogContent(
+	{ className, children, resizable, ...props }:
+		& React.ComponentProps<typeof DialogPrimitive.Content>
+		& { resizable?: boolean },
+) {
+	if (resizable) {
+		return (
+			<ResizableDialogContent className={className} {...props}>
+				{children}
+			</ResizableDialogContent>
+		);
+	}
+
 	return (
 		<DialogPortal data-slot="dialog-portal">
 			<DialogOverlay />
@@ -53,10 +143,7 @@ function DialogContent({ className, children, ...props }: React.ComponentProps<t
 				{...props}
 			>
 				{children}
-				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-					<XIcon className="text-popover-foreground" />
-					<span className="sr-only">Close</span>
-				</DialogPrimitive.Close>
+				<DialogCloseButton />
 			</DialogPrimitive.Content>
 		</DialogPortal>
 	);

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -108,19 +108,51 @@ export function useResizableDialog() {
 
 	const startDrag = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
+		const node = lastNodeRef.current;
 		const startX = event.clientX;
 		const startY = event.clientY;
 		const origin = { ...positionRef.current };
 		setIsDragging(true);
 
+		// Move imperatively via a compositor `transform`, coalesced to one update per frame, so the
+		// heavy editor subtree is never re-rendered or re-laid-out mid-drag. We commit to React
+		// state (left/top) only on release.
+		let frame = 0;
+		let dx = 0;
+		let dy = 0;
+		const apply = () => {
+			frame = 0;
+			if (node) {
+				node.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+			}
+		};
 		const onMove = (e: MouseEvent) => {
 			// No clamping mid-drag: allow dragging past the edge so the user can peek behind the modal.
-			setPosition({ x: origin.x + (e.clientX - startX), y: origin.y + (e.clientY - startY) });
+			dx = e.clientX - startX;
+			dy = e.clientY - startY;
+			if (!frame) {
+				frame = requestAnimationFrame(apply);
+			}
 		};
 		const onUp = () => {
+			if (frame) {
+				cancelAnimationFrame(frame);
+			}
 			setIsDragging(false);
 			// Snap back fully into view.
-			setPosition(clampPosition(positionRef.current, sizeRef.current, window.innerWidth, window.innerHeight));
+			const clamped = clampPosition(
+				{ x: origin.x + dx, y: origin.y + dy },
+				sizeRef.current,
+				window.innerWidth,
+				window.innerHeight,
+			);
+			// Commit to left/top and drop the live transform together so there's no flash.
+			if (node) {
+				node.style.left = `${clamped.x}px`;
+				node.style.top = `${clamped.y}px`;
+				node.style.transform = '';
+			}
+			setPosition(clamped);
 			window.removeEventListener('mousemove', onMove);
 			window.removeEventListener('mouseup', onUp);
 		};
@@ -131,12 +163,26 @@ export function useResizableDialog() {
 	const startResize = useCallback((direction: ResizeDirection) => (event: React.MouseEvent) => {
 		event.preventDefault();
 		event.stopPropagation();
+		const node = lastNodeRef.current;
 		const startX = event.clientX;
 		const startY = event.clientY;
 		const startSize = { ...sizeRef.current };
 		const startPos = { ...positionRef.current };
 		setIsResizing(true);
 
+		// Like dragging, apply size/position imperatively (once per frame) and commit to state on release.
+		let frame = 0;
+		let nextSize = startSize;
+		let nextPos = startPos;
+		const apply = () => {
+			frame = 0;
+			if (node) {
+				node.style.width = `${nextSize.width}px`;
+				node.style.height = `${nextSize.height}px`;
+				node.style.left = `${nextPos.x}px`;
+				node.style.top = `${nextPos.y}px`;
+			}
+		};
 		const onMove = (e: MouseEvent) => {
 			const vw = window.innerWidth;
 			const vh = window.innerHeight;
@@ -158,27 +204,32 @@ export function useResizableDialog() {
 				height = startSize.height - dy;
 			}
 
-			const clamped = clampSize({ width, height }, vw, vh);
+			nextSize = clampSize({ width, height }, vw, vh);
 
 			// When resizing from the top/left edges, keep the opposite edge anchored.
 			let { x, y } = startPos;
 			if (direction.includes('w')) {
-				x = startPos.x + startSize.width - clamped.width;
+				x = startPos.x + startSize.width - nextSize.width;
 			}
 			if (direction.includes('n')) {
-				y = startPos.y + startSize.height - clamped.height;
+				y = startPos.y + startSize.height - nextSize.height;
 			}
+			nextPos = { x, y };
 
-			setSize(clamped);
-			setPosition({ x, y });
+			if (!frame) {
+				frame = requestAnimationFrame(apply);
+			}
 		};
 		const onUp = () => {
+			if (frame) {
+				cancelAnimationFrame(frame);
+			}
 			setIsResizing(false);
 			const vw = window.innerWidth;
 			const vh = window.innerHeight;
-			const finalSize = clampSize(sizeRef.current, vw, vh);
+			const finalSize = clampSize(nextSize, vw, vh);
 			setSize(finalSize);
-			setPosition(clampPosition(positionRef.current, finalSize, vw, vh));
+			setPosition(clampPosition(nextPos, finalSize, vw, vh));
 			// Persist the new size under the shared key so every resizable modal remembers it.
 			setStoredSize(finalSize);
 			window.removeEventListener('mousemove', onMove);

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -63,6 +63,7 @@ export function useResizableDialog() {
 	const [position, setPosition] = useState<DialogPosition>(() => centerOf(size, window.innerWidth, window.innerHeight));
 	const [isDragging, setIsDragging] = useState(false);
 	const [isResizing, setIsResizing] = useState(false);
+	const [isMaximized, setIsMaximized] = useState(false);
 
 	// Mirror the latest values into refs so window listeners and the mount-time ref
 	// callback can read current state without re-subscribing on every change.
@@ -70,6 +71,10 @@ export function useResizableDialog() {
 	sizeRef.current = size;
 	const positionRef = useRef(position);
 	positionRef.current = position;
+	const isMaximizedRef = useRef(isMaximized);
+	isMaximizedRef.current = isMaximized;
+	// Size/position captured before maximizing, so the button can restore them.
+	const restoreRef = useRef<{ size: DialogSize; position: DialogPosition } | null>(null);
 	// The user's persisted, *unclamped* preferred size. The rendered size is always a clamped
 	// view of this, so shrinking the window and growing it back restores their chosen size.
 	const desiredSizeRef = useRef(storedSize);
@@ -85,6 +90,9 @@ export function useResizableDialog() {
 			return;
 		}
 		lastNodeRef.current = node;
+		// A fresh open always starts un-maximized at the preferred size.
+		setIsMaximized(false);
+		restoreRef.current = null;
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
 		const clamped = clampSize(desiredSizeRef.current, vw, vh);
@@ -98,6 +106,13 @@ export function useResizableDialog() {
 		const onResize = () => {
 			const vw = window.innerWidth;
 			const vh = window.innerHeight;
+			if (isMaximizedRef.current) {
+				// Stay filling the (new) screen.
+				const maxSize = clampSize({ width: vw, height: vh }, vw, vh);
+				setSize(maxSize);
+				setPosition(centerOf(maxSize, vw, vh));
+				return;
+			}
 			const clamped = clampSize(desiredSizeRef.current, vw, vh);
 			setSize(clamped);
 			setPosition(clampPosition(positionRef.current, clamped, vw, vh));
@@ -113,6 +128,8 @@ export function useResizableDialog() {
 		const startY = event.clientY;
 		const origin = { ...positionRef.current };
 		setIsDragging(true);
+		// A manual move means we're no longer "maximized".
+		setIsMaximized(false);
 
 		// Move imperatively via a compositor `transform`, coalesced to one update per frame, so the
 		// heavy editor subtree is never re-rendered or re-laid-out mid-drag. We commit to React
@@ -169,6 +186,8 @@ export function useResizableDialog() {
 		const startSize = { ...sizeRef.current };
 		const startPos = { ...positionRef.current };
 		setIsResizing(true);
+		// A manual resize means we're no longer "maximized".
+		setIsMaximized(false);
 
 		// Like dragging, apply size/position imperatively (once per frame) and commit to state on release.
 		let frame = 0;
@@ -239,5 +258,27 @@ export function useResizableDialog() {
 		window.addEventListener('mouseup', onUp);
 	}, [setStoredSize]);
 
-	return { size, position, isDragging, isResizing, contentRef, startDrag, startResize };
+	// Maximize fills the screen (within the standard margin); toggling again restores the size and
+	// position from just before. Maximizing never touches the persisted preferred size.
+	const toggleMaximize = useCallback(() => {
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		if (isMaximizedRef.current) {
+			const prev = restoreRef.current;
+			if (prev) {
+				const restoredSize = clampSize(prev.size, vw, vh);
+				setSize(restoredSize);
+				setPosition(clampPosition(prev.position, restoredSize, vw, vh));
+			}
+			setIsMaximized(false);
+		} else {
+			restoreRef.current = { size: sizeRef.current, position: positionRef.current };
+			const maxSize = clampSize({ width: vw, height: vh }, vw, vh);
+			setSize(maxSize);
+			setPosition(centerOf(maxSize, vw, vh));
+			setIsMaximized(true);
+		}
+	}, []);
+
+	return { size, position, isDragging, isResizing, isMaximized, contentRef, startDrag, startResize, toggleMaximize };
 }

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -1,0 +1,192 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface DialogSize {
+	width: number;
+	height: number;
+}
+
+export interface DialogPosition {
+	x: number;
+	y: number;
+}
+
+export type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+const MIN_WIDTH = 360;
+const MIN_HEIGHT = 280;
+/** Keep at least this much gap between the modal and the viewport edges when snapped/clamped into view. */
+const MARGIN = 16;
+const DEFAULT_SIZE: DialogSize = { width: 820, height: 680 };
+
+/** Never let the modal grow larger than the viewport (minus a margin) or shrink below a usable minimum. */
+function clampSize({ width, height }: DialogSize, vw: number, vh: number): DialogSize {
+	return {
+		width: Math.round(Math.max(MIN_WIDTH, Math.min(width, vw - MARGIN * 2))),
+		height: Math.round(Math.max(MIN_HEIGHT, Math.min(height, vh - MARGIN * 2))),
+	};
+}
+
+function centerOf({ width, height }: DialogSize, vw: number, vh: number): DialogPosition {
+	return {
+		x: Math.round((vw - width) / 2),
+		y: Math.round((vh - height) / 2),
+	};
+}
+
+/** Pull a (possibly off-screen) position back so the whole modal sits within the viewport. */
+function clampPosition(
+	{ x, y }: DialogPosition,
+	{ width, height }: DialogSize,
+	vw: number,
+	vh: number,
+): DialogPosition {
+	const maxX = Math.max(MARGIN, vw - width - MARGIN);
+	const maxY = Math.max(MARGIN, vh - height - MARGIN);
+	return {
+		x: Math.min(Math.max(x, MARGIN), maxX),
+		y: Math.min(Math.max(y, MARGIN), maxY),
+	};
+}
+
+/**
+ * Drag + resize state for a modal. The size is persisted to local storage under a single shared key,
+ * so resizing one modal is remembered across every resizable modal. The position is intentionally not
+ * persisted: each time the modal opens it re-centers, and while dragging the user may pull it past the
+ * edge (to peek behind it) — on release it snaps back fully into view.
+ */
+export function useResizableDialog() {
+	const [storedSize, setStoredSize] = useLocalStorage<DialogSize>(LocalStorageKeys.ResizableModalSize, DEFAULT_SIZE);
+
+	const [size, setSize] = useState<DialogSize>(() => clampSize(storedSize, window.innerWidth, window.innerHeight));
+	const [position, setPosition] = useState<DialogPosition>(() => centerOf(size, window.innerWidth, window.innerHeight));
+	const [isDragging, setIsDragging] = useState(false);
+	const [isResizing, setIsResizing] = useState(false);
+
+	// Mirror the latest values into refs so window listeners and the mount-time ref
+	// callback can read current state without re-subscribing on every change.
+	const sizeRef = useRef(size);
+	sizeRef.current = size;
+	const positionRef = useRef(position);
+	positionRef.current = position;
+	// The user's persisted, *unclamped* preferred size. The rendered size is always a clamped
+	// view of this, so shrinking the window and growing it back restores their chosen size.
+	const desiredSizeRef = useRef(storedSize);
+	desiredSizeRef.current = storedSize;
+
+	// Re-center each time the dialog content mounts (i.e. each time the modal opens),
+	// re-deriving the rendered size from the persisted preferred size. Radix may invoke this
+	// ref more than once per render and on unmount, so we only act on a brand-new content
+	// node — otherwise the setState here would re-trigger the ref and loop forever.
+	const lastNodeRef = useRef<HTMLElement | null>(null);
+	const contentRef = useCallback((node: HTMLElement | null) => {
+		if (!node || node === lastNodeRef.current) {
+			return;
+		}
+		lastNodeRef.current = node;
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const clamped = clampSize(desiredSizeRef.current, vw, vh);
+		setSize(clamped);
+		setPosition(centerOf(clamped, vw, vh));
+	}, []);
+
+	// Keep the modal within the viewport as the window changes: re-clamp the preferred size
+	// (so it grows back when there's room again) and pull the position back into view.
+	useEffect(() => {
+		const onResize = () => {
+			const vw = window.innerWidth;
+			const vh = window.innerHeight;
+			const clamped = clampSize(desiredSizeRef.current, vw, vh);
+			setSize(clamped);
+			setPosition(clampPosition(positionRef.current, clamped, vw, vh));
+		};
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, []);
+
+	const startDrag = useCallback((event: React.MouseEvent) => {
+		event.preventDefault();
+		const startX = event.clientX;
+		const startY = event.clientY;
+		const origin = { ...positionRef.current };
+		setIsDragging(true);
+
+		const onMove = (e: MouseEvent) => {
+			// No clamping mid-drag: allow dragging past the edge so the user can peek behind the modal.
+			setPosition({ x: origin.x + (e.clientX - startX), y: origin.y + (e.clientY - startY) });
+		};
+		const onUp = () => {
+			setIsDragging(false);
+			// Snap back fully into view.
+			setPosition(clampPosition(positionRef.current, sizeRef.current, window.innerWidth, window.innerHeight));
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('mouseup', onUp);
+		};
+		window.addEventListener('mousemove', onMove);
+		window.addEventListener('mouseup', onUp);
+	}, []);
+
+	const startResize = useCallback((direction: ResizeDirection) => (event: React.MouseEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+		const startX = event.clientX;
+		const startY = event.clientY;
+		const startSize = { ...sizeRef.current };
+		const startPos = { ...positionRef.current };
+		setIsResizing(true);
+
+		const onMove = (e: MouseEvent) => {
+			const vw = window.innerWidth;
+			const vh = window.innerHeight;
+			const dx = e.clientX - startX;
+			const dy = e.clientY - startY;
+
+			let width = startSize.width;
+			let height = startSize.height;
+			if (direction.includes('e')) {
+				width = startSize.width + dx;
+			}
+			if (direction.includes('w')) {
+				width = startSize.width - dx;
+			}
+			if (direction.includes('s')) {
+				height = startSize.height + dy;
+			}
+			if (direction.includes('n')) {
+				height = startSize.height - dy;
+			}
+
+			const clamped = clampSize({ width, height }, vw, vh);
+
+			// When resizing from the top/left edges, keep the opposite edge anchored.
+			let { x, y } = startPos;
+			if (direction.includes('w')) {
+				x = startPos.x + startSize.width - clamped.width;
+			}
+			if (direction.includes('n')) {
+				y = startPos.y + startSize.height - clamped.height;
+			}
+
+			setSize(clamped);
+			setPosition({ x, y });
+		};
+		const onUp = () => {
+			setIsResizing(false);
+			const vw = window.innerWidth;
+			const vh = window.innerHeight;
+			const finalSize = clampSize(sizeRef.current, vw, vh);
+			setSize(finalSize);
+			setPosition(clampPosition(positionRef.current, finalSize, vw, vh));
+			// Persist the new size under the shared key so every resizable modal remembers it.
+			setStoredSize(finalSize);
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('mouseup', onUp);
+		};
+		window.addEventListener('mousemove', onMove);
+		window.addEventListener('mouseup', onUp);
+	}, [setStoredSize]);
+
+	return { size, position, isDragging, isResizing, contentRef, startDrag, startResize };
+}

--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -108,6 +108,7 @@ export function AddTableRowModal({
 			{/* NOTE - Is this okay to do for the aria describedby? */}
 			<DialogContent
 				aria-describedby={undefined}
+				resizable
 				onEscapeKeyDown={(event) => {
 					if (madeChanges) {
 						event.preventDefault();
@@ -126,13 +127,13 @@ export function AddTableRowModal({
 						</div>
 					)}
 				<Editor
-					className="w-full h-96"
+					className="w-full flex-1 min-h-0"
 					language="json"
 					theme={monacoTheme}
 					value={sampleJSON}
 					onValidate={onValidate}
 					onChange={setAddTableRecordData}
-					options={{ minimap: { enabled: false } }}
+					options={{ minimap: { enabled: false }, automaticLayout: true }}
 					onMount={handleEditorDidMount}
 				/>
 				<div className="text-sm text-gray-500">

--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -126,16 +126,23 @@ export function AddTableRowModal({
 							auto-generate. You may manually add it if you want to specify its value.
 						</div>
 					)}
-				<Editor
-					className="w-full flex-1 min-h-0"
-					language="json"
-					theme={monacoTheme}
-					value={sampleJSON}
-					onValidate={onValidate}
-					onChange={setAddTableRecordData}
-					options={{ minimap: { enabled: false }, automaticLayout: true }}
-					onMount={handleEditorDidMount}
-				/>
+				{
+					/* Wrapper owns the flex sizing: @monaco-editor/react applies `className` to its inner
+				    element, not the layout wrapper, so `flex-1 min-h-0` has to live on a div we control
+				    for the editor to shrink with the modal. */
+				}
+				<div className="flex-1 min-h-0 w-full">
+					<Editor
+						className="w-full h-full"
+						language="json"
+						theme={monacoTheme}
+						value={sampleJSON}
+						onValidate={onValidate}
+						onChange={setAddTableRecordData}
+						options={{ minimap: { enabled: false }, automaticLayout: true }}
+						onMount={handleEditorDidMount}
+					/>
+				</div>
 				<div className="text-sm text-gray-500">
 					<strong>Provide an [array]</strong> if you want to add more than one record at a time.
 				</div>

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -63,17 +63,22 @@ export function EditTableRowModal({
 				</DialogHeader>
 				{data
 					? (
-						<Editor
-							className="w-full flex-1 min-h-0"
-							language="json"
-							theme={monacoTheme}
-							options={{ readOnly: !canEditRecords, automaticLayout: true }}
-							value={value}
-							onValidate={onValidate}
-							onChange={(updatedValue) => {
-								setUpdatedTableRecordData(updatedValue);
-							}}
-						/>
+						// Wrapper owns the flex sizing: @monaco-editor/react applies `className` to its inner
+						// element, not the layout wrapper, so `flex-1 min-h-0` has to live on a div we control
+						// for the editor to shrink with the modal.
+						<div className="flex-1 min-h-0 w-full">
+							<Editor
+								className="w-full h-full"
+								language="json"
+								theme={monacoTheme}
+								options={{ readOnly: !canEditRecords, automaticLayout: true }}
+								value={value}
+								onValidate={onValidate}
+								onChange={(updatedValue) => {
+									setUpdatedTableRecordData(updatedValue);
+								}}
+							/>
+						</div>
 					)
 					: <Loading />}
 				<DialogFooter>

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -48,6 +48,7 @@ export function EditTableRowModal({
 			{/* NOTE - Is this okay to do for the aria describedby? */}
 			<DialogContent
 				aria-describedby={undefined}
+				resizable
 				autoFocus={canEditRecords}
 				onEscapeKeyDown={canEditRecords
 					? (event) => {
@@ -63,10 +64,10 @@ export function EditTableRowModal({
 				{data
 					? (
 						<Editor
-							className="w-full h-96"
+							className="w-full flex-1 min-h-0"
 							language="json"
 							theme={monacoTheme}
-							options={canEditRecords ? undefined : { readOnly: true }}
+							options={{ readOnly: !canEditRecords, automaticLayout: true }}
 							value={value}
 							onValidate={onValidate}
 							onChange={(updatedValue) => {

--- a/src/features/instance/log/modals/ViewLogModal.tsx
+++ b/src/features/instance/log/modals/ViewLogModal.tsx
@@ -40,13 +40,13 @@ export function ViewLogModal({
 
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
-			<DialogContent aria-describedby={undefined} className="max-w-2xl">
+			<DialogContent aria-describedby={undefined} resizable>
 				<DialogHeader>
 					<DialogTitle>Log Entry</DialogTitle>
 				</DialogHeader>
 				{data
 					? (
-						<div className="flex flex-col gap-2 text-popover-foreground">
+						<div className="flex flex-1 min-h-0 flex-col gap-2 text-popover-foreground">
 							<div className="rounded-md border border-border/50 bg-muted/20 px-3 py-1">
 								<MetaRow label="Level">
 									<Badge variant={renderBadgeLogLevelVariant(data.level)}>
@@ -71,9 +71,9 @@ export function ViewLogModal({
 								)}
 							</div>
 
-							<div>
+							<div className="flex flex-1 min-h-0 flex-col">
 								<p className="text-xs font-medium text-muted-foreground mb-1.5">Message</p>
-								<div className="rounded-md overflow-hidden border border-border/50 h-72">
+								<div className="rounded-md overflow-hidden border border-border/50 flex-1 min-h-0">
 									<Editor
 										className="w-full h-full"
 										language={isJsonString(data.message) ? 'json' : 'text'}
@@ -85,6 +85,7 @@ export function ViewLogModal({
 											scrollBeyondLastLine: false,
 											fontSize: 12,
 											padding: { top: 12, bottom: 12 },
+											automaticLayout: true,
 										}}
 									/>
 								</div>

--- a/src/lib/storage/localStorageKeys.ts
+++ b/src/lib/storage/localStorageKeys.ts
@@ -3,6 +3,7 @@ export const enum LocalStorageKeys {
 	'ApplicationChatWidth' = 'ApplicationChatWidth',
 	'ChatAlwaysApprovedTools' = 'ChatAlwaysApprovedTools',
 	'LogsOrderReversed' = 'LogsOrderReversed',
+	'ResizableModalSize' = 'ResizableModalSize',
 	'SavedClusterState' = 'SavedClusterState',
 	'Theme' = 'Theme',
 }


### PR DESCRIPTION
Closes #1342.

## Problem

The modal shown when clicking a log entry or a database record was fixed at a small size — too small to comfortably read a long log message or a wide JSON record.

## What changed

A new opt-in `resizable` prop on `DialogContent` (in `src/components/ui/dialog.tsx`, backed by a new `useResizableDialog` hook) makes a dialog resizable and draggable. It's enabled on the three record/log modals:

- `ViewLogModal` (click a log entry)
- `EditTableRowModal` (click a database record)
- `AddTableRowModal` (add a record)

### Behavior

- **Resize** from any edge or corner (8 handles).
- **Size is remembered** in local storage under a single shared key (`ResizableModalSize`), so resizing one modal is remembered across all of them.
- **Never exceeds the browser**: the size is always clamped to the viewport. It shrinks when the window shrinks and restores the preferred size when there's room again.
- **Drag** the title bar (grip at the top) to move the modal aside and see what's behind it. While dragging, the **backdrop drops to 0% opacity** and the modal can be pulled **past the screen edge**; on release it **snaps fully back into view**.
- Each modal **opens centered**. The Monaco editors now flex to fill the available height (`automaticLayout`) instead of a fixed height.

### Snappy drag/resize (follow-up)

Dragging initially felt laggy: the content carried an implicit `transition: all 200ms` (from `duration-200` + the default `transition-property: all`), so every move eased 200ms behind the cursor, and updating `left`/`top` via React state re-laid-out the Monaco subtree each frame. Now the gesture is applied **imperatively + coalesced to one update per `requestAnimationFrame`**: dragging uses a compositor `translate3d` (no reflow, no re-render) and resizing sets dimensions directly; React state is committed only on release. The transition is removed (open/close animations are unaffected — they're CSS animations). Result: the modal tracks the cursor 1:1.

### Auto-copy `.env.local` into worktrees (follow-up)

Unrelated dev-tooling nicety: only `.env.local.example` is checked in, so a fresh git worktree has no `.env.local` and `npm run dev` starts unconfigured. Added a `SessionStart` hook (`.claude/hooks/copy-env-local.sh`) that copies `.env.local` from the main worktree into a linked worktree when it's missing. Idempotent and safe — never overwrites an existing file, never touches the main checkout, always exits 0.

## Verification

Verified in the live preview against a real instance:

- ✅ Resize via corner/edge handles; new size persists to local storage.
- ✅ Size shared across all three modals (resized the log modal → the Add/Edit record modals opened at the same size).
- ✅ Shrinking the window clamps the modal into view (1120×890 → 868×608 at a 900×640 viewport); growing it back restores 1120×890.
- ✅ Dragging makes the backdrop transparent, allows dragging past the edge, and snaps back into view on release.
- ✅ Drag now tracks the cursor exactly 1:1 via `translate3d` with no easing; transform cleared cleanly on release (no flash).
- ✅ `.env.local` hook copies from the main worktree when missing, no-ops when present, exits 0.
- ✅ Full test suite (892 passing), `tsc`, oxlint, and dprint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)