### PR TITLE
feat: Add Select all / Deselect all to the Columns selector

### DIFF
--- a/src/features/instance/databases/components/PickColumnsDropdown.test.tsx
+++ b/src/features/instance/databases/components/PickColumnsDropdown.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { formatBrowseDataTableHeader } from '@/features/instance/databases/functions/formatBrowseDataTableHeader';
+import { VisibilityState } from '@tanstack/react-table';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { PickColumnsDropdown } from './PickColumnsDropdown';
+
+// Radix's menu relies on a handful of DOM APIs that jsdom doesn't implement.
+beforeAll(() => {
+	Element.prototype.hasPointerCapture ??= () => false;
+	Element.prototype.setPointerCapture ??= () => undefined;
+	Element.prototype.releasePointerCapture ??= () => undefined;
+	Element.prototype.scrollIntoView ??= () => undefined;
+	if (typeof window.PointerEvent === 'undefined') {
+		// Radix opens the menu on pointerdown; jsdom has no PointerEvent, so back
+		// it with MouseEvent (which carries the `button` field Radix checks).
+		window.PointerEvent = class extends MouseEvent {} as typeof PointerEvent;
+	}
+});
+
+afterEach(() => cleanup());
+
+const columns = [{ header: 'id' }, { header: 'name' }, { header: 'email' }] as ReturnType<
+	typeof formatBrowseDataTableHeader
+>['dataTableColumns'];
+
+function Harness({ initial = {} as VisibilityState }) {
+	const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(initial);
+	return (
+		<PickColumnsDropdown
+			columns={columns}
+			columnVisibility={columnVisibility}
+			setColumnVisibility={setColumnVisibility}
+		/>
+	);
+}
+
+function openMenu() {
+	fireEvent.pointerDown(screen.getByRole('button', { name: /columns/i }), { button: 0, ctrlKey: false });
+}
+
+function checkboxItems() {
+	return screen.getAllByRole('menuitemcheckbox');
+}
+
+function isDisabled(el: HTMLElement) {
+	return el.getAttribute('aria-disabled') === 'true' || el.hasAttribute('data-disabled');
+}
+
+describe('PickColumnsDropdown', () => {
+	it('offers Select all and Deselect all actions alongside the columns', () => {
+		render(<Harness />);
+		openMenu();
+		expect(screen.getByRole('menuitem', { name: 'Select all' })).toBeTruthy();
+		expect(screen.getByRole('menuitem', { name: 'Deselect all' })).toBeTruthy();
+		expect(checkboxItems().map(el => el.textContent)).toEqual(['id', 'name', 'email']);
+	});
+
+	it('Deselect all hides every column in one click', () => {
+		render(<Harness />);
+		openMenu();
+		// All columns start visible (default when unset).
+		expect(checkboxItems().every(el => el.getAttribute('aria-checked') === 'true')).toBe(true);
+
+		fireEvent.click(screen.getByRole('menuitem', { name: 'Deselect all' }));
+
+		expect(checkboxItems().every(el => el.getAttribute('aria-checked') === 'false')).toBe(true);
+	});
+
+	it('Select all shows every column in one click', () => {
+		render(<Harness initial={{ id: false, name: false, email: false }} />);
+		openMenu();
+		expect(checkboxItems().every(el => el.getAttribute('aria-checked') === 'false')).toBe(true);
+
+		fireEvent.click(screen.getByRole('menuitem', { name: 'Select all' }));
+
+		expect(checkboxItems().every(el => el.getAttribute('aria-checked') === 'true')).toBe(true);
+	});
+
+	it('disables Select all when all visible and Deselect all when none visible', () => {
+		render(<Harness />);
+		openMenu();
+		// Everything visible: nothing more to select.
+		expect(isDisabled(screen.getByRole('menuitem', { name: 'Select all' }))).toBe(true);
+		expect(isDisabled(screen.getByRole('menuitem', { name: 'Deselect all' }))).toBe(false);
+
+		fireEvent.click(screen.getByRole('menuitem', { name: 'Deselect all' }));
+
+		// Nothing visible: nothing more to deselect.
+		expect(isDisabled(screen.getByRole('menuitem', { name: 'Select all' }))).toBe(false);
+		expect(isDisabled(screen.getByRole('menuitem', { name: 'Deselect all' }))).toBe(true);
+	});
+
+	it('keeps the menu open after a bulk action so columns can be refined', () => {
+		render(<Harness />);
+		openMenu();
+		fireEvent.click(screen.getByRole('menuitem', { name: 'Deselect all' }));
+		// The menu (and its checkbox items) are still on screen.
+		expect(within(screen.getByRole('menu')).getAllByRole('menuitemcheckbox')).toHaveLength(3);
+	});
+});

