### PR TITLE
feat: Clear UTM parameters from the URL after signing in or signing up

### DIFF
--- a/src/features/auth/CheckOAuth.tsx
+++ b/src/features/auth/CheckOAuth.tsx
@@ -3,6 +3,7 @@ import { authStore, OverallAppSignIn } from '@/features/auth/store/authStore';
 import { loginSuccessDatadogAction } from '@/integrations/datadog/datadog';
 import { reoClient } from '@/integrations/reo/reo';
 import { parseCompanyFromEmail } from '@/lib/string/parseCompanyFromEmail';
+import { clearUtmParamsFromUrl } from '@/lib/urls/clearUtmParams';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useRouter, useSearch } from '@tanstack/react-router';
@@ -30,6 +31,7 @@ export function CheckOAuth() {
 				await navigate({ to: '/sign-in' });
 			} else {
 				authStore.setUserForEntity(OverallAppSignIn, user);
+				clearUtmParamsFromUrl();
 				const defaultCloudRoute = getDefaultSignedInCloudRouteForUser(user);
 
 				loginSuccessDatadogAction(user);

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { reoClient } from '@/integrations/reo/reo';
 import { parseCompanyFromEmail } from '@/lib/string/parseCompanyFromEmail';
 import { personNameRegex } from '@/lib/string/regex/personNameRegex';
+import { clearUtmParamsFromUrl } from '@/lib/urls/clearUtmParams';
 import { zodRequireEmail } from '@/lib/zod/email';
 import { zodRequirePassword } from '@/lib/zod/password';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -93,6 +94,7 @@ export function SignUp() {
 					lastname: userData.lastname,
 					...(company ? { company } : {}),
 				});
+				clearUtmParamsFromUrl();
 				void navigate({ to: '/verifying?email=' + encodeURIComponent(userData.email) });
 			},
 		});

--- a/src/features/auth/hooks/useCloudSignIn.ts
+++ b/src/features/auth/hooks/useCloudSignIn.ts
@@ -6,6 +6,7 @@ import { EmailSignInSchema } from '@/integrations/api/instance/auth/signInSchema
 import { loginSuccessDatadogAction } from '@/integrations/datadog/datadog';
 import { reoClient } from '@/integrations/reo/reo';
 import { parseCompanyFromEmail } from '@/lib/string/parseCompanyFromEmail';
