### PR TITLE
fix: Make Select dropdown carrot full-opacity foreground for visibility

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -28,7 +28,7 @@ function SelectTrigger({ className, children, ...props }: React.ComponentProps<t
 		>
 			{children}
 			<SelectPrimitive.Icon asChild>
-				<ChevronDownIcon className="opacity-50 size-4" />
+				<ChevronDownIcon className="size-4 text-foreground dark:text-white" />
 			</SelectPrimitive.Icon>
 		</SelectPrimitive.Trigger>
 	);


### PR DESCRIPTION
Closes #1313

## Problem

Users reported difficulty noticing the dropdown carrot under **Databases** in the new Fabric Studio. The chevron in the shared `SelectTrigger` was styled `opacity-50` *and* inherited `text-muted-foreground` (gray) — dimmed and muted at once, so it was easy to miss. This affects every dropdown built on the shared `Select`, not just Databases.

## Change

`src/components/ui/select.tsx` — the `SelectTrigger` chevron:

```diff
- <ChevronDownIcon className="opacity-50 size-4" />
+ <ChevronDownIcon className="size-4 text-foreground dark:text-white" />
```

- Full opacity (drops `opacity-50`).
- `text-foreground dark:text-white` makes the carrot match the trigger's own text color. Adding a `text-` class also lets it escape the trigger's `[&_svg:not([class*='text-'])]:text-muted-foreground` muting rule.

Note: literally "brighter white" only works in dark mode — on the light theme's white trigger a white carrot would vanish — so this uses the theme foreground, which is visible in both. Applied globally so the Databases dropdown stays consistent with the other ~13 selects in the app.

## Verification

Inspected computed styles on the real Databases dropdown (and other selects) in the running app:

| | Carrot color | Opacity |
|---|---|---|
| Before | `rgb(163,163,163)` muted gray | `0.5` |
| After — dark | `rgb(254,254,254)` near-white | `1` |
| After — light | `rgb(23,23,23)` near-black on white trigger | `1` |

Pre-commit suite passed locally: 915 tests, oxlint, dprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)