### PR TITLE
feat: Guide SSH key selection and verify host on application import

### DIFF
--- a/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
+++ b/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
@@ -1,0 +1,172 @@
+import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { FormControl } from '@/components/ui/form/FormControl';
+import { FormField } from '@/components/ui/form/FormField';
+import { FormItem } from '@/components/ui/form/FormItem';
+import { FormLabel } from '@/components/ui/form/FormLabel';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { getSSHKeyQueryOptions } from '@/integrations/api/instance/ssh/getSSHKey';
+import { listSSHKeysQueryOptions } from '@/integrations/api/instance/ssh/listSSHKeys';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { CheckCircle2Icon, TriangleAlertIcon } from 'lucide-react';
+import { ReactNode, useCallback } from 'react';
+import { Control, UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import { z } from 'zod';
+import { extractGitUrlHost, replaceGitUrlHost } from './gitUrl';
+import { NewApplicationSchema } from './schema';
+
+export function ImportAuthorization({
+	control,
+	setValue,
+	watch,
+}: {
+	control: Control<z.infer<typeof NewApplicationSchema>>;
+	setValue: UseFormSetValue<z.infer<typeof NewApplicationSchema>>;
+	watch: UseFormWatch<z.infer<typeof NewApplicationSchema>>;
+}) {
+	const instanceParams = useInstanceClientIdParams();
+	const requiresAuth = watch('contents.requiresAuth');
+	const ref = watch('contents.ref');
+	const sshKeyName = watch('contents.sshKeyName');
+
+	const { data: sshKeys, isLoading: areKeysLoading } = useQuery({
+		...listSSHKeysQueryOptions(instanceParams),
+		enabled: requiresAuth,
+	});
+
+	// Fetch the selected key's host so we can verify the URL targets it. No polling needed here.
+	const { data: selectedKey } = useQuery({
+		...getSSHKeyQueryOptions({ ...instanceParams, name: sshKeyName }),
+		refetchInterval: false,
+		enabled: requiresAuth && !!sshKeyName,
+	});
+
+	const urlHost = extractGitUrlHost(ref);
+	const keyHost = selectedKey?.host;
+	const hostMatches = !!urlHost && !!keyHost && urlHost.toLowerCase() === keyHost.toLowerCase();
+	const hostMismatch = !!urlHost && !!keyHost && !hostMatches;
+	const suggestedUrl = hostMismatch ? replaceGitUrlHost(ref, keyHost) : '';
+
+	const useSuggestedUrl = useCallback(() => {
+		setValue('contents.ref', suggestedUrl, { shouldValidate: true, shouldDirty: true });
+	}, [setValue, suggestedUrl]);
+
+	let body: ReactNode;
+	if (areKeysLoading) {
+		body = <TextLoadingSkeleton className="w-full" />;
+	} else if (!sshKeys || sshKeys.length === 0) {
+		body = (
+			<Alert>
+				<AlertDescription>
+					<span>
+						You don't have any SSH keys yet. Add one over in <Link to="config" className="underline">Config</Link> &gt;
+						{' '}
+						<Link to="config/ssh-keys" className="underline">SSH Keys</Link>{' '}
+						to enable SSH based auth for private repos, i.e. following the pattern of{' '}
+						<a
+							href="https://github.com/HarperFast/Studio"
+							target="_blank"
+							rel="noreferrer"
+							className="underline"
+						>
+							git@github.com:HarperFast/studio.git
+						</a>. If you have more than one key, make sure to utilize unique hostnames!
+					</span>
+				</AlertDescription>
+			</Alert>
+		);
+	} else {
+		body = (
+			<>
+				<FormField
+					control={control}
+					name="contents.sshKeyName"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel className="pb-1">SSH Key</FormLabel>
+							<FormControl>
+								<Select value={field.value || ''} onValueChange={field.onChange}>
+									<SelectTrigger className="w-full">
+										<SelectValue placeholder="Choose an SSH key" />
+									</SelectTrigger>
+									<SelectContent>
+										{sshKeys.map((key) => (
+											<SelectItem key={key.name} value={key.name}>
+												{key.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</FormControl>
+						</FormItem>
+					)}
+				/>
+
+				{!sshKeyName && (
+					<p className="text-sm text-muted-foreground">
+						Select the SSH key this repository uses so we can verify the URL.
+					</p>
+				)}
+
+				{hostMatches && (
+					<Alert>
+						<CheckCircle2Icon />
+						<AlertDescription>
+							This URL targets <code>{keyHost}</code>, matching the selected key.
+						</AlertDescription>
+					</Alert>
+				)}
+
+				{hostMismatch && (
+					<Alert variant="warning">
+						<TriangleAlertIcon />
+						<AlertDescription>
+							<span>
+								The URL targets <code>{urlHost}</code>, but the selected key <strong>{sshKeyName}</strong> uses the host
+								{' '}
+								<code>{keyHost}</code>. SSH auth resolves the key from the host in the URL, so this import will likely
+								fail to authenticate. Did you mean:
+							</span>
+							<code className="block break-all">{suggestedUrl}</code>
+							<Button type="button" variant="defaultOutline" size="sm" onClick={useSuggestedUrl}>
+								Use suggested URL
+							</Button>
+						</AlertDescription>
+					</Alert>
+				)}
+			</>
+		);
+	}
+
+	return (
+		<>
+			<FormLabel>Authorization</FormLabel>
+			<FormField
+				control={control}
+				name="contents.requiresAuth"
+				render={({ field }) => (
+					<Tabs
+						className="w-full pt-2 pb-0 mb-0"
+						value={String(field.value)}
+						onValueChange={(value) => field.onChange(value === 'true')}
+					>
+						<TabsList className="grid w-full grid-cols-2">
+							<TabsTrigger value="false">Public Access</TabsTrigger>
+							<TabsTrigger value="true">Requires Auth</TabsTrigger>
+						</TabsList>
+
+						<TabsContent value="false" className="space-y-4 mt-4" />
+
+						<TabsContent value="true" className="space-y-4 mt-4">
+							{body}
+						</TabsContent>
+					</Tabs>
+				)}
+			/>
+		</>
+	);
+}

--- a/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
+++ b/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
@@ -33,7 +33,7 @@ export function ImportAuthorization({
 	const ref = watch('contents.ref');
 	const sshKeyName = watch('contents.sshKeyName');
 
-	const { data: sshKeys, isLoading: areKeysLoading } = useQuery({
+	const { data: sshKeys, isLoading: areKeysLoading, isError: isKeysError } = useQuery({
 		...listSSHKeysQueryOptions(instanceParams),
 		enabled: requiresAuth,
 	});
@@ -58,6 +58,14 @@ export function ImportAuthorization({
 	let body: ReactNode;
 	if (areKeysLoading) {
 		body = <TextLoadingSkeleton className="w-full" />;
+	} else if (isKeysError) {
+		body = (
+			<Alert variant="destructive">
+				<AlertDescription>
+					Failed to load SSH keys. Please try again.
+				</AlertDescription>
+			</Alert>
+		);
 	} else if (!sshKeys || sshKeys.length === 0) {
 		body = (
 			<Alert>
@@ -114,7 +122,7 @@ export function ImportAuthorization({
 
 				{hostMatches && (
 					<Alert>
-						<CheckCircle2Icon />
+						<CheckCircle2Icon className="h-4 w-4" />
 						<AlertDescription>
 							This URL targets <code>{keyHost}</code>, matching the selected key.
 						</AlertDescription>
@@ -123,7 +131,7 @@ export function ImportAuthorization({
 
 				{hostMismatch && (
 					<Alert variant="warning">
-						<TriangleAlertIcon />
+						<TriangleAlertIcon className="h-4 w-4" />
 						<AlertDescription>
 							<span>
 								The URL targets <code>{urlHost}</code>, but the selected key <strong>{sshKeyName}</strong> uses the host

--- a/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
+++ b/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
@@ -1,4 +1,3 @@
-import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { FormControl } from '@/components/ui/form/FormControl';
@@ -33,7 +32,7 @@ export function ImportAuthorization({
 	const ref = watch('contents.ref');
 	const sshKeyName = watch('contents.sshKeyName');
 
-	const { data: sshKeys, isLoading: areKeysLoading, isError: isKeysError } = useQuery({
+	const { data: sshKeys } = useQuery({
 		...listSSHKeysQueryOptions(instanceParams),
 		enabled: requiresAuth,
 	});
@@ -56,38 +55,7 @@ export function ImportAuthorization({
 	}, [setValue, suggestedUrl]);
 
 	let body: ReactNode;
-	if (areKeysLoading) {
-		body = <TextLoadingSkeleton className="w-full" />;
-	} else if (isKeysError) {
-		body = (
-			<Alert variant="destructive">
-				<AlertDescription>
-					Failed to load SSH keys. Please try again.
-				</AlertDescription>
-			</Alert>
-		);
-	} else if (!sshKeys || sshKeys.length === 0) {
-		body = (
-			<Alert>
-				<AlertDescription>
-					<span>
-						You don't have any SSH keys yet. Add one over in <Link to="config" className="underline">Config</Link> &gt;
-						{' '}
-						<Link to="config/ssh-keys" className="underline">SSH Keys</Link>{' '}
-						to enable SSH based auth for private repos, i.e. following the pattern of{' '}
-						<a
-							href="https://github.com/HarperFast/Studio"
-							target="_blank"
-							rel="noreferrer"
-							className="underline"
-						>
-							git@github.com:HarperFast/studio.git
-						</a>. If you have more than one key, make sure to utilize unique hostnames!
-					</span>
-				</AlertDescription>
-			</Alert>
-		);
-	} else {
+	if (sshKeys && sshKeys.length > 0) {
 		body = (
 			<>
 				<FormField
@@ -149,6 +117,29 @@ export function ImportAuthorization({
 					</Alert>
 				)}
 			</>
+		);
+	} else {
+		// No keys configured yet, still loading, or the list couldn't be fetched. Fall back to the
+		// informational guidance the screen showed before the picker existed, so a slow or failing
+		// list_ssh_keys degrades gracefully instead of surfacing a loading bar or an error.
+		body = (
+			<Alert>
+				<AlertDescription>
+					<span>
+						Manage your SSH keys in <Link to="config" className="underline">Config</Link> &gt;{' '}
+						<Link to="config/ssh-keys" className="underline">SSH Keys</Link>. This enables SSH based auth for private
+						repos, i.e. following the pattern of{' '}
+						<a
+							href="https://github.com/HarperFast/Studio"
+							target="_blank"
+							rel="noreferrer"
+							className="underline"
+						>
+							git@github.com:HarperFast/studio.git
+						</a>. If you have more than one key, make sure to utilize unique hostnames!
+					</span>
+				</AlertDescription>
+			</Alert>
 		);
 	}
 

--- a/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
+++ b/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx
@@ -124,7 +124,9 @@ export function ImportAuthorization({
 					<Alert>
 						<CheckCircle2Icon className="h-4 w-4" />
 						<AlertDescription>
-							This URL targets <code>{keyHost}</code>, matching the selected key.
+							<span>
+								This URL targets <code>{keyHost}</code>, matching the selected key.
+							</span>
 						</AlertDescription>
 					</Alert>
 				)}

--- a/src/features/instance/applications/components/NewApplication/ImportInstructions.tsx
+++ b/src/features/instance/applications/components/NewApplication/ImportInstructions.tsx
@@ -1,4 +1,3 @@
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { FormControl } from '@/components/ui/form/FormControl';
@@ -9,11 +8,11 @@ import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Link } from '@tanstack/react-router';
 import { GitMergeIcon, LinkIcon, PackageIcon, RocketIcon } from 'lucide-react';
 import { useCallback } from 'react';
 import { Control, FormState, UseFormSetValue, UseFormWatch } from 'react-hook-form';
 import { z } from 'zod';
+import { ImportAuthorization } from './ImportAuthorization';
 import { NewApplicationSchema } from './schema';
 
 export function ImportInstructions({
@@ -153,61 +152,7 @@ export function ImportInstructions({
 					)}
 				/>
 
-				<FormLabel>Authorization</FormLabel>
-				<FormField
-					control={control}
-					name="contents.requiresAuth"
-					render={({ field }) => (
-						<Tabs
-							className="w-full pt-2 pb-0 mb-0"
-							value={String(field.value)}
-							onValueChange={value => field.onChange(value === 'true')}
-						>
-							<TabsList className="grid w-full grid-cols-2">
-								<TabsTrigger value="false">
-									Public Access
-								</TabsTrigger>
-								<TabsTrigger value="true">
-									Requires Auth
-								</TabsTrigger>
-							</TabsList>
-
-							<TabsContent value="false" className="space-y-4 mt-4">
-							</TabsContent>
-
-							<TabsContent value="true" className="space-y-4 mt-4">
-								<Alert>
-									<AlertDescription>
-										<span>
-											You can manage your certificates over in{' '}
-											<Link
-												to="config"
-												className="underline"
-											>
-												Config
-											</Link>{' '}
-											&gt;{' '}
-											<Link
-												to="config/ssh-keys"
-												className="underline"
-											>
-												SSH Keys
-											</Link>. This enables SSH based auth for private repos, i.e. following the pattern of{' '}
-											<a
-												href="https://github.com/HarperFast/Studio"
-												target="_blank"
-												rel="noreferrer"
-												className="underline"
-											>
-												git@github.com:HarperFast/studio.git
-											</a>. If you have more than one key, make sure to utilize unique hostnames!
-										</span>
-									</AlertDescription>
-								</Alert>
-							</TabsContent>
-						</Tabs>
-					)}
-				/>
+				{importSource === 'git' && <ImportAuthorization control={control} setValue={setValue} watch={watch} />}
 
 				<Separator className="bg-border" />
 

--- a/src/features/instance/applications/components/NewApplication/gitUrl.test.ts
+++ b/src/features/instance/applications/components/NewApplication/gitUrl.test.ts
@@ -63,4 +63,9 @@ describe('replaceGitUrlHost', () => {
 	it('returns the reference unchanged when no host is detectable', () => {
 		expect(replaceGitUrlHost('some-package', 'github.com')).toBe('some-package');
 	});
+
+	it('treats $ sequences in the new host literally (no replacement-pattern injection)', () => {
+		expect(replaceGitUrlHost('git@github.com:org/repo.git', 'weird$&host.com'))
+			.toBe('git@weird$&host.com:org/repo.git');
+	});
 });

--- a/src/features/instance/applications/components/NewApplication/gitUrl.test.ts
+++ b/src/features/instance/applications/components/NewApplication/gitUrl.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { extractGitUrlHost, replaceGitUrlHost } from './gitUrl';
+
+describe('extractGitUrlHost', () => {
+	it('parses scp-like git URLs', () => {
+		expect(extractGitUrlHost('git@github.com:HarperFast/studio.git')).toBe('github.com');
+		expect(extractGitUrlHost('git@your-repo.github.com:HarperFast/studio.git')).toBe('your-repo.github.com');
+	});
+
+	it('parses scp-like URLs without a user', () => {
+		expect(extractGitUrlHost('github.com:HarperFast/studio.git')).toBe('github.com');
+	});
+
+	it('parses ssh:// URLs, ignoring user and port', () => {
+		expect(extractGitUrlHost('ssh://git@github.com/HarperFast/studio.git')).toBe('github.com');
+		expect(extractGitUrlHost('ssh://git@github.com:22/HarperFast/studio.git')).toBe('github.com');
+	});
+
+	it('parses https:// URLs, ignoring port', () => {
+		expect(extractGitUrlHost('https://github.com/HarperFast/studio.git')).toBe('github.com');
+		expect(extractGitUrlHost('https://github.com:443/HarperFast/studio.git')).toBe('github.com');
+	});
+
+	it('trims surrounding whitespace', () => {
+		expect(extractGitUrlHost('  git@github.com:HarperFast/studio.git  ')).toBe('github.com');
+	});
+
+	it('returns null for references without a detectable host', () => {
+		expect(extractGitUrlHost('')).toBeNull();
+		expect(extractGitUrlHost('   ')).toBeNull();
+		expect(extractGitUrlHost('@harperdb/some-package')).toBeNull();
+		expect(extractGitUrlHost('some-package')).toBeNull();
+		expect(extractGitUrlHost('package@1.2.3')).toBeNull();
+	});
+});
+
+describe('replaceGitUrlHost', () => {
+	it('swaps the host in scp-like URLs, preserving user and path', () => {
+		expect(replaceGitUrlHost('git@github.com:HarperFast/studio.git', 'your-repo.github.com'))
+			.toBe('git@your-repo.github.com:HarperFast/studio.git');
+	});
+
+	it('swaps the host in scp-like URLs without a user', () => {
+		expect(replaceGitUrlHost('github.com:HarperFast/studio.git', 'your-repo.github.com'))
+			.toBe('your-repo.github.com:HarperFast/studio.git');
+	});
+
+	it('swaps the host in ssh:// URLs, preserving port and path', () => {
+		expect(replaceGitUrlHost('ssh://git@github.com:22/HarperFast/studio.git', 'your-repo.github.com'))
+			.toBe('ssh://git@your-repo.github.com:22/HarperFast/studio.git');
+	});
+
+	it('swaps the host in https:// URLs', () => {
+		expect(replaceGitUrlHost('https://github.com/HarperFast/studio.git', 'your-repo.github.com'))
+			.toBe('https://your-repo.github.com/HarperFast/studio.git');
+	});
+
+	it('only replaces the host, not matching path segments', () => {
+		expect(replaceGitUrlHost('https://github.com/github.com/repo.git', 'alias.github.com'))
+			.toBe('https://alias.github.com/github.com/repo.git');
+	});
+
+	it('returns the reference unchanged when no host is detectable', () => {
+		expect(replaceGitUrlHost('some-package', 'github.com')).toBe('some-package');
+	});
+});

--- a/src/features/instance/applications/components/NewApplication/gitUrl.ts
+++ b/src/features/instance/applications/components/NewApplication/gitUrl.ts
@@ -46,5 +46,6 @@ export function replaceGitUrlHost(ref: string, newHost: string): string {
 	// The host sits at the start of the string, or after `@` (userinfo) or `//` (scheme), and is
 	// followed by `:` (port/path), `/` (path), or the end of the string.
 	const hostPattern = new RegExp(`(^|@|//)${escaped}(?=[:/]|$)`);
-	return trimmed.replace(hostPattern, `$1${newHost}`);
+	// Use a replacer fn so a `newHost` containing `$`/`$&` isn't treated as a replacement pattern.
+	return trimmed.replace(hostPattern, (_, prefix) => `${prefix}${newHost}`);
 }

--- a/src/features/instance/applications/components/NewApplication/gitUrl.ts
+++ b/src/features/instance/applications/components/NewApplication/gitUrl.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers for reasoning about the host segment of a git remote URL. Used by the import flow to
+ * verify that the entered URL targets the same host alias as the selected SSH key (issue #1318):
+ * SSH auth resolves the key purely from the host in the URL, so a mismatch silently fails to
+ * authenticate.
+ */
+
+const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const SCP_LIKE = /^(?:[^@/]+@)?([^/:]+):/;
+
+/**
+ * Extract the host from a git remote URL, supporting the shapes the import flow accepts:
+ * - scp-like:  `git@github.com:org/repo.git`       -> `github.com`
+ * - ssh url:   `ssh://git@github.com:22/org/repo`  -> `github.com`
+ * - https url: `https://github.com/org/repo.git`   -> `github.com`
+ *
+ * Returns `null` for anything without a detectable host (e.g. a bare npm package reference).
+ */
+export function extractGitUrlHost(ref: string): string | null {
+	const trimmed = ref.trim();
+	if (!trimmed) {
+		return null;
+	}
+	if (SCHEME_PREFIX.test(trimmed)) {
+		try {
+			return new URL(trimmed).hostname || null;
+		} catch {
+			return null;
+		}
+	}
+	const scpMatch = SCP_LIKE.exec(trimmed);
+	return scpMatch ? scpMatch[1] : null;
+}
+
+/**
+ * Replace the host segment of `ref` with `newHost`, preserving the user, port, and path. Returns
+ * the (trimmed) reference unchanged when no host can be detected.
+ */
+export function replaceGitUrlHost(ref: string, newHost: string): string {
+	const trimmed = ref.trim();
+	const oldHost = extractGitUrlHost(trimmed);
+	if (!oldHost) {
+		return ref;
+	}
+	const escaped = oldHost.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	// The host sits at the start of the string, or after `@` (userinfo) or `//` (scheme), and is
+	// followed by `:` (port/path), `/` (path), or the end of the string.
+	const hostPattern = new RegExp(`(^|@|//)${escaped}(?=[:/]|$)`);
+	return trimmed.replace(hostPattern, `$1${newHost}`);
+}

--- a/src/features/instance/applications/components/NewApplication/schema.ts
+++ b/src/features/instance/applications/components/NewApplication/schema.ts
@@ -17,6 +17,9 @@ export const ImportSchema = z.object({
 	ref: z.string().nonempty('Please enter a URL or package reference.'),
 	installCommand: z.string(),
 	requiresAuth: z.boolean(),
+	// The SSH key the import URL is expected to use. Form-only state used to verify the URL's host
+	// — it is not sent to deploy_component (the backend resolves the key from the URL host alias).
+	sshKeyName: z.string(),
 });
 
 export const defaultImportOptions: z.infer<typeof ImportSchema> = {
@@ -25,6 +28,7 @@ export const defaultImportOptions: z.infer<typeof ImportSchema> = {
 	ref: '',
 	requiresAuth: false,
 	installCommand: '',
+	sshKeyName: '',
 };
 
 export const CLISchema = z.object({

--- a/src/integrations/api/instance/ssh/getSSHKey.ts
+++ b/src/integrations/api/instance/ssh/getSSHKey.ts
@@ -22,7 +22,7 @@ async function getSSHKey({ name, instanceClient }: GetSSHKeyFormData) {
 
 export function getSSHKeyQueryOptions(params: GetSSHKeyFormData) {
 	return queryOptions({
-		queryKey: [params.entityId, 'get_ssh_key'] as const,
+		queryKey: [params.entityId, 'get_ssh_key', params.name] as const,
 		queryFn: () => getSSHKey(params),
 		refetchInterval: 10_000,
 	});


### PR DESCRIPTION
Resolves #1318.

## What & why

When importing a **Git** application with **Requires Auth**, the old UI just showed a static "go configure SSH keys" alert. Under the hood, SSH auth resolves which key to use purely from the **host alias in the URL** (e.g. `git@your-repo.github.com:org/repo.git`), so entering the real hostname (`github.com`) instead of the key's alias silently fails to authenticate — with no feedback.

This adds an interactive picker + URL safety check on the Git tab:

1. **Pick a key** — lists the instance's SSH key names (`list_ssh_keys`). If none exist, keeps the original guidance (link to Config › SSH Keys).
2. **Verify host** — once a key is selected, fetches its `host` (`get_ssh_key`) and compares it to the host parsed from the Git URL:
   - **Match** → subtle confirmation.
   - **Mismatch** → non-blocking warning naming both hosts, plus a **"Use suggested URL"** button that rewrites the URL to the correct host alias.

### Scope decisions
- **Soft enforcement**: nothing ever disables Import — picking a key is recommended, and a host mismatch is a warning, not a block.
- **Git source only**: NPM/Tarball show no auth section, since `git@host` SSH doesn't apply there.

## Implementation notes
- New pure helpers `extractGitUrlHost` / `replaceGitUrlHost` (handles scp-like, `ssh://`, and `https://` shapes), with 12 unit tests.
- `sshKeyName` added to the import form schema is **form-only** state for verification — it is **not** sent to `deploy_component` (the backend resolves the key from the URL host).
- Drive-by fix: added the key `name` to `get_ssh_key`'s react-query key, which previously collided across keys (also benefits the Edit SSH Key modal).

## Verification
- `vitest run` — 12 new tests + full suite **927 passed / 0 failed** (11 pre-existing skips).
- `tsc -b` and `oxlint` clean (also enforced by the pre-commit hook).
- Not verified live in-browser: the New Application screen is auth-gated and a worktree dev server can't sign in. Manual path for a reviewer: New Application → Import → Git → **Requires Auth** → pick a key → enter a URL with the wrong host → warning + suggestion appears → **Use suggested URL** corrects it; Import stays enabled throughout; NPM/Tarball hide the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)