### PR TITLE
fix: Clear 'Reloading sidebar' toast when an upload is canceled

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
@@ -145,8 +145,12 @@ ${humanFileSize(uploadedBytes)} of ${humanFileSize(totalBytes)}`,
 				}
 			}
 
+			// Always reuse the same toast id so the single upload toast transitions
+			// from loading into a terminal state. Using `undefined` here (e.g. when
+			// canceled) would spawn a brand-new loading toast that nothing ever
+			// replaces or dismisses, leaving "Reloading sidebar..." spinning forever.
 			toast.loading(`Reloading sidebar...`, {
-				id: canceled ? undefined : id,
+				id,
 				action: toastOKAction,
 				description: '',
 			});
@@ -159,12 +163,15 @@ ${humanFileSize(uploadedBytes)} of ${humanFileSize(totalBytes)}`,
 						action: toastOKAction,
 						description: '',
 					});
+				} else {
+					// Nothing was uploaded or rejected — don't leave the loading toast hanging.
+					toast.dismiss(id);
 				}
 			} else {
 				// Note: this console.log is deliberate. It lets developers know all the files that were rejected.
 				console.log(filesRejected);
 				toast.error(canceled ? 'Cancelled uploads' : 'Rejected uploads', {
-					id: canceled ? undefined : id,
+					id,
 					action: toastOKAction,
 					descriptionClassName: 'whitespace-pre overflow-y-auto',
 					description: filesRejected


### PR DESCRIPTION
Fixes #1324

## Problem

When you drag a folder of files into the Cluster Application Editor and then cancel the upload mid-flight, the **"Reloading sidebar..." toast stays stuck in a loading state forever**.

## Root cause

In [`DropTarget.tsx`](https://github.com/HarperFast/studio/blob/stage/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx), all the upload toasts share one stable id (`'uploading-files'`) so a single toast morphs through states: *Upload in progress → Reloading sidebar → Uploaded!/Rejected*. That works on the happy path.

But two calls used `id: canceled ? undefined : id`:
- the `toast.loading('Reloading sidebar...')` call, and
- the final `toast.error(...)` call.

On cancel, cancelled files get pushed into `filesRejected`, so the error branch runs — and both calls pass `id: undefined`. Sonner treats `undefined` as "create a new toast", so:

1. "Reloading sidebar..." spawns as a **brand-new loading toast**, and
2. the "Cancelled uploads" error spawns as **yet another new toast** instead of replacing it.

Nothing ever replaces or dismisses that loading toast → it spins forever. The same gap meant a `reloadRootEntries()` failure on a cancelled run couldn't be cleaned up by the `catch`'s `toast.dismiss(id)` either, since it targeted the wrong (orphaned) id.

## Fix

- Always reuse the stable `id` for both calls, so the toast reliably transitions into a terminal (non-loading) state and the `catch`/`dismiss` paths can always target it.
- Added a `toast.dismiss(id)` for the edge case where nothing was uploaded *or* rejected (no success toast would otherwise show), so the loading toast can't linger there either.

## Verification

- `tsc -b` — no type errors
- `oxlint` + `dprint check` — clean
- Full `vitest` suite — 892 passed (ran via the pre-commit hook)

Not exercised in a browser preview because reproducing requires a live Harper instance, auth, the Cluster Application Editor, an OS-level folder drag-drop, and timing a cancel mid-upload — none of which the preview tooling can drive. The fix is a focused control-flow change that guarantees the upload toast always lands in a terminal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)