### PR TITLE
feat: Resize modals from center by holding Alt

### DIFF
--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -207,31 +207,43 @@ export function useResizableDialog() {
 			const vh = window.innerHeight;
 			const dx = e.clientX - startX;
 			const dy = e.clientY - startY;
+			// Hold Alt (Option on macOS) to resize symmetrically about the modal's center: the dragged edge
+			// is mirrored on the opposite edge, so the size changes by twice the cursor delta. Read live from
+			// the event so the user can toggle the behavior mid-resize by pressing/releasing Alt.
+			const fromCenter = e.altKey;
+			const scale = fromCenter ? 2 : 1;
 
 			let width = startSize.width;
 			let height = startSize.height;
 			if (direction.includes('e')) {
-				width = startSize.width + dx;
+				width = startSize.width + dx * scale;
 			}
 			if (direction.includes('w')) {
-				width = startSize.width - dx;
+				width = startSize.width - dx * scale;
 			}
 			if (direction.includes('s')) {
-				height = startSize.height + dy;
+				height = startSize.height + dy * scale;
 			}
 			if (direction.includes('n')) {
-				height = startSize.height - dy;
+				height = startSize.height - dy * scale;
 			}
 
 			nextSize = clampSize({ width, height }, vw, vh);
 
-			// When resizing from the top/left edges, keep the opposite edge anchored.
 			let { x, y } = startPos;
-			if (direction.includes('w')) {
-				x = startPos.x + startSize.width - nextSize.width;
-			}
-			if (direction.includes('n')) {
-				y = startPos.y + startSize.height - nextSize.height;
+			if (fromCenter) {
+				// Keep the center fixed: split the size change evenly between both edges. Unchanged axes
+				// keep their start position (nextSize matches startSize there, so the offset is zero).
+				x = Math.round(startPos.x + (startSize.width - nextSize.width) / 2);
+				y = Math.round(startPos.y + (startSize.height - nextSize.height) / 2);
+			} else {
+				// When resizing from the top/left edges, keep the opposite edge anchored.
+				if (direction.includes('w')) {
+					x = startPos.x + startSize.width - nextSize.width;
+				}
+				if (direction.includes('n')) {
+					y = startPos.y + startSize.height - nextSize.height;
+				}
 			}
 			nextPos = { x, y };
 


### PR DESCRIPTION
## What

Closes #1345.

Holding **Alt** (Option on macOS) while dragging a resizable modal's edge or corner now resizes it symmetrically about its center: the dragged edge is mirrored on the opposite edge, so the modal grows/shrinks by twice the cursor delta and its center stays put. Release Alt and it goes back to the normal edge-anchored behavior.

## How

The whole resize lifecycle lives in `useResizableDialog`'s `startResize`, which already listens to the global `mousemove`. I read `e.altKey` live on each move (so it can be toggled mid-resize) and:

- scale the size delta by 2 when Alt is held, and
- recompute the position to keep the center fixed instead of anchoring the opposite edge.

Unchanged axes need no special-casing — their size doesn't change, so the center offset is zero. Clamping to the viewport/min-size is unchanged, and the center stays fixed even after clamping.

No changes to `dialog.tsx` were needed since the hook reads the modifier straight from the event.

## Verifying

- `tsc -b`, `oxlint`, and `dprint` all clean.
- Full test suite passes (892 passing) via the pre-commit hook.
- Confirmed working in the running app: dragging an edge with Alt held grows/shrinks the modal from the center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)