### PR TITLE
chore(preview): add generic "studio (worktree)" launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,7 +2,7 @@
 	"version": "0.0.1",
 	"configurations": [
 		{
-			"name": "studio",
+			"name": "studio (main branch)",
 			"runtimeExecutable": "pnpm",
 			"runtimeArgs": ["run", "dev"],
 			"port": 5173

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
 			"runtimeExecutable": "pnpm",
 			"runtimeArgs": ["run", "dev"],
 			"port": 5173
+		},
+		{
+			"name": "studio (worktree)",
+			"runtimeExecutable": "bash",
+			"runtimeArgs": [".claude/preview-worktree.sh"],
+			"port": 5173
 		}
 	]
 }

--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -9,8 +9,7 @@
 # Solution: this script reads the target directory from `.claude/preview-cwd` (a path relative
 # to the repo root, gitignored — write it before starting the server), falls back to the main
 # checkout when that file is absent, and starts the dev server there. To keep a fresh worktree
-# zero-setup it symlinks node_modules from the main checkout and copies .env.local if missing
-# (mirroring the copy-env-local.sh SessionStart hook).
+# zero-setup it symlinks node_modules and .env.local from the main checkout when missing.
 #
 # Usage: echo .claude/worktrees/<name> > .claude/preview-cwd  # then preview_start "studio (worktree)"
 set -e
@@ -26,9 +25,9 @@ if [ ! -e node_modules ]; then
 	ln -s "$root/node_modules" node_modules
 	echo "[preview] Symlinked node_modules from the main checkout." >&2
 fi
-if [ ! -f .env.local ] && [ -f "$root/.env.local" ]; then
-	cp "$root/.env.local" .env.local
-	echo "[preview] Copied .env.local from the main checkout." >&2
+if [ ! -e .env.local ] && [ -f "$root/.env.local" ]; then
+	ln -s "$root/.env.local" .env.local
+	echo "[preview] Symlinked .env.local from the main checkout." >&2
 fi
 
 echo "[preview] Serving $(pwd) on port 5173" >&2

--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -17,15 +17,28 @@ set -e
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 cd "$root"
 
-target="$(cat .claude/preview-cwd 2>/dev/null || echo .)"
-cd "$target"
+# Read the target worktree from .claude/preview-cwd (repo-relative). `read` trims surrounding
+# whitespace and tolerates a missing trailing newline; fall back to the main checkout when the
+# file is absent or empty.
+target=""
+if [ -f .claude/preview-cwd ]; then
+	read -r target < .claude/preview-cwd || :
+fi
+target="${target:-.}"
+
+if ! cd "$target" 2>/dev/null; then
+	echo "[preview] Error: target directory '$target' (from .claude/preview-cwd) is missing or inaccessible." >&2
+	exit 1
+fi
 
 # Zero-setup provisioning (only ever creates what's missing; never touches the main checkout).
-if [ ! -e node_modules ]; then
+# Guard with both -e and -L so an existing real dir/file AND a dangling symlink are left alone
+# (a broken symlink passes -e but `ln -s` over it would fail with "File exists").
+if [ ! -e node_modules ] && [ ! -L node_modules ]; then
 	ln -s "$root/node_modules" node_modules
 	echo "[preview] Symlinked node_modules from the main checkout." >&2
 fi
-if [ ! -e .env.local ] && [ -f "$root/.env.local" ]; then
+if [ ! -e .env.local ] && [ ! -L .env.local ] && [ -f "$root/.env.local" ]; then
 	ln -s "$root/.env.local" .env.local
 	echo "[preview] Symlinked .env.local from the main checkout." >&2
 fi

--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Launch helper for the "studio (worktree)" preview config.
+#
+# Problem: `preview_start` reads .claude/launch.json from the *main* checkout (the session
+# cwd) and takes no arguments, so it always serves the main checkout. When you're working in
+# a linked worktree you want the preview to serve THAT worktree's code — and on the same port
+# (5173) so the backend's auth/origin carries over.
+#
+# Solution: this script reads the target directory from `.claude/preview-cwd` (a path relative
+# to the repo root, gitignored — write it before starting the server), falls back to the main
+# checkout when that file is absent, and starts the dev server there. To keep a fresh worktree
+# zero-setup it symlinks node_modules from the main checkout and copies .env.local if missing
+# (mirroring the copy-env-local.sh SessionStart hook).
+#
+# Usage: echo .claude/worktrees/<name> > .claude/preview-cwd  # then preview_start "studio (worktree)"
+set -e
+
+root="${CLAUDE_PROJECT_DIR:-$PWD}"
+cd "$root"
+
+target="$(cat .claude/preview-cwd 2>/dev/null || echo .)"
+cd "$target"
+
+# Zero-setup provisioning (only ever creates what's missing; never touches the main checkout).
+if [ ! -e node_modules ]; then
+	ln -s "$root/node_modules" node_modules
+	echo "[preview] Symlinked node_modules from the main checkout." >&2
+fi
+if [ ! -f .env.local ] && [ -f "$root/.env.local" ]; then
+	cp "$root/.env.local" .env.local
+	echo "[preview] Copied .env.local from the main checkout." >&2
+fi
+
+echo "[preview] Serving $(pwd) on port 5173" >&2
+exec pnpm run dev

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ CLAUDE.local.md
 .vscode/*
 !.vscode/extensions.json
 .claude/worktrees
+.claude/preview-cwd
 .idea
 .DS_Store
 *.suo


### PR DESCRIPTION
## Summary

Adds a reusable Claude-preview launch config so a preview started from the **main checkout** can serve a **linked worktree's** code — on the same port (5173) so the backend's auth/origin carries over.

### Why

`preview_start` reads `.claude/launch.json` from the main checkout (the session cwd) and **takes no arguments**, so the existing config always serves the main checkout. When you're working in a worktree (e.g. `.claude/worktrees/<name>`), the running preview shows `stage`, not your branch.

### How

New `studio (worktree)` config backed by `.claude/preview-worktree.sh`:

- Reads the target dir from **`.claude/preview-cwd`** — a repo-relative path you write before starting (this is the "argument" channel, since `preview_start` has none). Gitignored.
- Falls back to the main checkout when the pointer file is absent.
- **Symlinks** `node_modules` and `.env.local` from the main checkout when missing, so a fresh worktree is zero-setup (complements the existing `copy-env-local.sh` SessionStart hook).

Also renames the existing `studio` config to **`studio (main branch)`** to disambiguate it from `studio (worktree)`.

### Why both configs stay on port 5173

studio's auth lives in `localStorage` keyed to the `localhost:5173` origin and does **not** carry to a different `localhost:<port>` — a unique port would land on the sign-in wall, unable to reach real cluster data. (And `preview_start` only attaches to the fixed `port` declared here, so an auto/dynamic port wouldn't be discoverable anyway.) Both configs therefore share 5173 in a take-over model: one preview at a time.

### Usage

```sh
echo .claude/worktrees/my-feature > .claude/preview-cwd
# then: preview_start "studio (worktree)"
```

### Verified

Exercised end-to-end via `preview_start "studio (worktree)"` pointed at a feature worktree: 5173 served the worktree's code (branch-only markers present) and the session stayed signed in on the same origin. Script dry-run + a clean-room test confirmed the pointer/fallback resolution and that both `node_modules` and `.env.local` symlinks are created for a fresh worktree.

> Note: the `node_modules` symlink assumes the worktree's branch hasn't changed dependencies (true for typical feature branches). Swap the `ln -s` for `pnpm install` in the script if a branch diverges on deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)