### PR TITLE
fix: Guard the log viewer's Monaco editor against oversized messages

### DIFF
--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -2,10 +2,7 @@ import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { ALL_EDITOR_COMMAND_IDS } from '@/features/instance/applications/components/editorMenuCommands';
 import { setEditorShortcutLabels } from '@/features/instance/applications/components/editorShortcutLabels';
 import { useEditorFileContent } from '@/features/instance/applications/context/editorFileContent';
-import {
-	MAX_WORKER_MODEL_CHARS,
-	useApplicationTypeIntelligence,
-} from '@/features/instance/applications/hooks/useApplicationTypeIntelligence';
+import { useApplicationTypeIntelligence } from '@/features/instance/applications/hooks/useApplicationTypeIntelligence';
 import { useCodeNavigation } from '@/features/instance/applications/hooks/useCodeNavigation';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { registerWithEditor } from '@/features/instance/applications/shortcuts';
@@ -13,6 +10,7 @@ import { useMonacoTheme } from '@/hooks/useMonacoTheme';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { useListener } from '@/lib/events/listener';
 import { Editor } from '@/lib/monaco/MonacoEditor';
+import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { parseFileExtension } from '@/lib/string/parseFileExtension';
 import type { EditorProps, OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useState } from 'react';

--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -29,6 +29,7 @@ import { FileEntry } from '@/features/instance/applications/context/fileEntry';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { getComponentFileQueryOptions } from '@/integrations/api/instance/applications/getComponentFile';
 import { typescript } from '@/lib/monaco/languageServices';
