### PR TITLE
chore: Ignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+.claude/worktrees
 .idea
 .DS_Store
 *.suo


### PR DESCRIPTION
## Summary
Adds `.claude/worktrees` to `.gitignore`.

## Purpose
Agent git worktrees are created under `.claude/worktrees`; this keeps those transient working copies out of version control. The rest of `.claude` (shared skills, settings, hooks) stays tracked.

## Attention
One-line `.gitignore` addition. `.claude/worktrees` is not currently tracked, so no `git rm --cached` was needed — the rule simply prevents future worktrees from showing up as untracked changes.

_Generated by an LLM (Claude Opus 4.8)._