### PR TITLE
chore: Exclude nested git worktrees from vitest runs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
 		exclude: [
 			'**/node_modules/**',
 			'**/dist/**',
+			// Nested git worktrees live under .claude/worktrees/; without this
+			// their test files get swept into runs from the main checkout.
+			'**/.claude/worktrees/**',
 		],
 		setupFiles: [
 			'./src/features/instance/status/analytics/__tests__/setup.ts',


### PR DESCRIPTION
## Summary

Git worktrees created under `.claude/worktrees/` contain their own copies of the test suite. Because vitest's `include` glob matches the whole tree, a `vitest run` started from the main checkout sweeps in those worktrees' test files — so failing tests in unrelated, in-progress branches break the pre-commit hook (and local runs) here even when the main checkout is perfectly green.

This adds `**/.claude/worktrees/**` to vitest's `exclude` so a run only covers the checkout it was started from.

## Testing

Before: `vitest run` from the main checkout collected nested-worktree tests and reported failures from other branches.

After: 148 files / 939 tests pass, 11 skipped, and **zero** `.claude/worktrees/` files are collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)