### PR TITLE
feat: Identify roles by id and make role/user modals resizable

### DIFF
--- a/src/components/RoleOptionLabel.tsx
+++ b/src/components/RoleOptionLabel.tsx
@@ -1,0 +1,13 @@
+/**
+ * Renders a role's name alongside its unique id. Role names are not guaranteed to be unique, so the
+ * id is shown (muted, monospace) to let users tell apart roles that share a name. Used inside role
+ * `<SelectItem>`s — the same markup also renders in the select trigger once a role is chosen.
+ */
+export function RoleOptionLabel({ name, id }: { name: string; id: string }) {
+	return (
+		<span className="flex items-baseline gap-2 truncate">
+			<span className="truncate">{name}</span>
+			<span className="text-muted-foreground font-mono text-xs">{id}</span>
+		</span>
+	);
+}

--- a/src/features/instance/config/roles/constants/tableDefinition.tsx
+++ b/src/features/instance/config/roles/constants/tableDefinition.tsx
@@ -11,6 +11,17 @@ export const dataTableColumns: Array<ColumnDef<LocalRole>> = [
 		enableSorting: false,
 	},
 	columnHelper.display({
+		header: 'ID',
+		id: 'id',
+		enableSorting: false,
+		// Role names are not unique; surfacing the id makes roles that share a name distinguishable.
+		cell: (props) => (
+			<span className="font-mono text-xs text-muted-foreground" title={props.row.original.id}>
+				{props.row.original.id}
+			</span>
+		),
+	}),
+	columnHelper.display({
 		header: 'Created',
 		enableSorting: false,
 		id: '__createdtime__',

--- a/src/features/instance/config/roles/index.tsx
+++ b/src/features/instance/config/roles/index.tsx
@@ -32,8 +32,8 @@ export function ConfigRolesIndex() {
 	const selectedRole = useMemo(() => localRoles?.find((role) => role.id === roleId), [localRoles, roleId]);
 
 	const onSelectRole = useCallback(
-		(newRole: string | undefined) => {
-			const parts = [roleId ? '..' : '', newRole].filter(Boolean);
+		(newRoleId: string | undefined) => {
+			const parts = [roleId ? '..' : '', newRoleId].filter(Boolean);
 			void navigate({ to: parts.join('/') });
 		},
 		[roleId, navigate],
@@ -46,15 +46,15 @@ export function ConfigRolesIndex() {
 	const onAddClicked = useCallback(() => {
 		setIsAddModalOpen(true);
 	}, [setIsAddModalOpen]);
-	const onRoleAdded = useCallback((roleName: string) => {
+	const onRoleAdded = useCallback((newRoleId: string) => {
 		void refetch();
 		setIsAddModalOpen(false);
-		onSelectRole(roleName);
+		onSelectRole(newRoleId);
 	}, [onSelectRole, refetch]);
 
 	const onRowClick = useCallback(
 		(rowData: Row<LocalRole>) => {
-			onSelectRole(rowData.original.role);
+			onSelectRole(rowData.original.id);
 		},
 		[onSelectRole],
 	);

--- a/src/features/instance/config/roles/modals/AddRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/AddRoleModal.tsx
@@ -29,7 +29,7 @@ export function AddRoleModal({
 	setIsModalOpen,
 }: {
 	isModalOpen: boolean;
-	onChangesSaved: (roleName: string) => void;
+	onChangesSaved: (roleId: string) => void;
 	setIsModalOpen: (open: boolean) => void;
 }) {
 	const form = useForm({
@@ -54,9 +54,9 @@ export function AddRoleModal({
 						...instanceParams,
 					},
 					{
-						onSuccess: () => {
+						onSuccess: (newRole) => {
 							form.reset();
-							onChangesSaved(formData.role);
+							onChangesSaved(newRole.id);
 							toast.success('Role added successfully!');
 							setIsModalOpen(false);
 						},

--- a/src/features/instance/config/roles/modals/EditRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/EditRoleModal.tsx
@@ -49,7 +49,7 @@ export function EditRoleModal({
 		getRegistrationInfoQueryOptions(instanceParams),
 	);
 	const auth = useInstanceAuth(instanceId ?? clusterId);
-	const isSelf = auth.user?.role?.role === data.role;
+	const isSelf = auth.user?.role?.id === data.id;
 
 	const [showAttributes, onShowAttributesChanged] = useCheckboxCallback(updatedPermissions?.includes('attribute_name'));
 
@@ -149,7 +149,7 @@ export function EditRoleModal({
 
 	return (
 		<Dialog onOpenChange={closeModal} open={isModalOpen}>
-			<DialogContent className="sm:max-w-[750px]">
+			<DialogContent resizable>
 				<DialogTitle>{isSelf ? 'View' : 'Edit'} Role "{role}"</DialogTitle>
 				<DialogDescription>
 					{isSelf
@@ -157,20 +157,22 @@ export function EditRoleModal({
 							+ ' role to edit this role.'
 						: "Edit the role's permissions in JSON format or remove the role entirely."}
 				</DialogDescription>
-				{defaultValue
-					? (
-						<Editor
-							theme={monacoTheme}
-							height="400px"
-							defaultLanguage="json"
-							value={updatedPermissions}
-							options={isSelf ? { readOnly: true } : undefined}
-							onValidate={onValidate}
-							onChange={setUpdatedPermissions}
-							defaultValue={defaultValue}
-						/>
-					)
-					: <TextLoadingSkeleton />}
+				<div className="flex-1 min-h-0">
+					{defaultValue
+						? (
+							<Editor
+								className="w-full h-full"
+								theme={monacoTheme}
+								defaultLanguage="json"
+								value={updatedPermissions}
+								options={{ readOnly: isSelf, automaticLayout: true }}
+								onValidate={onValidate}
+								onChange={setUpdatedPermissions}
+								defaultValue={defaultValue}
+							/>
+						)
+						: <TextLoadingSkeleton />}
+				</div>
 				<DialogFooter>
 					{!isSelf && (
 						<div className="flex justify-between w-full">

--- a/src/features/instance/config/users/components/AlterUserForm.tsx
+++ b/src/features/instance/config/users/components/AlterUserForm.tsx
@@ -39,13 +39,17 @@ export function AlterUserForm({
 	onUserUpdated: () => void;
 }) {
 	const instanceParams = useInstanceClientIdParams();
-	const { data: roles, isLoading: isRolesLoading } = useQuery(getListRolesQueryOptions(instanceParams));
+	const { data: roles, isLoading: isRolesLoading } = useQuery({
+		...getListRolesQueryOptions(instanceParams),
+		// Keep the previous useSuspenseQuery behavior of surfacing fetch errors to the ErrorBoundary.
+		throwOnError: true,
+	});
 	const { mutate: alterUser, isPending: isUpdateUserPending } = useAlterUser();
 	const alterForm = useForm({
 		resolver: zodResolver(AlterUserFormSchema),
 		defaultValues: {
 			username: data.username,
-			role: data.role.id,
+			role: data.role?.id ?? '',
 			newPassword: '',
 			confirmPassword: '',
 		},

--- a/src/features/instance/config/users/components/AlterUserForm.tsx
+++ b/src/features/instance/config/users/components/AlterUserForm.tsx
@@ -1,3 +1,4 @@
+import { RoleOptionLabel } from '@/components/RoleOptionLabel';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Button } from '@/components/ui/button';
 import { DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -23,9 +24,9 @@ import { AlterUserRequestBody, useAlterUser } from '@/integrations/api/instance/
 import { AlterUserFormSchema } from '@/integrations/api/instance/auth/alterUserFormSchema';
 import { getListRolesQueryOptions } from '@/integrations/api/instance/auth/getListRoles';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Save } from 'lucide-react';
-import { Suspense, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -38,13 +39,13 @@ export function AlterUserForm({
 	onUserUpdated: () => void;
 }) {
 	const instanceParams = useInstanceClientIdParams();
-	const { data: roles } = useSuspenseQuery(getListRolesQueryOptions(instanceParams));
+	const { data: roles, isLoading: isRolesLoading } = useQuery(getListRolesQueryOptions(instanceParams));
 	const { mutate: alterUser, isPending: isUpdateUserPending } = useAlterUser();
 	const alterForm = useForm({
 		resolver: zodResolver(AlterUserFormSchema),
 		defaultValues: {
 			username: data.username,
-			role: data.role.role,
+			role: data.role.id,
 			newPassword: '',
 			confirmPassword: '',
 		},
@@ -148,7 +149,7 @@ export function AlterUserForm({
 						<FormItem>
 							<FormLabel className="pb-1">Role</FormLabel>
 
-							<Suspense fallback={<TextLoadingSkeleton />}>
+							{isRolesLoading ? <TextLoadingSkeleton /> : (
 								<FormControl>
 									<Select {...field} onValueChange={(role) => field.onChange(role)}>
 										<SelectTrigger className="w-full">
@@ -162,14 +163,14 @@ export function AlterUserForm({
 														key={role.id}
 														value={role.id}
 													>
-														{role.role}
+														<RoleOptionLabel name={role.role} id={role.id} />
 													</SelectItem>
 												))}
 											</SelectGroup>
 										</SelectContent>
 									</Select>
 								</FormControl>
-							</Suspense>
+							)}
 							<FormMessage />
 						</FormItem>
 					)}

--- a/src/features/instance/config/users/modals/AddUserModal.tsx
+++ b/src/features/instance/config/users/modals/AddUserModal.tsx
@@ -1,3 +1,4 @@
+import { RoleOptionLabel } from '@/components/RoleOptionLabel';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -22,9 +23,9 @@ import { useAddUserMutation } from '@/integrations/api/instance/auth/addUser';
 import { AddUserFormSchema } from '@/integrations/api/instance/auth/addUserFormSchema';
 import { getListRolesQueryOptions } from '@/integrations/api/instance/auth/getListRoles';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Save } from 'lucide-react';
-import { Suspense, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -39,7 +40,7 @@ export function AddUserModal({
 	setIsModalOpen: (open: boolean) => void;
 }) {
 	const instanceParams = useInstanceClientIdParams();
-	const { data: roles } = useSuspenseQuery(getListRolesQueryOptions(instanceParams));
+	const { data: roles, isLoading: isRolesLoading } = useQuery(getListRolesQueryOptions(instanceParams));
 	const form = useForm({
 		resolver: zodResolver(AddUserFormSchema),
 		defaultValues: {
@@ -151,7 +152,7 @@ export function AddUserModal({
 								<FormItem>
 									<FormLabel className="pb-1">Role</FormLabel>
 
-									<Suspense fallback={<TextLoadingSkeleton />}>
+									{isRolesLoading ? <TextLoadingSkeleton /> : (
 										<FormControl>
 											<Select {...field} onValueChange={(role) => field.onChange(role)}>
 												<SelectTrigger className="w-full">
@@ -165,14 +166,14 @@ export function AddUserModal({
 																key={role.id}
 																value={role.id}
 															>
-																{role.role}
+																<RoleOptionLabel name={role.role} id={role.id} />
 															</SelectItem>
 														))}
 													</SelectGroup>
 												</SelectContent>
 											</Select>
 										</FormControl>
-									</Suspense>
+									)}
 									<FormMessage />
 								</FormItem>
 							)}

--- a/src/features/instance/config/users/modals/AddUserModal.tsx
+++ b/src/features/instance/config/users/modals/AddUserModal.tsx
@@ -40,7 +40,11 @@ export function AddUserModal({
 	setIsModalOpen: (open: boolean) => void;
 }) {
 	const instanceParams = useInstanceClientIdParams();
-	const { data: roles, isLoading: isRolesLoading } = useQuery(getListRolesQueryOptions(instanceParams));
+	const { data: roles, isLoading: isRolesLoading } = useQuery({
+		...getListRolesQueryOptions(instanceParams),
+		// Keep the previous useSuspenseQuery behavior of surfacing fetch errors to the ErrorBoundary.
+		throwOnError: true,
+	});
 	const form = useForm({
 		resolver: zodResolver(AddUserFormSchema),
 		defaultValues: {

--- a/src/features/instance/config/users/modals/EditUserModal.tsx
+++ b/src/features/instance/config/users/modals/EditUserModal.tsx
@@ -29,7 +29,7 @@ export function EditUserModal({
 
 	return (
 		<Dialog onOpenChange={closeModal} open={isModalOpen}>
-			<DialogContent className="sm:max-w-[750px]">
+			<DialogContent resizable>
 				<AlterUserForm data={data} onUserUpdated={onUserUpdated} />
 				{canDelete && <DeleteUserForm data={data} onUserDeleted={onUserDeleted} />}
 			</DialogContent>

--- a/src/features/organization/roles/constants/tableDefinition.tsx
+++ b/src/features/organization/roles/constants/tableDefinition.tsx
@@ -10,6 +10,17 @@ export const dataTableColumns: Array<ColumnDef<SchemaOrganizationRole>> = [
 		enableSorting: false,
 	},
 	columnHelper.display({
+		header: 'ID',
+		id: 'id',
+		enableSorting: false,
+		// Role names are not unique; surfacing the id makes roles that share a name distinguishable.
+		cell: (props) => (
+			<span className="font-mono text-xs text-muted-foreground" title={props.row.original.id}>
+				{props.row.original.id}
+			</span>
+		),
+	}),
+	columnHelper.display({
 		header: 'Users Assigned',
 		enableSorting: false,
 		id: 'userIds',

--- a/src/features/organization/roles/modals/AddOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/AddOrganizationRoleModal.tsx
@@ -104,69 +104,71 @@ export function AddOrganizationRoleModal({
 
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
-			<DialogContent>
+			<DialogContent resizable>
 				<DialogTitle>Add New Organization Role</DialogTitle>
 				<DialogDescription>Set the new organization role permissions.</DialogDescription>
 				<Form {...form}>
 					<form
 						id="org-add-role-form"
 						name="org-add-role-form"
-						className="grid grid-cols-2 gap-4 my-4"
+						className="flex flex-1 min-h-0 flex-col gap-4 my-4"
 						onSubmit={form.handleSubmit(onSubmitRoleEdits)}
 					>
-						<FormField
-							control={form.control}
-							name="name"
-							render={({ field }) => (
-								<FormItem className="col-span-2">
-									<FormLabel className="pb-1">Role Name</FormLabel>
-									<FormControl>
-										<Input type="text" className="" {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="update"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel className="pb-1">Can Update Organization</FormLabel>
-									<FormControl>
-										<Input
-											type="checkbox"
-											className="w-6 ml-2"
-											checked={field.value}
-											onChange={(e) => field.onChange(e.target.checked)}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="delete"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel className="pb-1">Can Delete Organization</FormLabel>
-									<FormControl>
-										<Input
-											type="checkbox"
-											className="w-6 ml-2"
-											checked={field.value}
-											onChange={(e) => field.onChange(e.target.checked)}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<div className="col-span-2">
+						<div className="grid grid-cols-2 gap-4">
+							<FormField
+								control={form.control}
+								name="name"
+								render={({ field }) => (
+									<FormItem className="col-span-2">
+										<FormLabel className="pb-1">Role Name</FormLabel>
+										<FormControl>
+											<Input type="text" className="" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="update"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="pb-1">Can Update Organization</FormLabel>
+										<FormControl>
+											<Input
+												type="checkbox"
+												className="w-6 ml-2"
+												checked={field.value}
+												onChange={(e) => field.onChange(e.target.checked)}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="delete"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="pb-1">Can Delete Organization</FormLabel>
+										<FormControl>
+											<Input
+												type="checkbox"
+												className="w-6 ml-2"
+												checked={field.value}
+												onChange={(e) => field.onChange(e.target.checked)}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<div className="flex-1 min-h-0">
 							<Editor
+								className="w-full h-full"
 								theme={monacoTheme}
-								height="300px"
 								defaultLanguage="json"
 								onValidate={onValidate}
 								onChange={(value) => {
@@ -174,10 +176,11 @@ export function AddOrganizationRoleModal({
 										setUpdatedPermissions(value);
 									}
 								}}
+								options={{ automaticLayout: true }}
 								defaultValue={JSON.stringify(defaultPermissions, null, 2)}
 							/>
 						</div>
-						<DialogFooter className="col-span-2">
+						<DialogFooter>
 							<div className="flex justify-between w-full">
 								<Button
 									variant="destructiveOutline"

--- a/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
@@ -1,3 +1,4 @@
+import { Loading } from '@/components/Loading';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form/Form';
@@ -24,7 +25,7 @@ import { Editor } from '@/lib/monaco/MonacoEditor';
 import { safeParse } from '@/lib/string/safeParse';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { ConfirmDeletionContent } from './ConfirmDeletionContent';
@@ -38,12 +39,47 @@ export function EditOrganizationRoleModal({
 	isModalOpen: boolean;
 	closeModal: (madeChanges: boolean) => void;
 }) {
+	const onOpenChanges = useCallback(() => closeModal(false), [closeModal]);
+	return (
+		<Dialog onOpenChange={onOpenChanges} open={isModalOpen}>
+			<DialogContent resizable>
+				{
+					/*
+					Render the dialog shell (overlay + close button) immediately and load the role's
+					details behind an inner Suspense boundary. Opening a role now shows a loading state
+					inside the modal — and stays closeable — instead of bubbling up and blanking the list.
+				*/
+				}
+				<Suspense fallback={<EditOrganizationRoleModalLoading roleName={data.roleName} />}>
+					<EditOrganizationRoleModalContent data={data} closeModal={closeModal} />
+				</Suspense>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function EditOrganizationRoleModalLoading({ roleName }: { roleName: string }) {
+	return (
+		<>
+			<DialogTitle>Organization Role "{roleName}"</DialogTitle>
+			<Loading centered text="Loading role…" className="flex-1 min-h-0" />
+		</>
+	);
+}
+
+function EditOrganizationRoleModalContent({
+	data,
+	closeModal,
+}: {
+	data: SchemaOrganizationRole;
+	closeModal: (madeChanges: boolean) => void;
+}) {
 	const queryClient = useQueryClient();
 	const { data: roleInfo } = useSuspenseQuery(
 		getOrganizationRoleInfoQueryOptions({ roleId: data.id, organizationId: data.organizationId }),
 	);
 	const auth = useCloudAuth();
-	const isSelf = auth.user && auth.user?.roles?.[data.organizationId]?.role === data.roleName;
+	const isSelf = auth.user && auth.user?.roles?.[data.organizationId]?.id === data.id;
 	const { update, remove } = useOrganizationRolePermissions(data.organizationId);
 	const { mutate: updateOrganizationRole, isPending: isRoleUpdatePending } = useUpdateOrganizationRole();
 	const { mutate: deleteOrganizationRole, isPending: isRoleDeletionPending } = useDeleteOrganizationRole();
@@ -162,135 +198,129 @@ export function EditOrganizationRoleModal({
 		],
 	);
 
-	const onOpenChanges = useCallback(() => closeModal(false), [closeModal]);
-
-	return (
-		<Dialog onOpenChange={onOpenChanges} open={isModalOpen}>
-			<DialogContent>
-				{isConfirmingRoleDeletion
-					? (
-						<ConfirmDeletionContent
-							onRoleDeleteClick={onRoleDeleteClick}
-							setIsConfirmingRoleDeletion={setIsConfirmingRoleDeletion}
-							isRoleDeletionPending={isRoleDeletionPending}
-						/>
-					)
-					: (
-						<>
-							<DialogTitle>{isSelf || !update ? 'View' : 'Edit'} Organization Role "{data.roleName}"</DialogTitle>
-							<Form {...form}>
-								<form
-									id="org-edit-role-form"
-									name="org-edit-role-form"
-									className="grid grid-cols-2 gap-4 my-4"
-									onSubmit={form.handleSubmit(onSubmitRoleEdits)}
-								>
-									<FormField
-										control={form.control}
-										name="name"
-										render={({ field }) => (
-											<FormItem className="col-span-2">
-												<FormLabel className="pb-1">Role Name</FormLabel>
-												<FormControl>
-													<Input
-														type="text"
-														className=""
-														{...field}
-														disabled={true}
-														readOnly={true}
-													/>
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="update"
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel className="pb-1">Can Update Organization</FormLabel>
-												<FormControl>
-													<Input
-														type="checkbox"
-														className="w-6 ml-2"
-														disabled={isSelf || !update}
-														readOnly={isSelf || !update}
-														checked={field.value}
-														onChange={(e) => field.onChange(e.target.checked)}
-													/>
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="delete"
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel className="pb-1">Can Delete Organization</FormLabel>
-												<FormControl>
-													<Input
-														type="checkbox"
-														className="w-6 ml-2"
-														disabled={isSelf || !update}
-														readOnly={isSelf || !update}
-														checked={field.value}
-														onChange={(e) => field.onChange(e.target.checked)}
-													/>
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-									<div className="col-span-2">
-										<Editor
-											theme={monacoTheme}
-											height="300px"
-											defaultLanguage="json"
-											onValidate={onValidate}
-											onChange={(value) => {
-												if (value) {
-													setUpdatedPermissions(value);
-												}
-											}}
-											options={isSelf || !update ? { readOnly: true } : undefined}
-											defaultValue={updatedPermissions}
-										/>
-									</div>
-									{(!isSelf && (remove || update)) && (
-										<DialogFooter className="col-span-2">
-											<div className="flex justify-between w-full">
-												{remove && (
-													<Button
-														type="button"
-														variant="destructiveOutline"
-														className="rounded-full"
-														onClick={() => setIsConfirmingRoleDeletion(true)}
-														disabled={isRoleUpdatePending}
-													>
-														Delete Role
-													</Button>
-												)}
-												{update && (
-													<Button
-														variant="submit"
-														className="rounded-full"
-														disabled={!isValidJSON || isRoleUpdatePending || !form.formState.isValid
-															|| (!form.formState.isDirty && !isPermissionsDirty)}
-													>
-														Save Changes
-													</Button>
-												)}
-											</div>
-										</DialogFooter>
+	return isConfirmingRoleDeletion
+		? (
+			<ConfirmDeletionContent
+				onRoleDeleteClick={onRoleDeleteClick}
+				setIsConfirmingRoleDeletion={setIsConfirmingRoleDeletion}
+				isRoleDeletionPending={isRoleDeletionPending}
+			/>
+		)
+		: (
+			<>
+				<DialogTitle>{isSelf || !update ? 'View' : 'Edit'} Organization Role "{data.roleName}"</DialogTitle>
+				<Form {...form}>
+					<form
+						id="org-edit-role-form"
+						name="org-edit-role-form"
+						className="flex flex-1 min-h-0 flex-col gap-4 my-4"
+						onSubmit={form.handleSubmit(onSubmitRoleEdits)}
+					>
+						<div className="grid grid-cols-2 gap-4">
+							<FormField
+								control={form.control}
+								name="name"
+								render={({ field }) => (
+									<FormItem className="col-span-2">
+										<FormLabel className="pb-1">Role Name</FormLabel>
+										<FormControl>
+											<Input
+												type="text"
+												className=""
+												{...field}
+												disabled={true}
+												readOnly={true}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="update"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="pb-1">Can Update Organization</FormLabel>
+										<FormControl>
+											<Input
+												type="checkbox"
+												className="w-6 ml-2"
+												disabled={isSelf || !update}
+												readOnly={isSelf || !update}
+												checked={field.value}
+												onChange={(e) => field.onChange(e.target.checked)}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="delete"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="pb-1">Can Delete Organization</FormLabel>
+										<FormControl>
+											<Input
+												type="checkbox"
+												className="w-6 ml-2"
+												disabled={isSelf || !update}
+												readOnly={isSelf || !update}
+												checked={field.value}
+												onChange={(e) => field.onChange(e.target.checked)}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<div className="flex-1 min-h-0">
+							<Editor
+								className="w-full h-full"
+								theme={monacoTheme}
+								defaultLanguage="json"
+								onValidate={onValidate}
+								onChange={(value) => {
+									if (value) {
+										setUpdatedPermissions(value);
+									}
+								}}
+								options={{ readOnly: !!isSelf || !update, automaticLayout: true }}
+								defaultValue={updatedPermissions}
+							/>
+						</div>
+						{(!isSelf && (remove || update)) && (
+							<DialogFooter>
+								<div className="flex justify-between w-full">
+									{remove && (
+										<Button
+											type="button"
+											variant="destructiveOutline"
+											className="rounded-full"
+											onClick={() => setIsConfirmingRoleDeletion(true)}
+											disabled={isRoleUpdatePending}
+										>
+											Delete Role
+										</Button>
 									)}
-								</form>
-							</Form>
-						</>
-					)}
-			</DialogContent>
-		</Dialog>
-	);
+									{update && (
+										<Button
+											variant="submit"
+											className="rounded-full"
+											disabled={!isValidJSON || isRoleUpdatePending || !form.formState.isValid
+												|| (!form.formState.isDirty && !isPermissionsDirty)}
+										>
+											Save Changes
+										</Button>
+									)}
+								</div>
+							</DialogFooter>
+						)}
+					</form>
+				</Form>
+			</>
+		);
 }

--- a/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
@@ -79,7 +79,7 @@ function EditOrganizationRoleModalContent({
 		getOrganizationRoleInfoQueryOptions({ roleId: data.id, organizationId: data.organizationId }),
 	);
 	const auth = useCloudAuth();
-	const isSelf = auth.user && auth.user?.roles?.[data.organizationId]?.id === data.id;
+	const isSelf = auth.user?.roles?.[data.organizationId]?.id === data.id;
 	const { update, remove } = useOrganizationRolePermissions(data.organizationId);
 	const { mutate: updateOrganizationRole, isPending: isRoleUpdatePending } = useUpdateOrganizationRole();
 	const { mutate: deleteOrganizationRole, isPending: isRoleDeletionPending } = useDeleteOrganizationRole();
@@ -288,7 +288,7 @@ function EditOrganizationRoleModalContent({
 										setUpdatedPermissions(value);
 									}
 								}}
-								options={{ readOnly: !!isSelf || !update, automaticLayout: true }}
+								options={{ readOnly: isSelf || !update, automaticLayout: true }}
 								defaultValue={updatedPermissions}
 							/>
 						</div>

--- a/src/features/organization/users/components/OrgUserRoleCheckbox.tsx
+++ b/src/features/organization/users/components/OrgUserRoleCheckbox.tsx
@@ -24,7 +24,7 @@ export function OrgUserRoleCheckbox({
 }) {
 	const { mutate: addUser, isPending: isAddPending } = useAddUserToOrganizationRole();
 	const { mutate: removeUser, isPending: isRemovePending } = useRemoveUserFromOrganizationRole();
-	const userIsInRole = !!selectedRoles[orgRole.roleName];
+	const userIsInRole = !!selectedRoles[orgRole.id];
 	const [wasChecked, setWasChecked] = useState(userIsInRole);
 	const [isChecked, onCheckedChanged] = useCheckboxCallback(userIsInRole);
 	useEffect(() => {

--- a/src/features/organization/users/modals/AddUserModal.tsx
+++ b/src/features/organization/users/modals/AddUserModal.tsx
@@ -1,3 +1,4 @@
+import { RoleOptionLabel } from '@/components/RoleOptionLabel';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Button } from '@/components/ui/button';
 import {
@@ -31,11 +32,11 @@ import {
 import { useInviteUserToOrganizationRole } from '@/features/organization/mutations/inviteUserToOrganizationRole';
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import { MailWarningIcon, Save } from 'lucide-react';
-import { Suspense, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -50,7 +51,7 @@ export function AddUserModal({
 	setIsModalOpen: (open: boolean) => void;
 }) {
 	const { organizationId }: { organizationId: string } = useParams({ strict: false });
-	const { data: orgRoles } = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
+	const { data: orgRoles, isLoading: isRolesLoading } = useQuery(getOrganizationRolesQueryOptions(organizationId));
 	const [shouldInvite, setShouldInvite] = useState(false);
 
 	const form = useForm({
@@ -128,7 +129,7 @@ export function AddUserModal({
 								<FormItem>
 									<FormLabel className="pb-1">Roles</FormLabel>
 
-									<Suspense fallback={<TextLoadingSkeleton />}>
+									{isRolesLoading ? <TextLoadingSkeleton /> : (
 										<FormControl>
 											<Select {...field} onValueChange={(role) => field.onChange(role)}>
 												<SelectTrigger className="w-full">
@@ -140,14 +141,14 @@ export function AddUserModal({
 														<SelectLabel>Role</SelectLabel>
 														{orgRoles?.map((role) => (
 															<SelectItem key={role.id} value={role.id}>
-																{role.roleName}
+																<RoleOptionLabel name={role.roleName} id={role.id} />
 															</SelectItem>
 														))}
 													</SelectGroup>
 												</SelectContent>
 											</Select>
 										</FormControl>
-									</Suspense>
+									)}
 									<FormMessage />
 								</FormItem>
 							)}

--- a/src/features/organization/users/modals/AddUserModal.tsx
+++ b/src/features/organization/users/modals/AddUserModal.tsx
@@ -51,7 +51,11 @@ export function AddUserModal({
 	setIsModalOpen: (open: boolean) => void;
 }) {
 	const { organizationId }: { organizationId: string } = useParams({ strict: false });
-	const { data: orgRoles, isLoading: isRolesLoading } = useQuery(getOrganizationRolesQueryOptions(organizationId));
+	const { data: orgRoles, isLoading: isRolesLoading } = useQuery({
+		...getOrganizationRolesQueryOptions(organizationId),
+		// Keep the previous useSuspenseQuery behavior of surfacing fetch errors to the ErrorBoundary.
+		throwOnError: true,
+	});
 	const [shouldInvite, setShouldInvite] = useState(false);
 
 	const form = useForm({

--- a/src/features/organization/users/modals/EditUserModal.tsx
+++ b/src/features/organization/users/modals/EditUserModal.tsx
@@ -1,3 +1,4 @@
+import { Loading } from '@/components/Loading';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { OrgUserRoleCheckbox } from '@/features/organization/users/components/OrgUserRoleCheckbox';
@@ -7,7 +8,7 @@ import { SchemaUser } from '@/integrations/api/api.gen';
 import { keyBy } from '@/lib/keyBy';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 
 export function EditUserModal({
 	closeModal,
@@ -24,14 +25,12 @@ export function EditUserModal({
 	const auth = useCloudAuth();
 	const { update, remove } = useOrganizationRolePermissions(organizationId);
 	const isSelf = auth.user?.email === data.email;
-	const { data: orgRoles } = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
-	const selectedRoles = useMemo(() => data.roles ? keyBy(data.roles, 'roleName') : {}, [data]);
 	const [changesMade, setChangesMade] = useState<boolean>(false);
 
 	// TODO: Cancel invite
 	return (
 		<Dialog onOpenChange={changesMade ? onUserUpdated : closeModal} open={isModalOpen}>
-			<DialogContent className="sm:max-w-[750px]">
+			<DialogContent resizable>
 				<DialogHeader>
 					<DialogTitle>{update ? 'Edit ' : 'View '} {data.email} {isSelf ? '(yourself)' : ''}</DialogTitle>
 				</DialogHeader>
@@ -42,18 +41,50 @@ export function EditUserModal({
 					</DialogDescription>
 				)}
 
-				{orgRoles.map((orgRole) => (
-					<OrgUserRoleCheckbox
-						key={orgRole.id}
-						readOnly={!update}
-						canRemove={remove}
+				{/* The role list loads behind its own boundary so the dialog opens (and stays closeable) immediately. */}
+				<Suspense fallback={<Loading centered text="Loading roles…" className="flex-1 min-h-0" />}>
+					<EditUserRolesList
 						data={data}
-						orgRole={orgRole}
-						selectedRoles={selectedRoles}
+						organizationId={organizationId}
+						update={update}
+						remove={remove}
 						setChangesMade={setChangesMade}
 					/>
-				))}
+				</Suspense>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+function EditUserRolesList({
+	data,
+	organizationId,
+	update,
+	remove,
+	setChangesMade,
+}: {
+	data: SchemaUser;
+	organizationId: string;
+	update: boolean;
+	remove: boolean;
+	setChangesMade: (value: boolean) => void;
+}) {
+	const { data: orgRoles } = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
+	const selectedRoles = useMemo(() => data.roles ? keyBy(data.roles, 'id') : {}, [data]);
+
+	return (
+		<div className="flex flex-1 min-h-0 flex-col gap-2 overflow-y-auto">
+			{orgRoles.map((orgRole) => (
+				<OrgUserRoleCheckbox
+					key={orgRole.id}
+					readOnly={!update}
+					canRemove={remove}
+					data={data}
+					orgRole={orgRole}
+					selectedRoles={selectedRoles}
+					setChangesMade={setChangesMade}
+				/>
+			))}
+		</div>
 	);
 }

--- a/src/integrations/api/instance/auth/addRole.ts
+++ b/src/integrations/api/instance/auth/addRole.ts
@@ -1,4 +1,5 @@
 import { InstanceClientConfig } from '@/config/instanceClientConfig';
+import { LocalRole } from '@/integrations/api/api.patch';
 import { useMutation } from '@tanstack/react-query';
 
 export interface AddRoleFormData {
@@ -7,7 +8,7 @@ export interface AddRoleFormData {
 	structure_user?: boolean;
 }
 
-export async function onAddRoleSubmit(formData: AddRoleFormData & InstanceClientConfig) {
+export async function onAddRoleSubmit(formData: AddRoleFormData & InstanceClientConfig): Promise<LocalRole> {
 	const { role, super_user, structure_user, instanceClient } = formData;
 	const { data } = await instanceClient.post(
 		'/',
@@ -20,7 +21,9 @@ export async function onAddRoleSubmit(formData: AddRoleFormData & InstanceClient
 			},
 		},
 	);
-	return data;
+	// add_role echoes back the created role, including its unique `id`, which we use to navigate
+	// to the new role for editing (role names are not unique, so the name can't identify it).
+	return data as LocalRole;
 }
 
 export function useAddRoleMutation() {


### PR DESCRIPTION
## Why

Roles can share a name (multiple `admin` roles), so identifying them by name is ambiguous and, in a few places, buggy. This makes the UI reference roles by their unique `id` and surfaces the id where names alone aren't enough to tell roles apart. While in these modals, it also brings them in line with the resizable, in-modal-loading behavior of the logs and add-row modals.

Closes #1337

## 1. Identify roles by id (the issue)

- **Link by id, not name** — the instance roles list navigated by role *name* on row-click while the lookup matched by `id` (a latent mismatch); it now navigates by `id`, consistent with the org list. The "add role → open editor" flow navigates to the new role by the `id` returned from `add_role`.
- **Display the id in the picker** — every role picker (org/instance Add User, instance Edit User) now shows the name plus a muted, monospace id via a shared `RoleOptionLabel`.
- **Indicate roles in the list** — added an `ID` column (monospace, hover tooltip) to the org and instance role tables.
- **Duplicate-name correctness fixes** (same root cause):
  - Org "Edit User" role checkboxes were keyed by `roleName` (two same-named roles would toggle together) → keyed by `id`.
  - Instance "Edit User" role select defaulted to the role *name* while options were id-valued (showed "Choose Role" instead of the current role) → defaults to `id`.
  - The "is this my own role?" read-only checks in both edit-role modals now compare by `id`.

## 2. In-modal loading (no more page blank)

Modals that fetch on open now render their dialog shell immediately (overlay + close stay available) and show a loading state **inside** the dialog, instead of suspending up to the page-level boundary and blanking the list:

- Org Edit Role / Edit User — split into a shell + inner `<Suspense>` with an in-dialog loading fallback.
- Instance Edit User (`AlterUserForm`) and the Add User pickers — switched to non-suspense `useQuery` + skeleton.

## 3. Resizable modals

The editor modals (org role add/edit, instance role edit) and the edit-user modals are now resizable/draggable/maximizable like the logs and add-row modals — sharing the same persisted size. The JSON editors fill the body (`flex-1 min-h-0` + `automaticLayout`) and footers stay pinned; the org edit-user role list fills and scrolls.

Per discussion, the short Add User / Add Role forms were left non-resizable (they'd just open oversized against the shared saved size).

## Verification

- `tsc -b`, `dprint check`, `oxlint`, and the full test suite (892 passing) all green; pre-commit hooks pass.
- Verified live in the preview: every touched modal opens immediately, loads in-modal, resizes/maximizes, and the editor fills / footer pins. Role lists show the ID column (org with real `rol-…` ids); pickers show name + id; org edit-user checkboxes resolve membership by id.

### Note
The instance Edit User modal is a short fixed-height form, so when resized it shows empty space below the actions. Easy to pin the buttons to the bottom if preferred — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