+import { clearUtmParamsFromUrl } from '@/lib/urls/clearUtmParams';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useRouter, useSearch } from '@tanstack/react-router';
@@ -24,6 +25,7 @@ export function useCloudSignIn() {
 		submitLoginData(formData, {
 			onSuccess: async (data) => {
 				authStore.setUserForEntity(OverallAppSignIn, data);
+				clearUtmParamsFromUrl();
 				const defaultCloudRoute = getDefaultSignedInCloudRouteForUser(data);
 
 				loginSuccessDatadogAction(data);

--- a/src/lib/urls/clearUtmParams.test.ts
+++ b/src/lib/urls/clearUtmParams.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearUtmParamsFromUrl, stripUtmParams } from './clearUtmParams';
+
+describe('stripUtmParams', () => {
+	it('removes a single utm parameter, leaving an empty search', () => {
+		expect(stripUtmParams('?utm_source=newsletter')).toBe('');
+	});
+
+	it('removes every utm_* parameter', () => {
+		expect(
+			stripUtmParams('?utm_source=x&utm_medium=email&utm_campaign=launch&utm_term=t&utm_content=c'),
+		).toBe('');
+	});
+
+	it('preserves non-utm parameters and their order', () => {
+		expect(stripUtmParams('?redirect=%2Fhome&utm_source=x&me=a%40b.com')).toBe('?redirect=%2Fhome&me=a%40b.com');
+	});
+
+	it('matches utm_ prefixes case-insensitively', () => {
+		expect(stripUtmParams('?UTM_Source=x&keep=1')).toBe('?keep=1');
+	});
+
+	it('does not strip params that merely contain "utm" elsewhere', () => {
+		expect(stripUtmParams('?autumn=leaves&product_utm=no')).toBe('?autumn=leaves&product_utm=no');
+	});
+
+	it('accepts a search string without the leading "?"', () => {
+		expect(stripUtmParams('utm_source=x&keep=1')).toBe('?keep=1');
+	});
+
+	it('returns the input verbatim when there is nothing to remove', () => {
+		expect(stripUtmParams('?keep=1')).toBe('?keep=1');
+		expect(stripUtmParams('')).toBe('');
+	});
+});
+
+describe('clearUtmParamsFromUrl', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function stubLocation(search: string, hash = '#/cloud/org') {
+		const replaceState = vi.fn();
+		vi.stubGlobal('location', { origin: 'https://studio.harperdb.io', pathname: '/', search, hash });
+		vi.stubGlobal('history', { state: { key: 'abc' }, replaceState });
+		return replaceState;
+	}
+
+	it('rewrites the URL without utm params, preserving pathname and hash', () => {
+		const replaceState = stubLocation('?utm_source=x&utm_campaign=y', '#/cloud/org');
+		clearUtmParamsFromUrl();
+		expect(replaceState).toHaveBeenCalledWith({ key: 'abc' }, '', 'https://studio.harperdb.io/#/cloud/org');
+	});
+
+	it('keeps non-utm params while dropping utm params', () => {
+		const replaceState = stubLocation('?utm_source=x&redirect=%2Fhome', '#/sign-in');
+		clearUtmParamsFromUrl();
+		expect(replaceState).toHaveBeenCalledWith(
+			{ key: 'abc' },
+			'',
+			'https://studio.harperdb.io/?redirect=%2Fhome#/sign-in',
+		);
+	});
+
+	it('does nothing when there are no utm params', () => {
+		const replaceState = stubLocation('?redirect=%2Fhome', '#/sign-in');
+		clearUtmParamsFromUrl();
+		expect(replaceState).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when there is no search string at all', () => {
+		const replaceState = stubLocation('', '#/sign-in');
+		clearUtmParamsFromUrl();
+		expect(replaceState).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/urls/clearUtmParams.test.ts
+++ b/src/lib/urls/clearUtmParams.test.ts
@@ -73,4 +73,9 @@ describe('clearUtmParamsFromUrl', () => {
 		clearUtmParamsFromUrl();
 		expect(replaceState).not.toHaveBeenCalled();
 	});
+
+	it('is a harmless no-op when browser globals are unavailable', () => {
+		// No stubs: `location`/`history` are undefined in the node test env.
+		expect(() => clearUtmParamsFromUrl()).not.toThrow();
+	});
 });

--- a/src/lib/urls/clearUtmParams.ts
+++ b/src/lib/urls/clearUtmParams.ts
@@ -36,6 +36,12 @@ export function stripUtmParams(search: string): string {
  * route) via history.replaceState so the current view is unaffected.
  */
 export function clearUtmParamsFromUrl(): void {
+	// Guard the browser globals so importing/calling this in a non-DOM context
+	// (e.g. the node-based test environment) is a harmless no-op rather than a
+	// ReferenceError.
+	if (typeof location === 'undefined' || typeof history === 'undefined') {
+		return;
+	}
 	const { search, pathname, hash, origin } = location;
 	const nextSearch = stripUtmParams(search);
 	if (nextSearch === search) {

--- a/src/lib/urls/clearUtmParams.ts
+++ b/src/lib/urls/clearUtmParams.ts
@@ -1,0 +1,45 @@
+const UTM_PARAM_PREFIX = 'utm_';
+
+/**
+ * Removes any `utm_*` tracking parameters from a query string, leaving every
+ * other parameter (and their order) untouched.
+ *
+ * Accepts a search string with or without the leading `?`. Returns a search
+ * string with a leading `?` when parameters remain, or an empty string when
+ * none do. When there is nothing to remove the input is returned verbatim so
+ * callers can cheaply detect "no change".
+ */
+export function stripUtmParams(search: string): string {
+	const params = new URLSearchParams(search);
+	// Snapshot the keys before deleting: URLSearchParams.keys() is a live
+	// iterator, so mutating mid-iteration can skip entries.
+	const utmKeys = Array.from(params.keys()).filter(key => key.toLowerCase().startsWith(UTM_PARAM_PREFIX));
+	if (utmKeys.length === 0) {
+		return search;
+	}
+	for (const key of utmKeys) {
+		params.delete(key);
+	}
+	const next = params.toString();
+	return next ? `?${next}` : '';
+}
+
+/**
+ * Clears `utm_*` tracking parameters from the browser's current URL without
+ * triggering a navigation.
+ *
+ * Marketing links append UTM parameters to the query string that precedes the
+ * hash route (e.g. `https://studio.harperdb.io/?utm_source=x#/sign-in`), which
+ * is what Google Tag Manager reads. Once they've been captured they only linger
+ * in the address bar, so we strip them after a user signs in or signs up. We
+ * rewrite only the search portion and preserve the hash (the app's actual
+ * route) via history.replaceState so the current view is unaffected.
+ */
+export function clearUtmParamsFromUrl(): void {
+	const { search, pathname, hash, origin } = location;
+	const nextSearch = stripUtmParams(search);
+	if (nextSearch === search) {
+		return;
+	}
+	history.replaceState(history.state, '', `${origin}${pathname}${nextSearch}${hash}`);
+}


### PR DESCRIPTION
## What & why

Closes #1332.

Marketing links append `utm_*` parameters to the query string that precedes the hash route — e.g. `https://studio.harperdb.io/?utm_source=newsletter#/sign-in` — which is what Google Tag Manager reads. The app uses hash-based routing, so TanStack Router never touches that pre-hash query string and the UTM params just linger in the address bar for a long time after they've served their purpose, looking unsightly.

This strips them once the user has signed in or signed up — after GTM has already captured them for attribution.

## How

- New util `src/lib/urls/clearUtmParams.ts`:
  - `stripUtmParams(search)` — pure, removes any `utm_*` key (case-insensitive), preserves all other params and their order.
  - `clearUtmParamsFromUrl()` — rewrites **only** the search portion via `history.replaceState`, preserving the hash route and the existing router history `state` so the current view and TanStack Router are unaffected.
- Called at the three auth-completion points:
  - `useCloudSignIn` `onSuccess` (email/password sign-in)
  - `CheckOAuth` success branch (Google/GitHub OAuth)
  - `SignUp` `onSuccess` (clears them as the user moves into the verify-email flow)

## Notes

- Scoped to the pre-hash query string, since that's what GTM reads and what lingers; the hash route is intentionally left untouched.
- Stripping is deferred to sign-in/sign-up (not on initial load) so GTM still captures attribution on the landing page view.
- Any param prefixed `utm_` is removed, so this covers `utm_source/medium/campaign/term/content` and any future UTM keys without an allowlist to maintain.

## Testing

- 11 new unit tests in `clearUtmParams.test.ts` (pure stripping + exact `history.replaceState` args, including no-op cases).
- Full suite green: 145 files, 926 passed / 11 skipped. `oxlint`, `tsc --noEmit`, and `dprint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
