### PR TITLE
fix: Tear down modal drag/resize listeners on mid-gesture unmount

### DIFF
--- a/src/components/ui/useResizableDialog.test.ts
+++ b/src/components/ui/useResizableDialog.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { centerOf, clampPosition, clampSize } from './useResizableDialog';
+
+// These mirror the constants in useResizableDialog: MIN_WIDTH 360, MIN_HEIGHT 280, MARGIN 16.
+const VW = 1280;
+const VH = 800;
+
+describe('clampSize', () => {
+	it('passes a size that already fits through unchanged', () => {
+		expect(clampSize({ width: 820, height: 680 }, VW, VH)).toEqual({ width: 820, height: 680 });
+	});
+
+	it('clamps below the usable minimum up to MIN_WIDTH/MIN_HEIGHT', () => {
+		expect(clampSize({ width: 100, height: 50 }, VW, VH)).toEqual({ width: 360, height: 280 });
+	});
+
+	it('clamps a size larger than the viewport to the viewport minus a margin on each side', () => {
+		// vw - 2*16 = 1248, vh - 2*16 = 768.
+		expect(clampSize({ width: 5000, height: 5000 }, VW, VH)).toEqual({ width: 1248, height: 768 });
+	});
+
+	it('rounds fractional dimensions to whole pixels', () => {
+		expect(clampSize({ width: 820.4, height: 680.6 }, VW, VH)).toEqual({ width: 820, height: 681 });
+	});
+
+	it('keeps the minimum even when the viewport is smaller than the minimum', () => {
+		// A tiny viewport can't satisfy both constraints; the minimum wins so the modal stays usable.
+		expect(clampSize({ width: 800, height: 600 }, 200, 150)).toEqual({ width: 360, height: 280 });
+	});
+});
+
+describe('centerOf', () => {
+	it('centers the modal within the viewport', () => {
+		expect(centerOf({ width: 820, height: 680 }, VW, VH)).toEqual({ x: 230, y: 60 });
+	});
+
+	it('rounds the centered position to whole pixels', () => {
+		// (1280 - 821) / 2 = 229.5 -> 230, (800 - 681) / 2 = 59.5 -> 60.
+		expect(centerOf({ width: 821, height: 681 }, VW, VH)).toEqual({ x: 230, y: 60 });
+	});
+
+	it('produces a negative origin when the modal is larger than the viewport', () => {
+		expect(centerOf({ width: 1480, height: 1000 }, VW, VH)).toEqual({ x: -100, y: -100 });
+	});
+});
+
+describe('clampPosition', () => {
+	const size = { width: 820, height: 680 };
+
+	it('leaves an in-view position unchanged', () => {
+		expect(clampPosition({ x: 230, y: 60 }, size, VW, VH)).toEqual({ x: 230, y: 60 });
+	});
+
+	it('pulls a position past the top-left edge back to the margin', () => {
+		expect(clampPosition({ x: -100, y: -50 }, size, VW, VH)).toEqual({ x: 16, y: 16 });
+	});
+
+	it('pulls a position past the bottom-right edge back so the whole modal stays in view', () => {
+		// maxX = vw - width - margin = 1280 - 820 - 16 = 444, maxY = 800 - 680 - 16 = 104.
+		expect(clampPosition({ x: 9999, y: 9999 }, size, VW, VH)).toEqual({ x: 444, y: 104 });
+	});
+
+	it('pins a modal larger than the viewport to the top-left margin', () => {
+		// When the modal can't fit, maxX/maxY collapse to MARGIN, so the modal anchors at (16, 16).
+		const oversized = { width: 2000, height: 2000 };
+		expect(clampPosition({ x: 500, y: 500 }, oversized, VW, VH)).toEqual({ x: 16, y: 16 });
+	});
+});

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -132,6 +132,9 @@ export function useResizableDialog() {
 
 	const startDrag = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
+		// End any still-live prior gesture (e.g. a dropped mouseup) before starting a new one,
+		// so its window listeners don't outlive this gesture overwriting activeGestureRef.
+		activeGestureRef.current?.();
 		const node = lastNodeRef.current;
 		const startX = event.clientX;
 		const startY = event.clientY;
@@ -168,7 +171,11 @@ export function useResizableDialog() {
 			}
 			window.removeEventListener('mousemove', onMove);
 			window.removeEventListener('mouseup', onUp);
-			activeGestureRef.current = null;
+			// Only clear the ref if it still points at this gesture — a newer gesture may have
+			// replaced it, and a late onUp from this one must not clobber the newer gesture's teardown.
+			if (activeGestureRef.current === teardown) {
+				activeGestureRef.current = null;
+			}
 		};
 		const onUp = () => {
 			teardown();
@@ -196,6 +203,9 @@ export function useResizableDialog() {
 	const startResize = useCallback((direction: ResizeDirection) => (event: React.MouseEvent) => {
 		event.preventDefault();
 		event.stopPropagation();
+		// End any still-live prior gesture (e.g. a dropped mouseup) before starting a new one,
+		// so its window listeners don't outlive this gesture overwriting activeGestureRef.
+		activeGestureRef.current?.();
 		const node = lastNodeRef.current;
 		const startX = event.clientX;
 		const startY = event.clientY;
@@ -263,7 +273,11 @@ export function useResizableDialog() {
 			}
 			window.removeEventListener('mousemove', onMove);
 			window.removeEventListener('mouseup', onUp);
-			activeGestureRef.current = null;
+			// Only clear the ref if it still points at this gesture — a newer gesture may have
+			// replaced it, and a late onUp from this one must not clobber the newer gesture's teardown.
+			if (activeGestureRef.current === teardown) {
+				activeGestureRef.current = null;
+			}
 		};
 		const onUp = () => {
 			teardown();

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -21,14 +21,14 @@ const MARGIN = 16;
 const DEFAULT_SIZE: DialogSize = { width: 820, height: 680 };
 
 /** Never let the modal grow larger than the viewport (minus a margin) or shrink below a usable minimum. */
-function clampSize({ width, height }: DialogSize, vw: number, vh: number): DialogSize {
+export function clampSize({ width, height }: DialogSize, vw: number, vh: number): DialogSize {
 	return {
 		width: Math.round(Math.max(MIN_WIDTH, Math.min(width, vw - MARGIN * 2))),
 		height: Math.round(Math.max(MIN_HEIGHT, Math.min(height, vh - MARGIN * 2))),
 	};
 }
 
-function centerOf({ width, height }: DialogSize, vw: number, vh: number): DialogPosition {
+export function centerOf({ width, height }: DialogSize, vw: number, vh: number): DialogPosition {
 	return {
 		x: Math.round((vw - width) / 2),
 		y: Math.round((vh - height) / 2),
@@ -36,7 +36,7 @@ function centerOf({ width, height }: DialogSize, vw: number, vh: number): Dialog
 }
 
 /** Pull a (possibly off-screen) position back so the whole modal sits within the viewport. */
-function clampPosition(
+export function clampPosition(
 	{ x, y }: DialogPosition,
 	{ width, height }: DialogSize,
 	vw: number,
@@ -79,6 +79,9 @@ export function useResizableDialog() {
 	// view of this, so shrinking the window and growing it back restores their chosen size.
 	const desiredSizeRef = useRef(storedSize);
 	desiredSizeRef.current = storedSize;
+	// While a drag/resize gesture is live, this holds the teardown for its window listeners. onUp
+	// clears it on release; if the dialog unmounts mid-gesture instead, the effect below runs it.
+	const activeGestureRef = useRef<(() => void) | null>(null);
 
 	// Re-center each time the dialog content mounts (i.e. each time the modal opens),
 	// re-deriving the rendered size from the persisted preferred size. Radix may invoke this
@@ -121,6 +124,12 @@ export function useResizableDialog() {
 		return () => window.removeEventListener('resize', onResize);
 	}, []);
 
+	// onUp tears down a gesture's window listeners on mouse release. If the dialog unmounts while a
+	// gesture is still live (Escape, route change, or a programmatic close with the button held),
+	// onUp never fires — so clean up the live gesture here, dropping its listeners and the closure
+	// capturing the now-stale content node.
+	useEffect(() => () => activeGestureRef.current?.(), []);
+
 	const startDrag = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
 		const node = lastNodeRef.current;
@@ -151,10 +160,18 @@ export function useResizableDialog() {
 				frame = requestAnimationFrame(apply);
 			}
 		};
-		const onUp = () => {
+		// Remove the window listeners and cancel any pending frame. Stored in activeGestureRef so an
+		// unmount mid-drag can run the same teardown (onUp would otherwise never fire to do it).
+		const teardown = () => {
 			if (frame) {
 				cancelAnimationFrame(frame);
 			}
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('mouseup', onUp);
+			activeGestureRef.current = null;
+		};
+		const onUp = () => {
+			teardown();
 			setIsDragging(false);
 			// Snap back fully into view.
 			const clamped = clampPosition(
@@ -170,11 +187,10 @@ export function useResizableDialog() {
 				node.style.transform = '';
 			}
 			setPosition(clamped);
-			window.removeEventListener('mousemove', onMove);
-			window.removeEventListener('mouseup', onUp);
 		};
 		window.addEventListener('mousemove', onMove);
 		window.addEventListener('mouseup', onUp);
+		activeGestureRef.current = teardown;
 	}, []);
 
 	const startResize = useCallback((direction: ResizeDirection) => (event: React.MouseEvent) => {
@@ -239,10 +255,18 @@ export function useResizableDialog() {
 				frame = requestAnimationFrame(apply);
 			}
 		};
-		const onUp = () => {
+		// Remove the window listeners and cancel any pending frame. Stored in activeGestureRef so an
+		// unmount mid-resize can run the same teardown (onUp would otherwise never fire to do it).
+		const teardown = () => {
 			if (frame) {
 				cancelAnimationFrame(frame);
 			}
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('mouseup', onUp);
+			activeGestureRef.current = null;
+		};
+		const onUp = () => {
+			teardown();
 			setIsResizing(false);
 			const vw = window.innerWidth;
 			const vh = window.innerHeight;
@@ -251,11 +275,10 @@ export function useResizableDialog() {
 			setPosition(clampPosition(nextPos, finalSize, vw, vh));
 			// Persist the new size under the shared key so every resizable modal remembers it.
 			setStoredSize(finalSize);
-			window.removeEventListener('mousemove', onMove);
-			window.removeEventListener('mouseup', onUp);
 		};
 		window.addEventListener('mousemove', onMove);
 		window.addEventListener('mouseup', onUp);
+		activeGestureRef.current = teardown;
 	}, [setStoredSize]);
 
 	// Maximize fills the screen (within the standard margin); toggling again restores the size and

--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -82,6 +82,9 @@ export function useResizableDialog() {
 	// While a drag/resize gesture is live, this holds the teardown for its window listeners. onUp
 	// clears it on release; if the dialog unmounts mid-gesture instead, the effect below runs it.
 	const activeGestureRef = useRef<(() => void) | null>(null);
+	// Set when the dialog unmounts, so a teardown triggered by unmount skips its state resets:
+	// the component is already gone, so setState would just be a wasted no-op.
+	const unmountedRef = useRef(false);
 
 	// Re-center each time the dialog content mounts (i.e. each time the modal opens),
 	// re-deriving the rendered size from the persisted preferred size. Radix may invoke this
@@ -127,8 +130,12 @@ export function useResizableDialog() {
 	// onUp tears down a gesture's window listeners on mouse release. If the dialog unmounts while a
 	// gesture is still live (Escape, route change, or a programmatic close with the button held),
 	// onUp never fires — so clean up the live gesture here, dropping its listeners and the closure
-	// capturing the now-stale content node.
-	useEffect(() => () => activeGestureRef.current?.(), []);
+	// capturing the now-stale content node. unmountedRef is flipped first so teardown skips its
+	// state resets — the component is gone, so those setState calls would just be wasted no-ops.
+	useEffect(() => () => {
+		unmountedRef.current = true;
+		activeGestureRef.current?.();
+	}, []);
 
 	const startDrag = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
@@ -171,6 +178,11 @@ export function useResizableDialog() {
 			}
 			window.removeEventListener('mousemove', onMove);
 			window.removeEventListener('mouseup', onUp);
+			// Drop the dragging flag so a lost mouseup (released off-window, blur mid-drag) can't leave
+			// the modal stuck mid-gesture (transparent overlay, no text selection). Skipped on unmount.
+			if (!unmountedRef.current) {
+				setIsDragging(false);
+			}
 			// Only clear the ref if it still points at this gesture — a newer gesture may have
 			// replaced it, and a late onUp from this one must not clobber the newer gesture's teardown.
 			if (activeGestureRef.current === teardown) {
@@ -179,7 +191,6 @@ export function useResizableDialog() {
 		};
 		const onUp = () => {
 			teardown();
-			setIsDragging(false);
 			// Snap back fully into view.
 			const clamped = clampPosition(
 				{ x: origin.x + dx, y: origin.y + dy },
@@ -273,6 +284,11 @@ export function useResizableDialog() {
 			}
 			window.removeEventListener('mousemove', onMove);
 			window.removeEventListener('mouseup', onUp);
+			// Drop the resizing flag so a lost mouseup (released off-window, blur mid-resize) can't leave
+			// the modal stuck mid-gesture (no text selection). Skipped on unmount.
+			if (!unmountedRef.current) {
+				setIsResizing(false);
+			}
 			// Only clear the ref if it still points at this gesture — a newer gesture may have
 			// replaced it, and a late onUp from this one must not clobber the newer gesture's teardown.
 			if (activeGestureRef.current === teardown) {
@@ -281,7 +297,6 @@ export function useResizableDialog() {
 		};
 		const onUp = () => {
 			teardown();
-			setIsResizing(false);
 			const vw = window.innerWidth;
 			const vh = window.innerHeight;
 			const finalSize = clampSize(nextSize, vw, vh);


### PR DESCRIPTION
Follow-up to [#1343](https://github.com/HarperFast/studio/pull/1343), addressing post-merge review feedback from @kriszyp.

## [significant] Listener leak on mid-gesture unmount — fixed

The window `mousemove`/`mouseup` listeners in `useResizableDialog`'s drag/resize handlers were torn down only inside `onUp`. If a resizable dialog unmounts mid-gesture (Escape, route change, or a programmatic close while the mouse button is held), `onUp` never fires — so those listeners, plus the closure capturing the now-stale content node, leak onto `window`.

Fix: each live gesture's teardown is tracked in a ref (`activeGestureRef`) and run from a `useEffect` cleanup, so the listeners are released on unmount as well as on normal release. `onUp` still calls the same teardown on release and clears the ref; the unmount path calls `teardown()` directly (never `onUp`), so no `setState` fires on an unmounting component.

## [suggestion] Pure helpers untested — added

`clampSize` / `clampPosition` / `centerOf` are now exported and covered by unit tests in `useResizableDialog.test.ts` (12 cases over the clamp/center invariants: minimums, viewport clamping, rounding, off-screen pull-back, oversized-modal pinning). They take explicit `vw`/`vh`, so they test cleanly in the existing node environment.

## Review notes not actioned

- **[question] Shared persisted size** — confirmed **intentional**; keeping the single shared key (resizing any modal sets the remembered size for all). No change.
- **[suggestion] Split the `.env.local` SessionStart hook** — moot: #1343 is already merged, so there's nothing left to split out. Noting for the record.

## Verification

- `vitest run` — 142 files, 904 passed / 11 skipped
- `tsc -b` — clean
- `oxlint` + `dprint check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)