### PR TITLE
feat(ssh): guide SSH key usage when adding and listing (#1322)

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -11,7 +11,7 @@ export function Textarea({ className, ...props }: React.ComponentProps<'textarea
         dark:aria-invalid:outline-destructive dark:aria-invalid:ring-destructive/50 ring-ring/10
         dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 aria-invalid:outline-destructive/60
         aria-invalid:ring-destructive/20 aria-invalid:border-destructive/60 dark:aria-invalid:border-destructive
-        flex w-full min-w-0 rounded-md border bg-white text-foreground dark:bg-grey-700 dark:text-white
+        flex w-full min-w-0 rounded-md border bg-white text-foreground dark:bg-grey-700 dark:text-white px-3 py-2 text-base
         file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium
         focus-visible:ring-1 focus-visible:outline-none focus-visible:ring-purple  disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50
         aria-invalid:focus-visible:ring-[1px] aria-invalid:focus-visible:outline-none md:text-sm dark:aria-invalid:focus-visible:ring-1`,

--- a/src/features/instance/config/sshKeys/constants/tableDefinition.ts
+++ b/src/features/instance/config/sshKeys/constants/tableDefinition.ts
@@ -7,4 +7,16 @@ export const dataTableColumns: Array<ColumnDef<SSHKeyName>> = [
 		accessorKey: 'name',
 		enableSorting: false,
 	},
+	{
+		header: 'Host',
+		accessorKey: 'host',
+		enableSorting: false,
+		cell: ({ getValue }) => (getValue() as string | undefined) || '—',
+	},
+	{
+		header: 'Hostname',
+		accessorKey: 'hostname',
+		enableSorting: false,
+		cell: ({ getValue }) => (getValue() as string | undefined) || '—',
+	},
 ];

--- a/src/features/instance/config/sshKeys/modals/EditSSHKeyModal.tsx
+++ b/src/features/instance/config/sshKeys/modals/EditSSHKeyModal.tsx
@@ -188,7 +188,7 @@ export function EditSSHKeyModal({
 							<FormMessage />
 						</FormItem>
 
-						<DialogFooter>
+						<DialogFooter className="md:col-span-2">
 							<Button
 								type="button"
 								variant="destructiveOutline"
@@ -198,8 +198,6 @@ export function EditSSHKeyModal({
 							>
 								Delete SSH Key
 							</Button>
-
-							<div className="grow" />
 
 							<Button
 								type="submit"

--- a/src/integrations/api/instance/ssh/addSSHKey.test.ts
+++ b/src/integrations/api/instance/ssh/addSSHKey.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { SSHKeySchema } from './addSSHKey';
+
+const validKey = {
+	name: 'my-repo',
+	key: 'PRIVATE KEY',
+	host: 'my-repo.github.com',
+	hostname: 'github.com',
+};
+
+describe('SSHKeySchema host alias guard', () => {
+	it('accepts a unique alias distinct from the hostname', () => {
+		expect(SSHKeySchema.safeParse(validKey).success).toBe(true);
+	});
+
+	it('rejects a bare registry hostname as the alias', () => {
+		for (const host of ['github.com', 'GitHub.com', 'ssh.github.com', 'gitlab.com', 'bitbucket.org']) {
+			const result = SSHKeySchema.safeParse({ ...validKey, host });
+			expect(result.success, `expected "${host}" to be rejected`).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0].path).toEqual(['host']);
+			}
+		}
+	});
+
+	it('rejects an alias equal to the hostname (case-insensitive)', () => {
+		const result = SSHKeySchema.safeParse({ ...validKey, host: 'Repo.Internal', hostname: 'repo.internal' });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].path).toEqual(['host']);
+		}
+	});
+
+	it('still requires host and hostname to be present', () => {
+		expect(SSHKeySchema.safeParse({ ...validKey, host: '' }).success).toBe(false);
+		expect(SSHKeySchema.safeParse({ ...validKey, hostname: '' }).success).toBe(false);
+	});
+});

--- a/src/integrations/api/instance/ssh/addSSHKey.test.ts
+++ b/src/integrations/api/instance/ssh/addSSHKey.test.ts
@@ -19,6 +19,8 @@ describe('SSHKeySchema host alias guard', () => {
 			expect(result.success, `expected "${host}" to be rejected`).toBe(false);
 			if (!result.success) {
 				expect(result.error.issues[0].path).toEqual(['host']);
+				// Guards against the refine custom message being dropped (e.g. wrong params key).
+				expect(result.error.issues[0].message).toContain('Use a unique alias');
 			}
 		}
 	});
@@ -28,6 +30,7 @@ describe('SSHKeySchema host alias guard', () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues[0].path).toEqual(['host']);
+			expect(result.error.issues[0].message).toContain('Host alias must differ from the hostname');
 		}
 	});
 

--- a/src/integrations/api/instance/ssh/addSSHKey.ts
+++ b/src/integrations/api/instance/ssh/addSSHKey.ts
@@ -3,17 +3,42 @@ import { ReplicatedResponse } from '@/integrations/api/replication';
 import { useMutation } from '@tanstack/react-query';
 import { z } from 'zod';
 
-export const SSHKeySchema = z.object({
-	name: z
-		.string()
-		.trim()
-		.min(1)
-		.regex(/^[a-zA-Z0-9-_]*$/, { error: 'Can only contain letters, numbers, dashes and underscores.' }),
-	key: z.string().min(1).trim(),
-	host: z.string().min(1).trim(),
-	hostname: z.string().min(1).trim(),
-	known_hosts: z.string().trim().optional(),
-});
+/**
+ * Bare registry hostnames that must not be used as the `host` alias. SSH auth resolves the
+ * key purely from the host in the URL, so reusing a bare registry hostname (e.g. github.com)
+ * across keys makes them collide and silently picks the wrong key. Each key needs a unique
+ * alias like "my-repo.github.com".
+ */
+const BARE_REGISTRY_HOSTS = new Set([
+	'github.com',
+	'ssh.github.com',
+	'gitlab.com',
+	'altssh.gitlab.com',
+	'bitbucket.org',
+]);
+
+const ALIAS_GUIDANCE = 'Use a unique alias like "my-repo.github.com" instead of a bare registry hostname.';
+
+export const SSHKeySchema = z
+	.object({
+		name: z
+			.string()
+			.trim()
+			.min(1)
+			.regex(/^[a-zA-Z0-9-_]*$/, { error: 'Can only contain letters, numbers, dashes and underscores.' }),
+		key: z.string().min(1).trim(),
+		host: z.string().min(1).trim(),
+		hostname: z.string().min(1).trim(),
+		known_hosts: z.string().trim().optional(),
+	})
+	.refine((data) => !BARE_REGISTRY_HOSTS.has(data.host.trim().toLowerCase()), {
+		path: ['host'],
+		error: ALIAS_GUIDANCE,
+	})
+	.refine((data) => data.host.trim().toLowerCase() !== data.hostname.trim().toLowerCase(), {
+		path: ['host'],
+		error: `Host alias must differ from the hostname. ${ALIAS_GUIDANCE}`,
+	});
 
 type AddSSHKeyFormData = z.infer<typeof SSHKeySchema> & InstanceClientIdConfig & InstanceTypeConfig;
 

--- a/src/integrations/api/instance/ssh/listSSHKeys.ts
+++ b/src/integrations/api/instance/ssh/listSSHKeys.ts
@@ -3,6 +3,10 @@ import { queryOptions } from '@tanstack/react-query';
 
 export interface SSHKeyName {
 	name: string;
+	/** The unique alias for this key (e.g. "my-repo.github.com"); used in URLs to pick the key. */
+	host?: string;
+	/** The actual hostname the request resolves to (e.g. "github.com"). */
+	hostname?: string;
 }
 
 async function listSSHKeys({ instanceClient }: InstanceClientIdConfig) {


### PR DESCRIPTION
Implements the remaining parts of #1322. The third ask — verifying the host when deploying a component with auth — already landed via #1318 ([`ImportAuthorization.tsx`](https://github.com/HarperFast/studio/blob/stage/src/features/instance/applications/components/NewApplication/ImportAuthorization.tsx)). This PR covers the other two, plus some UI polish on the SSH key forms.

### Why
SSH auth resolves the key purely from the **host alias** in the URL. If a user sets the alias to a bare registry hostname (e.g. `github.com`) and then adds a second key, the two collide and auth silently picks the wrong key. The fix steers users toward a unique alias like `my-repo.github.com`.

### 1. Add — prevent a bare registry hostname as the alias
`SSHKeySchema` now refines the `host` field to reject:
- a bare registry hostname (`github.com`, `ssh.github.com`, `gitlab.com`, `altssh.gitlab.com`, `bitbucket.org`), and
- an alias equal to the `hostname` (case-insensitive).

The form's submit button is already gated on `isValid`, so the `FormMessage` surfaces the guidance and blocks submission.

### 2. List — show host name and alias
Per the issue, the core `list_ssh_keys` route now returns the host and alias. This threads `host` + `hostname` through `listSSHKeys` and adds **Host** and **Hostname** columns to the SSH Keys table (matching the existing Add/Edit modal field labels), falling back to `—` when absent.

### 3. UI polish (spotted while verifying on a live cluster)
- **Textarea** had no padding utilities, so text sat flush against the border — added `px-3 py-2 text-base` to match the `Input` convention.
- **Edit SSH Key** footer used a `grow` spacer that split Delete/Update to opposite ends; dropped it and added `md:col-span-2` so both buttons group at the right.

### Tests / checks
- New `addSSHKey.test.ts` covers the schema guard (accept valid alias; reject bare registry hostnames; reject alias == hostname; still require both fields).
- Full suite green: 994 passed, plus `tsc`, `oxlint`, and `dprint` clean.

### Verification
Browser-verified on a live stage cluster:
- The SSH Keys table renders **Host** / **Hostname** columns populated from real backend data (`studio` → `studio.github.com` → `github.com`).
- Entering a bare `github.com` as the Host alias surfaces *"Use a unique alias like "my-repo.github.com" instead of a bare registry hostname."* and disables the submit button; a unique alias clears it.
- Textarea padding and right-aligned Edit footer buttons confirmed in the modal.

Closes #1322