### PR TITLE
feat(deploy): SSE deployments — live progress, health check, and history/detail

### DIFF
--- a/src/components/ui/useResizableDialog.ts
+++ b/src/components/ui/useResizableDialog.ts
@@ -132,9 +132,16 @@ export function useResizableDialog() {
 	// onUp never fires — so clean up the live gesture here, dropping its listeners and the closure
 	// capturing the now-stale content node. unmountedRef is flipped first so teardown skips its
 	// state resets — the component is gone, so those setState calls would just be wasted no-ops.
-	useEffect(() => () => {
-		unmountedRef.current = true;
-		activeGestureRef.current?.();
+	useEffect(() => {
+		// Reset on (re)mount: StrictMode's dev mount→cleanup→remount fires the cleanup once,
+		// and refs persist across it, so without this the flag would stay `true` after mount and
+		// every later teardown would skip its state resets (e.g. setIsDragging(false)) — leaving
+		// the overlay stuck transparent after a drag.
+		unmountedRef.current = false;
+		return () => {
+			unmountedRef.current = true;
+			activeGestureRef.current?.();
+		};
 	}, []);
 
 	const startDrag = useCallback((event: React.MouseEvent) => {

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -236,6 +236,22 @@ class AuthStore {
 	}
 
 	/**
+	 * True when operations for this id go straight to the instance (Basic auth, a direct
+	 * operation-token Bearer, or a non-Fabric-Connect direct URL) rather than through the
+	 * central-manager proxy. The proxy buffers `text/event-stream`, so only direct
+	 * connections can consume SSE live — callers gate streaming features on this.
+	 */
+	public isDirectConnection(id: EntityIds): boolean {
+		// A direct operation token always streams straight from the instance. Otherwise it's
+		// direct only when Fabric Connect isn't in play — when the flag is set with no token,
+		// operations route through the buffering proxy (proxy wins, mirroring getInstanceClient).
+		if (this.getOperationToken(id)) {
+			return true;
+		}
+		return !this.checkForFabricConnect(id);
+	}
+
+	/**
 	 * Recovers a fresh operation token for a direct-connect id whose token was rejected (typically 401
 	 * from mid-session expiry — Harper operation tokens default to ~1 day). Prefers exchanging the
 	 * refresh token directly at the instance; falls back to re-minting a fresh pair through the proxy.

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -32,6 +32,7 @@ import {
 	GitGraphIcon,
 	GlobeIcon,
 	KeyIcon,
+	RocketIcon,
 	ScaleIcon,
 	ServerIcon,
 	TrashIcon,
@@ -195,6 +196,13 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 			disabled: signingOut,
 			icon: <ServerIcon className="text-orange-300" />,
 			label: 'Instances',
+		},
+		isActive && view && {
+			key: 'deployments',
+			to: `${cluster.id}/config/deployments`,
+			disabled: signingOut,
+			icon: <RocketIcon className="text-sky-400" />,
+			label: 'Deployments',
 		},
 
 		isActive && view && !!cluster.fqdn && { type: 'separator' as const, key: 'copy-separator' },

--- a/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
+++ b/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
@@ -61,9 +61,9 @@ export function DeployProgress({ state }: { state: DeploymentStreamState }) {
 					<div className="mb-1 text-xs font-medium text-muted-foreground">Install output</div>
 					<ScrollArea className="h-40 rounded-md border bg-muted/40">
 						<pre className="whitespace-pre-wrap break-words p-2 font-mono text-xs leading-relaxed">
-							{state.installLog.map((entry, i) => (
+							{state.installLog.map((entry) => (
 								<div
-									key={i}
+									key={entry.id}
 									className={cn(entry.stream === 'stderr' && 'text-destructive')}
 								>
 									{entry.line}

--- a/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
+++ b/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
@@ -1,0 +1,115 @@
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scrollArea';
+import { Separator } from '@/components/ui/separator';
+import { DEPLOY_PHASE_ORDER } from '@/integrations/api/instance/applications/deployComponentStream';
+import { cn } from '@/lib/cn';
+import { CheckIcon, CircleDashedIcon, CircleIcon, Loader2Icon, XIcon } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { DeploymentStreamState, PhaseStatus } from './useDeploymentStream';
+
+const PHASE_LABELS: Record<string, string> = {
+	prepare: 'Prepare',
+	load: 'Load',
+	replicate: 'Replicate',
+	restart: 'Restart',
+	success: 'Finish',
+};
+
+function PhaseIcon({ status, isCurrent }: { status?: PhaseStatus; isCurrent: boolean }) {
+	if (status === 'done') {
+		return <CheckIcon className="size-4 text-success" />;
+	}
+	if (status === 'error') {
+		return <XIcon className="size-4 text-destructive" />;
+	}
+	if (status === 'start' || isCurrent) {
+		return <Loader2Icon className="size-4 animate-spin text-primary" />;
+	}
+	return <CircleDashedIcon className="size-4 text-muted-foreground" />;
+}
+
+/** Renders live `deploy_component` progress: phase checklist, install log tail, peer results. */
+export function DeployProgress({ state }: { state: DeploymentStreamState }) {
+	const logEndRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		logEndRef.current?.scrollIntoView({ block: 'end' });
+	}, [state.installLog.length]);
+
+	const phasesFailed = state.lifecycle === 'error';
+
+	return (
+		<div className="flex flex-col gap-4">
+			<ol className="flex flex-col gap-2">
+				{DEPLOY_PHASE_ORDER.map((phase) => {
+					const status = state.phases[phase];
+					const isCurrent = state.currentPhase === phase && status !== 'done';
+					return (
+						<li key={phase} className="flex items-center gap-2 text-sm">
+							<PhaseIcon status={status} isCurrent={isCurrent} />
+							<span className={cn(status ? 'text-foreground' : 'text-muted-foreground')}>
+								{PHASE_LABELS[phase] ?? phase}
+							</span>
+						</li>
+					);
+				})}
+			</ol>
+
+			{state.installLog.length > 0 && (
+				<div>
+					<Separator className="mb-2" />
+					<div className="mb-1 text-xs font-medium text-muted-foreground">Install output</div>
+					<ScrollArea className="h-40 rounded-md border bg-muted/40">
+						<pre className="whitespace-pre-wrap break-words p-2 font-mono text-xs leading-relaxed">
+							{state.installLog.map((entry, i) => (
+								<div
+									key={i}
+									className={cn(entry.stream === 'stderr' && 'text-destructive')}
+								>
+									{entry.line}
+								</div>
+							))}
+							<div ref={logEndRef} />
+						</pre>
+					</ScrollArea>
+				</div>
+			)}
+
+			{state.peers.length > 0 && (
+				<div>
+					<Separator className="mb-2" />
+					<div className="mb-1 text-xs font-medium text-muted-foreground">Replication</div>
+					<ul className="flex flex-col gap-1 text-sm">
+						{state.peers.map((peer, i) => {
+							const failed = peer.status === 'failed';
+							return (
+								<li key={i} className="flex items-center justify-between gap-2">
+									<span className="flex items-center gap-2">
+										{failed
+											? <XIcon className="size-4 text-destructive" />
+											: <CheckIcon className="size-4 text-success" />}
+										<span className="truncate">{peer.node ?? `node ${i + 1}`}</span>
+									</span>
+									{failed && peer.reason && <span className="truncate text-xs text-destructive">{peer.reason}</span>}
+								</li>
+							);
+						})}
+					</ul>
+				</div>
+			)}
+
+			{phasesFailed && state.error && (
+				<div className="flex items-start gap-2 text-sm text-destructive">
+					<CircleIcon className="mt-0.5 size-4 shrink-0" />
+					<span>{state.error}</span>
+				</div>
+			)}
+
+			{state.lifecycle === 'inconclusive' && (
+				<Badge variant="warning" className="self-start">
+					Live updates ended early — verifying…
+				</Badge>
+			)}
+		</div>
+	);
+}

--- a/src/features/instance/applications/components/DeployProgress/useDeploymentStream.ts
+++ b/src/features/instance/applications/components/DeployProgress/useDeploymentStream.ts
@@ -1,0 +1,95 @@
+import { DeployPeerEvent, DeployStreamEvent } from '@/integrations/api/instance/applications/deployComponentStream';
+import { useCallback, useMemo, useReducer } from 'react';
+
+export type DeploymentLifecycle = 'idle' | 'streaming' | 'success' | 'error' | 'inconclusive';
+export type PhaseStatus = 'start' | 'done' | 'error';
+
+export interface InstallLine {
+	stream?: string;
+	line: string;
+}
+
+export interface DeploymentStreamState {
+	lifecycle: DeploymentLifecycle;
+	/** Latest status seen per phase, e.g. `{ prepare: 'done', load: 'start' }`. */
+	phases: Record<string, PhaseStatus>;
+	currentPhase?: string;
+	installLog: InstallLine[];
+	peers: DeployPeerEvent[];
+	error?: string;
+}
+
+const INITIAL_STATE: DeploymentStreamState = {
+	lifecycle: 'idle',
+	phases: {},
+	installLog: [],
+	peers: [],
+};
+
+// Keep the rendered install log bounded so a very chatty install can't grow state without
+// limit; the server already aggregates, this is a UI safety net.
+const MAX_INSTALL_LINES = 1000;
+
+type Action =
+	| { kind: 'reset' }
+	| { kind: 'start' }
+	| { kind: 'event'; event: DeployStreamEvent }
+	| { kind: 'settled'; lifecycle: Extract<DeploymentLifecycle, 'success' | 'error' | 'inconclusive'>; error?: string };
+
+function reducer(state: DeploymentStreamState, action: Action): DeploymentStreamState {
+	switch (action.kind) {
+		case 'reset':
+			return INITIAL_STATE;
+		case 'start':
+			return { ...INITIAL_STATE, lifecycle: 'streaming' };
+		case 'event': {
+			const { event } = action;
+			if (event.type === 'phase') {
+				const { phase, status } = event.data;
+				return {
+					...state,
+					lifecycle: 'streaming',
+					phases: { ...state.phases, [phase]: status },
+					currentPhase: status === 'start' ? phase : state.currentPhase,
+				};
+			}
+			if (event.type === 'install') {
+				const next = state.installLog.concat({ stream: event.data.stream, line: event.data.line });
+				return {
+					...state,
+					installLog: next.length > MAX_INSTALL_LINES ? next.slice(-MAX_INSTALL_LINES) : next,
+				};
+			}
+			// peer
+			return { ...state, peers: state.peers.concat(event.data) };
+		}
+		case 'settled':
+			return { ...state, lifecycle: action.lifecycle, error: action.error };
+	}
+}
+
+/**
+ * Accumulate live `deploy_component` SSE events into render-ready state.
+ *
+ * Returns `onEvent` to pass into the deploy mutation, plus `markStarted`/`markSettled`
+ * to bracket the lifecycle from the mutation's callbacks. A stream is a sequence of
+ * side-effects, not cacheable data, so this is component state (a reducer) rather than a
+ * React Query cache entry — the mutation still owns initiation and toast ergonomics.
+ */
+export function useDeploymentStream() {
+	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+
+	const onEvent = useCallback((event: DeployStreamEvent) => dispatch({ kind: 'event', event }), []);
+	const markStarted = useCallback(() => dispatch({ kind: 'start' }), []);
+	const reset = useCallback(() => dispatch({ kind: 'reset' }), []);
+	const markSettled = useCallback(
+		(lifecycle: 'success' | 'error' | 'inconclusive', error?: string) =>
+			dispatch({ kind: 'settled', lifecycle, error }),
+		[],
+	);
+
+	return useMemo(
+		() => ({ state, onEvent, markStarted, markSettled, reset }),
+		[state, onEvent, markStarted, markSettled, reset],
+	);
+}

--- a/src/features/instance/applications/components/DeployProgress/useDeploymentStream.ts
+++ b/src/features/instance/applications/components/DeployProgress/useDeploymentStream.ts
@@ -5,6 +5,8 @@ export type DeploymentLifecycle = 'idle' | 'streaming' | 'success' | 'error' | '
 export type PhaseStatus = 'start' | 'done' | 'error';
 
 export interface InstallLine {
+	/** Stable, monotonically increasing id so React keys survive front-slicing of the log. */
+	id: number;
 	stream?: string;
 	line: string;
 }
@@ -54,7 +56,9 @@ function reducer(state: DeploymentStreamState, action: Action): DeploymentStream
 				};
 			}
 			if (event.type === 'install') {
-				const next = state.installLog.concat({ stream: event.data.stream, line: event.data.line });
+				// Derive the next id from the last line's so keys stay stable across slicing.
+				const nextId = (state.installLog[state.installLog.length - 1]?.id ?? 0) + 1;
+				const next = state.installLog.concat({ id: nextId, stream: event.data.stream, line: event.data.line });
 				return {
 					...state,
 					installLog: next.length > MAX_INSTALL_LINES ? next.slice(-MAX_INSTALL_LINES) : next,

--- a/src/features/instance/applications/components/NewApplication/useImportApplication.ts
+++ b/src/features/instance/applications/components/NewApplication/useImportApplication.ts
@@ -1,11 +1,23 @@
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useComponentHealthCheck } from '@/features/instance/applications/hooks/useComponentHealthCheck';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { useSupportsDeploymentSSE } from '@/features/instance/applications/hooks/useSupportsDeploymentSSE';
+import { reportDeployHealth } from '@/features/instance/applications/modals/reportDeployHealth';
 import { useDeployComponentMutation } from '@/integrations/api/instance/applications/deployComponent';
+import { SSEInconclusiveError } from '@/integrations/api/sse/errors';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { ImportSchema } from './schema';
+
+const PHASE_LABELS: Record<string, string> = {
+	prepare: 'Preparing…',
+	load: 'Loading component…',
+	replicate: 'Replicating to nodes…',
+	restart: 'Restarting…',
+	success: 'Finishing…',
+};
 
 export function useImportApplication(
 	setIsReloading: (isReloading: boolean) => void,
@@ -14,7 +26,27 @@ export function useImportApplication(
 
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();
+	const sseDeploy = useSupportsDeploymentSSE();
+	const runHealthCheck = useComponentHealthCheck(instanceParams);
 	const { reloadRootEntries, setFocusedItem, setExpandedItems, setSelectedItems } = useEditorView();
+
+	const onImported = useCallback((project: string) => {
+		setIsReloading(true);
+		void queryClient.invalidateQueries({ queryKey: [instanceParams.entityId] });
+		void reloadRootEntries();
+		setFocusedItem(project);
+		setSelectedItems([project]);
+		setExpandedItems([project]);
+	}, [
+		queryClient,
+		instanceParams.entityId,
+		reloadRootEntries,
+		setFocusedItem,
+		setSelectedItems,
+		setExpandedItems,
+		setIsReloading,
+	]);
+
 	const callback = useCallback(({
 		contents,
 		project,
@@ -30,35 +62,45 @@ export function useImportApplication(
 			applicationName: project,
 			applicationUrl: contents.ref,
 			installCommand: contents.installCommand,
+			useSSE: sseDeploy,
+			onEvent: (event) => {
+				// Stream the current phase into the loading toast so the user sees live progress.
+				if (event.type === 'phase' && event.data.status === 'start') {
+					toast.loading(`Importing ${project}…`, {
+						id: toastId,
+						description: PHASE_LABELS[event.data.phase] ?? event.data.phase,
+						duration: 300_000,
+					});
+				}
+			},
 			...instanceParams,
 		}, {
-			onSuccess: () => {
-				toast.success(`Imported successfully`, {
-					description: `${project} will be available once you restart your ${instanceParams.entityType}!`,
-					id: toastId,
-					duration: 5_000,
-				});
-				setIsReloading(true);
-				void queryClient.invalidateQueries({ queryKey: [instanceParams.entityId] });
-				void reloadRootEntries();
-				setFocusedItem(project);
-				setSelectedItems([project]);
-				setExpandedItems([project]);
-			},
-			onError: () => {
+			onSuccess: async () => {
 				toast.dismiss(toastId);
+				onImported(project);
+				if (sseDeploy) {
+					reportDeployHealth(project, await runHealthCheck(project));
+				} else {
+					toast.success(`Imported successfully`, {
+						description: `${project} will be available once you restart your ${instanceParams.entityType}!`,
+						duration: 5_000,
+					});
+				}
+			},
+			onError: async (error) => {
+				toast.dismiss(toastId);
+				// Live stream dropped after the deploy started — verify rather than assume failure.
+				if (error instanceof SSEInconclusiveError) {
+					onImported(project);
+					reportDeployHealth(project, await runHealthCheck(project));
+					return;
+				}
+				toast.error(`Failed to import ${project}`, {
+					description: error instanceof Error ? error.message : undefined,
+				});
 			},
 		});
-	}, [
-		mutate,
-		queryClient,
-		instanceParams,
-		setIsReloading,
-		reloadRootEntries,
-		setFocusedItem,
-		setExpandedItems,
-		setSelectedItems,
-	]);
+	}, [mutate, sseDeploy, instanceParams, runHealthCheck, onImported]);
 
 	return useMemo(() => ({
 		isImportingApplication,

--- a/src/features/instance/applications/components/NewApplication/useImportApplication.ts
+++ b/src/features/instance/applications/components/NewApplication/useImportApplication.ts
@@ -64,11 +64,18 @@ export function useImportApplication(
 			installCommand: contents.installCommand,
 			useSSE: sseDeploy,
 			onEvent: (event) => {
-				// Stream the current phase into the loading toast so the user sees live progress.
+				// Stream live progress into the loading toast: phase transitions, and the latest
+				// install output line during the install/load phase (so npm output shows through).
 				if (event.type === 'phase' && event.data.status === 'start') {
 					toast.loading(`Importing ${project}…`, {
 						id: toastId,
 						description: PHASE_LABELS[event.data.phase] ?? event.data.phase,
+						duration: 300_000,
+					});
+				} else if (event.type === 'install' && event.data.line?.trim()) {
+					toast.loading(`Importing ${project}…`, {
+						id: toastId,
+						description: event.data.line.trim().slice(0, 140),
 						duration: 300_000,
 					});
 				}

--- a/src/features/instance/applications/hooks/useComponentHealthCheck.ts
+++ b/src/features/instance/applications/hooks/useComponentHealthCheck.ts
@@ -1,0 +1,62 @@
+import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import {
+	APIDirectoryEntry,
+	ComponentStatusLevel,
+	getComponents,
+} from '@/integrations/api/instance/applications/getComponents';
+import { sleep } from '@/lib/sleep';
+import { useCallback } from 'react';
+
+export interface ComponentHealthResult {
+	/** Final observed status, or 'indeterminate' if it never settled within the window. */
+	level: ComponentStatusLevel | 'indeterminate';
+	message?: string;
+}
+
+// The new deploy_component returns before worker threads finish loading the component, so a
+// freshly-deployed component is briefly `loading`/`unknown`. Poll a few times to let it
+// settle before reporting health (issue #1233).
+const INITIAL_DELAY_MS = 1_500;
+const POLL_INTERVAL_MS = 2_000;
+const MAX_ATTEMPTS = 8;
+
+const SETTLED: ReadonlySet<ComponentStatusLevel> = new Set(['healthy', 'warning', 'error']);
+
+function findComponent(tree: APIDirectoryEntry, project: string): APIDirectoryEntry | undefined {
+	return tree.entries.find(
+		(entry): entry is APIDirectoryEntry => entry.name === project && 'entries' in entry,
+	);
+}
+
+/**
+ * Verify a freshly-deployed component became healthy. Returns a function that polls
+ * `get_components` until the component's status settles (healthy/warning/error) or a short
+ * window elapses, so callers can surface a definitive health result after a deploy.
+ */
+export function useComponentHealthCheck(params: InstanceClientIdConfig) {
+	return useCallback(
+		async (project: string): Promise<ComponentHealthResult> => {
+			await sleep(INITIAL_DELAY_MS);
+			let last: ComponentHealthResult = { level: 'indeterminate' };
+			for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+				try {
+					const tree = await getComponents(params);
+					const status = findComponent(tree, project)?.status;
+					if (status) {
+						last = { level: status.status, message: status.message };
+						if (SETTLED.has(status.status)) {
+							return last;
+						}
+					}
+				} catch {
+					// Transient read failure (e.g. instance mid-restart) — keep polling.
+				}
+				if (attempt < MAX_ATTEMPTS - 1) {
+					await sleep(POLL_INTERVAL_MS);
+				}
+			}
+			return last;
+		},
+		[params],
+	);
+}

--- a/src/features/instance/applications/hooks/useSupportsDeploymentSSE.ts
+++ b/src/features/instance/applications/hooks/useSupportsDeploymentSSE.ts
@@ -1,0 +1,38 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+import { getRegistrationInfoQueryOptions } from '@/integrations/api/instance/status/getRegistrationInfo';
+import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Minimum Harper version that supports the SSE deploy/get_deployment stream and the
+ * `hdb_deployment` audit table. Verified against release tags: the `SSE_PROGRESS_OPERATIONS`
+ * branch ships in 5.1.0 and is absent in 5.0.x.
+ */
+export const MIN_DEPLOYMENT_SSE_VERSION = '5.1.0';
+
+/**
+ * True when the instance/cluster is Harper >= 5.1.0, so the deployment history/detail
+ * feature (`list_deployments` / `get_deployment`) is available. This gates feature
+ * visibility regardless of connection type — the list/detail work over plain polling.
+ */
+export function useDeploymentsAvailable(): boolean {
+	const params = useInstanceClientIdParams();
+	const { data } = useQuery(getRegistrationInfoQueryOptions(params));
+	return !!data?.version && wasAReleasedBeforeB(MIN_DEPLOYMENT_SSE_VERSION, data.version);
+}
+
+/**
+ * True when we should attempt a LIVE SSE stream (deploy progress / detail tail).
+ *
+ * Requires 5.1.0+ AND a direct connection: the central-manager fabric-connect proxy
+ * buffers `text/event-stream` (verified — it withholds the whole response until the op
+ * completes), so streaming over it yields no live progress and only wastes the idle window
+ * before falling back. Proxied entities use the buffered deploy + polling detail instead.
+ * If the proxy gains streaming passthrough, drop the fabric-connect check here.
+ */
+export function useSupportsDeploymentSSE(): boolean {
+	const params = useInstanceClientIdParams();
+	const available = useDeploymentsAvailable();
+	return available && !authStore.checkForFabricConnect(params.entityId);
+}

--- a/src/features/instance/applications/hooks/useSupportsDeploymentSSE.ts
+++ b/src/features/instance/applications/hooks/useSupportsDeploymentSSE.ts
@@ -28,11 +28,13 @@ export function useDeploymentsAvailable(): boolean {
  * Requires 5.1.0+ AND a direct connection: the central-manager fabric-connect proxy
  * buffers `text/event-stream` (verified — it withholds the whole response until the op
  * completes), so streaming over it yields no live progress and only wastes the idle window
- * before falling back. Proxied entities use the buffered deploy + polling detail instead.
- * If the proxy gains streaming passthrough, drop the fabric-connect check here.
+ * before falling back. Fabric Connect now usually resolves to a direct Bearer connection
+ * (see authStore.establishFabricConnectAuth), which DOES stream — so we gate on
+ * `isDirectConnection`, not merely on the absence of the Fabric Connect flag. Proxy-only
+ * connections fall back to the buffered deploy + polling detail.
  */
 export function useSupportsDeploymentSSE(): boolean {
 	const params = useInstanceClientIdParams();
 	const available = useDeploymentsAvailable();
-	return available && !authStore.checkForFabricConnect(params.entityId);
+	return available && authStore.isDirectConnection(params.entityId);
 }

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -8,26 +8,36 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { DeployProgress } from '@/features/instance/applications/components/DeployProgress/DeployProgress';
+import { useDeploymentStream } from '@/features/instance/applications/components/DeployProgress/useDeploymentStream';
+import { useComponentHealthCheck } from '@/features/instance/applications/hooks/useComponentHealthCheck';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { useSupportsDeploymentSSE } from '@/features/instance/applications/hooks/useSupportsDeploymentSSE';
 import { useDeployComponentMutation } from '@/integrations/api/instance/applications/deployComponent';
+import { SSEInconclusiveError } from '@/integrations/api/sse/errors';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { RefreshCwIcon } from 'lucide-react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { reportDeployHealth } from './reportDeployHealth';
 
 export function RedeployApplicationModal() {
 	const { value: isModalOpen, trigger } = useWatchedValue('ShowRedeployApplicationModal', false);
 
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();
+	const sseDeploy = useSupportsDeploymentSSE();
+	const stream = useDeploymentStream();
+	const runHealthCheck = useComponentHealthCheck(instanceParams);
 
 	const { openedEntry } = useEditorView();
 	const packageUrl = openedEntry?.package;
 
 	const { mutate: reDeployApplication, isPending } = useDeployComponentMutation();
+	const [isStreaming, setIsStreaming] = useState(false);
 
 	const methods = useForm({
 		defaultValues: {
@@ -46,45 +56,100 @@ export function RedeployApplicationModal() {
 		setWatchedValue('ShowRedeployApplicationModal', false);
 		attemptToRestoreFocus(trigger);
 		reset({ applicationUrl: packageUrl });
-	}, [reset, packageUrl, trigger]);
+		setIsStreaming(false);
+		stream.reset();
+	}, [reset, packageUrl, trigger, stream]);
 
-	const redeployPackage = useCallback((applicationUrl: string, installCommand: string | undefined) => {
-		if (!openedEntry) {
-			return;
-		}
-		closeModal();
-
-		const toastId = toast.loading('Redeploying...');
-		reDeployApplication({
-			applicationName: openedEntry.project,
-			applicationUrl,
-			installCommand,
-			...instanceParams,
-		}, {
-			onSuccess: () => {
-				toast.success(
-					`Application ${openedEntry.project} redeployed successfully`,
-					{
-						id: toastId,
-					},
-				);
-				void queryClient.invalidateQueries({
-					queryKey: [instanceParams.entityId, 'get_components'],
-					refetchType: 'active',
-				});
-			},
-			onError: () => {
-				toast.dismiss(toastId);
-			},
+	const invalidateComponents = useCallback(() => {
+		void queryClient.invalidateQueries({
+			queryKey: [instanceParams.entityId, 'get_components'],
+			refetchType: 'active',
 		});
-	}, [reDeployApplication, openedEntry, instanceParams, queryClient, closeModal]);
+	}, [queryClient, instanceParams.entityId]);
+
+	const redeployWithProgress = useCallback(
+		(applicationUrl: string, installCommand: string | undefined) => {
+			if (!openedEntry) {
+				return;
+			}
+			const project = openedEntry.project;
+			stream.reset();
+			stream.markStarted();
+			setIsStreaming(true);
+
+			reDeployApplication(
+				{
+					applicationName: project,
+					applicationUrl,
+					installCommand,
+					useSSE: true,
+					onEvent: stream.onEvent,
+					...instanceParams,
+				},
+				{
+					onSuccess: async () => {
+						stream.markSettled('success');
+						invalidateComponents();
+						const health = await runHealthCheck(project);
+						reportDeployHealth(project, health);
+						closeModal();
+					},
+					onError: async (error) => {
+						// The deploy started but the live stream dropped — verify via health check
+						// instead of reporting a failure we don't actually know happened.
+						if (error instanceof SSEInconclusiveError) {
+							stream.markSettled('inconclusive');
+							invalidateComponents();
+							const health = await runHealthCheck(project);
+							reportDeployHealth(project, health);
+							closeModal();
+							return;
+						}
+						stream.markSettled('error', error instanceof Error ? error.message : String(error));
+						toast.error(`Failed to redeploy ${project}`, {
+							description: error instanceof Error ? error.message : undefined,
+						});
+					},
+				},
+			);
+		},
+		[reDeployApplication, openedEntry, instanceParams, stream, invalidateComponents, runHealthCheck, closeModal],
+	);
+
+	const redeployBuffered = useCallback(
+		(applicationUrl: string, installCommand: string | undefined) => {
+			if (!openedEntry) {
+				return;
+			}
+			closeModal();
+			const toastId = toast.loading('Redeploying...');
+			reDeployApplication(
+				{ applicationName: openedEntry.project, applicationUrl, installCommand, ...instanceParams },
+				{
+					onSuccess: () => {
+						toast.success(`Application ${openedEntry.project} redeployed successfully`, { id: toastId });
+						invalidateComponents();
+					},
+					onError: () => {
+						toast.dismiss(toastId);
+					},
+				},
+			);
+		},
+		[reDeployApplication, openedEntry, instanceParams, invalidateComponents, closeModal],
+	);
 
 	const submitForm = ({ applicationUrl, installCommand }: {
 		applicationUrl: string | undefined;
 		installCommand: string | undefined;
 	}) => {
-		if (applicationUrl) {
-			redeployPackage(applicationUrl, installCommand);
+		if (!applicationUrl) {
+			return;
+		}
+		if (sseDeploy) {
+			redeployWithProgress(applicationUrl, installCommand);
+		} else {
+			redeployBuffered(applicationUrl, installCommand);
 		}
 	};
 
@@ -96,59 +161,15 @@ export function RedeployApplicationModal() {
 			<DialogContent aria-describedby={undefined} className="text-popover-foreground">
 				<DialogHeader>
 					<DialogTitle>Redeploy Package</DialogTitle>
-					<DialogDescription>Redeploy this package?</DialogDescription>
+					<DialogDescription>
+						{isStreaming ? `Redeploying ${openedEntry?.project ?? 'package'}…` : 'Redeploy this package?'}
+					</DialogDescription>
 				</DialogHeader>
 
-				<div>
-					<Form {...methods}>
-						<form
-							id="instance-redeploy-app-form"
-							name="instance-redeploy-app-form"
-							className="flex flex-col w-full gap-4"
-							onSubmit={handleSubmit(submitForm)}
-						>
-							<FormField
-								control={control}
-								name="applicationUrl"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel className="pb-1">Package Reference</FormLabel>
-										<FormControl>
-											<Input
-												type="text"
-												autoFocus={true}
-												{...field}
-											/>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={control}
-								name="installCommand"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel className="pb-1">Install Command</FormLabel>
-										<FormControl>
-											<Input
-												type="text"
-												placeholder="npm install"
-												{...field}
-											/>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-							<Button
-								variant="positiveOutline"
-								type="submit"
-								className="w-full rounded-full"
-								disabled={isPending}
-							>
-								<RefreshCwIcon /> Redeploy Application
-							</Button>
+				{isStreaming
+					? (
+						<div className="flex flex-col gap-4">
+							<DeployProgress state={stream.state} />
 							<Button
 								type="button"
 								variant="ghostOutline"
@@ -156,11 +177,74 @@ export function RedeployApplicationModal() {
 								onClick={closeModal}
 								disabled={isPending}
 							>
-								Cancel
+								{isPending ? 'Deploying…' : 'Close'}
 							</Button>
-						</form>
-					</Form>
-				</div>
+						</div>
+					)
+					: (
+						<div>
+							<Form {...methods}>
+								<form
+									id="instance-redeploy-app-form"
+									name="instance-redeploy-app-form"
+									className="flex flex-col w-full gap-4"
+									onSubmit={handleSubmit(submitForm)}
+								>
+									<FormField
+										control={control}
+										name="applicationUrl"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel className="pb-1">Package Reference</FormLabel>
+												<FormControl>
+													<Input
+														type="text"
+														autoFocus={true}
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={control}
+										name="installCommand"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel className="pb-1">Install Command</FormLabel>
+												<FormControl>
+													<Input
+														type="text"
+														placeholder="npm install"
+														{...field}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<Button
+										variant="positiveOutline"
+										type="submit"
+										className="w-full rounded-full"
+										disabled={isPending}
+									>
+										<RefreshCwIcon /> Redeploy Application
+									</Button>
+									<Button
+										type="button"
+										variant="ghostOutline"
+										className="w-full rounded-full"
+										onClick={closeModal}
+										disabled={isPending}
+									>
+										Cancel
+									</Button>
+								</form>
+							</Form>
+						</div>
+					)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/features/instance/applications/modals/reportDeployHealth.ts
+++ b/src/features/instance/applications/modals/reportDeployHealth.ts
@@ -1,0 +1,35 @@
+import { ComponentHealthResult } from '@/features/instance/applications/hooks/useComponentHealthCheck';
+import { toast } from 'sonner';
+
+/**
+ * Surface the post-deploy health-check result as a toast.
+ *
+ * The new `deploy_component` returns before the component finishes loading on worker
+ * threads, so a successful deploy call doesn't guarantee a working component (#1233). This
+ * translates the polled status into clear user feedback.
+ */
+export function reportDeployHealth(project: string, health: ComponentHealthResult): void {
+	switch (health.level) {
+		case 'healthy':
+			toast.success(`${project} deployed and healthy`, { description: health.message });
+			return;
+		case 'warning':
+			toast.warning(`${project} deployed with warnings`, {
+				description: health.message ?? 'The component loaded but reported a warning.',
+			});
+			return;
+		case 'error':
+			toast.error(`${project} deployed but failed to load`, {
+				description: health.message ?? 'The component reported an error after deploying.',
+			});
+			return;
+		case 'loading':
+		case 'unknown':
+		case 'indeterminate':
+		default:
+			toast.success(`${project} deployed`, {
+				description: 'Still verifying — the component is loading. Check its status shortly.',
+			});
+			return;
+	}
+}

--- a/src/features/instance/config/deployments/components/DeploymentDetail.tsx
+++ b/src/features/instance/config/deployments/components/DeploymentDetail.tsx
@@ -1,0 +1,191 @@
+import { Loading } from '@/components/Loading';
+import { Separator } from '@/components/ui/separator';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { DeployProgress } from '@/features/instance/applications/components/DeployProgress/DeployProgress';
+import { useDeploymentStream } from '@/features/instance/applications/components/DeployProgress/useDeploymentStream';
+import { useSupportsDeploymentSSE } from '@/features/instance/applications/hooks/useSupportsDeploymentSSE';
+import { getDeploymentQueryOptions, getDeploymentStream } from '@/integrations/api/instance/deployments/getDeployment';
+import { Deployment, isTerminalDeploymentStatus } from '@/integrations/api/instance/deployments/types';
+import { humanFileSize } from '@/lib/humanFileSize';
+import { translateSecondsToAgo } from '@/lib/translateSecondsToAgo';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { DeploymentStatusBadge } from './deploymentStatusBadge';
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+	if (value === undefined || value === null || value === '') {
+		return null;
+	}
+	return (
+		<div className="flex flex-col gap-0.5">
+			<span className="text-xs text-muted-foreground">{label}</span>
+			<span className="break-words text-sm">{value}</span>
+		</div>
+	);
+}
+
+function timestamp(ms?: number) {
+	return ms ? translateSecondsToAgo((Date.now() - ms) / 1000, ms) : undefined;
+}
+
+export function DeploymentDetail({ deploymentId }: { deploymentId: string }) {
+	const instanceParams = useInstanceClientIdParams();
+	const sseSupported = useSupportsDeploymentSSE();
+	const queryClient = useQueryClient();
+	const stream = useDeploymentStream();
+
+	const { data: deployment, isLoading, error } = useQuery(
+		// Poll while the deploy is active; the refetchInterval stops itself at a terminal
+		// status. This is the correctness backbone — the SSE tail below only adds live
+		// phase/log granularity on top.
+		getDeploymentQueryOptions({ ...instanceParams, deploymentId, pollWhileActive: true }),
+	);
+
+	const isActive = !!deployment && !isTerminalDeploymentStatus(deployment.status);
+
+	useEffect(() => {
+		if (!sseSupported || !isActive) {
+			return;
+		}
+		const controller = new AbortController();
+		stream.reset();
+		stream.markStarted();
+		getDeploymentStream({
+			connection: { id: instanceParams.entityId },
+			deploymentId,
+			signal: controller.signal,
+			onEvent: stream.onEvent,
+		})
+			.then(() => stream.markSettled('success'))
+			.catch(() => {
+				if (!controller.signal.aborted) {
+					// SSE dropped — polling (above) remains the source of truth.
+					stream.markSettled('inconclusive');
+				}
+			})
+			.finally(() => {
+				if (!controller.signal.aborted) {
+					void queryClient.invalidateQueries({
+						queryKey: [instanceParams.entityId, 'get_deployment', deploymentId],
+					});
+				}
+			});
+		// Abort the tail on unmount (unlike the deploy modal, the detail view is transient).
+		return () => controller.abort();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [sseSupported, isActive, deploymentId, instanceParams.entityId]);
+
+	if (isLoading) {
+		return <Loading className="flex h-full flex-col items-center justify-center" text="Loading deployment..." />;
+	}
+	if (error || !deployment) {
+		return <div className="p-4 text-sm text-destructive">Could not load this deployment.</div>;
+	}
+
+	const showLiveProgress = isActive
+		&& (stream.state.installLog.length > 0 || Object.keys(stream.state.phases).length > 0);
+
+	return (
+		<div className="flex flex-col gap-4 p-1">
+			<div className="flex flex-wrap items-center gap-2">
+				<h2 className="text-lg font-semibold">{deployment.project}</h2>
+				<DeploymentStatusBadge status={deployment.status} />
+				{deployment.phase && <span className="text-sm text-muted-foreground">{deployment.phase}</span>}
+			</div>
+
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+				<Field label="Deployment ID" value={<span className="font-mono text-xs">{deployment.deployment_id}</span>} />
+				<Field label="User" value={deployment.user} />
+				<Field label="Origin node" value={deployment.origin_node} />
+				<Field label="Started" value={timestamp(deployment.started_at)} />
+				<Field label="Completed" value={timestamp(deployment.completed_at)} />
+				<Field label="Restart mode" value={deployment.restart_mode ?? undefined} />
+				<Field label="Package" value={deployment.package_identifier ?? undefined} />
+				<Field
+					label="Payload size"
+					value={deployment.payload_size != null ? humanFileSize(deployment.payload_size) : undefined}
+				/>
+				<Field
+					label="Payload hash"
+					value={deployment.payload_hash
+						? <span className="font-mono text-xs">{deployment.payload_hash}</span>
+						: undefined}
+				/>
+				<Field
+					label="Restorable"
+					value={deployment.restorable === undefined ? undefined : deployment.restorable ? 'Yes' : 'No'}
+				/>
+				<Field
+					label="Rollback of"
+					value={deployment.rollback_of
+						? <span className="font-mono text-xs">{deployment.rollback_of}</span>
+						: undefined}
+				/>
+			</div>
+
+			{showLiveProgress && (
+				<>
+					<Separator />
+					<DeployProgress state={stream.state} />
+				</>
+			)}
+
+			{deployment.error && (
+				<>
+					<Separator />
+					<div className="flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+						<span className="font-medium text-destructive">
+							Error{deployment.error.phase ? ` during ${deployment.error.phase}` : ''}
+							{deployment.error.code ? ` (${deployment.error.code})` : ''}
+						</span>
+						<span className="break-words">{deployment.error.message}</span>
+					</div>
+				</>
+			)}
+
+			{!!deployment.peer_results?.length && (
+				<>
+					<Separator />
+					<div>
+						<div className="mb-1 text-xs font-medium text-muted-foreground">Replication</div>
+						<ul className="flex flex-col gap-1 text-sm">
+							{deployment.peer_results.map((peer, i) => (
+								<li key={peer.node ?? i} className="flex items-center justify-between gap-2">
+									<span className="truncate">{peer.node}</span>
+									<span className={peer.status === 'failed' ? 'text-destructive' : 'text-success'}>
+										{peer.status ?? 'ok'}
+										{peer.error ? `: ${peer.error}` : ''}
+									</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				</>
+			)}
+
+			{!!deployment.event_log?.length && <DeploymentEventLog deployment={deployment} />}
+		</div>
+	);
+}
+
+function DeploymentEventLog({ deployment }: { deployment: Deployment }) {
+	return (
+		<>
+			<Separator />
+			<div>
+				<div className="mb-1 text-xs font-medium text-muted-foreground">Activity</div>
+				<ol className="flex flex-col gap-1 text-xs">
+					{deployment.event_log!.map((entry, i) => (
+						<li key={i} className="flex gap-2">
+							<span className="shrink-0 text-muted-foreground">{new Date(entry.t).toLocaleTimeString()}</span>
+							<span className="font-medium">{entry.event}</span>
+							<span className="break-words text-muted-foreground">
+								{typeof entry.data === 'string' ? entry.data : JSON.stringify(entry.data)}
+							</span>
+						</li>
+					))}
+				</ol>
+			</div>
+		</>
+	);
+}

--- a/src/features/instance/config/deployments/components/deploymentStatusBadge.tsx
+++ b/src/features/instance/config/deployments/components/deploymentStatusBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from '@/components/ui/badge';
+import { DeploymentStatus } from '@/integrations/api/instance/deployments/types';
+
+type BadgeVariant = 'default' | 'secondary' | 'warning' | 'success' | 'destructive' | 'outline';
+
+const STATUS_VARIANT: Record<DeploymentStatus, BadgeVariant> = {
+	pending: 'warning',
+	extracting: 'warning',
+	installing: 'warning',
+	loading: 'warning',
+	replicating: 'warning',
+	restarting: 'warning',
+	success: 'success',
+	failed: 'destructive',
+	rolled_back: 'destructive',
+};
+
+const STATUS_LABEL: Record<DeploymentStatus, string> = {
+	pending: 'Pending',
+	extracting: 'Extracting',
+	installing: 'Installing',
+	loading: 'Loading',
+	replicating: 'Replicating',
+	restarting: 'Restarting',
+	success: 'Success',
+	failed: 'Failed',
+	rolled_back: 'Rolled back',
+};
+
+export function DeploymentStatusBadge({ status }: { status: DeploymentStatus }) {
+	return <Badge variant={STATUS_VARIANT[status] ?? 'secondary'}>{STATUS_LABEL[status] ?? status}</Badge>;
+}

--- a/src/features/instance/config/deployments/constants/tableDefinition.tsx
+++ b/src/features/instance/config/deployments/constants/tableDefinition.tsx
@@ -1,0 +1,46 @@
+import { Deployment } from '@/integrations/api/instance/deployments/types';
+import { translateSecondsToAgo } from '@/lib/translateSecondsToAgo';
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { DeploymentStatusBadge } from '../components/deploymentStatusBadge';
+
+const columnHelper = createColumnHelper<Deployment>();
+
+function ago(ms?: number) {
+	return ms ? translateSecondsToAgo((Date.now() - ms) / 1000, ms) : '—';
+}
+
+export const deploymentColumns: Array<ColumnDef<Deployment>> = [
+	{
+		header: 'Project',
+		accessorKey: 'project',
+		enableSorting: false,
+	},
+	columnHelper.display({
+		header: 'Status',
+		id: 'status',
+		enableSorting: false,
+		cell: (props) => <DeploymentStatusBadge status={props.row.original.status} />,
+	}),
+	columnHelper.display({
+		header: 'Started',
+		id: 'started_at',
+		enableSorting: false,
+		cell: (props) => ago(props.row.original.started_at),
+	}),
+	columnHelper.display({
+		header: 'Completed',
+		id: 'completed_at',
+		enableSorting: false,
+		cell: (props) => ago(props.row.original.completed_at),
+	}),
+	{
+		header: 'User',
+		accessorKey: 'user',
+		enableSorting: false,
+	},
+	{
+		header: 'Origin',
+		accessorKey: 'origin_node',
+		enableSorting: false,
+	},
+];

--- a/src/features/instance/config/deployments/index.tsx
+++ b/src/features/instance/config/deployments/index.tsx
@@ -20,7 +20,7 @@ export function ConfigDeploymentsIndex() {
 	const instanceParams = useInstanceClientIdParams();
 
 	const { data, isFetching, isRefetching, refetch, error } = useQuery(
-		getDeploymentsQueryOptions({ ...instanceParams, limit: 100, enabled: canManage }),
+		getDeploymentsQueryOptions({ ...instanceParams, limit: 100, enabled: canManage, pollWhileOpen: true }),
 	);
 	const deployments = useMemo(() => data?.deployments ?? [], [data]);
 

--- a/src/features/instance/config/deployments/index.tsx
+++ b/src/features/instance/config/deployments/index.tsx
@@ -1,0 +1,79 @@
+import { SimpleBrowseDataTable } from '@/components/SimpleBrowseDataTable';
+import { Button } from '@/components/ui/button';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useInstanceManagePermission } from '@/hooks/usePermissions';
+import { useRefreshClick } from '@/hooks/useRefreshClick';
+import { getDeploymentsQueryOptions } from '@/integrations/api/instance/deployments/listDeployments';
+import { Deployment } from '@/integrations/api/instance/deployments/types';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { Row } from '@tanstack/react-table';
+import { RefreshCwIcon } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { deploymentColumns } from './constants/tableDefinition';
+import { DeploymentDetailModal } from './modals/DeploymentDetailModal';
+
+export function ConfigDeploymentsIndex() {
+	const navigate = useNavigate();
+	const canManage = useInstanceManagePermission();
+	const { deploymentId }: { deploymentId?: string } = useParams({ strict: false });
+	const instanceParams = useInstanceClientIdParams();
+
+	const { data, isFetching, isRefetching, refetch, error } = useQuery(
+		getDeploymentsQueryOptions({ ...instanceParams, limit: 100, enabled: canManage }),
+	);
+	const deployments = useMemo(() => data?.deployments ?? [], [data]);
+
+	const onSelect = useCallback(
+		(next: string | undefined) => {
+			const parts = [deploymentId ? '..' : '', next].filter(Boolean);
+			void navigate({ to: parts.join('/') || '.' });
+		},
+		[deploymentId, navigate],
+	);
+	const onRowClick = useCallback((row: Row<Deployment>) => onSelect(row.original.deployment_id), [onSelect]);
+	const closeModal = useCallback(() => onSelect(undefined), [onSelect]);
+	const onRefreshClick = useRefreshClick(refetch);
+
+	if (!canManage) {
+		return (
+			<div className="p-2 text-sm text-muted-foreground">
+				Viewing deployments requires super-user permissions on this instance.
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<SimpleBrowseDataTable<Deployment, unknown>
+				data={deployments}
+				isFetching={isFetching || isRefetching}
+				columns={deploymentColumns}
+				onRowClick={onRowClick}
+			>
+				<Button
+					variant="defaultOutline"
+					onClick={onRefreshClick}
+					accessKey="r"
+					disabled={isFetching || isRefetching}
+				>
+					<RefreshCwIcon />{' '}
+					<span className="hidden lg:inline-block">
+						<u>R</u>efresh
+					</span>
+				</Button>
+			</SimpleBrowseDataTable>
+			{error && (
+				<div className="mt-2 text-sm text-muted-foreground">
+					Could not load deployments. This instance may not support deployment history.
+				</div>
+			)}
+			{!error && !isFetching && deployments.length === 0 && (
+				<div className="mt-2 text-sm text-muted-foreground">No deployments yet.</div>
+			)}
+			{!!deploymentId && (
+				<DeploymentDetailModal deploymentId={deploymentId} isModalOpen={true} closeModal={closeModal} />
+			)}
+		</>
+	);
+}

--- a/src/features/instance/config/deployments/modals/DeploymentDetailModal.tsx
+++ b/src/features/instance/config/deployments/modals/DeploymentDetailModal.tsx
@@ -12,11 +12,20 @@ export function DeploymentDetailModal({
 }) {
 	return (
 		<Dialog onOpenChange={closeModal} open={isModalOpen}>
-			<DialogContent resizable className="max-h-[85vh] overflow-y-auto">
+			{
+				/*
+				No overflow/max-h on DialogContent itself: the resizable shell leaves the outer
+				content unclipped so its resize handles (which extend past the edges) stay reachable.
+				Clipping here swallows them. Scrolling lives on the inner flex-1/min-h-0 body instead.
+			*/
+			}
+			<DialogContent resizable aria-describedby={undefined}>
 				<DialogHeader>
 					<DialogTitle>Deployment</DialogTitle>
 				</DialogHeader>
-				<DeploymentDetail deploymentId={deploymentId} />
+				<div className="min-h-0 flex-1 overflow-y-auto">
+					<DeploymentDetail deploymentId={deploymentId} />
+				</div>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/features/instance/config/deployments/modals/DeploymentDetailModal.tsx
+++ b/src/features/instance/config/deployments/modals/DeploymentDetailModal.tsx
@@ -1,0 +1,23 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { DeploymentDetail } from '@/features/instance/config/deployments/components/DeploymentDetail';
+
+export function DeploymentDetailModal({
+	deploymentId,
+	isModalOpen,
+	closeModal,
+}: {
+	deploymentId: string;
+	isModalOpen: boolean;
+	closeModal: () => void;
+}) {
+	return (
+		<Dialog onOpenChange={closeModal} open={isModalOpen}>
+			<DialogContent resizable className="max-h-[85vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>Deployment</DialogTitle>
+				</DialogHeader>
+				<DeploymentDetail deploymentId={deploymentId} />
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -8,7 +8,7 @@ import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Outlet, useLoaderData, useParams } from '@tanstack/react-router';
-import { GlobeIcon, HandshakeIcon, KeyIcon, PieChartIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
+import { GlobeIcon, HandshakeIcon, KeyIcon, PieChartIcon, RocketIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
 import { ReactNode, Suspense } from 'react';
 
 const sharedClasses = 'flex items-center p-2 rounded-lg group';
@@ -23,6 +23,7 @@ export function ConfigIndex() {
 	} = useParams({ strict: false });
 	const { version }: RegistrationInfoResponse = useLoaderData({ strict: false });
 	const certsAvailable = wasAReleasedBeforeB('4.6.0', version);
+	const deploymentsAvailable = wasAReleasedBeforeB('5.1.0', version);
 
 	const { clusterId } = params;
 	const canManage = useInstanceManagePermission();
@@ -53,6 +54,18 @@ export function ConfigIndex() {
 					<HandshakeIcon className="hidden md:inline-block" /> <span className="ms-3">Roles</span>
 				</Link>
 			</li>
+			{deploymentsAvailable && (
+				<li>
+					<Link
+						to={buildAbsoluteLinkToPage(params, 'config/deployments')}
+						className={sharedClasses}
+						inactiveProps={inactiveProps}
+						activeProps={activeProps}
+					>
+						<RocketIcon className="hidden md:inline-block" /> <span className="ms-3">Deployments</span>
+					</Link>
+				</li>
+			)}
 			{certsAvailable && (
 				<li>
 					<Link

--- a/src/features/instance/config/routes.ts
+++ b/src/features/instance/config/routes.ts
@@ -1,4 +1,5 @@
 import { ConfigCertificatesIndex } from '@/features/instance/config/certificates';
+import { ConfigDeploymentsIndex } from '@/features/instance/config/deployments';
 import { ConfigDomainsIndex } from '@/features/instance/config/domains';
 import { ConfigIndex } from '@/features/instance/config/index';
 import { ConfigOverviewIndex } from '@/features/instance/config/overview';
@@ -71,6 +72,19 @@ export function createConfigRouteTree(instanceLayoutRoute: ReturnType<typeof cre
 		component: ConfigSSHKeysIndex,
 	});
 
+	const instanceConfigDeploymentsRoute = createRoute({
+		getParentRoute: () => instanceConfigRoute,
+		path: 'deployments',
+		head: () => ({ meta: [{ title: 'Deployments — Harper Fabric' }] }),
+		component: ConfigDeploymentsIndex,
+	});
+	const instanceConfigDeploymentRoute = createRoute({
+		getParentRoute: () => instanceConfigRoute,
+		path: 'deployments/$deploymentId',
+		head: () => ({ meta: [{ title: 'Deployments — Harper Fabric' }] }),
+		component: ConfigDeploymentsIndex,
+	});
+
 	const instanceConfigCertificatesRoute = createRoute({
 		getParentRoute: () => instanceConfigRoute,
 		path: 'certificates',
@@ -94,6 +108,9 @@ export function createConfigRouteTree(instanceLayoutRoute: ReturnType<typeof cre
 		instanceConfigUserRoute,
 
 		instanceConfigDomainsRoute,
+
+		instanceConfigDeploymentsRoute,
+		instanceConfigDeploymentRoute,
 
 		instanceConfigSSHKeysRoute,
 		instanceConfigSSHKeyRoute,

--- a/src/integrations/api/instance/applications/deployComponent.test.ts
+++ b/src/integrations/api/instance/applications/deployComponent.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./deployComponentStream', () => ({
+	deployComponentStream: vi.fn(),
+}));
+
+import { SSEOperationError, SSEUnsupportedError } from '@/integrations/api/sse/errors';
+import { onDeployComponentSubmit } from './deployComponent';
+import { deployComponentStream } from './deployComponentStream';
+
+const mockStream = vi.mocked(deployComponentStream);
+
+function fakeClient(data: unknown) {
+	return { post: vi.fn().mockResolvedValue({ data }) };
+}
+
+const baseArgs = {
+	applicationName: 'my-app',
+	applicationUrl: 'npm:my-app',
+	entityId: 'ins-1' as const,
+	entityType: 'instance' as const,
+};
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('onDeployComponentSubmit', () => {
+	it('uses the buffered axios path when SSE is not requested', async () => {
+		const client = fakeClient({ message: 'buffered' });
+		const result = await onDeployComponentSubmit({
+			...baseArgs,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			instanceClient: client as any,
+		});
+		expect(result).toEqual({ message: 'buffered' });
+		expect(client.post).toHaveBeenCalledOnce();
+		expect(mockStream).not.toHaveBeenCalled();
+	});
+
+	it('returns the streamed result when SSE succeeds', async () => {
+		mockStream.mockResolvedValue({ message: 'streamed', deployment_id: 'd1' });
+		const client = fakeClient({ message: 'buffered' });
+		const result = await onDeployComponentSubmit({
+			...baseArgs,
+			useSSE: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			instanceClient: client as any,
+		});
+		expect(result).toEqual({ message: 'streamed', deployment_id: 'd1' });
+		// SSE succeeded → must NOT also POST (no double-deploy).
+		expect(client.post).not.toHaveBeenCalled();
+	});
+
+	it('falls back to the buffered path when the stream is unsupported', async () => {
+		mockStream.mockRejectedValue(new SSEUnsupportedError('no stream'));
+		const client = fakeClient({ message: 'buffered' });
+		const result = await onDeployComponentSubmit({
+			...baseArgs,
+			useSSE: true,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			instanceClient: client as any,
+		});
+		expect(result).toEqual({ message: 'buffered' });
+		expect(client.post).toHaveBeenCalledOnce();
+	});
+
+	it('rethrows a deploy failure without re-POSTing (no double deploy)', async () => {
+		mockStream.mockRejectedValue(new SSEOperationError('deploy failed'));
+		const client = fakeClient({ message: 'buffered' });
+		await expect(
+			onDeployComponentSubmit({
+				...baseArgs,
+				useSSE: true,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				instanceClient: client as any,
+			}),
+		).rejects.toBeInstanceOf(SSEOperationError);
+		expect(client.post).not.toHaveBeenCalled();
+	});
+});

--- a/src/integrations/api/instance/applications/deployComponent.ts
+++ b/src/integrations/api/instance/applications/deployComponent.ts
@@ -1,6 +1,9 @@
 import { InstanceClientConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import { EntityIds } from '@/features/auth/store/authStore';
 import { ReplicatedResponse } from '@/integrations/api/replication';
+import { SSEUnsupportedError } from '@/integrations/api/sse/errors';
 import { useMutation } from '@tanstack/react-query';
+import { DeployComponentResult, deployComponentStream, DeployStreamEvent } from './deployComponentStream';
 
 export interface DeployComponentFormData {
 	applicationName: string;
@@ -8,26 +11,67 @@ export interface DeployComponentFormData {
 	installCommand?: string;
 }
 
-async function onDeployComponentSubmit({
+export interface DeployComponentArgs extends DeployComponentFormData, InstanceClientConfig, InstanceTypeConfig {
+	/** Entity id, used to resolve the SSE connection. Present on `useInstanceClientIdParams`. */
+	entityId?: EntityIds;
+	/** Opt into the live SSE deploy (only when the instance is Harper >= 5.1.0). */
+	useSSE?: boolean;
+	/** Live deploy events, when streaming. */
+	onEvent?: (event: DeployStreamEvent) => void;
+	/** Aborts the stream (e.g. explicit cancel). Modal close should NOT abort an in-flight deploy. */
+	signal?: AbortSignal;
+}
+
+export async function onDeployComponentSubmit({
 	applicationName,
 	applicationUrl,
 	installCommand,
 	entityType,
+	entityId,
 	instanceClient,
-}: DeployComponentFormData & InstanceClientConfig & InstanceTypeConfig): Promise<ReplicatedResponse> {
+	useSSE,
+	onEvent,
+	signal,
+}: DeployComponentArgs): Promise<DeployComponentResult> {
+	const replicated = entityType === 'cluster';
+
+	if (useSSE && entityId) {
+		try {
+			return await deployComponentStream({
+				connection: { id: entityId },
+				package: applicationUrl,
+				project: applicationName,
+				replicated,
+				install_command: installCommand,
+				restart: 'rolling',
+				signal,
+				onEvent,
+			});
+		} catch (error) {
+			// Couldn't establish a stream (bad response/content-type/connection) and no deploy
+			// has started yet — safe to fall back to the proven buffered path below.
+			if (!(error instanceof SSEUnsupportedError)) {
+				// A terminal error, an inconclusive stream, or a deliberate abort. The deploy has
+				// already started server-side, so we must NOT re-POST it (that would deploy
+				// twice). Let the caller handle it (show the error, or poll on inconclusive).
+				throw error;
+			}
+		}
+	}
+
 	const { data } = await instanceClient.post(
 		'/',
 		{
 			operation: 'deploy_component',
 			package: applicationUrl,
 			project: applicationName,
-			replicated: entityType === 'cluster',
+			replicated,
 			install_command: installCommand || undefined,
 			restart: 'rolling',
 		},
 		{ timeout: 300_000 },
 	);
-	return data;
+	return data as ReplicatedResponse;
 }
 
 export function useDeployComponentMutation() {

--- a/src/integrations/api/instance/applications/deployComponentStream.ts
+++ b/src/integrations/api/instance/applications/deployComponentStream.ts
@@ -1,0 +1,104 @@
+import { ReplicatedResponse } from '@/integrations/api/replication';
+import { parseSSEData } from '@/integrations/api/sse/parseSSEStream';
+import { ResolveInstanceConnectionParams } from '@/integrations/api/sse/resolveInstanceConnection';
+import { streamOperation } from '@/integrations/api/sse/streamOperation';
+
+/** Lifecycle phases Harper's `deploy_component` emits, in order. */
+export const DEPLOY_PHASE_ORDER = ['prepare', 'load', 'replicate', 'restart', 'success'] as const;
+export type DeployPhase = (typeof DEPLOY_PHASE_ORDER)[number];
+
+export interface DeployPhaseEvent {
+	phase: string;
+	status: 'start' | 'done' | 'error';
+	message?: string;
+	rolling?: boolean;
+}
+
+export interface DeployInstallEvent {
+	manager?: string;
+	/** 'stdout' | 'stderr' */
+	stream?: string;
+	line: string;
+}
+
+/** Per-node replication result emitted as the origin fans the deploy out to peers. */
+export interface DeployPeerEvent {
+	node?: string;
+	status?: string;
+	reason?: string;
+	[key: string]: unknown;
+}
+
+/** A live deploy event, discriminated by `type`, surfaced to the UI via `onEvent`. */
+export type DeployStreamEvent =
+	| { type: 'phase'; data: DeployPhaseEvent }
+	| { type: 'install'; data: DeployInstallEvent }
+	| { type: 'peer'; data: DeployPeerEvent };
+
+export interface DeployComponentResult extends ReplicatedResponse {
+	deployment_id?: string;
+	phase?: string;
+}
+
+export interface DeployComponentStreamParams {
+	connection: ResolveInstanceConnectionParams;
+	package: string;
+	project: string;
+	replicated: boolean;
+	install_command?: string;
+	restart?: string;
+	signal?: AbortSignal;
+	/** Called for each live deploy event so the UI can render progress. */
+	onEvent?: (event: DeployStreamEvent) => void;
+}
+
+/**
+ * Run `deploy_component` over SSE, forwarding live phase/install/peer events to `onEvent`
+ * and resolving with the terminal `done` result.
+ *
+ * Throws the transport errors from `@/integrations/api/sse/errors`:
+ * - `SSEUnsupportedError` — the server/proxy didn't stream; caller should retry buffered.
+ * - `SSEOperationError` — the deploy failed (terminal `error` event).
+ * - `SSEInconclusiveError` — the stream ended without a verdict; caller must poll.
+ */
+export async function deployComponentStream({
+	connection,
+	package: packageRef,
+	project,
+	replicated,
+	install_command,
+	restart,
+	signal,
+	onEvent,
+}: DeployComponentStreamParams): Promise<DeployComponentResult> {
+	const result = await streamOperation({
+		connection,
+		body: {
+			operation: 'deploy_component',
+			package: packageRef,
+			project,
+			replicated,
+			install_command: install_command || undefined,
+			restart,
+		},
+		signal,
+		onMessage: (message) => {
+			if (!onEvent) {
+				return;
+			}
+			switch (message.event) {
+				case 'phase':
+					onEvent({ type: 'phase', data: parseSSEData(message) as DeployPhaseEvent });
+					break;
+				case 'install':
+					onEvent({ type: 'install', data: parseSSEData(message) as DeployInstallEvent });
+					break;
+				case 'peer':
+					onEvent({ type: 'peer', data: parseSSEData(message) as DeployPeerEvent });
+					break;
+			}
+		},
+	});
+
+	return (result ?? {}) as DeployComponentResult;
+}

--- a/src/integrations/api/instance/applications/getComponents.ts
+++ b/src/integrations/api/instance/applications/getComponents.ts
@@ -1,9 +1,21 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { queryOptions } from '@tanstack/react-query';
 
+/** Harper component status levels (Harper >= 5.1.0). */
+export type ComponentStatusLevel = 'healthy' | 'warning' | 'error' | 'unknown' | 'loading';
+
+export interface ComponentStatus {
+	status: ComponentStatusLevel;
+	message?: string;
+	/** Per-worker check timestamps; shape varies, kept loose. */
+	lastChecked?: unknown;
+}
+
 export interface APIDirectoryEntry extends APIFileEntry {
 	entries: Array<APIDirectoryEntry | APIFileEntry>;
 	package?: string;
+	/** Present on Harper >= 5.1.0 for top-level component entries. */
+	status?: ComponentStatus;
 }
 
 export interface APIFileEntry {

--- a/src/integrations/api/instance/deployments/getDeployment.ts
+++ b/src/integrations/api/instance/deployments/getDeployment.ts
@@ -1,0 +1,91 @@
+import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { EntityIds } from '@/features/auth/store/authStore';
+import {
+	DeployInstallEvent,
+	DeployPeerEvent,
+	DeployPhaseEvent,
+	DeployStreamEvent,
+} from '@/integrations/api/instance/applications/deployComponentStream';
+import { parseSSEData } from '@/integrations/api/sse/parseSSEStream';
+import { ResolveInstanceConnectionParams } from '@/integrations/api/sse/resolveInstanceConnection';
+import { streamOperation } from '@/integrations/api/sse/streamOperation';
+import { queryOptions } from '@tanstack/react-query';
+import { Deployment, isTerminalDeploymentStatus } from './types';
+
+export interface GetDeploymentParams extends InstanceClientIdConfig {
+	deploymentId: string;
+}
+
+export async function getDeployment({
+	instanceClient,
+	deploymentId,
+}: GetDeploymentParams): Promise<Deployment> {
+	const { data } = await instanceClient.post('/', {
+		operation: 'get_deployment',
+		deployment_id: deploymentId,
+	});
+	return data as Deployment;
+}
+
+export function getDeploymentQueryOptions(params: GetDeploymentParams & { pollWhileActive?: boolean }) {
+	return queryOptions({
+		queryKey: [params.entityId, 'get_deployment', params.deploymentId] as const,
+		queryFn: () => getDeployment(params),
+		retry: false,
+		// While the detail view falls back to polling (no SSE), keep refetching until the
+		// deployment reaches a terminal status, then stop.
+		refetchInterval: (query) =>
+			params.pollWhileActive && !isTerminalDeploymentStatus(query.state.data?.status) ? 2_000 : false,
+	});
+}
+
+export interface GetDeploymentStreamParams {
+	connection: ResolveInstanceConnectionParams;
+	deploymentId: string;
+	signal?: AbortSignal;
+	/** Live events: replayed `event_log` entries first, then live tail until terminal. */
+	onEvent?: (event: DeployStreamEvent) => void;
+}
+
+/**
+ * Tail a deployment's progress over SSE: `get_deployment` with `Accept: text/event-stream`
+ * replays the row's `event_log`, then streams live `ProgressEmitter` events until the
+ * deploy reaches a terminal status, resolving with the final post-deploy row.
+ *
+ * Throws the transport errors from `@/integrations/api/sse/errors` (caller falls back to
+ * polling `getDeploymentQueryOptions` on `SSEUnsupportedError` / `SSEInconclusiveError`).
+ */
+export async function getDeploymentStream({
+	connection,
+	deploymentId,
+	signal,
+	onEvent,
+}: GetDeploymentStreamParams): Promise<Deployment> {
+	const result = await streamOperation({
+		connection,
+		body: { operation: 'get_deployment', deployment_id: deploymentId },
+		signal,
+		onMessage: (message) => {
+			if (!onEvent) {
+				return;
+			}
+			switch (message.event) {
+				case 'phase':
+					onEvent({ type: 'phase', data: parseSSEData(message) as DeployPhaseEvent });
+					break;
+				case 'install':
+					onEvent({ type: 'install', data: parseSSEData(message) as DeployInstallEvent });
+					break;
+				case 'peer':
+					onEvent({ type: 'peer', data: parseSSEData(message) as DeployPeerEvent });
+					break;
+			}
+		},
+	});
+	return (result ?? {}) as Deployment;
+}
+
+/** Resolve the SSE connection params for an entity. */
+export function deploymentConnection(id: EntityIds): ResolveInstanceConnectionParams {
+	return { id };
+}

--- a/src/integrations/api/instance/deployments/listDeployments.ts
+++ b/src/integrations/api/instance/deployments/listDeployments.ts
@@ -1,6 +1,6 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { queryOptions } from '@tanstack/react-query';
-import { DeploymentStatus, ListDeploymentsResponse } from './types';
+import { DeploymentStatus, isTerminalDeploymentStatus, ListDeploymentsResponse } from './types';
 
 export interface ListDeploymentsParams extends InstanceClientIdConfig {
 	project?: string;
@@ -10,7 +10,18 @@ export interface ListDeploymentsParams extends InstanceClientIdConfig {
 	limit?: number;
 	offset?: number;
 	enabled?: boolean;
+	/**
+	 * Poll the list while the view is open so deploys triggered elsewhere appear and their
+	 * status transitions land without a manual refresh. `hdb_deployment` is a system table and
+	 * isn't exposed as a subscribable resource, so polling is the live-update mechanism.
+	 */
+	pollWhileOpen?: boolean;
 }
+
+// Poll fast while a deploy is in flight (status changes every few seconds), slower otherwise
+// (just catching newly-started deploys).
+const ACTIVE_POLL_MS = 2_000;
+const IDLE_POLL_MS = 10_000;
 
 export async function listDeployments({
 	instanceClient,
@@ -34,11 +45,18 @@ export async function listDeployments({
 }
 
 export function getDeploymentsQueryOptions(params: ListDeploymentsParams) {
-	const { entityId, project, status, since, until, limit, offset } = params;
+	const { entityId, project, status, since, until, limit, offset, pollWhileOpen } = params;
 	return queryOptions({
 		queryKey: [entityId, 'list_deployments', { project, status, since, until, limit, offset }] as const,
 		queryFn: () => listDeployments(params),
 		retry: false,
 		enabled: params.enabled !== false,
+		refetchInterval: pollWhileOpen
+			? (query) => {
+				const deployments = query.state.data?.deployments ?? [];
+				const anyActive = deployments.some((d) => !isTerminalDeploymentStatus(d.status));
+				return anyActive ? ACTIVE_POLL_MS : IDLE_POLL_MS;
+			}
+			: false,
 	});
 }

--- a/src/integrations/api/instance/deployments/listDeployments.ts
+++ b/src/integrations/api/instance/deployments/listDeployments.ts
@@ -1,0 +1,44 @@
+import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { queryOptions } from '@tanstack/react-query';
+import { DeploymentStatus, ListDeploymentsResponse } from './types';
+
+export interface ListDeploymentsParams extends InstanceClientIdConfig {
+	project?: string;
+	status?: DeploymentStatus;
+	since?: number;
+	until?: number;
+	limit?: number;
+	offset?: number;
+	enabled?: boolean;
+}
+
+export async function listDeployments({
+	instanceClient,
+	project,
+	status,
+	since,
+	until,
+	limit,
+	offset,
+}: ListDeploymentsParams): Promise<ListDeploymentsResponse> {
+	const { data } = await instanceClient.post('/', {
+		operation: 'list_deployments',
+		project,
+		status,
+		since,
+		until,
+		limit,
+		offset,
+	});
+	return data as ListDeploymentsResponse;
+}
+
+export function getDeploymentsQueryOptions(params: ListDeploymentsParams) {
+	const { entityId, project, status, since, until, limit, offset } = params;
+	return queryOptions({
+		queryKey: [entityId, 'list_deployments', { project, status, since, until, limit, offset }] as const,
+		queryFn: () => listDeployments(params),
+		retry: false,
+		enabled: params.enabled !== false,
+	});
+}

--- a/src/integrations/api/instance/deployments/types.test.ts
+++ b/src/integrations/api/instance/deployments/types.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { DeploymentStatus, isTerminalDeploymentStatus } from './types';
+
+describe('isTerminalDeploymentStatus', () => {
+	it.each<[DeploymentStatus, boolean]>([
+		['pending', false],
+		['extracting', false],
+		['installing', false],
+		['loading', false],
+		['replicating', false],
+		['restarting', false],
+		['success', true],
+		['failed', true],
+		['rolled_back', true],
+	])('%s -> terminal=%s', (status, expected) => {
+		expect(isTerminalDeploymentStatus(status)).toBe(expected);
+	});
+
+	it('treats undefined as non-terminal', () => {
+		expect(isTerminalDeploymentStatus(undefined)).toBe(false);
+	});
+});

--- a/src/integrations/api/instance/deployments/types.ts
+++ b/src/integrations/api/instance/deployments/types.ts
@@ -1,0 +1,73 @@
+/** Lifecycle status of an `hdb_deployment` row (Harper >= 5.1.0). */
+export type DeploymentStatus =
+	| 'pending'
+	| 'extracting'
+	| 'installing'
+	| 'loading'
+	| 'replicating'
+	| 'restarting'
+	| 'success'
+	| 'failed'
+	| 'rolled_back';
+
+export const TERMINAL_DEPLOYMENT_STATUSES: ReadonlySet<DeploymentStatus> = new Set([
+	'success',
+	'failed',
+	'rolled_back',
+]);
+
+export function isTerminalDeploymentStatus(status: DeploymentStatus | undefined): boolean {
+	return !!status && TERMINAL_DEPLOYMENT_STATUSES.has(status);
+}
+
+export interface DeploymentEventLogEntry {
+	/** Epoch ms. */
+	t: number;
+	event: string;
+	data: unknown;
+}
+
+export interface DeploymentPeerResult {
+	node: string;
+	status?: string;
+	error?: string;
+	started_at?: number;
+	completed_at?: number;
+}
+
+export interface DeploymentError {
+	message: string;
+	code?: string | number;
+	phase?: string;
+}
+
+/**
+ * A row from Harper's replicated `hdb_deployment` table. `payload_blob` never travels over
+ * the operations API — `list_deployments` and `get_deployment` strip it and expose
+ * `payload_blob_present` instead.
+ */
+export interface Deployment {
+	deployment_id: string;
+	project: string;
+	package_identifier?: string | null;
+	payload_hash?: string | null;
+	payload_size?: number | null;
+	payload_blob_present?: boolean;
+	status: DeploymentStatus;
+	phase?: string;
+	event_log?: DeploymentEventLogEntry[];
+	peer_results?: DeploymentPeerResult[];
+	origin_node?: string;
+	restart_mode?: string | null;
+	started_at?: number;
+	completed_at?: number;
+	user?: string;
+	restorable?: boolean;
+	rollback_of?: string | null;
+	error?: DeploymentError | null;
+}
+
+export interface ListDeploymentsResponse {
+	deployments: Deployment[];
+	total: number;
+}

--- a/src/integrations/api/sse/errors.ts
+++ b/src/integrations/api/sse/errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Distinct failure modes for the browser SSE transport (`streamOperation`). Callers use
+ * these to decide whether to retry on the classic buffered axios path or to fall back to
+ * polling — never to silently assume success.
+ */
+
+/**
+ * The server did not (or could not) speak SSE for this request: the response was not OK,
+ * arrived without a `text/event-stream` content-type (e.g. an older Harper that ignores
+ * the `Accept` header, or a proxy that rewrote it), or the connection failed before any
+ * bytes streamed. The caller should fall back to the classic buffered operation.
+ */
+export class SSEUnsupportedError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = 'SSEUnsupportedError';
+	}
+}
+
+/**
+ * The stream opened and was consumed, but ended without a terminal `done` or `error`
+ * event — for example a proxy that buffered then truncated the response, or an idle
+ * timeout. The outcome is genuinely unknown, so the caller must determine the real result
+ * by polling (`get_deployment` / `get_components`) rather than treating it as success.
+ */
+export class SSEInconclusiveError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = 'SSEInconclusiveError';
+	}
+}
+
+/**
+ * A terminal `error` event was received over the stream. Carries the structured fields
+ * Harper emits so the UI can surface phase/code alongside the message.
+ */
+export class SSEOperationError extends Error {
+	readonly code?: string | number;
+	readonly phase?: string;
+	readonly deploymentId?: string;
+
+	constructor(message: string, details?: { code?: string | number; phase?: string; deploymentId?: string }) {
+		super(message);
+		this.name = 'SSEOperationError';
+		this.code = details?.code;
+		this.phase = details?.phase;
+		this.deploymentId = details?.deploymentId;
+	}
+}

--- a/src/integrations/api/sse/parseSSEStream.test.ts
+++ b/src/integrations/api/sse/parseSSEStream.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { parseSSEData, parseSSEStream, SSEMessage } from './parseSSEStream';
+
+function streamFrom(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) {
+				controller.enqueue(encoder.encode(chunk));
+			}
+			controller.close();
+		},
+	});
+}
+
+async function collect(chunks: string[]): Promise<SSEMessage[]> {
+	const out: SSEMessage[] = [];
+	for await (const message of parseSSEStream(streamFrom(chunks))) {
+		out.push(message);
+	}
+	return out;
+}
+
+describe('parseSSEStream', () => {
+	it('parses a single event/data record', async () => {
+		const messages = await collect(['event: phase\ndata: {"phase":"prepare"}\n\n']);
+		expect(messages).toEqual([{ event: 'phase', data: '{"phase":"prepare"}', id: undefined, retry: undefined }]);
+	});
+
+	it('joins multi-line data with newlines', async () => {
+		const [message] = await collect(['event: install\ndata: line one\ndata: line two\n\n']);
+		expect(message.event).toBe('install');
+		expect(message.data).toBe('line one\nline two');
+	});
+
+	it('ignores the opening comment line', async () => {
+		const messages = await collect([': stream open\n\n', 'event: done\ndata: {"result":1}\n\n']);
+		expect(messages).toHaveLength(1);
+		expect(messages[0].event).toBe('done');
+	});
+
+	it('reassembles records split across chunk boundaries', async () => {
+		const messages = await collect(['event: pha', 'se\ndata: {"phase":', '"load"}\n', '\n']);
+		expect(messages).toEqual([{ event: 'phase', data: '{"phase":"load"}', id: undefined, retry: undefined }]);
+	});
+
+	it('handles CRLF line endings', async () => {
+		const [message] = await collect(['event: peer\r\ndata: ok\r\n\r\n']);
+		expect(message).toMatchObject({ event: 'peer', data: 'ok' });
+	});
+
+	it('surfaces a trailing record with no terminating blank line', async () => {
+		const [message] = await collect(['event: done\ndata: {"result":true}']);
+		expect(message).toMatchObject({ event: 'done', data: '{"result":true}' });
+	});
+
+	it('strips a single leading space after the field colon', async () => {
+		const [message] = await collect(['data:  two spaces\n\n']);
+		// First space stripped, the second is preserved.
+		expect(message.data).toBe(' two spaces');
+	});
+
+	it('stops early when the signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const out: SSEMessage[] = [];
+		for await (const message of parseSSEStream(streamFrom(['event: phase\ndata: x\n\n']), controller.signal)) {
+			out.push(message);
+		}
+		expect(out).toHaveLength(0);
+	});
+});
+
+describe('parseSSEData', () => {
+	it('parses JSON payloads', () => {
+		expect(parseSSEData({ event: 'done', data: '{"result":{"deployment_id":"d1"}}' })).toEqual({
+			result: { deployment_id: 'd1' },
+		});
+	});
+
+	it('falls back to the raw string for non-JSON payloads', () => {
+		expect(parseSSEData({ event: 'install', data: 'npm warn deprecated' })).toBe('npm warn deprecated');
+	});
+});

--- a/src/integrations/api/sse/parseSSEStream.test.ts
+++ b/src/integrations/api/sse/parseSSEStream.test.ts
@@ -60,6 +60,26 @@ describe('parseSSEStream', () => {
 		expect(message.data).toBe(' two spaces');
 	});
 
+	it('cancels the underlying stream when the consumer breaks early', async () => {
+		let cancelled = false;
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				// Enqueue one record but never close — the only way the reader releases is via cancel.
+				controller.enqueue(encoder.encode('event: phase\ndata: {"phase":"prepare"}\n\n'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+
+		for await (const _message of parseSSEStream(stream)) {
+			break; // bail after the first message, like streamOperation does on `done`
+		}
+
+		expect(cancelled).toBe(true);
+	});
+
 	it('stops early when the signal is already aborted', async () => {
 		const controller = new AbortController();
 		controller.abort();

--- a/src/integrations/api/sse/parseSSEStream.ts
+++ b/src/integrations/api/sse/parseSSEStream.ts
@@ -23,6 +23,7 @@ export async function* parseSSEStream(
 	const reader = body.getReader();
 	const decoder = new TextDecoder('utf-8');
 	let buffer = '';
+	let completed = false;
 	try {
 		while (true) {
 			if (signal?.aborted) {
@@ -30,6 +31,7 @@ export async function* parseSSEStream(
 			}
 			const { value, done } = await reader.read();
 			if (done) {
+				completed = true;
 				break;
 			}
 			buffer += decoder.decode(value, { stream: true });
@@ -45,6 +47,12 @@ export async function* parseSSEStream(
 			}
 		}
 	} finally {
+		// If a consumer breaks early (e.g. on a terminal `done` event) or aborts, the stream
+		// hasn't drained — cancel it so the underlying network connection is released rather
+		// than left open (browsers cap concurrent connections per host).
+		if (!completed) {
+			void reader.cancel().catch(() => {});
+		}
 		reader.releaseLock();
 	}
 

--- a/src/integrations/api/sse/parseSSEStream.ts
+++ b/src/integrations/api/sse/parseSSEStream.ts
@@ -1,0 +1,127 @@
+export interface SSEMessage {
+	event: string;
+	data: string;
+	id?: string;
+	retry?: number;
+}
+
+/**
+ * Parse a browser `ReadableStream<Uint8Array>` carrying Server-Sent Events into structured
+ * messages, one per blank-line-terminated record.
+ *
+ * Handles the things the wire doesn't guarantee: split `data:` lines, CRLF or LF endings,
+ * comment lines (`: stream open`), and arbitrary chunk boundaries (the network does not
+ * align chunks to SSE record boundaries). Mirrors Harper's own consumer in
+ * `bin/sseConsumer.ts` so client and server agree on framing.
+ *
+ * Pass an `AbortSignal` to stop early; the underlying reader is always released.
+ */
+export async function* parseSSEStream(
+	body: ReadableStream<Uint8Array>,
+	signal?: AbortSignal,
+): AsyncGenerator<SSEMessage> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder('utf-8');
+	let buffer = '';
+	try {
+		while (true) {
+			if (signal?.aborted) {
+				return;
+			}
+			const { value, done } = await reader.read();
+			if (done) {
+				break;
+			}
+			buffer += decoder.decode(value, { stream: true });
+			yield* drainRecords();
+		}
+		buffer += decoder.decode();
+		// A trailing record without a terminating blank line (connection closed mid-flush)
+		// is still surfaced, matching the looser behavior browsers exhibit on close.
+		if (buffer.trim()) {
+			const msg = parseRecord(buffer);
+			if (msg) {
+				yield msg;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	function* drainRecords(): Generator<SSEMessage> {
+		while (true) {
+			const lfEnd = buffer.indexOf('\n\n');
+			const crlfEnd = buffer.indexOf('\r\n\r\n');
+			let endIdx = -1;
+			let delimLen = 0;
+			if (lfEnd !== -1 && (crlfEnd === -1 || lfEnd < crlfEnd)) {
+				endIdx = lfEnd;
+				delimLen = 2;
+			} else if (crlfEnd !== -1) {
+				endIdx = crlfEnd;
+				delimLen = 4;
+			}
+			if (endIdx === -1) {
+				return;
+			}
+			const record = buffer.slice(0, endIdx);
+			buffer = buffer.slice(endIdx + delimLen);
+			const msg = parseRecord(record);
+			if (msg) {
+				yield msg;
+			}
+		}
+	}
+}
+
+function parseRecord(record: string): SSEMessage | null {
+	const lines = record.split(/\r?\n/);
+	let event = 'message';
+	let id: string | undefined;
+	let retry: number | undefined;
+	const dataLines: string[] = [];
+	for (const line of lines) {
+		// Blank lines and comments (lines beginning with ':') are ignored per the SSE spec.
+		if (line === '' || line.startsWith(':')) {
+			continue;
+		}
+		const colon = line.indexOf(':');
+		const field = colon === -1 ? line : line.slice(0, colon);
+		let value = colon === -1 ? '' : line.slice(colon + 1);
+		// A single leading space after the colon is stripped per spec.
+		if (value.startsWith(' ')) {
+			value = value.slice(1);
+		}
+		switch (field) {
+			case 'event':
+				event = value;
+				break;
+			case 'data':
+				dataLines.push(value);
+				break;
+			case 'id':
+				id = value;
+				break;
+			case 'retry': {
+				const n = Number(value);
+				if (Number.isFinite(n)) {
+					retry = n;
+				}
+				break;
+			}
+		}
+	}
+	if (dataLines.length === 0 && event === 'message') {
+		return null;
+	}
+	return { event, data: dataLines.join('\n'), id, retry };
+}
+
+/** Parse an {@link SSEMessage}'s data payload as JSON, falling back to the raw string. */
+export function parseSSEData(message: SSEMessage): unknown {
+	try {
+		return JSON.parse(message.data);
+	} catch {
+		return message.data;
+	}
+}

--- a/src/integrations/api/sse/resolveInstanceConnection.test.ts
+++ b/src/integrations/api/sse/resolveInstanceConnection.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/features/auth/store/authStore', () => ({
 		getOperationsUrl: vi.fn(),
 		checkForFabricConnect: vi.fn(),
 		checkForBasicAuth: vi.fn(),
+		getOperationToken: vi.fn(),
 	},
 }));
 
@@ -22,6 +23,7 @@ beforeEach(() => {
 	vi.resetAllMocks();
 	mockAuthStore.checkForFabricConnect.mockReturnValue(false);
 	mockAuthStore.checkForBasicAuth.mockReturnValue(undefined);
+	mockAuthStore.getOperationToken.mockReturnValue(undefined);
 });
 
 describe('resolveInstanceConnection', () => {
@@ -29,7 +31,7 @@ describe('resolveInstanceConnection', () => {
 		mockAuthStore.getOperationsUrl.mockReturnValue('https://host:9925');
 		mockAuthStore.checkForBasicAuth.mockReturnValue({ username: 'admin', password: 'pw' });
 
-		const { url, headers, credentials } = resolveInstanceConnection({ id: 'ins-1' });
+		const { url, headers, credentials, mode } = resolveInstanceConnection({ id: 'ins-1' });
 
 		expect(url).toBe('https://host:9925/');
 		expect(headers.Authorization).toBe(`Basic ${btoa('admin:pw')}`);
@@ -37,6 +39,21 @@ describe('resolveInstanceConnection', () => {
 		expect(headers['Content-Type']).toBe('application/json');
 		// Direct + basic auth → no cookies needed.
 		expect(credentials).toBe('same-origin');
+		expect(mode).toBe('direct');
+	});
+
+	it('uses a direct Bearer token when Fabric Connect resolved to direct', () => {
+		mockAuthStore.getOperationsUrl.mockReturnValue('https://host:9925');
+		mockAuthStore.checkForFabricConnect.mockReturnValue(true);
+		mockAuthStore.getOperationToken.mockReturnValue('jwt-123');
+
+		const { url, headers, credentials, mode } = resolveInstanceConnection({ id: 'clu-abc' });
+
+		// Direct instance URL (NOT the proxy) + Bearer → SSE streams.
+		expect(url).toBe('https://host:9925/');
+		expect(headers.Authorization).toBe('Bearer jwt-123');
+		expect(credentials).toBe('same-origin');
+		expect(mode).toBe('direct');
 	});
 
 	it('uses cookie credentials for a direct connection without basic auth', () => {
@@ -54,11 +71,12 @@ describe('resolveInstanceConnection', () => {
 		// Basic auth must be ignored on the proxy path (cookies are used instead).
 		mockAuthStore.checkForBasicAuth.mockReturnValue({ username: 'admin', password: 'pw' });
 
-		const { url, headers, credentials } = resolveInstanceConnection({ id: 'clu-abc' });
+		const { url, headers, credentials, mode } = resolveInstanceConnection({ id: 'clu-abc' });
 
 		expect(url).toBe('https://cm.example.com/Cluster/clu-abc/operation/');
 		expect(headers.Authorization).toBeUndefined();
 		expect(credentials).toBe('include');
+		expect(mode).toBe('proxy');
 	});
 
 	it('routes an instance through the fabric-connect proxy', () => {

--- a/src/integrations/api/sse/resolveInstanceConnection.test.ts
+++ b/src/integrations/api/sse/resolveInstanceConnection.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/config/apiClient', () => ({
+	apiClient: { defaults: { baseURL: 'https://cm.example.com' } },
+}));
+
+vi.mock('@/features/auth/store/authStore', () => ({
+	OverallAppSignIn: 'OverallAppSignIn',
+	authStore: {
+		getOperationsUrl: vi.fn(),
+		checkForFabricConnect: vi.fn(),
+		checkForBasicAuth: vi.fn(),
+	},
+}));
+
+import { authStore } from '@/features/auth/store/authStore';
+import { resolveInstanceConnection } from './resolveInstanceConnection';
+
+const mockAuthStore = vi.mocked(authStore);
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	mockAuthStore.checkForFabricConnect.mockReturnValue(false);
+	mockAuthStore.checkForBasicAuth.mockReturnValue(undefined);
+});
+
+describe('resolveInstanceConnection', () => {
+	it('uses basic auth for a direct connection', () => {
+		mockAuthStore.getOperationsUrl.mockReturnValue('https://host:9925');
+		mockAuthStore.checkForBasicAuth.mockReturnValue({ username: 'admin', password: 'pw' });
+
+		const { url, headers, credentials } = resolveInstanceConnection({ id: 'ins-1' });
+
+		expect(url).toBe('https://host:9925/');
+		expect(headers.Authorization).toBe(`Basic ${btoa('admin:pw')}`);
+		expect(headers.Accept).toBe('text/event-stream');
+		expect(headers['Content-Type']).toBe('application/json');
+		// Direct + basic auth → no cookies needed.
+		expect(credentials).toBe('same-origin');
+	});
+
+	it('uses cookie credentials for a direct connection without basic auth', () => {
+		mockAuthStore.getOperationsUrl.mockReturnValue('https://host:9925/');
+
+		const { url, headers, credentials } = resolveInstanceConnection({ id: 'ins-1' });
+
+		expect(url).toBe('https://host:9925/');
+		expect(headers.Authorization).toBeUndefined();
+		expect(credentials).toBe('include');
+	});
+
+	it('routes a cluster through the fabric-connect proxy', () => {
+		mockAuthStore.checkForFabricConnect.mockReturnValue(true);
+		// Basic auth must be ignored on the proxy path (cookies are used instead).
+		mockAuthStore.checkForBasicAuth.mockReturnValue({ username: 'admin', password: 'pw' });
+
+		const { url, headers, credentials } = resolveInstanceConnection({ id: 'clu-abc' });
+
+		expect(url).toBe('https://cm.example.com/Cluster/clu-abc/operation/');
+		expect(headers.Authorization).toBeUndefined();
+		expect(credentials).toBe('include');
+	});
+
+	it('routes an instance through the fabric-connect proxy', () => {
+		mockAuthStore.checkForFabricConnect.mockReturnValue(true);
+
+		const { url } = resolveInstanceConnection({ id: 'ins-xyz' });
+
+		expect(url).toBe('https://cm.example.com/HDBInstance/ins-xyz/operation/');
+	});
+
+	it('honors an explicit operationsUrl with port/secure overrides', () => {
+		const { url } = resolveInstanceConnection({
+			id: 'ins-1',
+			operationsUrl: 'https://host:9925',
+			port: 9999,
+			secure: false,
+		});
+
+		expect(url).toBe('http://host:9999/');
+	});
+
+	it('throws when no operations URL can be resolved', () => {
+		mockAuthStore.getOperationsUrl.mockReturnValue(undefined);
+		expect(() => resolveInstanceConnection({ id: 'ins-1' })).toThrow(/No operations URL/);
+	});
+});

--- a/src/integrations/api/sse/resolveInstanceConnection.ts
+++ b/src/integrations/api/sse/resolveInstanceConnection.ts
@@ -15,6 +15,12 @@ export interface ResolvedInstanceConnection {
 	url: string;
 	headers: Record<string, string>;
 	credentials: RequestCredentials;
+	/**
+	 * `'direct'` = talking straight to the instance (Bearer/Basic/cookie) — SSE streams.
+	 * `'proxy'` = routed through the central-manager fabric-connect proxy, which buffers
+	 * `text/event-stream`, so live streaming is not available on this connection.
+	 */
+	mode: 'direct' | 'proxy';
 }
 
 /**
@@ -23,13 +29,16 @@ export interface ResolvedInstanceConnection {
  *
  * SSE has to be consumed with `fetch()` + a streaming body reader (axios is XHR-based and
  * buffers the whole response), so we can't reuse the axios client. This mirrors the
- * connection/auth resolution in `src/config/getInstanceClient.ts` (lines 27-54) one-way:
- * `getInstanceClient` is deliberately left untouched so its battle-tested axios path —
- * including the `rejectReplicationFailures` / gateway-retry interceptors that this fetch
- * path intentionally does NOT carry — keeps working for every non-streaming caller.
+ * connection/auth resolution in `src/config/getInstanceClient.ts` one-way: `getInstanceClient`
+ * is deliberately left untouched so its battle-tested axios path — including the
+ * `rejectReplicationFailures` / gateway-retry interceptors that this fetch path intentionally
+ * does NOT carry — keeps working for every non-streaming caller. Callers recover gateway/
+ * cold-start resilience by falling back to the axios path when the stream can't be established.
  *
- * Note this path loses those interceptors; callers recover gateway/cold-start resilience
- * by falling back to the axios path when the stream can't be established.
+ * Fabric Connect now resolves to a direct Bearer (operation token) connection when it can
+ * (see authStore.establishFabricConnectAuth); we prefer that so SSE streams straight from
+ * the instance instead of through the buffering proxy. Only genuinely proxy-only connections
+ * get the `/Cluster|/HDBInstance/{id}/operation` proxy URL and `mode: 'proxy'`.
  */
 export function resolveInstanceConnection({
 	id = OverallAppSignIn,
@@ -53,7 +62,16 @@ export function resolveInstanceConnection({
 		}
 	}
 
-	const fabricConnect = !disableFabricConnect && (forceFabricConnect || authStore.checkForFabricConnect(id));
+	const basicAuth = authStore.checkForBasicAuth(id);
+	// Prefer a direct operation token (Bearer) unless basic auth is present or the proxy is
+	// forced — matching getInstanceClient's precedence. When the Fabric Connect flag is set
+	// and no token has been minted yet, the proxy still wins over any stale basic-auth entry
+	// (again mirroring getInstanceClient), so `fabricConnect` intentionally ignores basicAuth.
+	const operationToken = forceFabricConnect || disableFabricConnect || basicAuth
+		? undefined
+		: authStore.getOperationToken(id);
+	const fabricConnect = !operationToken && !disableFabricConnect
+		&& (forceFabricConnect || authStore.checkForFabricConnect(id));
 	if (fabricConnect) {
 		if (id.startsWith('clu-')) {
 			baseURL = apiClient.defaults.baseURL + `/Cluster/${id}/operation`;
@@ -66,13 +84,13 @@ export function resolveInstanceConnection({
 		throw new Error(`No operations URL is known for "${id}"; cannot open an SSE stream.`);
 	}
 
-	const basicAuth = fabricConnect ? undefined : authStore.checkForBasicAuth(id);
-
 	const headers: Record<string, string> = {
 		'Content-Type': 'application/json',
 		Accept: 'text/event-stream',
 	};
-	if (basicAuth) {
+	if (operationToken) {
+		headers.Authorization = `Bearer ${operationToken}`;
+	} else if (basicAuth && !fabricConnect) {
 		// btoa is Latin1-only; Harper credentials are ASCII in practice. axios handles
 		// UTF-8 internally — if non-ASCII creds ever surface, encode via TextEncoder here.
 		headers.Authorization = `Basic ${btoa(`${basicAuth.username}:${basicAuth.password}`)}`;
@@ -84,7 +102,8 @@ export function resolveInstanceConnection({
 		// route resolves the same way it does for the buffered path.
 		url: baseURL.replace(/\/+$/, '') + '/',
 		headers,
-		// Mirror getInstanceClient's `withCredentials: fabricConnect || !basicAuth`.
-		credentials: fabricConnect || !basicAuth ? 'include' : 'same-origin',
+		// Mirror getInstanceClient's `withCredentials: fabricConnect || (!basicAuth && !operationToken)`.
+		credentials: fabricConnect || (!basicAuth && !operationToken) ? 'include' : 'same-origin',
+		mode: fabricConnect ? 'proxy' : 'direct',
 	};
 }

--- a/src/integrations/api/sse/resolveInstanceConnection.ts
+++ b/src/integrations/api/sse/resolveInstanceConnection.ts
@@ -1,0 +1,90 @@
+import { apiClient } from '@/config/apiClient';
+import { authStore, EntityIds, OverallAppSignIn } from '@/features/auth/store/authStore';
+
+export interface ResolveInstanceConnectionParams {
+	id?: EntityIds;
+	operationsUrl?: string | null;
+	port?: number;
+	secure?: boolean;
+	forceFabricConnect?: boolean;
+	disableFabricConnect?: boolean;
+}
+
+export interface ResolvedInstanceConnection {
+	/** Fully-qualified operations endpoint to POST to. */
+	url: string;
+	headers: Record<string, string>;
+	credentials: RequestCredentials;
+}
+
+/**
+ * Resolve the operations endpoint, auth headers, and credentials mode for an instance —
+ * the `fetch()` equivalent of {@link getInstanceClient}'s axios setup.
+ *
+ * SSE has to be consumed with `fetch()` + a streaming body reader (axios is XHR-based and
+ * buffers the whole response), so we can't reuse the axios client. This mirrors the
+ * connection/auth resolution in `src/config/getInstanceClient.ts` (lines 27-54) one-way:
+ * `getInstanceClient` is deliberately left untouched so its battle-tested axios path —
+ * including the `rejectReplicationFailures` / gateway-retry interceptors that this fetch
+ * path intentionally does NOT carry — keeps working for every non-streaming caller.
+ *
+ * Note this path loses those interceptors; callers recover gateway/cold-start resilience
+ * by falling back to the axios path when the stream can't be established.
+ */
+export function resolveInstanceConnection({
+	id = OverallAppSignIn,
+	operationsUrl,
+	port,
+	secure,
+	forceFabricConnect,
+	disableFabricConnect,
+}: ResolveInstanceConnectionParams = {}): ResolvedInstanceConnection {
+	let baseURL = operationsUrl || authStore.getOperationsUrl(id);
+	if (baseURL) {
+		if (port || secure !== undefined) {
+			const newURL = new URL(baseURL);
+			if (port) {
+				newURL.port = String(port);
+			}
+			if (secure !== undefined) {
+				newURL.protocol = secure ? 'https:' : 'http:';
+			}
+			baseURL = newURL.toString();
+		}
+	}
+
+	const fabricConnect = !disableFabricConnect && (forceFabricConnect || authStore.checkForFabricConnect(id));
+	if (fabricConnect) {
+		if (id.startsWith('clu-')) {
+			baseURL = apiClient.defaults.baseURL + `/Cluster/${id}/operation`;
+		} else if (id.startsWith('ins-')) {
+			baseURL = apiClient.defaults.baseURL + `/HDBInstance/${id}/operation`;
+		}
+	}
+
+	if (!baseURL) {
+		throw new Error(`No operations URL is known for "${id}"; cannot open an SSE stream.`);
+	}
+
+	const basicAuth = fabricConnect ? undefined : authStore.checkForBasicAuth(id);
+
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+		Accept: 'text/event-stream',
+	};
+	if (basicAuth) {
+		// btoa is Latin1-only; Harper credentials are ASCII in practice. axios handles
+		// UTF-8 internally — if non-ASCII creds ever surface, encode via TextEncoder here.
+		headers.Authorization = `Basic ${btoa(`${basicAuth.username}:${basicAuth.password}`)}`;
+	}
+
+	return {
+		// axios posts to '/', which combineURLs renders as the base with a single trailing
+		// slash (e.g. `.../operation/`). Match that exactly so the fabric-connect proxy
+		// route resolves the same way it does for the buffered path.
+		url: baseURL.replace(/\/+$/, '') + '/',
+		headers,
+		// Mirror getInstanceClient's `withCredentials: fabricConnect || !basicAuth`.
+		credentials: fabricConnect || !basicAuth ? 'include' : 'same-origin',
+	};
+}

--- a/src/integrations/api/sse/streamOperation.test.ts
+++ b/src/integrations/api/sse/streamOperation.test.ts
@@ -77,6 +77,14 @@ describe('streamOperation', () => {
 		expect(SSEOperationError).toBeDefined();
 	});
 
+	it('does not crash on a null error payload', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sseResponse('event: error\ndata: null\n\n')));
+
+		await expect(
+			streamOperation({ connection: { id: 'ins-1' }, body: { operation: 'deploy_component' } }),
+		).rejects.toMatchObject({ name: 'SSEOperationError', message: 'The operation failed.' });
+	});
+
 	it('falls back (SSEUnsupportedError) when the response is not an event stream', async () => {
 		vi.stubGlobal(
 			'fetch',

--- a/src/integrations/api/sse/streamOperation.test.ts
+++ b/src/integrations/api/sse/streamOperation.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./resolveInstanceConnection', () => ({
+	resolveInstanceConnection: () => ({
+		url: 'https://host:9925/',
+		headers: { Accept: 'text/event-stream' },
+		credentials: 'include' as RequestCredentials,
+	}),
+}));
+
+import { SSEInconclusiveError, SSEOperationError, SSEUnsupportedError } from './errors';
+import { SSEMessage } from './parseSSEStream';
+import { streamOperation } from './streamOperation';
+
+function sseResponse(body: string, init?: { status?: number; contentType?: string }): Response {
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(body));
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: init?.status ?? 200,
+		headers: { 'content-type': init?.contentType ?? 'text/event-stream' },
+	});
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('streamOperation', () => {
+	it('resolves with the result from the terminal done event', async () => {
+		const messages: SSEMessage[] = [];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse(
+					': stream open\n\n'
+						+ 'event: phase\ndata: {"phase":"prepare","status":"start"}\n\n'
+						+ 'event: done\ndata: {"result":{"deployment_id":"d1","message":"ok"}}\n\n',
+				),
+			),
+		);
+
+		const result = await streamOperation({
+			connection: { id: 'ins-1' },
+			body: { operation: 'deploy_component' },
+			onMessage: (m) => messages.push(m),
+		});
+
+		expect(result).toEqual({ deployment_id: 'd1', message: 'ok' });
+		expect(messages.map((m) => m.event)).toEqual(['phase', 'done']);
+	});
+
+	it('throws SSEOperationError on a terminal error event', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse('event: error\ndata: {"message":"boom","code":500,"phase":"load","deployment_id":"d2"}\n\n'),
+			),
+		);
+
+		await expect(
+			streamOperation({ connection: { id: 'ins-1' }, body: { operation: 'deploy_component' } }),
+		).rejects.toMatchObject({
+			name: 'SSEOperationError',
+			message: 'boom',
+			code: 500,
+			phase: 'load',
+			deploymentId: 'd2',
+		});
+		expect(SSEOperationError).toBeDefined();
+	});
+
+	it('falls back (SSEUnsupportedError) when the response is not an event stream', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse('{"message":"ok"}', { contentType: 'application/json' })),
+		);
+
+		await expect(
+			streamOperation({ connection: { id: 'ins-1' }, body: { operation: 'deploy_component' } }),
+		).rejects.toBeInstanceOf(SSEUnsupportedError);
+	});
+
+	it('falls back (SSEUnsupportedError) when fetch rejects before streaming', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network down')));
+
+		await expect(
+			streamOperation({ connection: { id: 'ins-1' }, body: { operation: 'deploy_component' } }),
+		).rejects.toBeInstanceOf(SSEUnsupportedError);
+	});
+
+	it('throws SSEInconclusiveError when the stream ends without a terminal event', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse('event: phase\ndata: {"phase":"prepare","status":"start"}\n\n')),
+		);
+
+		await expect(
+			streamOperation({ connection: { id: 'ins-1' }, body: { operation: 'deploy_component' } }),
+		).rejects.toBeInstanceOf(SSEInconclusiveError);
+	});
+
+	it('propagates a caller abort rather than masking it', async () => {
+		const controller = new AbortController();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation((_url, init?: RequestInit) => {
+				return Promise.reject(
+					Object.assign(new Error('aborted'), { name: 'AbortError', signal: init?.signal }),
+				);
+			}),
+		);
+		controller.abort();
+
+		await expect(
+			streamOperation({
+				connection: { id: 'ins-1' },
+				body: { operation: 'deploy_component' },
+				signal: controller.signal,
+			}),
+		).rejects.not.toBeInstanceOf(SSEUnsupportedError);
+	});
+});

--- a/src/integrations/api/sse/streamOperation.ts
+++ b/src/integrations/api/sse/streamOperation.ts
@@ -1,0 +1,156 @@
+import { SSEInconclusiveError, SSEOperationError, SSEUnsupportedError } from './errors';
+import { parseSSEData, parseSSEStream, SSEMessage } from './parseSSEStream';
+import { resolveInstanceConnection, ResolveInstanceConnectionParams } from './resolveInstanceConnection';
+
+export interface StreamOperationOptions {
+	/** Connection target — same shape `getInstanceClient`/`resolveInstanceConnection` accept. */
+	connection: ResolveInstanceConnectionParams;
+	/** Operation body, e.g. `{ operation: 'deploy_component', package, project, ... }`. */
+	body: Record<string, unknown>;
+	/** Caller-owned abort (modal cancel, component unmount). */
+	signal?: AbortSignal;
+	/**
+	 * Abort the stream if no event arrives for this long. A deploy legitimately streams for
+	 * minutes, so this is an IDLE timeout (reset per event), not a total-duration cap.
+	 * Defaults to 120s.
+	 */
+	idleTimeoutMs?: number;
+	/** Called for every SSE record as it arrives, to drive live UI. */
+	onMessage?: (message: SSEMessage) => void;
+}
+
+/**
+ * Run a Harper operation over SSE and return the final `done` event's `result`.
+ *
+ * Failure modes are explicit (see `./errors`):
+ * - {@link SSEUnsupportedError} — couldn't establish a stream (bad response, wrong
+ *   content-type, or connection error before any bytes). Caller should fall back to the
+ *   buffered axios path.
+ * - {@link SSEOperationError} — a terminal `error` event arrived.
+ * - {@link SSEInconclusiveError} — the stream ended (or idled out) without a terminal
+ *   event. The outcome is unknown; caller must poll to determine it, never assume success.
+ */
+export async function streamOperation({
+	connection,
+	body,
+	signal,
+	idleTimeoutMs = 120_000,
+	onMessage,
+}: StreamOperationOptions): Promise<unknown> {
+	const { url, headers, credentials } = resolveInstanceConnection(connection);
+
+	// Idle watchdog: its own controller aborts the fetch when no event arrives in time. We
+	// combine it with the caller's signal so either source can stop the stream, and we can
+	// tell them apart afterwards (idle → inconclusive, caller → propagate the abort).
+	const idleController = new AbortController();
+	const combinedSignal = anySignal([signal, idleController.signal]);
+
+	let idleTimer: ReturnType<typeof setTimeout> | undefined;
+	const resetIdleTimer = () => {
+		if (idleTimer) {
+			clearTimeout(idleTimer);
+		}
+		idleTimer = setTimeout(() => idleController.abort(), idleTimeoutMs);
+	};
+
+	let response: Response;
+	try {
+		resetIdleTimer();
+		response = await fetch(url, {
+			method: 'POST',
+			headers,
+			credentials,
+			body: JSON.stringify(body),
+			signal: combinedSignal,
+		});
+	} catch (error) {
+		clearTimeout(idleTimer);
+		// The caller aborted deliberately — surface that, don't mask it as "unsupported".
+		if (signal?.aborted) {
+			throw error;
+		}
+		// Anything else (network error, DNS, idle before headers) means we never got a
+		// stream going; let the caller fall back to the buffered request.
+		throw new SSEUnsupportedError('Failed to open the SSE stream.', { cause: error });
+	}
+
+	const contentType = response.headers.get('content-type') ?? '';
+	if (!response.ok || !contentType.includes('text/event-stream') || !response.body) {
+		clearTimeout(idleTimer);
+		// Drain the body so the connection can be reused, then fall back.
+		await response.body?.cancel().catch(() => {});
+		throw new SSEUnsupportedError(
+			`Server did not return an event stream (status ${response.status}, content-type "${contentType}").`,
+		);
+	}
+
+	let sawTerminal = false;
+	let result: unknown;
+	try {
+		for await (const message of parseSSEStream(response.body, combinedSignal)) {
+			resetIdleTimer();
+			onMessage?.(message);
+
+			if (message.event === 'done') {
+				sawTerminal = true;
+				const data = parseSSEData(message);
+				result = (data as { result?: unknown } | undefined)?.result ?? data;
+				break;
+			}
+			if (message.event === 'error') {
+				sawTerminal = true;
+				const data = parseSSEData(message) as
+					| { message?: string; code?: string | number; phase?: string; deployment_id?: string }
+					| string;
+				if (typeof data === 'string') {
+					throw new SSEOperationError(data || 'The operation failed.');
+				}
+				throw new SSEOperationError(data.message ?? 'The operation failed.', {
+					code: data.code,
+					phase: data.phase,
+					deploymentId: data.deployment_id,
+				});
+			}
+		}
+	} catch (error) {
+		// Distinguish an idle-watchdog abort from a deliberate caller abort.
+		if (idleController.signal.aborted && !signal?.aborted) {
+			throw new SSEInconclusiveError('The stream went idle before completing.', { cause: error });
+		}
+		throw error;
+	} finally {
+		clearTimeout(idleTimer);
+	}
+
+	if (!sawTerminal) {
+		// Stream closed cleanly but never told us how it ended (e.g. a proxy buffered and
+		// truncated). The result is genuinely unknown — caller must poll.
+		throw new SSEInconclusiveError('The stream ended without a terminal event.');
+	}
+
+	return result;
+}
+
+/**
+ * Combine multiple `AbortSignal`s into one that aborts when any input does. Uses the native
+ * `AbortSignal.any` when available (modern browsers / Node 20+) and falls back to manual
+ * wiring otherwise.
+ */
+function anySignal(signals: Array<AbortSignal | undefined>): AbortSignal {
+	const real = signals.filter((s): s is AbortSignal => !!s);
+	if (real.length === 1) {
+		return real[0];
+	}
+	if (typeof AbortSignal.any === 'function') {
+		return AbortSignal.any(real);
+	}
+	const controller = new AbortController();
+	for (const s of real) {
+		if (s.aborted) {
+			controller.abort(s.reason);
+			break;
+		}
+		s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
+	}
+	return controller.signal;
+}

--- a/src/integrations/api/sse/streamOperation.ts
+++ b/src/integrations/api/sse/streamOperation.ts
@@ -43,7 +43,7 @@ export async function streamOperation({
 	// combine it with the caller's signal so either source can stop the stream, and we can
 	// tell them apart afterwards (idle → inconclusive, caller → propagate the abort).
 	const idleController = new AbortController();
-	const combinedSignal = anySignal([signal, idleController.signal]);
+	const { signal: combinedSignal, cleanup: cleanupSignal } = anySignal([signal, idleController.signal]);
 
 	let idleTimer: ReturnType<typeof setTimeout> | undefined;
 	const resetIdleTimer = () => {
@@ -53,104 +53,120 @@ export async function streamOperation({
 		idleTimer = setTimeout(() => idleController.abort(), idleTimeoutMs);
 	};
 
-	let response: Response;
 	try {
-		resetIdleTimer();
-		response = await fetch(url, {
-			method: 'POST',
-			headers,
-			credentials,
-			body: JSON.stringify(body),
-			signal: combinedSignal,
-		});
-	} catch (error) {
-		clearTimeout(idleTimer);
-		// The caller aborted deliberately — surface that, don't mask it as "unsupported".
-		if (signal?.aborted) {
+		let response: Response;
+		try {
+			resetIdleTimer();
+			response = await fetch(url, {
+				method: 'POST',
+				headers,
+				credentials,
+				body: JSON.stringify(body),
+				signal: combinedSignal,
+			});
+		} catch (error) {
+			// The caller aborted deliberately — surface that, don't mask it as "unsupported".
+			if (signal?.aborted) {
+				throw error;
+			}
+			// Anything else (network error, DNS, idle before headers) means we never got a
+			// stream going; let the caller fall back to the buffered request.
+			throw new SSEUnsupportedError('Failed to open the SSE stream.', { cause: error });
+		}
+
+		const contentType = response.headers.get('content-type') ?? '';
+		if (!response.ok || !contentType.includes('text/event-stream') || !response.body) {
+			// Drain the body so the connection can be reused, then fall back.
+			await response.body?.cancel().catch(() => {});
+			throw new SSEUnsupportedError(
+				`Server did not return an event stream (status ${response.status}, content-type "${contentType}").`,
+			);
+		}
+
+		let sawTerminal = false;
+		let result: unknown;
+		try {
+			for await (const message of parseSSEStream(response.body, combinedSignal)) {
+				resetIdleTimer();
+				onMessage?.(message);
+
+				if (message.event === 'done') {
+					sawTerminal = true;
+					const data = parseSSEData(message);
+					result = (data as { result?: unknown } | undefined)?.result ?? data;
+					break;
+				}
+				if (message.event === 'error') {
+					sawTerminal = true;
+					const data = parseSSEData(message);
+					// Guard against a null/primitive payload — accessing .message on it would throw.
+					if (!data || typeof data !== 'object') {
+						throw new SSEOperationError(typeof data === 'string' && data ? data : 'The operation failed.');
+					}
+					const err = data as { message?: string; code?: string | number; phase?: string; deployment_id?: string };
+					throw new SSEOperationError(err.message ?? 'The operation failed.', {
+						code: err.code,
+						phase: err.phase,
+						deploymentId: err.deployment_id,
+					});
+				}
+			}
+		} catch (error) {
+			// Distinguish an idle-watchdog abort from a deliberate caller abort.
+			if (idleController.signal.aborted && !signal?.aborted) {
+				throw new SSEInconclusiveError('The stream went idle before completing.', { cause: error });
+			}
 			throw error;
 		}
-		// Anything else (network error, DNS, idle before headers) means we never got a
-		// stream going; let the caller fall back to the buffered request.
-		throw new SSEUnsupportedError('Failed to open the SSE stream.', { cause: error });
-	}
 
-	const contentType = response.headers.get('content-type') ?? '';
-	if (!response.ok || !contentType.includes('text/event-stream') || !response.body) {
-		clearTimeout(idleTimer);
-		// Drain the body so the connection can be reused, then fall back.
-		await response.body?.cancel().catch(() => {});
-		throw new SSEUnsupportedError(
-			`Server did not return an event stream (status ${response.status}, content-type "${contentType}").`,
-		);
-	}
-
-	let sawTerminal = false;
-	let result: unknown;
-	try {
-		for await (const message of parseSSEStream(response.body, combinedSignal)) {
-			resetIdleTimer();
-			onMessage?.(message);
-
-			if (message.event === 'done') {
-				sawTerminal = true;
-				const data = parseSSEData(message);
-				result = (data as { result?: unknown } | undefined)?.result ?? data;
-				break;
-			}
-			if (message.event === 'error') {
-				sawTerminal = true;
-				const data = parseSSEData(message) as
-					| { message?: string; code?: string | number; phase?: string; deployment_id?: string }
-					| string;
-				if (typeof data === 'string') {
-					throw new SSEOperationError(data || 'The operation failed.');
-				}
-				throw new SSEOperationError(data.message ?? 'The operation failed.', {
-					code: data.code,
-					phase: data.phase,
-					deploymentId: data.deployment_id,
-				});
-			}
+		if (!sawTerminal) {
+			// Stream closed cleanly but never told us how it ended (e.g. a proxy buffered and
+			// truncated). The result is genuinely unknown — caller must poll.
+			throw new SSEInconclusiveError('The stream ended without a terminal event.');
 		}
-	} catch (error) {
-		// Distinguish an idle-watchdog abort from a deliberate caller abort.
-		if (idleController.signal.aborted && !signal?.aborted) {
-			throw new SSEInconclusiveError('The stream went idle before completing.', { cause: error });
-		}
-		throw error;
+
+		return result;
 	} finally {
 		clearTimeout(idleTimer);
+		// Detach the listeners anySignal may have attached to the caller's (possibly long-lived)
+		// signal, so short-lived stream calls don't accumulate listeners on it.
+		cleanupSignal();
 	}
-
-	if (!sawTerminal) {
-		// Stream closed cleanly but never told us how it ended (e.g. a proxy buffered and
-		// truncated). The result is genuinely unknown — caller must poll.
-		throw new SSEInconclusiveError('The stream ended without a terminal event.');
-	}
-
-	return result;
 }
 
 /**
- * Combine multiple `AbortSignal`s into one that aborts when any input does. Uses the native
- * `AbortSignal.any` when available (modern browsers / Node 20+) and falls back to manual
- * wiring otherwise.
+ * Combine multiple `AbortSignal`s into one that aborts when any input does, plus a `cleanup`
+ * to detach any listeners it attached. Uses the native `AbortSignal.any` when available
+ * (modern browsers / Node 20+) — which manages its own listeners — and falls back to manual
+ * wiring (with real cleanup) otherwise.
  */
-function anySignal(signals: Array<AbortSignal | undefined>): AbortSignal {
+function anySignal(signals: Array<AbortSignal | undefined>): { signal: AbortSignal; cleanup: () => void } {
+	const noop = () => {};
 	const real = signals.filter((s): s is AbortSignal => !!s);
 	if (real.length === 1) {
-		return real[0];
+		return { signal: real[0], cleanup: noop };
 	}
 	if (typeof AbortSignal.any === 'function') {
-		return AbortSignal.any(real);
+		return { signal: AbortSignal.any(real), cleanup: noop };
 	}
 	const controller = new AbortController();
+	// Function declarations (hoisted) so onAbort and cleanup can reference each other.
+	function cleanup() {
+		for (const s of real) {
+			s.removeEventListener('abort', onAbort);
+		}
+	}
+	function onAbort(event: Event) {
+		controller.abort((event.target as AbortSignal).reason);
+		cleanup();
+	}
 	for (const s of real) {
 		if (s.aborted) {
 			controller.abort(s.reason);
+			cleanup();
 			break;
 		}
-		s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
+		s.addEventListener('abort', onAbort);
 	}
-	return controller.signal;
+	return { signal: controller.signal, cleanup };
 }


### PR DESCRIPTION
## What & why

Adopts Harper 5.1.0's SSE deploy stream and the replicated `hdb_deployment` audit table ([harper#641](https://github.com/HarperFast/harper/issues/641)) in Studio. Everything is gated on **Harper ≥ 5.1.0** (verified against release tags: the `SSE_PROGRESS_OPERATIONS` branch ships in `v5.1.0` and is absent in `v5.0.31`); 5.0.x keeps today's buffered deploy path unchanged.

Closes #1233 · Closes #1231 · Closes #1230

## Reusable browser SSE transport — `src/integrations/api/sse/`
The axios client is XHR-based and can't stream response bodies, and `EventSource` is GET-only (deploy is a POST), so SSE is consumed via `fetch()` + a stream reader.

- **`resolveInstanceConnection`** — fetch-equivalent of `getInstanceClient`'s base-URL/auth resolution (basic-auth header vs `credentials: 'include'` for the fabric-connect proxy). `getInstanceClient` itself is left untouched so its interceptors keep serving every non-streaming caller.
- **`parseSSEStream`** — SSE record parser (chunk-split, CRLF, multi-line `data:`, `:` comments).
- **`streamOperation`** — three explicit outcomes: `SSEUnsupportedError` (fall back to buffered), `SSEOperationError` (failed), `SSEInconclusiveError` (poll — never assume success); idle-timeout watchdog.

## Deploy — #1233
- `deployComponentStream` + the `deployComponent` mutation stream when supported, and fall back to the buffered POST **only** on `SSEUnsupportedError` (never re-POST after a deploy has started → no double deploys).
- `DeployProgress` + `useDeploymentStream`: live phase checklist, install-log tail, peer results — wired into the redeploy modal and import flow.
- **Post-deploy health check** (`useComponentHealthCheck`): polls `get_components` for the new per-component `status`, since `deploy_component` now returns before worker threads finish loading the component.

## Deployments history + detail — #1230 / #1231
- `list_deployments` / `get_deployment` (JSON read **and** SSE tail) + `hdb_deployment` types.
- New **Config → Deployments** sub-nav: a table (project · status · started · completed · user · origin) with a row → **detail modal** showing metadata, `peer_results`, and the `event_log` activity timeline. Deep-linked from the cluster card's options menu.
- Detail uses active-polling as the correctness backbone, with the SSE tail layered on for live granularity.

## ⚠️ Fabric-connect proxy buffers SSE
Verified live against a 5.1.14 cluster: a redeploy with `Accept: text/event-stream` through the central-manager proxy sat **170s+ with zero response bytes** while `get_components`/`list_deployments` returned instantly — the proxy **buffers** `text/event-stream`. So live SSE is gated to **direct connections**; proxied (fabric-connect) entities use the buffered deploy + polling detail, which work fully. Drop the `checkForFabricConnect` check in `useSupportsDeploymentSSE` if/when the proxy gains streaming passthrough.

## Verification
- Unit: SSE parser, connection resolver, deploy fallback paths, deployment status helpers (full suite **1030 passed**, lint clean, production build succeeds).
- Live against a Harper **5.1.14** cluster: Config → Deployments renders; a real buffered redeploy completed in ~6s, populated `hdb_deployment`, appeared in the list, and the detail modal rendered full metadata + peer result + the event-log timeline; cluster-card deep-link navigates correctly; nav/version gating confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
