### PR TITLE
fix: Handle compressed/binary files in the Applications editor (#1338)

### DIFF
--- a/src/features/instance/applications/components/ContentViewer.tsx
+++ b/src/features/instance/applications/components/ContentViewer.tsx
@@ -3,8 +3,9 @@ import { isDirectory } from '@/features/instance/applications/context/isDirector
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useReadMeUrlTransformer } from '@/features/instance/applications/lib/readMeUrlTransform';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { isBinaryFile } from '@/lib/string/binaryFileType';
 import { getMediaFileType, MediaFileType } from '@/lib/string/mediaFileType';
-import { CopyIcon } from 'lucide-react';
+import { CopyIcon, FileArchive } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -40,7 +41,29 @@ export function ContentViewer() {
 		return <MediaPreview name={openedEntry?.name} base64={openedEntryContents} media={mediaType} />;
 	}
 
+	// Archives and other binary files would otherwise be decoded as UTF-8 and
+	// dumped into the text editor as garbage (and a large archive can lock Monaco
+	// up entirely). Show a placeholder instead — its contents are never fetched.
+	if (isBinaryFile(openedEntry?.name)) {
+		return <BinaryFilePreview name={openedEntry?.name} />;
+	}
+
 	return <TextEditorView />;
+}
+
+/** Placeholder shown for binary files that can't be edited or previewed as text. */
+function BinaryFilePreview({ name }: { name: string | undefined }) {
+	return (
+		<div className="absolute inset-0 mt-9 flex items-center justify-center p-8 text-center text-muted-foreground">
+			<div className="max-w-md">
+				<FileArchive className="mx-auto mb-4 h-10 w-10 opacity-60" />
+				<p className="font-medium text-foreground">{name ?? 'This file'} can&rsquo;t be previewed</p>
+				<p className="mt-1 text-sm">
+					It&rsquo;s a binary file. You can still rename or delete it from the file tree.
+				</p>
+			</div>
+		</div>
+	);
 }
 
 /**

--- a/src/features/instance/applications/context/EditorViewProvider.tsx
+++ b/src/features/instance/applications/context/EditorViewProvider.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/integrations/api/instance/applications/setComponentFile';
 import { useListener } from '@/lib/events/listener';
 import { setWatchedValue } from '@/lib/events/watcher';
+import { isBinaryFile } from '@/lib/string/binaryFileType';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
@@ -131,15 +132,20 @@ export function EditorViewProvider({ children }: PropsWithChildren) {
 		openedEntry && (isDirectory(openedEntry) ? openedEntry.overviewEntry?.project : openedEntry.project) || '';
 	const loadedOverviewEntry = openedEntry && (isDirectory(openedEntry) ? !!openedEntry.overviewEntry?.path : false)
 		|| false;
+	// Binary files (archives, fonts, etc.) are shown as a placeholder, so don't
+	// fetch their contents — decoding a large archive as text wastes bandwidth and
+	// risks choking the editor. Leave the file undefined to disable the query.
+	const isBinaryEntry = !!openedEntry && !isDirectory(openedEntry) && isBinaryFile(openedEntry.name);
+	const fileToLoad = isBinaryEntry ? undefined : pathToLoad?.split('/').slice(1).join('/');
 	const fileQueryKey = getComponentFileQueryKey({
-		file: pathToLoad?.split('/').slice(1).join('/'),
+		file: fileToLoad,
 		project: projectToLoad,
 		...instanceParams,
 	});
 	const { data: getComponentFileQueryData } = useQuery(
 		getComponentFileQueryOptions(
 			{
-				file: pathToLoad?.split('/').slice(1).join('/'),
+				file: fileToLoad,
 				project: projectToLoad,
 				...instanceParams,
 			},

--- a/src/features/instance/applications/lib/deleteSelectedItems.test.ts
+++ b/src/features/instance/applications/lib/deleteSelectedItems.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deleteSelectedItems } from './deleteSelectedItems';
+
+describe('deleteSelectedItems', () => {
+	it('splits each path into project + nested file and drops them in order', async () => {
+		const dropItem = vi.fn().mockResolvedValue(undefined);
+
+		const result = await deleteSelectedItems(['app/build/output.tgz', 'app'], { dropItem });
+
+		expect(dropItem.mock.calls).toEqual([
+			['app', 'build/output.tgz'],
+			['app', undefined],
+		]);
+		expect(result).toEqual({ deleted: 2, canceled: false, lastSplit: ['app'] });
+	});
+
+	it('reports progress before each drop', async () => {
+		const dropItem = vi.fn().mockResolvedValue(undefined);
+		const onProgress = vi.fn();
+
+		await deleteSelectedItems(['a/one', 'a/two'], { dropItem, onProgress });
+
+		expect(onProgress.mock.calls).toEqual([[0], [1]]);
+	});
+
+	// The bug: a rejected drop used to escape the caller's await loop, leaving the
+	// loading toast spinning forever. The helper must instead stop and report it.
+	it('stops at the first failed drop and returns the error without throwing', async () => {
+		const error = new Error('cannot drop component');
+		const dropItem = vi
+			.fn()
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(error);
+
+		const result = await deleteSelectedItems(['a/one', 'a/two', 'a/three'], { dropItem });
+
+		expect(result.error).toBe(error);
+		expect(result.canceled).toBe(false);
+		expect(result.deleted).toBe(1);
+		expect(result.lastSplit).toEqual(['a', 'two']);
+		// Never attempts the item after the failure.
+		expect(dropItem).toHaveBeenCalledTimes(2);
+	});
+
+	it('stops when canceled mid-run', async () => {
+		const dropItem = vi.fn().mockResolvedValue(undefined);
+		let canceled = false;
+		const isCanceled = () => canceled;
+
+		const result = await deleteSelectedItems(['a/one', 'a/two', 'a/three'], {
+			dropItem,
+			isCanceled,
+			onProgress: () => {
+				canceled = true;
+			},
+		});
+
+		expect(result.canceled).toBe(true);
+		// First item is dropped, then the cancel check halts the run.
+		expect(dropItem).toHaveBeenCalledTimes(1);
+		expect(result.deleted).toBe(0);
+	});
+
+	it('handles an empty selection', async () => {
+		const dropItem = vi.fn();
+
+		const result = await deleteSelectedItems([], { dropItem });
+
+		expect(dropItem).not.toHaveBeenCalled();
+		expect(result).toEqual({ deleted: 0, canceled: false, lastSplit: [] });
+	});
+});

--- a/src/features/instance/applications/lib/deleteSelectedItems.test.ts
+++ b/src/features/instance/applications/lib/deleteSelectedItems.test.ts
@@ -56,9 +56,9 @@ describe('deleteSelectedItems', () => {
 		});
 
 		expect(result.canceled).toBe(true);
-		// First item is dropped, then the cancel check halts the run.
+		// First item is dropped (and counted), then the cancel check halts the run.
 		expect(dropItem).toHaveBeenCalledTimes(1);
-		expect(result.deleted).toBe(0);
+		expect(result.deleted).toBe(1);
 	});
 
 	it('handles an empty selection', async () => {

--- a/src/features/instance/applications/lib/deleteSelectedItems.ts
+++ b/src/features/instance/applications/lib/deleteSelectedItems.ts
@@ -48,6 +48,7 @@ export async function deleteSelectedItems(
 
 		try {
 			await dropItem(project, file);
+			deleted += 1;
 		} catch (error) {
 			return { deleted, canceled: false, error, lastSplit };
 		}
@@ -55,8 +56,6 @@ export async function deleteSelectedItems(
 		if (isCanceled?.()) {
 			return { deleted, canceled: true, lastSplit };
 		}
-
-		deleted += 1;
 	}
 
 	return { deleted, canceled: false, lastSplit };

--- a/src/features/instance/applications/lib/deleteSelectedItems.ts
+++ b/src/features/instance/applications/lib/deleteSelectedItems.ts
@@ -1,0 +1,63 @@
+export interface DeleteSelectedItemsResult {
+	/** Number of items successfully dropped before the run ended. */
+	deleted: number;
+	/** True when the user canceled partway through. */
+	canceled: boolean;
+	/**
+	 * Set when a drop threw. The run stops at the first failure and surfaces the
+	 * error so the caller can replace its progress spinner instead of leaving it
+	 * spinning forever (the bug this helper exists to prevent).
+	 */
+	error?: unknown;
+	/** The `/`-split path of the last item attempted, used to refocus the tree. */
+	lastSplit: string[];
+}
+
+export interface DeleteSelectedItemsCallbacks {
+	/** Drops a single component file: the project name and an optional nested file path. */
+	dropItem: (project: string, file: string | undefined) => Promise<unknown>;
+	/** Called before each drop so the caller can update its progress indicator. */
+	onProgress?: (deletedSoFar: number) => void;
+	/** Polled after each drop; returning true stops the run as canceled. */
+	isCanceled?: () => boolean;
+}
+
+/**
+ * Drops a list of selected file-tree paths one at a time. Each path is
+ * `project/nested/file/path`; the first segment is the project and the rest (if
+ * any) is the file within it.
+ *
+ * Unlike a bare `await` loop, a rejected drop does not escape this function — it
+ * stops the run and is returned in {@link DeleteSelectedItemsResult.error} so the
+ * UI can show a failure instead of hanging on the loading toast.
+ */
+export async function deleteSelectedItems(
+	items: readonly string[],
+	{ dropItem, onProgress, isCanceled }: DeleteSelectedItemsCallbacks,
+): Promise<DeleteSelectedItemsResult> {
+	let deleted = 0;
+	let lastSplit: string[] = [];
+
+	for (const item of items) {
+		const split = item.split('/');
+		lastSplit = split;
+		const project = split[0];
+		const file = split.length > 1 ? split.slice(1).join('/') : undefined;
+
+		onProgress?.(deleted);
+
+		try {
+			await dropItem(project, file);
+		} catch (error) {
+			return { deleted, canceled: false, error, lastSplit };
+		}
+
+		if (isCanceled?.()) {
+			return { deleted, canceled: true, lastSplit };
+		}
+
+		deleted += 1;
+	}
+
+	return { deleted, canceled: false, lastSplit };
+}

