### PR TITLE
fix(explorer): full-width hover/selection for overflowing file names

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/file-explorer-base.css
+++ b/src/features/instance/applications/components/ApplicationsSidebar/file-explorer-base.css
@@ -31,6 +31,14 @@
 	font-family: sans-serif;
 	background-color: var(--rct-color-tree-bg);
 	padding: 4px 0;
+	/* Size the tree to its widest row, not just the scroll viewport, so rows
+	   that overflow horizontally still get a full-width hover/selection
+	   background instead of having the overflowed text spill past it (#1307).
+	   The block descendants (ul/li/title-container) fill 100% of this, and the
+	   row button flex-grows to match — so short and long rows align uniformly.
+	   `min-width: 100%` keeps rows at least as wide as the viewport. */
+	width: max-content;
+	min-width: 100%;
 }
 
 .rct-tree-root-focus {


### PR DESCRIPTION
## Summary

The application explorer (`.app-tree-scroll`) scrolls **horizontally** to reveal long file/folder names, but every row (`button` → `title-container` → `li` → `ul` → `rct-tree-root`) was clamped to the scroll *viewport* width while the content scrolled past it. So when a name overflowed, the hover/selection background only painted the visible portion and the overflowed text spilled past with no background behind it.

This is the leftover from #1307 — the resizable-sidebar work resolved the original "text crowding into the icon" alignment; this PR closes the remaining hover-width gap.

## Fix

One rule on `.rct-tree-root` in `file-explorer-base.css`:

```css
width: max-content;
min-width: 100%;
```

Sizing the tree to its widest row lets the block descendants fill it and the row button flex-grow to match, giving every row a uniform full-width background. `min-width: 100%` keeps rows at least viewport-wide, so short names still fill the sidebar.

## Verification

Verified live against real cluster data on the branch preview:
- An overflowing row (`globalTypes.d.ts`) grew from 137px → 196px so the background covers the full text (`hoverCoversText: true`).
- Short rows (e.g. `src`) still fill the viewport width.
- No new horizontal overflow on the button itself (`scrollWidth === clientWidth`).

Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)