### PR TITLE
feat(editor): editor experience enhancements (#1321)

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
@@ -4,6 +4,7 @@ import { authStore } from '@/features/auth/store/authStore';
 import { useDraggingHook } from '@/features/instance/applications/components/ApplicationsSidebar/useDraggingHook';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { confirmOverwrite } from '@/features/instance/applications/modals/confirmOverwrite';
 import { setComponentFile } from '@/integrations/api/instance/applications/setComponentFile';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { pluralize } from '@/lib/pluralize';
@@ -52,6 +53,10 @@ export function DropTarget() {
 
 		const filesToUpload: FileWithPath[] = [];
 		const filesRejected: FileRejection[] = rawRejectedFiles.slice();
+		// Files whose destination path already exists. Rather than rejecting them outright,
+		// collect them and ask once whether to overwrite (uploading a folder over an existing
+		// one this way merges it — only the colliding files are replaced).
+		const collisions: { file: FileWithPath; path: string }[] = [];
 
 		for (const file of rawAcceptedFiles) {
 			const filePath = getFilePath(targetPath, file);
@@ -66,17 +71,23 @@ export function DropTarget() {
 					],
 				});
 			} else if (entryExists(`${targetProject}/${filePath}`)) {
-				filesRejected.push({
-					file,
-					errors: [
-						{
-							message: `${filePath} already exists`,
-							code: 'duplicate',
-						},
-					],
-				});
+				collisions.push({ file, path: `${targetProject}/${filePath}` });
 			} else {
 				filesToUpload.push(file);
+			}
+		}
+
+		if (collisions.length > 0) {
+			const overwrite = await confirmOverwrite({ files: collisions.map(c => c.path), directories: [] });
+			for (const collision of collisions) {
+				if (overwrite) {
+					filesToUpload.push(collision.file);
+				} else {
+					filesRejected.push({
+						file: collision.file,
+						errors: [{ message: `${getFilePath(targetPath, collision.file)} already exists`, code: 'duplicate' }],
+					});
+				}
 			}
 		}
 

--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
@@ -10,9 +10,9 @@ import type { DirectoryEntry } from '@/features/instance/applications/context/di
 import type { FileEntry } from '@/features/instance/applications/context/fileEntry';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useEntryActions } from '@/features/instance/applications/hooks/useEntryActions';
