### PR TITLE
fix(rum): survive browser-translation DOM mutation (#1388)

### DIFF
--- a/src/features/instance/applications/components/Chat/components/ToolInvocation.tsx
+++ b/src/features/instance/applications/components/Chat/components/ToolInvocation.tsx
@@ -42,9 +42,11 @@ export function ToolInvocation({ part, onApprove, onDeny, onAlwaysApprove, isApp
 					<span>{toolName}</span>
 				</div>
 				<div className="tool-status">
-					{part.state === 'input-streaming' && 'Thinking...'}
+					{part.state === 'input-streaming' && <span>Thinking...</span>}
 					{part.state === 'input-available'
-						&& (isApproving ? 'Executing...' : (requiresApproval ? 'Awaiting Approval...' : 'Executing...'))}
+						&& (
+							<span>{isApproving ? 'Executing...' : (requiresApproval ? 'Awaiting Approval...' : 'Executing...')}</span>
+						)}
 					{part.state === 'output-available'
 						&& ((part.output as any)?.error ? <XCircle size={14} className="text-destructive" /> : <Check size={14} />)}
 				</div>

--- a/src/lib/installBrowserTranslationDomGuard.test.ts
+++ b/src/lib/installBrowserTranslationDomGuard.test.ts
@@ -66,4 +66,20 @@ describe('installBrowserTranslationDomGuard', () => {
 		installBrowserTranslationDomGuard();
 		expect(Node.prototype.removeChild).toBe(after);
 	});
+
+	it('defines the guard marker as a non-enumerable property', () => {
+		const descriptor = Object.getOwnPropertyDescriptor(Node.prototype, guardFlag);
+		expect(descriptor?.enumerable).toBe(false);
+		// It must not leak into for...in iteration over a node.
+		const node = document.createElement('div');
+		for (const key in node) {
+			expect(key).not.toBe(guardFlag);
+		}
+	});
+
+	it('lets the browser throw for non-Node arguments instead of masking the bug', () => {
+		const parent = document.createElement('div');
+		// A non-Node argument should fall through to native removeChild and throw.
+		expect(() => parent.removeChild({} as unknown as Node)).toThrow();
+	});
 });

--- a/src/lib/installBrowserTranslationDomGuard.test.ts
+++ b/src/lib/installBrowserTranslationDomGuard.test.ts
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { installBrowserTranslationDomGuard } from './installBrowserTranslationDomGuard';
+
+// Capture the pristine implementations so each test can restore them — the guard
+// patches Node.prototype globally and we don't want it leaking across the file.
+const pristineRemoveChild = Node.prototype.removeChild;
+const pristineInsertBefore = Node.prototype.insertBefore;
+const guardFlag = '__harperTranslationGuarded__';
+
+describe('installBrowserTranslationDomGuard', () => {
+	beforeEach(() => {
+		Node.prototype.removeChild = pristineRemoveChild;
+		Node.prototype.insertBefore = pristineInsertBefore;
+		delete (Node.prototype as unknown as Record<string, unknown>)[guardFlag];
+		installBrowserTranslationDomGuard();
+	});
+
+	afterEach(() => {
+		Node.prototype.removeChild = pristineRemoveChild;
+		Node.prototype.insertBefore = pristineInsertBefore;
+		delete (Node.prototype as unknown as Record<string, unknown>)[guardFlag];
+	});
+
+	it('still removes a genuine child', () => {
+		const parent = document.createElement('div');
+		const child = document.createElement('span');
+		parent.appendChild(child);
+
+		expect(parent.removeChild(child)).toBe(child);
+		expect(parent.contains(child)).toBe(false);
+	});
+
+	it('does not throw when removing a node that is no longer a child (the #1388 crash)', () => {
+		const parent = document.createElement('div');
+		const stranger = document.createElement('span'); // never parented to `parent`
+
+		expect(() => parent.removeChild(stranger)).not.toThrow();
+		expect(parent.removeChild(stranger)).toBe(stranger);
+	});
+
+	it('still inserts before a genuine reference node', () => {
+		const parent = document.createElement('div');
+		const ref = document.createElement('span');
+		const inserted = document.createElement('b');
+		parent.appendChild(ref);
+
+		parent.insertBefore(inserted, ref);
+		expect(parent.firstChild).toBe(inserted);
+		expect(parent.childNodes[1]).toBe(ref);
+	});
+
+	it('does not throw when the reference node belongs to another parent; appends instead', () => {
+		const parent = document.createElement('div');
+		const otherParent = document.createElement('div');
+		const ref = document.createElement('span');
+		const inserted = document.createElement('b');
+		otherParent.appendChild(ref); // ref's parent is NOT `parent`
+
+		expect(() => parent.insertBefore(inserted, ref)).not.toThrow();
+		expect(parent.contains(inserted)).toBe(true);
+	});
+
+	it('is idempotent — calling twice does not double-wrap', () => {
+		const after = Node.prototype.removeChild;
+		installBrowserTranslationDomGuard();
+		expect(Node.prototype.removeChild).toBe(after);
+	});
+});