+import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { useQueryClient } from '@tanstack/react-query';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { useEffect, useMemo, useRef } from 'react';
@@ -42,17 +43,6 @@ const IGNORED_DIR = /^(node_modules|dist|build|out|coverage|\.git|\.next|\.turbo
 const IGNORED_FILE = /^(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$/i;
 /** Cap simultaneous file fetches so large projects don't flood the connection pool. */
 const FETCH_CONCURRENCY = 5;
-/**
- * Skip files larger than this when feeding the language worker. Monaco clones a
- * model's full text to its worker over `postMessage` (structured clone), and
- * `setEagerModelSync(true)` does so for every model we create here. A large
- * file — a checked-in bundle, generated data, a minified vendor script — can
- * overflow the clone buffer and crash the worker with "DataCloneError: Data
- * cannot be cloned, out of memory.", and even short of that it bloats worker
- * memory and slows the language service. Real source never approaches this, and
- * such files add nothing to IntelliSense.
- */
-export const MAX_WORKER_MODEL_CHARS = 512 * 1024;
 
 type AnyEntry = DirectoryEntry | FileEntry;
 

--- a/src/features/instance/log/modals/ViewLogModal.tsx
+++ b/src/features/instance/log/modals/ViewLogModal.tsx
@@ -7,15 +7,7 @@ import { useMonacoTheme } from '@/hooks/useMonacoTheme';
 import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
 import { Editor } from '@/lib/monaco/MonacoEditor';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
-
-function isJsonString(str: string) {
-	try {
-		JSON.parse(str);
-	} catch {
-		return false;
-	}
-	return true;
-}
+import { chooseLogEditorLanguage } from './logEditorLanguage';
 
 function MetaRow({ label, children }: { label: string; children: React.ReactNode }) {
 	return (
@@ -76,7 +68,7 @@ export function ViewLogModal({
 								<div className="rounded-md overflow-hidden border border-border/50 flex-1 min-h-0">
 									<Editor
 										className="w-full h-full"
-										language={isJsonString(data.message) ? 'json' : 'text'}
+										language={chooseLogEditorLanguage(data.message)}
 										theme={monacoTheme}
 										value={data.message}
 										options={{

--- a/src/features/instance/log/modals/logEditorLanguage.test.ts
+++ b/src/features/instance/log/modals/logEditorLanguage.test.ts
@@ -11,8 +11,10 @@ describe('chooseLogEditorLanguage', () => {
 		expect(chooseLogEditorLanguage('plain log line, not json')).toBe('plaintext');
 	});
 
-	it('treats an empty message as plaintext', () => {
+	it('treats an empty or nullish message as plaintext', () => {
 		expect(chooseLogEditorLanguage('')).toBe('plaintext');
+		expect(chooseLogEditorLanguage(undefined)).toBe('plaintext');
+		expect(chooseLogEditorLanguage(null)).toBe('plaintext');
 	});
 
 	it('renders an oversized JSON message as plaintext to avoid the worker OOM', () => {

--- a/src/features/instance/log/modals/logEditorLanguage.test.ts
+++ b/src/features/instance/log/modals/logEditorLanguage.test.ts
@@ -1,0 +1,44 @@
+import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
+import { describe, expect, it } from 'vitest';
+import { chooseLogEditorLanguage } from './logEditorLanguage';
+
+describe('chooseLogEditorLanguage', () => {
+	it('uses json highlighting for a small JSON message', () => {
+		expect(chooseLogEditorLanguage('{"level":"info","msg":"started"}')).toBe('json');
+	});
+
+	it('falls back to plaintext for non-JSON messages', () => {
+		expect(chooseLogEditorLanguage('plain log line, not json')).toBe('plaintext');
+	});
+
+	it('treats an empty message as plaintext', () => {
+		expect(chooseLogEditorLanguage('')).toBe('plaintext');
+	});
+
+	it('renders an oversized JSON message as plaintext to avoid the worker OOM', () => {
+		// Valid JSON that exceeds the worker clone limit: a string literal padded
+		// past MAX_WORKER_MODEL_CHARS. Without the size guard this would be sent to
+		// the json worker and can crash it with a DataCloneError.
+		const huge = JSON.stringify({ msg: 'x'.repeat(MAX_WORKER_MODEL_CHARS + 1) });
+		expect(huge.length).toBeGreaterThan(MAX_WORKER_MODEL_CHARS);
+		expect(isJson(huge)).toBe(true);
+		expect(chooseLogEditorLanguage(huge)).toBe('plaintext');
+	});
+
+	it('keeps json highlighting right up to the size limit', () => {
+		// A JSON message whose length is exactly the limit is still safe.
+		const padTarget = MAX_WORKER_MODEL_CHARS - '{"msg":""}'.length;
+		const atLimit = JSON.stringify({ msg: 'x'.repeat(padTarget) });
+		expect(atLimit.length).toBe(MAX_WORKER_MODEL_CHARS);
+		expect(chooseLogEditorLanguage(atLimit)).toBe('json');
+	});
+});
+
+function isJson(value: string): boolean {
+	try {
+		JSON.parse(value);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/src/features/instance/log/modals/logEditorLanguage.ts
+++ b/src/features/instance/log/modals/logEditorLanguage.ts
@@ -1,0 +1,27 @@
+import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
+
+function isJsonString(str: string): boolean {
+	try {
+		JSON.parse(str);
+	} catch {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Pick the editor language for a log message. JSON entries get syntax
+ * highlighting — but only when small enough to be safe: the `json` language runs
+ * a worker, and Monaco clones the model's full text to it over `postMessage`. An
+ * oversized message overflows the structured-clone buffer and crashes the worker
+ * ("DataCloneError: ... out of memory.", followed by "FAILED to post message to
+ * worker"), flooding the session with unhandled errors. Oversized or non-JSON
+ * messages render as `plaintext`, which has no language worker — the same guard
+ * the Applications editor applies to large files.
+ */
+export function chooseLogEditorLanguage(message: string): 'json' | 'plaintext' {
+	if (message.length > MAX_WORKER_MODEL_CHARS) {
+		return 'plaintext';
+	}
+	return isJsonString(message) ? 'json' : 'plaintext';
+}

--- a/src/features/instance/log/modals/logEditorLanguage.ts
+++ b/src/features/instance/log/modals/logEditorLanguage.ts
@@ -19,8 +19,8 @@ function isJsonString(str: string): boolean {
  * messages render as `plaintext`, which has no language worker — the same guard
  * the Applications editor applies to large files.
  */
-export function chooseLogEditorLanguage(message: string): 'json' | 'plaintext' {
-	if (message.length > MAX_WORKER_MODEL_CHARS) {
+export function chooseLogEditorLanguage(message: string | undefined | null): 'json' | 'plaintext' {
+	if (!message || message.length > MAX_WORKER_MODEL_CHARS) {
 		return 'plaintext';
 	}
 	return isJsonString(message) ? 'json' : 'plaintext';

--- a/src/lib/monaco/workerLimits.ts
+++ b/src/lib/monaco/workerLimits.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared limit for content handed to Monaco's worker-backed languages.
+ *
+ * Monaco clones a model's full text to its language worker over `postMessage`
+ * (a structured clone), and the TypeScript/JavaScript defaults sync eagerly via
+ * `setEagerModelSync(true)`. A very large model can overflow the clone buffer and
+ * crash the worker with "DataCloneError: Data cannot be cloned, out of memory.",
+ * which Monaco 0.55 reports as an unhandled error (and follows with a second
+ * "FAILED to post message to worker") — flooding the session with errors and
+ * leaving the worker stuck. Even short of crashing, a huge model bloats worker
+ * memory and slows the language service.
+ *
+ * Content past this size should be rendered as `plaintext` (which has no language
+ * worker) instead. Real source files and log entries never approach this; the
+ * inputs that do are checked-in bundles, generated data, or pathological log
+ * payloads that add nothing to highlighting or IntelliSense.
+ */
+export const MAX_WORKER_MODEL_CHARS = 512 * 1024;


### PR DESCRIPTION
## Summary

Fixes #1370 — the Monaco worker OOM error flood (`DataCloneError: …out of memory` + `FAILED to post message to worker`) on the logs flow.

**Root cause.** [`ViewLogModal`](https://github.com/HarperFast/studio/blob/stage/src/features/instance/log/modals/ViewLogModal.tsx) fed an unbounded `data.message` straight into Monaco's worker-backed `json` language. A large log entry (serialized errors, request bodies, stack traces) overflows the structured-clone buffer when Monaco posts the model to its worker, crashing it. In `monaco-editor@0.55.1`, a single failed `worker.postMessage()` fires **two** `onUnexpectedError` calls — the original `DataCloneError` *and* a wrapper `FAILED to post message to worker` — which is why the two Datadog issues track in lockstep (131 / 130) and why the wrapper looks "new" since the 0.55.1 upgrade. The `postMessage` is fire-and-forget with no backoff, so one stuck worker floods the session (and Datadog) with errors.

The Applications editor already fixed this **exact** error for large files by falling back to `plaintext` (which has no language worker) — see `TextEditorView`'s `oversized` guard. The log viewer was simply never given the same guard.

## What changed

- **New `src/lib/monaco/workerLimits.ts`** — promotes the shared `MAX_WORKER_MODEL_CHARS` limit out of the applications hook so the logs modal doesn't depend on it; the two existing call sites now import from here.
- **New `logEditorLanguage.ts`** — `chooseLogEditorLanguage()` uses `json` only for JSON messages under the limit; oversized or non-JSON messages render as `plaintext` (no worker). `ViewLogModal` now uses it.
- **New `logEditorLanguage.test.ts`** — covers small JSON, non-JSON, empty, at-limit, and oversized-JSON cases.

Normal-sized logs are unchanged (JSON still highlighted); only pathological large entries degrade to plaintext instead of crashing the worker.

## Testing

- Full suite green via the pre-commit hook: **958 passed / 11 skipped (151 files)**.
- New unit test (5 cases) passes; `oxlint` and `dprint` clean.

## Note for follow-up

A compounding vector remains: the Applications editor's TS worker accumulates eager-synced models + type-acquisition `extraLibs` over a long session, and monaco 0.55 has no `postMessage` retry/backoff, so any single OOM becomes a flood. This PR fixes the reported logs flow; if the flood recurs from the applications side, a global Monaco `onUnexpectedError` de-noiser would be the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)