### PR TITLE
fix: Truncate long role names on the org card so View stays in bounds

### DIFF
--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -117,8 +117,8 @@ export function OrgCard({
 					<Link
 						to={organizationId}
 						className="text-sm shrink-0"
-						aria-label={`View ${organizationName}`}
-						title={`View ${organizationName}`}
+						aria-label={`View ${organizationName ?? organizationId}`}
+						title={`View ${organizationName ?? organizationId}`}
 					>
 						<span className="py-2 transition-all duration-100 ease-in-out border-0 hover:border-b-2 whitespace-nowrap">
 							View <ArrowRight className="inline-block" />

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -110,15 +110,17 @@ export function OrgCard({
 						<h2>{organizationName}</h2>
 					</CardTitle>
 				</CardHeader>
-				<CardContent className="flex justify-between">
-					<Badge>{capitalizeWords(roleName)}</Badge>
+				<CardContent className="flex items-center justify-between gap-2">
+					<Badge className="min-w-0 shrink" title={capitalizeWords(roleName)}>
+						<span className="truncate">{capitalizeWords(roleName)}</span>
+					</Badge>
 					<Link
 						to={organizationId}
-						className="text-sm"
+						className="text-sm shrink-0"
 						aria-label={`View ${organizationName}`}
 						title={`View ${organizationName}`}
 					>
-						<span className="py-2 transition-all duration-100 ease-in-out border-0 hover:border-b-2">
+						<span className="py-2 transition-all duration-100 ease-in-out border-0 hover:border-b-2 whitespace-nowrap">
 							View <ArrowRight className="inline-block" />
 						</span>
 					</Link>


### PR DESCRIPTION
## What

Fixes #1315.

A long role name like **"Dev Stage Admin Prod Reader"** forced the role `Badge` on the org card to its full width — the badge carried `shrink-0` + `whitespace-nowrap`, so it never gave ground. At narrower viewports this pushed the **"View >"** link to wrap onto a second line and out against the card's right edge.

## Fix

In [`OrgCard.tsx`](src/features/organizations/components/OrgCard.tsx):

- Let the badge **shrink and truncate** the role name with an ellipsis (`min-w-0 shrink` on the badge; the role text moved into a nested `<span className="truncate">`). The full value is preserved in a `title` tooltip.
- Keep the **"View >"** link from shrinking (`shrink-0` + `whitespace-nowrap`) so it always renders intact.
- Add `gap-2` + `items-center` on the `CardContent` so the badge and link never collide.

The ellipsis is rendered by the nested block-container span rather than directly on the `Badge`, because `text-overflow: ellipsis` does not apply to the badge's `inline-flex` box — verified empirically (direct `truncate` clips with no ellipsis; the nested span shows "…").

## Verification

- `tsc -b`, `oxlint`, `dprint`, and the full `vitest` suite (915 passed) all green via the pre-commit hook.
- Visually verified against the project's real compiled CSS at a narrow card width:

**Before** — "View >" shoved past the card edge.
**After** — role truncates to "Dev Stage Ad…", "View >" stays comfortably in bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)