--- a/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
@@ -3,10 +3,12 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { deleteSelectedItems } from '@/features/instance/applications/lib/deleteSelectedItems';
 import { dropComponent } from '@/integrations/api/instance/applications/dropComponent';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { pluralize } from '@/lib/pluralize';
+import { errorHandler } from '@/react-query/queryClient';
 import { Trash } from 'lucide-react';
 import { MouseEvent, useCallback } from 'react';
 import { toast } from 'sonner';
@@ -38,52 +40,45 @@ export function DeleteDirectoryOrFileModal() {
 	const handleDeleteFolderOrFile = useCallback(async () => {
 		closeModal();
 
-		let split: string[] = [];
-		let count = 0;
 		let canceled = false;
-
-		const toastCancelAction = {
-			label: 'Cancel',
-			onClick: () => {
-				canceled = true;
-			},
-		};
+		const id = 'deleting-files';
+		const total = pluralize(selectedItems.length, 'item', 'items');
 		const toastOKAction = {
 			label: 'OK',
 			onClick: () => undefined,
 		};
 
-		const id = 'deleting-files';
+		// Delete bottom-up so removing a child doesn't shift the path of a parent
+		// still queued for deletion. Copy first — `selectedItems` is shared state.
+		const result = await deleteSelectedItems(selectedItems.map(String).reverse(), {
+			dropItem: (project, file) => dropComponent({ file, project, ...instanceParams }),
+			onProgress: (deleted) => {
+				toast.loading(`${action} in progress...`, {
+					id,
+					description: `${deleted} of ${total}`,
+					action: {
+						label: 'Cancel',
+						onClick: () => {
+							canceled = true;
+						},
+					},
+				});
+			},
+			isCanceled: () => canceled,
+		});
 
-		for (const selectedItem of selectedItems.reverse()) {
-			split = (selectedItem as string).split('/');
-			const project = split[0];
-			const file = split.length > 1 ? split.slice(1).join('/') : undefined;
-
-			toast.loading(`${action} in progress...`, {
-				id,
-				description: `${count} of ${pluralize(selectedItems.length, 'item', 'items')}`,
-				action: toastCancelAction,
-			});
-			await dropComponent({
-				file,
-				project,
-				...instanceParams,
-			});
-			if (canceled) {
-				break;
-			}
-			count += 1;
-		}
-
-		if (canceled) {
+		if (result.error) {
+			// Replace the spinner so it can't hang, then surface the real error.
+			toast.dismiss(id);
+			errorHandler(result.error);
+		} else if (result.canceled) {
 			toast.warning(`${action} canceled!`, { id, description: '', action: toastOKAction });
 		} else {
 			toast.success(`${action} completed!`, { id, description: '', action: toastOKAction });
 		}
 
-		if (split.length) {
-			const itemToFocus = split.slice(0, -1).join('/');
+		if (result.lastSplit.length) {
+			const itemToFocus = result.lastSplit.slice(0, -1).join('/');
 			setFocusedItem(itemToFocus || undefined);
 			setSelectedItems(itemToFocus ? [itemToFocus] : []);
 			void reloadRootEntries();

--- a/src/lib/string/binaryFileType.test.ts
+++ b/src/lib/string/binaryFileType.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isBinaryFile } from './binaryFileType';
+
+describe('isBinaryFile', () => {
+	it('treats compressed archives as binary', () => {
+		expect(isBinaryFile('component.tgz')).toBe(true);
+		expect(isBinaryFile('archive.tar.gz')).toBe(true);
+		expect(isBinaryFile('bundle.tar')).toBe(true);
+		expect(isBinaryFile('release.zip')).toBe(true);
+		expect(isBinaryFile('data.gz')).toBe(true);
+		expect(isBinaryFile('logs.bz2')).toBe(true);
+		expect(isBinaryFile('image.xz')).toBe(true);
+		expect(isBinaryFile('snapshot.zst')).toBe(true);
+	});
+
+	it('treats other compiled/binary formats as binary', () => {
+		expect(isBinaryFile('addon.node')).toBe(true);
+		expect(isBinaryFile('module.wasm')).toBe(true);
+		expect(isBinaryFile('font.woff2')).toBe(true);
+		expect(isBinaryFile('clip.mp3')).toBe(true);
+		expect(isBinaryFile('doc.pdf')).toBe(true);
+		expect(isBinaryFile('store.sqlite')).toBe(true);
+	});
+
+	it('is case-insensitive', () => {
+		expect(isBinaryFile('COMPONENT.TGZ')).toBe(true);
+		expect(isBinaryFile('Release.Zip')).toBe(true);
+	});
+
+	it('does not flag editable text/code files', () => {
+		expect(isBinaryFile('index.ts')).toBe(false);
+		expect(isBinaryFile('schema.graphql')).toBe(false);
+		expect(isBinaryFile('config.yaml')).toBe(false);
+		expect(isBinaryFile('README.md')).toBe(false);
+		expect(isBinaryFile('package.json')).toBe(false);
+		expect(isBinaryFile('Dockerfile')).toBe(false);
+		expect(isBinaryFile('LICENSE')).toBe(false);
+	});
+
+	it('does not flag previewable media (handled as media, not binary)', () => {
+		expect(isBinaryFile('logo.png')).toBe(false);
+		expect(isBinaryFile('demo.mp4')).toBe(false);
+		expect(isBinaryFile('icon.svg')).toBe(false);
+	});
+
+	it('returns false for empty and undefined input', () => {
+		expect(isBinaryFile('')).toBe(false);
+		expect(isBinaryFile(undefined)).toBe(false);
+	});
+});

--- a/src/lib/string/binaryFileType.ts
+++ b/src/lib/string/binaryFileType.ts
@@ -1,0 +1,84 @@
+import { parseFileExtension } from '@/lib/string/parseFileExtension';
+
+/**
+ * Extensions of files that are binary and cannot be meaningfully edited or
+ * previewed as text. Decoding these as UTF-8 and handing them to the Monaco
+ * editor produces a wall of garbage (and, for a large archive, a multi-megabyte
+ * string that can lock up the editor), so the Applications view shows a
+ * "can't preview" placeholder for them instead.
+ *
+ * Media formats the editor *can* preview (images/videos) are handled separately
+ * by {@link import('./mediaFileType').getMediaFileType} and are intentionally
+ * left out of this list.
+ *
+ * Extensions are matched against the final segment only (see
+ * {@link parseFileExtension}), so `archive.tar.gz` matches via `gz`.
+ */
+const binaryExtensions = new Set([
+	// Compressed archives — the case this list was originally added for.
+	'7z',
+	'br',
+	'bz2',
+	'bzip2',
+	'cab',
+	'gz',
+	'gzip',
+	'lz',
+	'lz4',
+	'lzma',
+	'rar',
+	'tar',
+	'tbz',
+	'tbz2',
+	'tgz',
+	'txz',
+	'xz',
+	'z',
+	'zip',
+	'zst',
+	'zstd',
+	// Executables, libraries, and other compiled artifacts.
+	'a',
+	'bin',
+	'class',
+	'dll',
+	'dylib',
+	'exe',
+	'jar',
+	'node',
+	'o',
+	'so',
+	'wasm',
+	// Fonts.
+	'eot',
+	'otf',
+	'ttf',
+	'woff',
+	'woff2',
+	// Audio.
+	'aac',
+	'flac',
+	'm4a',
+	'mp3',
+	'oga',
+	'ogg',
+	'opus',
+	'wav',
+	'wma',
+	// Binary images the browser can't render inline (so not handled as media).
+	'heic',
+	'heif',
+	'psd',
+	'tif',
+	'tiff',
+	// Other binary documents and databases.
+	'db',
+	'pdf',
+	'sqlite',
+	'sqlite3',
+]);
+
+/** True when the file is a binary type that can't be opened in the text editor. */
+export function isBinaryFile(filename: string | undefined): boolean {
+	return binaryExtensions.has(parseFileExtension(filename).toLowerCase());
+}


### PR DESCRIPTION
Fixes #1338.

Two related problems with compressed/binary files (`.tgz`, `.zip`, `.tar`, …) in the Applications editor.

## 1. Clicking a binary file dumped raw bytes into the editor
Any file that wasn't a directory or previewable media was fetched as UTF-8 text and rendered in Monaco. For a `.tgz` that means the gzip bytes show up as garbage, and a large archive (fetched as a multi-MB string) can lock the editor up.

**Reproduced** against the stage instance — opening `example.tgz` showed the gzip magic bytes (`1f 8b 08…`) as garbage in the editor:

Now binary files render a placeholder ("can't be previewed — it's a binary file") and their contents are never fetched.

- `isBinaryFile()` classifier in `src/lib/string/binaryFileType.ts` (+ tests)
- `ContentViewer` renders `BinaryFilePreview` for those files
- `EditorViewProvider` skips the `get_component_file` request entirely for them

## 2. Deleting could spin forever
The delete handler awaited `dropComponent()` in a bare loop with **no error handling**. If a drop rejected, the `Delete in progress…` loading toast never resolved — the exact symptom in the issue (indefinite spinner, file not deleted).

- Extracted the loop into a tested `deleteSelectedItems()` helper that stops at the first failure and returns it
- The modal now dismisses the spinner and surfaces the error (same pattern already used for upload errors in `DropTarget`)
- Copies the selection before `.reverse()` so we stop mutating shared session state

> Note: I could not reproduce an actual *hang* against the current stage backend (v1.33.7) — deleting `example.tgz` there succeeds (`drop_component` → 200, file removed). This change hardens the frontend so that whenever the backend *does* reject a delete, the user sees the error instead of an endless spinner.

## Verification
- New unit tests for `isBinaryFile` and `deleteSelectedItems` (including the "stop and report on failure" case)
- Full suite green via the pre-commit hook (914 tests), `tsc -b`, lint, format, and `vite build` all pass
- Manually verified in-browser: binary placeholder renders with no Monaco editor; deleting a `.tgz` removes it from the tree with no stuck spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)