### PR TITLE
fix: Dismiss restart popup even when component unmounts (#1340)

### DIFF
--- a/src/hooks/useRestartInstanceClick.ts
+++ b/src/hooks/useRestartInstanceClick.ts
@@ -23,9 +23,9 @@ export function useRestartInstanceClick({
 }: RestartInstanceClickParams): RestartInstanceClickResponse {
 	const { clusterId, instanceId }: { clusterId?: string; instanceId?: string } = useParams({ strict: false });
 	const targetNoun = (instanceId || isLocalStudio) ? 'Instance' : 'Cluster';
-	const { mutate: restartInstance, isPending: isRestartPending } = useRestartInstance();
+	const { mutateAsync: restartInstance, isPending: isRestartPending } = useRestartInstance();
 	const queryClient = useQueryClient();
-	const onRestartClick = useCallback(() => {
+	const onRestartClick = useCallback(async () => {
 		const toastId = toast.loading('Restarting', {
 			description: `Restarting ${targetNoun.toLowerCase()}. This may take up to 60 seconds.`,
 			duration: 180_000,
@@ -34,35 +34,37 @@ export function useRestartInstanceClick({
 				onClick: () => toast.dismiss(),
 			},
 		});
-		restartInstance({
-			operation,
-			replicated: operation === 'restart_service' && targetNoun === 'Cluster',
-			instanceClient,
-		}, {
-			onSuccess: () => {
-				void queryClient.invalidateQueries({ queryKey: [clusterId] });
-				void queryClient.invalidateQueries({ queryKey: [instanceId] });
-				toast.dismiss(toastId);
-				toast.success('Success', {
-					description: `${targetNoun} restarted!`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-				onRestartedSuccessfully?.();
-			},
-			onError: () => {
-				toast.dismiss(toastId);
-				toast.error('Error', {
-					description: `Failed to restart ${targetNoun.toLowerCase()}.`,
-					action: {
-						label: 'Dismiss',
-						onClick: () => toast.dismiss(),
-					},
-				});
-			},
-		});
+		// Await the mutation directly rather than using the mutate() callbacks. Those callbacks are
+		// dropped if the component unmounts before the restart finishes (e.g. the user navigates to
+		// another tab while the instance comes back up), which would orphan the loading toast forever
+		// since sonner never auto-dismisses a loading toast. The awaited continuation runs regardless.
+		try {
+			await restartInstance({
+				operation,
+				replicated: operation === 'restart_service' && targetNoun === 'Cluster',
+				instanceClient,
+			});
+			void queryClient.invalidateQueries({ queryKey: [clusterId] });
+			void queryClient.invalidateQueries({ queryKey: [instanceId] });
+			toast.dismiss(toastId);
+			toast.success('Success', {
+				description: `${targetNoun} restarted!`,
+				action: {
+					label: 'Dismiss',
+					onClick: () => toast.dismiss(),
+				},
+			});
+			onRestartedSuccessfully?.();
+		} catch {
+			toast.dismiss(toastId);
+			toast.error('Error', {
+				description: `Failed to restart ${targetNoun.toLowerCase()}.`,
+				action: {
+					label: 'Dismiss',
+					onClick: () => toast.dismiss(),
+				},
+			});
+		}
 	}, [
 		clusterId,
 		instanceClient,


### PR DESCRIPTION
## Problem

Fixes #1340 — the **"Restarting cluster. This may take up to 60 seconds."** popup never dismisses, even after the restart completes.

## Root cause

The restart toast in [`useRestartInstanceClick`](src/hooks/useRestartInstanceClick.ts) was dismissed **only** from the `onSuccess`/`onError` callbacks passed as the second argument to `mutate()`. Two facts combine into a permanently-stuck toast:

1. **TanStack Query drops `mutate()` callbacks on unmount.** Per the [docs](https://tanstack.com/query/latest/docs/framework/react/guides/mutations#mutation-side-effects), the callbacks passed to `mutate()` "won't run if your component unmounts _before_ the mutation finishes." The restart health check (`restartInstance` → `sleep(10s)` + up to 12×15s `user_info` retries) can run well over a minute, and users routinely click **Restart** and then navigate to another tab (Status / Logs) to watch progress — which unmounts `ContentActions` / `RestartButton` and silently discards the dismiss logic.

2. **sonner never auto-dismisses a `loading` toast.** Its auto-close timer returns early for `loading`-type toasts (`if (... || toast.type === 'loading') return;`), so the `duration: 180_000` on the loading toast is effectively ignored. Nothing else ever closes it.

With the dismiss callback dropped and no auto-dismiss, the global toast is orphaned forever — exactly the reported symptom. (The reporter's `@harperfast/schema-codegen` / health-check hunch is a red herring: even on a fully successful restart, navigating away strands the toast.)

## Fix

Await the mutation with `mutateAsync` inside a `try`/`catch` instead of relying on the `mutate()` callbacks. The dismiss / success / error handling now runs as a plain promise continuation, which survives the owning component unmounting. This matches the pattern already used by the sibling hook [`useRestartClusterClick`](src/hooks/useRestartClusterClick.tsx), which runs its whole flow inline and is not affected by this bug.

No behavior change on the happy path; `isPending` still drives the button's disabled state.

## Testing

- `tsc -b` — clean
- `oxlint` — clean
- `dprint check` — clean
- `vitest run` — 892 passed, 11 skipped (141 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