--- a/src/features/instance/databases/components/PickColumnsDropdown.tsx
+++ b/src/features/instance/databases/components/PickColumnsDropdown.tsx
@@ -3,6 +3,8 @@ import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdownMenu';
 import { formatBrowseDataTableHeader } from '@/features/instance/databases/functions/formatBrowseDataTableHeader';
@@ -31,6 +33,20 @@ export function PickColumnsDropdown({
 			[columnHeader]: nextChecked,
 		});
 	}, [columnVisibility, setColumnVisibility]);
+	const setAllColumns = useCallback((nextChecked: boolean) => {
+		setColumnVisibility({
+			...columnVisibility,
+			...Object.fromEntries(columnHeaders.map(columnHeader => [columnHeader, nextChecked])),
+		});
+	}, [columnHeaders, columnVisibility, setColumnVisibility]);
+	const allVisible = useMemo(
+		() => columnHeaders.every(columnHeader => columnVisibility[columnHeader] ?? true),
+		[columnHeaders, columnVisibility],
+	);
+	const noneVisible = useMemo(
+		() => columnHeaders.every(columnHeader => !(columnVisibility[columnHeader] ?? true)),
+		[columnHeaders, columnVisibility],
+	);
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -40,6 +56,31 @@ export function PickColumnsDropdown({
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent>
+				{columnHeaders.length > 0 && (
+					<>
+						<DropdownMenuItem
+							inset
+							disabled={allVisible}
+							onSelect={e => {
+								e.preventDefault();
+								setAllColumns(true);
+							}}
+						>
+							Select all
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							inset
+							disabled={noneVisible}
+							onSelect={e => {
+								e.preventDefault();
+								setAllColumns(false);
+							}}
+						>
+							Deselect all
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+					</>
+				)}
 				{columnHeaders.map(columnHeader => (
 					<ColumnPicker
 						key={columnHeader}


### PR DESCRIPTION
## Summary

Closes #1325.

The column-visibility dropdown (`PickColumnsDropdown`) only offered per-column checkboxes, so hiding most columns of a wide table meant clicking each one off individually — the "chronic clicker fatigue" the issue describes.

This adds bulk actions at the top of the menu:

- **Select all** / **Deselect all** menu items, with a separator before the per-column checkboxes.
- **Deselect all** addresses the issue directly; **Select all** is paired with it so users aren't stranded in an all-hidden state and can restore in one click.
- Each action is **disabled when it would be a no-op** — Select all greys out when everything is already shown, Deselect all when nothing is.
- The menu **stays open** after a bulk action (matching the existing checkbox behavior), so you can deselect-all then re-tick just the columns you want.

## Changes

- `src/features/instance/databases/components/PickColumnsDropdown.tsx` — the feature.
- `src/features/instance/databases/components/PickColumnsDropdown.test.tsx` — new render test (5 cases).

## Testing

- New render test exercises the real Radix menu: confirms the actions render, that Deselect/Select all flip every column's `aria-checked` in one click, the disabled states are correct, and the menu stays open after a bulk action.
- Full suite green via the pre-commit hook (920 passed, 11 skipped); `oxlint`, `dprint`, and `tsc -b` all clean.

> Note: not verified in a browser preview — the dropdown lives behind the live table-browsing view (sign-in → org → cluster → database → table → Browse Data), which needs a running Harper backend with table data and isn't reachable in the sandbox. The render test covers the behavior instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)