+import { useCopyTextToClipboard } from '@/hooks/useCopyToClipboard';
 import { setWatchedValue } from '@/lib/events/watcher';
 import {
-	ClipboardCheckIcon,
 	CopyIcon,
 	DownloadIcon,
 	FilePlusIcon,
@@ -24,7 +24,6 @@ import {
 } from 'lucide-react';
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import type { TreeItem, TreeItemIndex } from 'react-complex-tree';
-import { toast } from 'sonner';
 import { setPendingContextAction } from '../../shortcuts/pendingContextAction';
 import { importedApplications, newApplication, rootId } from './specialItems';
 
@@ -120,15 +119,7 @@ export function FileTreeContextMenu({
 
 	// Copy is always available (it reads the right-clicked entry, needs no permission and
 	// changes no selection), so it reads `target` directly rather than going through `act`.
-	const copy = useCallback((text: string) => {
-		// `navigator.clipboard` is undefined in non-secure contexts (HTTP, non-localhost) and old browsers.
-		if (!navigator.clipboard) {
-			toast.error('Clipboard access is not available in this environment.');
-			return;
-		}
-		void navigator.clipboard.writeText(text);
-		toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
-	}, []);
+	const copy = useCopyTextToClipboard();
 
 	const hasActions = canAddEntries || canRename || canDownload || canRedeploy || canDeleteEntry;
 

--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
@@ -121,6 +121,11 @@ export function FileTreeContextMenu({
 	// Copy is always available (it reads the right-clicked entry, needs no permission and
 	// changes no selection), so it reads `target` directly rather than going through `act`.
 	const copy = useCallback((text: string) => {
+		// `navigator.clipboard` is undefined in non-secure contexts (HTTP, non-localhost) and old browsers.
+		if (!navigator.clipboard) {
+			toast.error('Clipboard access is not available in this environment.');
+			return;
+		}
 		void navigator.clipboard.writeText(text);
 		toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
 	}, []);

--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
@@ -11,9 +11,20 @@ import type { FileEntry } from '@/features/instance/applications/context/fileEnt
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useEntryActions } from '@/features/instance/applications/hooks/useEntryActions';
 import { setWatchedValue } from '@/lib/events/watcher';
-import { DownloadIcon, FilePlusIcon, FolderPlusIcon, PackageIcon, PencilIcon, TrashIcon } from 'lucide-react';
+import {
+	ClipboardCheckIcon,
+	CopyIcon,
+	DownloadIcon,
+	FilePlusIcon,
+	FolderPlusIcon,
+	LinkIcon,
+	PackageIcon,
+	PencilIcon,
+	TrashIcon,
+} from 'lucide-react';
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import type { TreeItem, TreeItemIndex } from 'react-complex-tree';
+import { toast } from 'sonner';
 import { setPendingContextAction } from '../../shortcuts/pendingContextAction';
 import { importedApplications, newApplication, rootId } from './specialItems';
 
@@ -107,6 +118,13 @@ export function FileTreeContextMenu({
 		fire();
 	}, [target, focusTarget]);
 
+	// Copy is always available (it reads the right-clicked entry, needs no permission and
+	// changes no selection), so it reads `target` directly rather than going through `act`.
+	const copy = useCallback((text: string) => {
+		void navigator.clipboard.writeText(text);
+		toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
+	}, []);
+
 	const hasActions = canAddEntries || canRename || canDownload || canRedeploy || canDeleteEntry;
 
 	return (
@@ -124,8 +142,19 @@ export function FileTreeContextMenu({
 					{children}
 				</div>
 			</ContextMenuTrigger>
-			{hasActions && (
+			{target && (
 				<ContextMenuContent className="min-w-44" onCloseAutoFocus={event => event.preventDefault()}>
+					<ContextMenuItem onSelect={() => copy(target.entry.name)}>
+						<CopyIcon />
+						Copy Name
+					</ContextMenuItem>
+					<ContextMenuItem onSelect={() => copy(target.entry.path)}>
+						<LinkIcon />
+						Copy Path
+					</ContextMenuItem>
+
+					{hasActions && <ContextMenuSeparator />}
+
 					{canAddEntries && (
 						<>
 							<ContextMenuItem onSelect={() => act(() => setWatchedValue('ShowAddDirectoryOrFileModalType', 'file'))}>

--- a/src/features/instance/applications/components/ApplicationsSidebar/SidebarResizeHandle.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/SidebarResizeHandle.tsx
@@ -1,0 +1,75 @@
+import { clampSidebarWidth } from '@/features/instance/applications/lib/clampSidebarWidth';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
+import { cx } from 'class-variance-authority';
+import { useCallback, useEffect, useState } from 'react';
+
+/** Matches the previous fixed `w-56` (224px) so existing layouts are unchanged on first load. */
+export const DEFAULT_SIDEBAR_WIDTH = 224;
+
+/**
+ * Drag-to-resize state for the file tray, persisted to local storage. Mirrors the resizable
+ * chat panel (see `Chat/FloatingChat.tsx`): mousedown arms the gesture, then window
+ * `mousemove`/`mouseup` listeners track it so the cursor can leave the handle. The tray is
+ * anchored at `left: 0`, so the new width is simply the clamped cursor X. `isResizing` lets
+ * the caller drop layout transitions mid-drag (they'd otherwise lag the editor pane).
+ */
+export function useResizableSidebar() {
+	const [width, setWidth] = useLocalStorage(LocalStorageKeys.ApplicationsSidebarWidth, DEFAULT_SIDEBAR_WIDTH);
+	const [isResizing, setIsResizing] = useState(false);
+
+	// If the viewport shrank since the width was stored, pull it back into range.
+	useEffect(() => {
+		const onResize = () => setWidth(current => clampSidebarWidth(current, window.innerWidth));
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, [setWidth]);
+
+	const startResizing = useCallback((event: React.MouseEvent) => {
+		event.preventDefault();
+		setIsResizing(true);
+	}, []);
+
+	useEffect(() => {
+		if (!isResizing) {
+			return;
+		}
+		const onMouseMove = (event: MouseEvent) => setWidth(clampSidebarWidth(event.clientX, window.innerWidth));
+		const onMouseUp = () => setIsResizing(false);
+		// Suppress text selection across the page while dragging.
+		const previousUserSelect = document.body.style.userSelect;
+		document.body.style.userSelect = 'none';
+		window.addEventListener('mousemove', onMouseMove);
+		window.addEventListener('mouseup', onMouseUp);
+		return () => {
+			document.body.style.userSelect = previousUserSelect;
+			window.removeEventListener('mousemove', onMouseMove);
+			window.removeEventListener('mouseup', onMouseUp);
+		};
+	}, [isResizing, setWidth]);
+
+	return { width, isResizing, startResizing };
+}
+
+/** The visible drag affordance pinned to the tray's right edge. */
+export function SidebarResizeHandle({
+	isResizing,
+	onMouseDown,
+}: {
+	isResizing: boolean;
+	onMouseDown: (event: React.MouseEvent) => void;
+}) {
+	return (
+		<div
+			role="separator"
+			aria-orientation="vertical"
+			aria-label="Resize sidebar"
+			onMouseDown={onMouseDown}
+			className={cx(
+				'absolute top-0 right-0 bottom-0 w-1 z-40 cursor-col-resize',
+				'hover:bg-violet-400/60 dark:hover:bg-violet-500/60 transition-colors',
+				isResizing && 'bg-violet-400/60 dark:bg-violet-500/60',
+			)}
+		/>
+	);
+}

--- a/src/features/instance/applications/components/ApplicationsSidebar/SidebarResizeHandle.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/SidebarResizeHandle.tsx
@@ -2,28 +2,45 @@ import { clampSidebarWidth } from '@/features/instance/applications/lib/clampSid
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
 import { cx } from 'class-variance-authority';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /** Matches the previous fixed `w-56` (224px) so existing layouts are unchanged on first load. */
 export const DEFAULT_SIDEBAR_WIDTH = 224;
 
 /**
- * Drag-to-resize state for the file tray, persisted to local storage. Mirrors the resizable
- * chat panel (see `Chat/FloatingChat.tsx`): mousedown arms the gesture, then window
- * `mousemove`/`mouseup` listeners track it so the cursor can leave the handle. The tray is
- * anchored at `left: 0`, so the new width is simply the clamped cursor X. `isResizing` lets
- * the caller drop layout transitions mid-drag (they'd otherwise lag the editor pane).
+ * Drag-to-resize state for the file tray. Mirrors the resizable chat panel
+ * (see `Chat/FloatingChat.tsx`): mousedown arms the gesture, then window `mousemove`/`mouseup`
+ * listeners track it so the cursor can leave the handle. The tray is anchored at `left: 0`, so
+ * the new width is simply the clamped cursor X. `isResizing` lets the caller drop layout
+ * transitions mid-drag (they'd otherwise lag the editor pane).
+ *
+ * While dragging we update only the transient `width` (one render per frame) and commit to
+ * local storage once on release — writing localStorage on every `mousemove` would stutter.
  */
 export function useResizableSidebar() {
-	const [width, setWidth] = useLocalStorage(LocalStorageKeys.ApplicationsSidebarWidth, DEFAULT_SIDEBAR_WIDTH);
+	const [persistedWidth, setPersistedWidth] = useLocalStorage(
+		LocalStorageKeys.ApplicationsSidebarWidth,
+		DEFAULT_SIDEBAR_WIDTH,
+	);
 	const [isResizing, setIsResizing] = useState(false);
+	const [width, setWidth] = useState(() => clampSidebarWidth(persistedWidth, window.innerWidth));
+	const widthRef = useRef(width);
+	widthRef.current = width;
+
+	// When not actively dragging, keep the rendered width in sync with the persisted value
+	// (e.g. after the resize handler below clamps it).
+	useEffect(() => {
+		if (!isResizing) {
+			setWidth(clampSidebarWidth(persistedWidth, window.innerWidth));
+		}
+	}, [persistedWidth, isResizing]);
 
 	// If the viewport shrank since the width was stored, pull it back into range.
 	useEffect(() => {
-		const onResize = () => setWidth(current => clampSidebarWidth(current, window.innerWidth));
+		const onResize = () => setPersistedWidth(current => clampSidebarWidth(current, window.innerWidth));
 		window.addEventListener('resize', onResize);
 		return () => window.removeEventListener('resize', onResize);
-	}, [setWidth]);
+	}, [setPersistedWidth]);
 
 	const startResizing = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
@@ -35,7 +52,11 @@ export function useResizableSidebar() {
 			return;
 		}
 		const onMouseMove = (event: MouseEvent) => setWidth(clampSidebarWidth(event.clientX, window.innerWidth));
-		const onMouseUp = () => setIsResizing(false);
+		const onMouseUp = () => {
+			setIsResizing(false);
+			// Persist the final width once, instead of on every mousemove.
+			setPersistedWidth(widthRef.current);
+		};
 		// Suppress text selection across the page while dragging.
 		const previousUserSelect = document.body.style.userSelect;
 		document.body.style.userSelect = 'none';
@@ -46,7 +67,7 @@ export function useResizableSidebar() {
 			window.removeEventListener('mousemove', onMouseMove);
 			window.removeEventListener('mouseup', onMouseUp);
 		};
-	}, [isResizing, setWidth]);
+	}, [isResizing, setPersistedWidth]);
 
 	return { width, isResizing, startResizing };
 }

--- a/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/index.tsx
@@ -1,11 +1,14 @@
 import type { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
 import type { FileEntry } from '@/features/instance/applications/context/fileEntry';
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useRenameFiles } from '@/features/instance/applications/hooks/useRenameFiles';
+import { confirmOverwrite } from '@/features/instance/applications/modals/confirmOverwrite';
 import { useGlobalShortcutKeys } from '@/features/instance/applications/shortcuts';
+import { useListener } from '@/lib/events/listener';
 import { extractFileNameFromPath } from '@/lib/string/paths/extractFileNameFromPath';
 import { joinPath } from '@/lib/string/paths/joinPath';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ControlledTreeEnvironment, InteractionMode, Tree, TreeItem } from 'react-complex-tree';
 import './file-explorer-modern.css';
 import { DraggingPosition } from 'react-complex-tree/src/types';
@@ -28,10 +31,35 @@ export function ApplicationsSidebar() {
 		setExpandedItems,
 		selectedItems,
 		setSelectedItems,
+		entryExists,
 	} = useEditorView();
 	const { items, rootId } = useMemo(() => buildItems(rootEntries), [rootEntries]);
 
 	useGlobalShortcutKeys();
+
+	// Move DOM focus into the tree after a modal closes (e.g. adding a directory, or
+	// deleting an entry and falling back to its parent). The row to land on is whatever
+	// the modal set as `focusedItem`; deferred a frame so it runs after the tree re-renders
+	// from the reload. Falls back to the tree container if the specific row isn't mounted.
+	const treeScrollRef = useRef<HTMLDivElement>(null);
+	useListener(
+		'FocusFileTree',
+		() => {
+			requestAnimationFrame(() => {
+				const container = treeScrollRef.current;
+				if (!container) {
+					return;
+				}
+				const row = focusedItem
+					? container.querySelector<HTMLElement>(`[data-rct-item-id="${CSS.escape(String(focusedItem))}"]`)
+					: null;
+				const target = row ?? container.querySelector<HTMLElement>('[role="tree"]');
+				target?.focus();
+				row?.scrollIntoView({ block: 'nearest' });
+			});
+		},
+		[focusedItem],
+	);
 
 	useEffect(function setOpenedEntryFromFocusedItem() {
 		if (openedEntry?.path !== focusedItem && focusedItem) {
@@ -45,31 +73,48 @@ export function ApplicationsSidebar() {
 
 	const renameFiles = useRenameFiles();
 	const onInternalDrop = useCallback(
-		(droppedItems: TreeItem<FileEntry | DirectoryEntry | undefined>[], target: DraggingPosition) => {
+		async (droppedItems: TreeItem<FileEntry | DirectoryEntry | undefined>[], target: DraggingPosition) => {
 			switch (target.targetType) {
-				case 'item':
+				case 'item': {
 					if (items[target.targetItem]?.data?.package) {
 						toast.error('Read-Only Imported Application', {
 							description: 'To make changes to an application, please click the "Redeploy" button and update the'
 								+ ' reference.',
 						});
-					} else {
-						return renameFiles(droppedItems.map(item => ({
-							from: item.index as string,
-							to: joinPath(target.targetItem as string, extractFileNameFromPath(item.index as string)),
-						})));
+						return;
 					}
-					break;
+					const changes = droppedItems.map(item => ({
+						from: item.index as string,
+						to: joinPath(target.targetItem as string, extractFileNameFromPath(item.index as string)),
+					}));
+					// Confirm before clobbering anything already at a destination path (files are
+					// overwritten, directories merged) instead of silently failing the move.
+					const collidingFiles: string[] = [];
+					const collidingDirectories: string[] = [];
+					for (const change of changes) {
+						if (change.from !== change.to && entryExists(change.to)) {
+							const existing = items[change.to]?.data;
+							(existing && isDirectory(existing) ? collidingDirectories : collidingFiles).push(change.to);
+						}
+					}
+					if (collidingFiles.length || collidingDirectories.length) {
+						const confirmed = await confirmOverwrite({ files: collidingFiles, directories: collidingDirectories });
+						if (!confirmed) {
+							return;
+						}
+					}
+					return renameFiles(changes);
+				}
 				default:
 					toast.error(`${target.targetType} drop not yet supported`);
 					break;
 			}
 		},
-		[items, renameFiles],
+		[items, renameFiles, entryExists],
 	);
 
 	return (
-		<div className="app-tree-scroll h-full overflow-auto pr-1.5 pb-18">
+		<div ref={treeScrollRef} className="app-tree-scroll h-full overflow-auto pr-1.5 pb-18">
 			<FileTreeContextMenu items={items}>
 				<ControlledTreeEnvironment
 					canDragAndDrop={true}

--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -138,6 +138,16 @@ export function TextEditorView() {
 		[mounted],
 	);
 
+	// Return focus to the editor after a file-tree modal closes (e.g. creating or renaming
+	// a file). Deferred a frame so it wins the focus race against the closing dialog.
+	useListener(
+		'FocusEditor',
+		() => {
+			requestAnimationFrame(() => mounted?.[0]?.focus());
+		},
+		[mounted],
+	);
+
 	// Publish each surfaced command's keyboard-shortcut label so the menus can
 	// show it. Done once the editor (and its keybinding registry) is available.
 	useEffect(() => {

--- a/src/features/instance/applications/index.tsx
+++ b/src/features/instance/applications/index.tsx
@@ -4,6 +4,7 @@ import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
 import { Navigate, useParams } from '@tanstack/react-router';
 import { cx } from 'class-variance-authority';
 import { ApplicationsSidebar } from './components/ApplicationsSidebar';
+import { SidebarResizeHandle, useResizableSidebar } from './components/ApplicationsSidebar/SidebarResizeHandle';
 import { ContentActions } from './components/ContentActions';
 import { ContentViewer } from './components/ContentViewer';
 import { EditorViewProvider } from './context/EditorViewProvider';
@@ -11,6 +12,7 @@ import { AddDirectoryOrFileModal } from './modals/AddDirectoryOrFileModal';
 import { DeleteDirectoryOrFileModal } from './modals/DeleteDirectoryOrFileModal';
 import { DownloadApplicationModal } from './modals/DownloadApplicationModal';
 import { NewTableModal } from './modals/NewTableModal';
+import { OverwriteConfirmModal } from './modals/OverwriteConfirmModal';
 import { RedeployApplicationModal } from './modals/RedeployApplicationModal';
 import { RenameFileModal } from './modals/RenameFileModal';
 
@@ -18,17 +20,23 @@ export function ApplicationsEditor() {
 	const canManage = useInstanceManagePermission();
 	const params = useParams({ strict: false });
 	const { toggle, toggled } = useSessionToggler('ApplicationsSidebarOpened', true);
+	const { width, isResizing, startResizing } = useResizableSidebar();
 
 	if (!canManage) {
 		return <Navigate to={buildAbsoluteLinkToPage(params, 'databases')} />;
 	}
 
+	// Drive the tray width through a CSS variable so the existing responsive/collapse
+	// classes (which can't be expressed inline) keep working while the width is dynamic.
+	const sidebarWidthVar = { '--app-sidebar-width': `${width}px` } as React.CSSProperties;
+
 	return (
 		<EditorViewProvider>
 			<aside
 				id="file-explorer-sidebar"
+				style={sidebarWidthVar}
 				className={cx(
-					'pt-[calc(--spacing(32))] w-56 fixed top-0 left-0 bottom-0 z-30',
+					'pt-[calc(--spacing(32))] w-[var(--app-sidebar-width)] fixed top-0 left-0 bottom-0 z-30',
 					'bg-violet-50 border-r border-violet-200 shadow shadow-black/10',
 					'dark:bg-grey-700 dark:border-grey-600 dark:shadow-black',
 					'transition-transform -translate-x-full',
@@ -37,16 +45,18 @@ export function ApplicationsEditor() {
 				aria-label="Sidebar"
 			>
 				<ApplicationsSidebar />
+				<SidebarResizeHandle isResizing={isResizing} onMouseDown={startResizing} />
 			</aside>
 
 			<div
+				style={sidebarWidthVar}
 				className={cx(
 					'applications-content',
 					'overflow-y-auto overflow-x-hidden',
 					'fixed top-32 right-0 bottom-0 left-0',
-					'transition-[left]',
-					'md:left-56',
-					toggled && 'sm:left-56',
+					!isResizing && 'transition-[left]',
+					'md:left-[var(--app-sidebar-width)]',
+					toggled && 'sm:left-[var(--app-sidebar-width)]',
 				)}
 			>
 				<ContentViewer />
@@ -59,6 +69,7 @@ export function ApplicationsEditor() {
 			<DownloadApplicationModal />
 			<RedeployApplicationModal />
 			<RenameFileModal />
+			<OverwriteConfirmModal />
 		</EditorViewProvider>
 	);
 }

--- a/src/features/instance/applications/lib/clampSidebarWidth.test.ts
+++ b/src/features/instance/applications/lib/clampSidebarWidth.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { clampSidebarWidth, MIN_SIDEBAR_WIDTH } from './clampSidebarWidth';
+
+describe('clampSidebarWidth', () => {
+	it('floors at the minimum width', () => {
+		expect(clampSidebarWidth(50, 1000)).toBe(MIN_SIDEBAR_WIDTH);
+		expect(clampSidebarWidth(0, 1000)).toBe(MIN_SIDEBAR_WIDTH);
+		expect(clampSidebarWidth(-100, 1000)).toBe(MIN_SIDEBAR_WIDTH);
+	});
+
+	it('caps at half the viewport', () => {
+		expect(clampSidebarWidth(900, 1000)).toBe(500);
+		expect(clampSidebarWidth(10_000, 1600)).toBe(800);
+	});
+
+	it('leaves an in-range width untouched', () => {
+		expect(clampSidebarWidth(300, 1000)).toBe(300);
+	});
+
+	it('keeps the minimum usable even on a narrow viewport (min wins over the half-cap)', () => {
+		// half of 200 is 100, below the minimum — the minimum takes precedence.
+		expect(clampSidebarWidth(100, 200)).toBe(MIN_SIDEBAR_WIDTH);
+		expect(clampSidebarWidth(400, 200)).toBe(MIN_SIDEBAR_WIDTH);
+	});
+
+	it('rounds to whole pixels', () => {
+		expect(clampSidebarWidth(300.6, 1000)).toBe(301);
+	});
+});

--- a/src/features/instance/applications/lib/clampSidebarWidth.ts
+++ b/src/features/instance/applications/lib/clampSidebarWidth.ts
@@ -1,0 +1,13 @@
+/** Narrowest the file tray may be dragged — below this the tree labels are unusable. */
+export const MIN_SIDEBAR_WIDTH = 180;
+
+/**
+ * Clamp a desired sidebar width to a usable range: never narrower than
+ * {@link MIN_SIDEBAR_WIDTH}, and never wider than half the viewport (so the editor
+ * always keeps the larger share of the screen). `viewportWidth` is passed in rather
+ * than read from `window` so this stays a pure, testable function.
+ */
+export function clampSidebarWidth(width: number, viewportWidth: number): number {
+	const max = Math.max(MIN_SIDEBAR_WIDTH, Math.floor(viewportWidth / 2));
+	return Math.round(Math.min(Math.max(width, MIN_SIDEBAR_WIDTH), max));
+}

--- a/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
@@ -21,13 +21,12 @@ import { useSetComponentFile } from '@/integrations/api/instance/applications/se
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
-import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 import z from 'zod';
+import { confirmOverwrite } from './confirmOverwrite';
 
 export function AddDirectoryOrFileModal() {
 	const { value: type, trigger } = useWatchedValue('ShowAddDirectoryOrFileModalType', false);
@@ -65,7 +64,7 @@ export function AddDirectoryOrFileModal() {
 		},
 	});
 
-	const submitForm = useCallback((data: z.infer<typeof NewFileFolderSchema>) => {
+	const submitForm = useCallback(async (data: z.infer<typeof NewFileFolderSchema>) => {
 		if (!openedEntry || !type) {
 			return;
 		}
@@ -76,11 +75,17 @@ export function AddDirectoryOrFileModal() {
 				: splitPath.slice(1, -1)
 		).join('/');
 		const file = filePath ? `${filePath}/${data.name}` : data.name;
-		if (entryExists(openedEntry.project + '/' + file)) {
-			toast.error(`${capitalizeWords(type)} already exists!`, {
-				description: file,
+		const fullPath = `${openedEntry.project}/${file}`;
+		// A name collision is no longer a hard error: let the user confirm overwriting the
+		// existing file (or merging into the existing directory) instead.
+		if (entryExists(fullPath)) {
+			const confirmed = await confirmOverwrite({
+				files: type === 'file' ? [fullPath] : [],
+				directories: type === 'directory' ? [fullPath] : [],
 			});
-			return;
+			if (!confirmed) {
+				return;
+			}
 		}
 		addFolderFile(
 			{
@@ -99,6 +104,11 @@ export function AddDirectoryOrFileModal() {
 					setSelectedItems([treeId]);
 					if (type === 'directory') {
 						setExpandedItems(expandedItems => [...expandedItems, treeId]);
+						// Land keyboard focus on the new directory in the tree.
+						setWatchedValue('FocusFileTree', true);
+					} else {
+						// Land keyboard focus in the editor, now showing the new file.
+						setWatchedValue('FocusEditor', true);
 					}
 				},
 			},

--- a/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
@@ -82,6 +82,8 @@ export function DeleteDirectoryOrFileModal() {
 			setFocusedItem(itemToFocus || undefined);
 			setSelectedItems(itemToFocus ? [itemToFocus] : []);
 			void reloadRootEntries();
+			// Land keyboard focus on the parent directory of what was just deleted.
+			setWatchedValue('FocusFileTree', true);
 		}
 	}, [action, closeModal, instanceParams, reloadRootEntries, selectedItems, setFocusedItem, setSelectedItems]);
 

--- a/src/features/instance/applications/modals/OverwriteConfirmModal.tsx
+++ b/src/features/instance/applications/modals/OverwriteConfirmModal.tsx
@@ -1,0 +1,90 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alertDialog';
+import { buttonVariants } from '@/components/ui/buttonVariants';
+import { pluralize } from '@/lib/pluralize';
+import { useCallback, useEffect, useState } from 'react';
+import { OverwriteRequest, registerOverwriteConfirmHandler } from './confirmOverwrite';
+
+interface Pending {
+	request: OverwriteRequest;
+	resolve: (confirmed: boolean) => void;
+}
+
+/** Builds the action-button label from what's colliding: overwrite files, merge dirs, or both. */
+function actionLabel({ files, directories }: OverwriteRequest): string {
+	const parts: string[] = [];
+	if (files.length) {
+		parts.push(`Overwrite ${pluralize(files.length, 'file', 'files')}`);
+	}
+	if (directories.length) {
+		parts.push(`Merge ${pluralize(directories.length, 'directory', 'directories')}`);
+	}
+	return parts.join(' & ') || 'Overwrite';
+}
+
+/**
+ * A single mounted confirmation dialog driven imperatively via {@link confirmOverwrite}. Any
+ * async flow (drag-drop upload, the New File/Directory modal, internal moves/renames) can
+ * `await` a yes/no answer before replacing existing files or merging into existing directories.
+ */
+export function OverwriteConfirmModal() {
+	const [pending, setPending] = useState<Pending | null>(null);
+
+	useEffect(() => {
+		registerOverwriteConfirmHandler((request, resolve) => {
+			// If a prior request is somehow still open, decline it before showing the new one.
+			setPending(prev => {
+				prev?.resolve(false);
+				return { request, resolve };
+			});
+		});
+		return () => registerOverwriteConfirmHandler(undefined);
+	}, []);
+
+	const settle = useCallback((confirmed: boolean) => {
+		setPending(prev => {
+			prev?.resolve(confirmed);
+			return null;
+		});
+	}, []);
+
+	const request = pending?.request;
+	const collisions = request ? [...request.directories, ...request.files] : [];
+
+	return (
+		<AlertDialog open={!!pending} onOpenChange={open => !open && settle(false)}>
+			<AlertDialogContent className="text-popover-foreground">
+				<AlertDialogHeader>
+					<AlertDialogTitle>Overwrite existing items?</AlertDialogTitle>
+					<AlertDialogDescription>
+						{request?.directories.length
+							? 'Some of these already exist. Files will be overwritten and directories merged.'
+							: 'Some of these files already exist and will be overwritten.'}
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				{collisions.length > 0 && (
+					<div className="max-h-48 overflow-y-auto rounded-md border border-border bg-muted/40 p-2 text-sm whitespace-pre">
+						{collisions.slice(0, 50).join('\n')}
+						{collisions.length > 50 ? `\n…and ${collisions.length - 50} more` : ''}
+					</div>
+				)}
+
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={() => settle(false)}>Cancel</AlertDialogCancel>
+					<AlertDialogAction className={buttonVariants({ variant: 'destructive' })} onClick={() => settle(true)}>
+						{request ? actionLabel(request) : 'Overwrite'}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/src/features/instance/applications/modals/OverwriteConfirmModal.tsx
+++ b/src/features/instance/applications/modals/OverwriteConfirmModal.tsx
@@ -72,7 +72,7 @@ export function OverwriteConfirmModal() {
 				</AlertDialogHeader>
 
 				{collisions.length > 0 && (
-					<div className="max-h-48 overflow-y-auto rounded-md border border-border bg-muted/40 p-2 text-sm whitespace-pre">
+					<div className="max-h-48 overflow-y-auto rounded-md border border-border bg-muted/40 p-2 text-sm whitespace-pre-wrap break-all">
 						{collisions.slice(0, 50).join('\n')}
 						{collisions.length > 50 ? `\n…and ${collisions.length - 50} more` : ''}
 					</div>

--- a/src/features/instance/applications/modals/RenameFileModal.tsx
+++ b/src/features/instance/applications/modals/RenameFileModal.tsx
@@ -31,6 +31,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import z from 'zod';
+import { confirmOverwrite } from './confirmOverwrite';
 
 /** Every file at or beneath an entry (directories are implicit in file paths). */
 function collectFiles(entry: DirectoryEntry | FileEntry): FileEntry[] {
@@ -78,16 +79,21 @@ export function RenameFileModal() {
 			return;
 		}
 		const to = renameFileInPath(openedEntry.path, data.name);
-		if (entryExists(to)) {
-			toast.error(`${isDirectory(openedEntry) ? 'Directory' : 'File'} already exists!`, {
-				description: to,
-			});
-			return;
-		}
-
 		// A directory can't be moved in a single file operation, so rebase every file
 		// beneath it onto the new path — the API recreates the directories implicitly.
 		const isDir = isDirectory(openedEntry);
+		// A name collision is no longer a hard error: let the user confirm overwriting the
+		// existing file (or merging into the existing directory) instead.
+		if (entryExists(to)) {
+			const confirmed = await confirmOverwrite({
+				files: isDir ? [] : [to],
+				directories: isDir ? [to] : [],
+			});
+			if (!confirmed) {
+				return;
+			}
+		}
+
 		const changes = isDir
 			? collectFiles(openedEntry).map(file => ({
 				from: file.path,
@@ -127,6 +133,8 @@ export function RenameFileModal() {
 		if (renamed) {
 			closeModal();
 			form.reset();
+			// Restore focus: a renamed directory stays in the tree; a renamed file is back in the editor.
+			setWatchedValue(isDir ? 'FocusFileTree' : 'FocusEditor', true);
 		}
 	}, [closeModal, entryExists, form, instanceParams, openedEntry, reloadRootEntries, renameFiles, setIsPending]);
 

--- a/src/features/instance/applications/modals/confirmOverwrite.test.ts
+++ b/src/features/instance/applications/modals/confirmOverwrite.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { confirmOverwrite, OverwriteRequest, registerOverwriteConfirmHandler } from './confirmOverwrite';
+
+afterEach(() => registerOverwriteConfirmHandler(undefined));
+
+describe('confirmOverwrite', () => {
+	it('auto-confirms when there are no collisions (nothing to ask about)', async () => {
+		// No handler registered, yet an empty request resolves true so the caller proceeds.
+		await expect(confirmOverwrite({ files: [], directories: [] })).resolves.toBe(true);
+	});
+
+	it('fails safe to false when collisions exist but no modal is mounted', async () => {
+		await expect(confirmOverwrite({ files: ['proj/a.js'], directories: [] })).resolves.toBe(false);
+	});
+
+	it('routes a real request to the handler and resolves with the user choice', async () => {
+		const seen: OverwriteRequest[] = [];
+		registerOverwriteConfirmHandler((request, resolve) => {
+			seen.push(request);
+			resolve(true);
+		});
+
+		await expect(confirmOverwrite({ files: ['proj/a.js'], directories: ['proj/dir'] })).resolves.toBe(true);
+		expect(seen).toEqual([{ files: ['proj/a.js'], directories: ['proj/dir'] }]);
+	});
+
+	it('resolves false when the handler declines', async () => {
+		registerOverwriteConfirmHandler((_request, resolve) => resolve(false));
+		await expect(confirmOverwrite({ files: ['proj/a.js'], directories: [] })).resolves.toBe(false);
+	});
+
+	it('does not invoke the handler for an empty request', async () => {
+		const handler = vi.fn();
+		registerOverwriteConfirmHandler(handler);
+		await confirmOverwrite({ files: [], directories: [] });
+		expect(handler).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/instance/applications/modals/confirmOverwrite.ts
+++ b/src/features/instance/applications/modals/confirmOverwrite.ts
@@ -1,0 +1,35 @@
+/** Paths that already exist at the destination of a create / upload / move. */
+export interface OverwriteRequest {
+	/** Existing files that would be replaced. */
+	files: string[];
+	/** Existing directories that would be merged into. */
+	directories: string[];
+}
+
+type Handler = (request: OverwriteRequest, resolve: (confirmed: boolean) => void) => void;
+
+let handler: Handler | undefined;
+
+/**
+ * Registered by the mounted {@link OverwriteConfirmModal}. Kept out of the React tree so any
+ * async flow (upload loop, rename, create) can `await confirmOverwrite(...)` imperatively.
+ */
+export function registerOverwriteConfirmHandler(next: Handler | undefined): void {
+	handler = next;
+}
+
+/**
+ * Ask the user to confirm overwriting files / merging directories. Resolves `true` to
+ * proceed, `false` to skip. If no modal is mounted (shouldn't happen in the editor), it
+ * fails safe by resolving `false` so nothing is silently overwritten.
+ */
+export function confirmOverwrite(request: OverwriteRequest): Promise<boolean> {
+	const hasCollisions = request.files.length > 0 || request.directories.length > 0;
+	if (!hasCollisions) {
+		return Promise.resolve(true); // nothing to confirm — proceed.
+	}
+	if (!handler) {
+		return Promise.resolve(false); // no modal mounted — fail safe, don't overwrite.
+	}
+	return new Promise<boolean>(resolve => handler!(request, resolve));
+}

--- a/src/features/organization/settings/index.tsx
+++ b/src/features/organization/settings/index.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { apiClient } from '@/config/apiClient';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { useCloudAuth } from '@/hooks/useAuth';
+import { writeToClipboard } from '@/hooks/useCopyToClipboard';
 import { useOrganizationPermissions } from '@/hooks/usePermissions';
 import { SchemaOrganization } from '@/integrations/api/api.gen';
 import { OAuthConfig } from '@/integrations/api/api.patch';
@@ -135,14 +136,16 @@ export function OrgSettingsIndex() {
 	const getCallbackUrl = (oauthConfigId: string) =>
 		`${import.meta.env.VITE_CENTRAL_MANAGER_API_URL}/oauth/${oauthConfigId}/callback`;
 
-	const copySignInUrl = async (url: string) => {
-		await navigator.clipboard.writeText(url);
-		toast.success('Sign-in URL copied.');
+	const copySignInUrl = (url: string) => {
+		if (writeToClipboard(url)) {
+			toast.success('Sign-in URL copied.');
+		}
 	};
 
-	const copyCallbackUrl = async (url: string) => {
-		await navigator.clipboard.writeText(url);
-		toast.success('Redirect URI copied.');
+	const copyCallbackUrl = (url: string) => {
+		if (writeToClipboard(url)) {
+			toast.success('Redirect URI copied.');
+		}
 	};
 
 	if (!canUpdate) {

--- a/src/features/organization/settings/index.tsx
+++ b/src/features/organization/settings/index.tsx
@@ -136,14 +136,14 @@ export function OrgSettingsIndex() {
 	const getCallbackUrl = (oauthConfigId: string) =>
 		`${import.meta.env.VITE_CENTRAL_MANAGER_API_URL}/oauth/${oauthConfigId}/callback`;
 
-	const copySignInUrl = (url: string) => {
-		if (writeToClipboard(url)) {
+	const copySignInUrl = async (url: string) => {
+		if (await writeToClipboard(url)) {
 			toast.success('Sign-in URL copied.');
 		}
 	};
 
-	const copyCallbackUrl = (url: string) => {
-		if (writeToClipboard(url)) {
+	const copyCallbackUrl = async (url: string) => {
+		if (await writeToClipboard(url)) {
 			toast.success('Redirect URI copied.');
 		}
 	};

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -6,23 +6,31 @@ import { toast } from 'sonner';
  * The single guarded entry point for writing to the clipboard. `navigator.clipboard` is
  * undefined in non-secure contexts (HTTP on a non-localhost host) and old browsers, where
  * touching `.writeText` would throw — so every clipboard write in the app funnels through
- * here. Returns `false` (after surfacing an error toast) when the API is unavailable, so
- * callers can skip their own success toast.
+ * here. `writeText` is also async and can reject (e.g. permission denied, document not
+ * focused), so we await it and only resolve `true` on a confirmed success — surfacing an
+ * error toast and resolving `false` otherwise, so callers can skip their own success toast.
  */
-export function writeToClipboard(text: string): boolean {
+export async function writeToClipboard(text: string): Promise<boolean> {
 	if (!navigator.clipboard) {
 		toast.error('Clipboard access is not available in this environment.');
 		return false;
 	}
-	void navigator.clipboard.writeText(text);
-	return true;
+	try {
+		await navigator.clipboard.writeText(text);
+		return true;
+	} catch {
+		toast.error('Failed to copy to clipboard.');
+		return false;
+	}
 }
 
-/** Copy text and show the standard confirmation toast. */
+/** Copy text and show the standard confirmation toast only once the write actually succeeds. */
 function copyWithToast(text: string): void {
-	if (writeToClipboard(text)) {
-		toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
-	}
+	void writeToClipboard(text).then(succeeded => {
+		if (succeeded) {
+			toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
+		}
+	});
 }
 
 /** One copy-with-toast callback per fixed text — e.g. a row of static values. */

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -2,17 +2,40 @@ import { ClipboardCheckIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { toast } from 'sonner';
 
+/**
+ * The single guarded entry point for writing to the clipboard. `navigator.clipboard` is
+ * undefined in non-secure contexts (HTTP on a non-localhost host) and old browsers, where
+ * touching `.writeText` would throw — so every clipboard write in the app funnels through
+ * here. Returns `false` (after surfacing an error toast) when the API is unavailable, so
+ * callers can skip their own success toast.
+ */
+export function writeToClipboard(text: string): boolean {
+	if (!navigator.clipboard) {
+		toast.error('Clipboard access is not available in this environment.');
+		return false;
+	}
+	void navigator.clipboard.writeText(text);
+	return true;
+}
+
+/** Copy text and show the standard confirmation toast. */
+function copyWithToast(text: string): void {
+	if (writeToClipboard(text)) {
+		toast.info('Copied to clipboard!', { icon: <ClipboardCheckIcon />, duration: 1000 });
+	}
+}
+
+/** One copy-with-toast callback per fixed text — e.g. a row of static values. */
 export function useCopyToClipboard(...texts: string[]): Array<() => void> {
 	return useMemo(() => {
-		return texts.map(text => (() => {
-			void navigator.clipboard.writeText(text);
-			toast.info('Copied to clipboard!', {
-				icon: <ClipboardCheckIcon />,
-				duration: 1000,
-			});
-		}));
+		return texts.map(text => () => copyWithToast(text));
 		// We can override the linting here because we know we're providing an accurate list of dependencies that will only
 		// change and trigger a re-render of the memo when the text contents change.
 		// eslint-disable-next-line react-hooks/use-memo,react-hooks/exhaustive-deps
 	}, texts);
+}
+
+/** A single stable callback that copies whatever text you pass at call time — e.g. a right-clicked entry. */
+export function useCopyTextToClipboard(): (text: string) => void {
+	return copyWithToast;
 }

--- a/src/lib/storage/localStorageKeys.ts
+++ b/src/lib/storage/localStorageKeys.ts
@@ -1,6 +1,7 @@
 export const enum LocalStorageKeys {
 	'ApplicationChatPosition' = 'ApplicationChatPosition',
 	'ApplicationChatWidth' = 'ApplicationChatWidth',
+	'ApplicationsSidebarWidth' = 'ApplicationsSidebarWidth',
 	'ChatAlwaysApprovedTools' = 'ChatAlwaysApprovedTools',
 	'LastUsedSignInMethod' = 'LastUsedSignInMethod',
 	'LogsOrderReversed' = 'LogsOrderReversed',

--- a/src/lib/storage/watchedValueKeys.ts
+++ b/src/lib/storage/watchedValueKeys.ts
@@ -16,6 +16,8 @@ export interface WatchedValuesTypeMap {
 	ShowDeleteTable: boolean;
 	'Session:{key}': unknown;
 	ReloadApplicationRootEntries: true;
+	FocusEditor: true;
+	FocusFileTree: true;
 }
 
 export type WatchedValueKeys = keyof WatchedValuesTypeMap;


### PR DESCRIPTION
Implements the remaining enhancements from #1321 for the application code editor.

## Changes

### Resizable left tray
- The file tray is now drag-resizable via a handle on its right edge; the width persists to local storage (`ApplicationsSidebarWidth`).
- Width is driven through a `--app-sidebar-width` CSS variable so the existing responsive/collapse behavior is preserved. Mirrors the existing resizable chat panel pattern.

### Copy Name / Copy Path
- Two new context-menu actions, always available regardless of permissions. Copy Path copies the full project-prefixed path.

### Restore focus after a modal closes
- New `FocusEditor` / `FocusFileTree` event-bus signals. After a tree modal succeeds: new/renamed **file** → editor; new/renamed **directory** and **delete** (parent dir) → file tree. Keyboard shortcuts inherit this automatically.

### Confirm overwrite / merge (instead of rejecting)
- Name collisions previously failed with a toast. Now a shared promise-based confirm dialog (`confirmOverwrite` + `OverwriteConfirmModal`) prompts to overwrite files / merge directories across **all three** flows: New File/Directory modal, drag-and-drop upload, and internal move/rename.

## Testing
- `tsc -b`, `oxlint`, `dprint` clean.
- Full suite green (990 tests / 156 files), incl. 10 new unit tests for the width-clamp and overwrite-confirm logic.
- Manually verified in the running app: tray resize + persistence, Copy Path writes the clipboard, context-menu items, tree-row focusability, and the overwrite-confirm dialog appearing on a colliding create (cancelled — no data mutated). No console errors.

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
