### PR TITLE
Expose the system database in dev and Local Studio

### DIFF
--- a/src/integrations/api/instance/database/getDescribeAll.test.ts
+++ b/src/integrations/api/instance/database/getDescribeAll.test.ts
@@ -1,0 +1,88 @@
+import type { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import type { AxiosInstance } from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const DATA_MAP = { data: { dog: { name: 'dog' } } };
+const SYSTEM_TABLES = { hdb_user: { name: 'hdb_user' }, hdb_role: { name: 'hdb_role' } };
+
+// `describe_all` deliberately omits the system database, so the mock mirrors the
+// server: it returns the base map for `describe_all` and the system tables only for
+// an explicit `describe_database` on `system`.
+function makeClient() {
+	const post = vi.fn(async (_url: string, body: { operation: string; database?: string }) => {
+		if (body.operation === 'describe_all') { return { data: { ...DATA_MAP } }; }
+		if (body.operation === 'describe_database' && body.database === 'system') { return { data: { ...SYSTEM_TABLES } }; }
+		throw new Error(`unexpected operation: ${body.operation}`);
+	});
+	return {
+		post,
+		config: { instanceClient: { post } as unknown as AxiosInstance, entityId: 'e1' } as InstanceClientIdConfig,
+	};
+}
+
+async function loadGetDescribeAll({ dev, localStudio }: { dev: boolean; localStudio: boolean }) {
+	vi.resetModules();
+	vi.stubEnv('DEV', dev);
+	vi.stubEnv('VITE_LOCAL_STUDIO', localStudio ? 'true' : 'false');
+	return (await import('./getDescribeAll')).getDescribeAll;
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('getDescribeAll system database exposure', () => {
+	it('merges the system database when running the Vite dev server', async () => {
+		const getDescribeAll = await loadGetDescribeAll({ dev: true, localStudio: false });
+		const { post, config } = makeClient();
+
+		const result = await getDescribeAll(config);
+
+		expect(result).toEqual({ ...DATA_MAP, system: SYSTEM_TABLES });
+		expect(post).toHaveBeenCalledWith('/', { operation: 'describe_database', database: 'system' });
+	});
+
+	it('merges the system database in Local Studio builds', async () => {
+		const getDescribeAll = await loadGetDescribeAll({ dev: false, localStudio: true });
+		const { post, config } = makeClient();
+
+		const result = await getDescribeAll(config);
+
+		expect(result).toEqual({ ...DATA_MAP, system: SYSTEM_TABLES });
+		expect(post).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not request the system database in non-dev, non-local builds', async () => {
+		const getDescribeAll = await loadGetDescribeAll({ dev: false, localStudio: false });
+		const { post, config } = makeClient();
+
+		const result = await getDescribeAll(config);
+
+		expect(result).toEqual(DATA_MAP);
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	it('skips the extra request when describe_all already returns system', async () => {
+		const getDescribeAll = await loadGetDescribeAll({ dev: true, localStudio: false });
+		const post = vi.fn(async () => ({ data: { ...DATA_MAP, system: SYSTEM_TABLES } }));
+		const config = { instanceClient: { post } as unknown as AxiosInstance, entityId: 'e1' } as InstanceClientIdConfig;
+
+		const result = await getDescribeAll(config);
+
+		expect(result).toEqual({ ...DATA_MAP, system: SYSTEM_TABLES });
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to the base map when the system describe fails', async () => {
+		const getDescribeAll = await loadGetDescribeAll({ dev: true, localStudio: false });
+		const post = vi.fn(async (_url: string, body: { operation: string }) => {
+			if (body.operation === 'describe_all') { return { data: { ...DATA_MAP } }; }
+			throw new Error('insufficient permissions');
+		});
+		const config = { instanceClient: { post } as unknown as AxiosInstance, entityId: 'e1' } as InstanceClientIdConfig;
+
+		const result = await getDescribeAll(config);
+
+		expect(result).toEqual(DATA_MAP);
+	});
+});

--- a/src/integrations/api/instance/database/getDescribeAll.ts
+++ b/src/integrations/api/instance/database/getDescribeAll.ts
@@ -1,12 +1,32 @@
+import { isLocalStudio } from '@/config/constants';
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
-import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { InstanceDatabaseMap, InstanceDatabaseTableMap } from '@/integrations/api/api.patch';
 import { queryOptions } from '@tanstack/react-query';
+
+// Harper's `describe_all` omits the internal `system` database — server-side it is a
+// non-enumerable property, so the operation's `for..in` loop skips it and it never
+// reaches Studio. An explicit `describe_database` still resolves it by key, so in dev
+// and Local Studio builds we fetch and merge it to make it inspectable.
+const exposeSystemDatabase = import.meta.env.DEV || isLocalStudio;
 
 export async function getDescribeAll({ instanceClient }: InstanceClientIdConfig) {
 	const { data } = await instanceClient.post<InstanceDatabaseMap>('/', {
 		operation: 'describe_all',
 	});
-	return data;
+	if (!exposeSystemDatabase || data.system) {
+		return data;
+	}
+	try {
+		const { data: systemTables } = await instanceClient.post<InstanceDatabaseTableMap>('/', {
+			operation: 'describe_database',
+			database: 'system',
+		});
+		return { ...data, system: systemTables };
+	} catch {
+		// Best-effort dev tooling: if the server denies or lacks the system database,
+		// fall back to the unmodified map rather than breaking the databases view.
+		return data;
+	}
 }
 
 export function getDescribeAllQueryOptions(params: InstanceClientIdConfig) {


### PR DESCRIPTION
## Summary

Surfaces Harper's internal `system` database in the Studio databases viewer when running in dev or Local Studio.

Harper's `describe_all` operation deliberately omits `system`: server-side it is a **non-enumerable** property on the `databases` object (`harper/resources/databases.ts`), so the handler's `for..in` loop skips it and it never reaches Studio. Studio itself does no filtering — it renders whatever `describe_all` returns. An explicit `describe_database` still resolves `system` by key, so this change fetches it that way and merges `{ system }` into the describe_all result.

The merge lives in the shared `getDescribeAll` query layer, so the sidebar and table view pick it up automatically.

## Purpose

Make the `system` database inspectable locally for debugging, without exposing it on deployed Fabric.

## Gating (`import.meta.env.DEV || isLocalStudio`)

- **Exposed:** any Vite dev server (`dev`, `dev:fabric`, `dev:local`) and the bundled Local Studio build (`build:local`, `VITE_LOCAL_STUDIO=true`) that ships in the `harper` package.
- **Not exposed:** Fabric `stage` / `prod` deploys.

## Worth a look

- **Local Studio exposure is broader than just "dev".** Because the gate includes `isLocalStudio`, the Local Studio UI bundled into the `harper` npm package will show `system` to anyone running Harper locally — not only Studio developers. This was an explicit choice (expose in dev *or* Local Studio); flagging in case we'd rather restrict to `import.meta.env.DEV` only.
- **The merge is central, so all `describe_all` consumers see `system` in dev**, not just the databases viewer — notably the role editor's default-permission calculator and the Chat tool's schema context. Harmless in dev, but intentional reach beyond the viewer.
- **Permissions:** for a non-super-user the explicit `describe_database` on `system` may be denied; the `try/catch` falls back to the unmodified map so the page still renders.

## Notes

- Not user-facing for deployed Fabric (dev-tooling only), so no docs change.
- Cross-model review (lifecycle step 10) was not run — the `cross-model-review` skill isn't available in this environment, and spawning a Claude reviewer is explicitly disallowed. The points above are surfaced here in lieu of that pass.
- Generated by an LLM (Claude Opus 4.8).