### PR TITLE
fix: Allow the API authorization modal to scroll on short viewports

### DIFF
--- a/src/features/instance/apis/swagger.css
+++ b/src/features/instance/apis/swagger.css
@@ -260,6 +260,38 @@
 	box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
 }
 
+/* Fit-to-viewport & scroll (#1310) — Swagger centres the dialog with
+ * `top: 50%; transform: translate(-50%, -50%)` and caps only the body at a
+ * fixed `max-height: 540px`. When the form is taller than the viewport the
+ * modal overflows both edges, pushing the header and the Authorize/Close
+ * buttons (which sit at the foot of the body) off-screen with no way to reach
+ * them — the body is the lone scroll region yet is itself partly clipped. Cap
+ * the whole dialog at the viewport and lay it out as a flex column so the
+ * header stays pinned while the body scrolls, buttons included. Mirrors
+ * DialogContent's `max-h-screen overflow-y-auto`. */
+.swagger-ui .dialog-ux .modal-ux {
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100vh - 2rem);
+	overflow: hidden; /* clip the scrolling body to the rounded corners */
+}
+.swagger-ui .dialog-ux .modal-dialog-ux,
+.swagger-ui .dialog-ux .modal-ux-inner {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	min-height: 0; /* let the body shrink below its content height so it can scroll */
+}
+.swagger-ui .dialog-ux .modal-ux-header {
+	flex: 0 0 auto;
+}
+.swagger-ui .dialog-ux .modal-ux-content {
+	flex: 1 1 auto;
+	min-height: 0;
+	max-height: none; /* override Swagger's fixed 540px */
+	overflow-y: auto;
+}
+
 .swagger-ui .dialog-ux .modal-ux-header {
 	border-bottom: 1px solid var(--border);
 }

--- a/src/features/instance/apis/swagger.css
+++ b/src/features/instance/apis/swagger.css
@@ -272,7 +272,7 @@
 .swagger-ui .dialog-ux .modal-ux {
 	display: flex;
 	flex-direction: column;
-	max-height: calc(100vh - 2rem);
+	max-height: calc(100dvh - 2rem); /* dvh, not vh: account for mobile dynamic toolbars/keyboard */
 	overflow: hidden; /* clip the scrolling body to the rounded corners */
 }
 .swagger-ui .dialog-ux .modal-dialog-ux,


### PR DESCRIPTION
## What

Fixes the API authorization (Swagger "Authorize") modal so it stays within the viewport and scrolls when the form is taller than the screen.

Closes #1310.

## Why

Swagger renders its auth dialog centred with `top: 50%; transform: translate(-50%, -50%)` and caps **only** the body at a fixed `max-height: 540px`. When the auth form is taller than the viewport, the whole modal overflows both edges: the header and the **Authorize/Close** buttons (which live at the foot of the body) end up off-screen with no way to reach them — the body is the lone scroll region and is itself partly clipped, and there's no scrollable ancestor since `.dialog-ux` is `position: fixed`.

## How

In [`swagger.css`](src/features/instance/apis/swagger.css), cap the whole dialog at the viewport (`max-height: calc(100vh - 2rem)`) and lay it out as a flex column so the header stays pinned while the body scrolls — buttons included. This mirrors Studio's own `DialogContent` (`max-h-screen overflow-y-auto`). CSS-only; no DOM/behaviour changes.

## Verification

Reproduced the exact Swagger modal DOM with the shipped default styles + this override at a short (1100×600) viewport:

- **Before:** modal overflows the viewport (top −16, bottom 616); the "Available authorizations" header is clipped above the top edge (top −15) and unreachable.
- **After:** modal fits (top 15, bottom 585); header pinned and fully visible; body scrolls (`scrollHeight` 1324 > client 518); the Authorize button is reachable on-screen after scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)