### PR TITLE
fix: Force patched undici to clear Dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   handlebars: ^4.7.9
   undici@>=7.0.0: ^7.28.0
+  undici@<6.27.0: ^6.27.0
   lodash-es: ^4.18.1
   form-data: ^4.0.6
   dompurify: ^3.4.11
@@ -6398,8 +6399,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.28.0:
@@ -6791,7 +6792,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -13734,7 +13735,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,8 @@ overrides:
   # All are transitive-only; bumping the minimum clears the advisories.
   handlebars: '^4.7.9'
   'undici@>=7.0.0': '^7.28.0'
+  # undici 6.x comes in via semantic-release's @actions/http-client (^6.23.0).
+  'undici@<6.27.0': '^6.27.0'
   lodash-es: '^4.18.1'
   form-data: '^4.0.6'
   dompurify: '^3.4.11'


### PR DESCRIPTION
## What

Adds a pnpm override pinning `undici` to `^6.27.0` to clear three Dependabot alerts.

## Why

The vulnerable `undici@6.26.0` was pulled in **transitively** — we don't depend on it directly:

```
undici@6.26.0  (< 6.27.0, vulnerable)
└─ @actions/http-client@4.0.1   (requires undici ^6.23.0)
   └─ @actions/core@3.0.1
      └─ @semantic-release/npm@13.1.5
         └─ semantic-release@25.0.5   ← devDependency (CI-only release tooling)
```

It only runs in CI during `semantic-release` (talking to npm/GitHub) and never ships in the browser app — Dependabot classifies all three as **development** scope, so practical risk is minimal. This just closes the alerts cleanly.

Alerts addressed (all fixed in undici 6.27.0):

| Severity | Advisory | Issue |
|----------|----------|-------|
| medium | GHSA-p88m-4jfj-68fv | HTTP header injection via Set-Cookie percent-decoding |
| low | GHSA-g8m3-5g58-fq7m | Set-Cookie SameSite downgrade via permissive substring matching |
| low | GHSA-35p6-xmwp-9g52 | HTTP response queue poisoning via keep-alive socket reuse |

## How

```yaml
# pnpm-workspace.yaml
overrides:
  undici@<6.27.0: '^6.27.0'
```

`@actions/http-client` requires `undici ^6.23.0`, so `6.27.0` is fully compatible. After `pnpm install`, `undici@6.26.0` is gone from the lockfile and `@actions/http-client` resolves to `undici@6.27.0`. The unrelated `undici@7.25.0` was never affected.

The override can be removed once `@actions/core` / `semantic-release` ship undici ≥6.27.0 upstream.

## Testing

Pre-commit hooks passed: 903 tests, oxlint, and dprint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)