--- a/src/lib/installBrowserTranslationDomGuard.ts
+++ b/src/lib/installBrowserTranslationDomGuard.ts
@@ -33,11 +33,16 @@ export function installBrowserTranslationDomGuard() {
 	if (proto[guardFlag]) {
 		return;
 	}
-	proto[guardFlag] = true;
+	// Define the marker non-enumerable so it doesn't leak into `for...in` loops that
+	// iterate over DOM nodes in third-party/legacy code.
+	Object.defineProperty(proto, guardFlag, { value: true, configurable: true, writable: true, enumerable: false });
 
 	const originalRemoveChild = Node.prototype.removeChild;
 	Node.prototype.removeChild = function removeChild<T extends Node>(this: Node, child: T): T {
-		if (child.parentNode !== this) {
+		// The `instanceof Node` guard ensures we only soften the failure for genuine nodes
+		// the translator moved — a non-Node argument still falls through to the native
+		// method so it throws a standard error rather than silently masking a real bug.
+		if (child instanceof Node && child.parentNode !== this) {
 			// The translator already detached/moved this node; nothing to remove.
 			return child;
 		}
@@ -50,7 +55,9 @@ export function installBrowserTranslationDomGuard() {
 		newNode: T,
 		referenceNode: Node | null,
 	): T {
-		if (referenceNode && referenceNode.parentNode !== this) {
+		// As above, only intercept genuine re-parented nodes; a null reference (a normal
+		// append) or a non-Node argument falls through to the native implementation.
+		if (referenceNode instanceof Node && referenceNode.parentNode !== this) {
 			// The reference node was re-parented by the translator; append instead of
 			// throwing, which is the closest safe equivalent of React's intent.
 			return originalInsertBefore.call(this, newNode, null) as T;

--- a/src/lib/installBrowserTranslationDomGuard.ts
+++ b/src/lib/installBrowserTranslationDomGuard.ts
@@ -1,0 +1,60 @@
+/**
+ * Make `Node.removeChild` / `Node.insertBefore` tolerant of DOM mutations made by
+ * browser page-translation tools, so they no longer throw and crash React.
+ *
+ * Page translators (Google Translate, Chrome's built-in translate, Edge, Firefox
+ * add-ons, etc.) rewrite the live DOM out from under React: they replace text nodes
+ * with translated ones and re-parent fragments. React's commit phase still holds
+ * references to the *original* nodes, so when it later unmounts a subtree it calls
+ * `removeChild` on a node the translator already moved — throwing
+ *
+ *   NotFoundError: Failed to execute 'removeChild' on 'Node':
+ *   The node to be removed is not a child of this node.
+ *
+ * and the same class of failure for `insertBefore`. This is a long-standing React +
+ * translation interaction (facebook/react#11538), not a Studio bug, but it surfaces
+ * in our RUM Error Tracking (issue #1388) and can wedge the UI for affected users —
+ * disproportionately those browsing in a non-English locale with translation on.
+ *
+ * The widely-used mitigation (Google ships it in their own apps) is to guard these
+ * two methods: if the node isn't parented where the caller expects, return without
+ * throwing instead of crashing — the translator has effectively already performed the
+ * mutation. Everything else falls through to the native implementation unchanged.
+ *
+ * Idempotent: safe to call more than once (e.g. across HMR reloads).
+ */
+export function installBrowserTranslationDomGuard() {
+	if (typeof Node !== 'function' || !Node.prototype) {
+		return;
+	}
+
+	const guardFlag = '__harperTranslationGuarded__';
+	const proto = Node.prototype as Node & { [guardFlag]?: boolean };
+	if (proto[guardFlag]) {
+		return;
+	}
+	proto[guardFlag] = true;
+
+	const originalRemoveChild = Node.prototype.removeChild;
+	Node.prototype.removeChild = function removeChild<T extends Node>(this: Node, child: T): T {
+		if (child.parentNode !== this) {
+			// The translator already detached/moved this node; nothing to remove.
+			return child;
+		}
+		return originalRemoveChild.call(this, child) as T;
+	};
+
+	const originalInsertBefore = Node.prototype.insertBefore;
+	Node.prototype.insertBefore = function insertBefore<T extends Node>(
+		this: Node,
+		newNode: T,
+		referenceNode: Node | null,
+	): T {
+		if (referenceNode && referenceNode.parentNode !== this) {
+			// The reference node was re-parented by the translator; append instead of
+			// throwing, which is the closest safe equivalent of React's intent.
+			return originalInsertBefore.call(this, newNode, null) as T;
+		}
+		return originalInsertBefore.call(this, newNode, referenceNode) as T;
+	};
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,13 @@
 import { App } from '@/App';
+import { installBrowserTranslationDomGuard } from '@/lib/installBrowserTranslationDomGuard';
 import { addReactError } from '@datadog/browser-rum-react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
+
+// Must run before React mounts: keeps browser page-translation from crashing React
+// with `removeChild`/`insertBefore` NotFoundErrors (issue #1388).
+installBrowserTranslationDomGuard();
 
 createRoot(
 	document.getElementById('root')!,


### PR DESCRIPTION
## Summary

Resolves #1388.

RUM Error Tracking reports a recurring, **handled** `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.` (and the same class for `insertBefore`), originating deep in React DOM's commit phase. Active since v2.106.0, still in v2.125.4.

This is the long-standing **React + browser page-translation** interaction ([facebook/react#11538](https://github.com/facebook/react/issues/11538)), not a Studio bug: Google Translate / Chrome / Edge / Firefox translation rewrites text nodes and re-parents fragments out from under React. React's commit phase still references the original nodes, so when it later unmounts a subtree it calls `removeChild`/`insertBefore` on a node the translator already moved → throw. The affected sessions are disproportionately non-English-locale users, consistent with translation being active.

## Changes

- **`src/lib/installBrowserTranslationDomGuard.ts`** — makes `Node.removeChild` / `Node.insertBefore` tolerant of translator mutations: if the node isn't parented where the caller expects, return without throwing (the translator effectively already performed the mutation) instead of crashing. Idempotent. This is the widely-used mitigation (Google ships an equivalent in their own apps). Wired into `main.tsx` **before React mounts**.
- **`ToolInvocation.tsx`** — wrap bare conditional text (`'Thinking...'`, `'Executing...'`, …) in `<span>` so React always reconciles element nodes rather than raw text nodes. This is the React-team-recommended app-side mitigation and removes one concrete in-app trigger.

## Testing

- `vitest run src/lib/installBrowserTranslationDomGuard.test.ts` — 5 pass: genuine removeChild/insertBefore still work; removing a non-child / inserting before a foreign reference node no longer throws; guard is idempotent.
- `tsc -b` clean; full suite green via pre-commit hook (975 pass).

## Why a global Node patch

The RUM stack is entirely inside React's minified reconciler (`fl`/`pl` = commit-deletion effects) with no app frame, so the crash can originate from any unmounting subtree, not one component. A targeted per-component fix can't cover it; the prototype guard does, and is scoped to exactly the two methods that throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)