### PR TITLE
feat(auth): direct-connect via JWT in Fabric Connect mode (+ fix #1333)

### DIFF
--- a/src/config/getInstanceClient.test.ts
+++ b/src/config/getInstanceClient.test.ts
@@ -81,4 +81,33 @@ describe('getInstanceClient', () => {
 		expect(client.defaults.baseURL).toBe(DIRECT_URL);
 		expect(client.defaults.withCredentials).toBe(true);
 	});
+
+	it('disableFabricConnect suppresses both the token and proxy routing', () => {
+		stubAuthStore({ operationToken: 'jwt-abc', fabricConnect: true });
+
+		const client = getInstanceClient({ id: INSTANCE_ID, disableFabricConnect: true });
+
+		expect(authHeader(client)).toBeUndefined();
+		expect(client.defaults.baseURL).toBe(DIRECT_URL);
+		expect(client.defaults.withCredentials).toBe(true);
+	});
+
+	it('forceOperationToken sends the Bearer token even when a basic-auth entry exists', () => {
+		stubAuthStore({ operationToken: 'jwt-abc', basicAuth: { username: 'admin', password: 'pw' } });
+
+		const client = getInstanceClient({ id: INSTANCE_ID, operationsUrl: DIRECT_URL, forceOperationToken: true });
+
+		expect(authHeader(client)).toBe('Bearer jwt-abc');
+		expect(client.defaults.auth).toBeUndefined();
+		expect(client.defaults.baseURL).toBe(DIRECT_URL);
+	});
+
+	it('routes a cluster id through the /Cluster proxy path under Fabric Connect', () => {
+		stubAuthStore({ fabricConnect: true });
+
+		const client = getInstanceClient({ id: 'clu-123' });
+
+		expect(client.defaults.baseURL).toContain('/Cluster/clu-123/operation');
+		expect(authHeader(client)).toBeUndefined();
+	});
 });

--- a/src/config/getInstanceClient.test.ts
+++ b/src/config/getInstanceClient.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+import { getInstanceClient } from '@/config/getInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const INSTANCE_ID = 'ins-123';
+const DIRECT_URL = 'https://my-instance.example.com:9925/';
+
+function stubAuthStore({
+	operationToken,
+	fabricConnect = false,
+	basicAuth,
+}: {
+	operationToken?: string;
+	fabricConnect?: boolean;
+	basicAuth?: { username: string; password: string };
+}) {
+	vi.spyOn(authStore, 'getOperationToken').mockReturnValue(operationToken);
+	vi.spyOn(authStore, 'checkForFabricConnect').mockReturnValue(fabricConnect);
+	vi.spyOn(authStore, 'checkForBasicAuth').mockReturnValue(basicAuth);
+	vi.spyOn(authStore, 'getOperationsUrl').mockReturnValue(DIRECT_URL);
+}
+
+function authHeader(client: ReturnType<typeof getInstanceClient>): unknown {
+	return (client.defaults.headers as Record<string, unknown>).Authorization;
+}
+
+describe('getInstanceClient', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('connects directly with a Bearer token when a Fabric Connect JWT is held', () => {
+		stubAuthStore({ operationToken: 'jwt-abc', fabricConnect: true });
+
+		const client = getInstanceClient({ id: INSTANCE_ID });
+
+		expect(authHeader(client)).toBe('Bearer jwt-abc');
+		expect(client.defaults.baseURL).toBe(DIRECT_URL);
+		expect(client.defaults.withCredentials).toBe(false);
+		expect(client.defaults.auth).toBeUndefined();
+	});
+
+	it('routes through the proxy when flagged for Fabric Connect but holding no token', () => {
+		stubAuthStore({ fabricConnect: true });
+
+		const client = getInstanceClient({ id: INSTANCE_ID });
+
+		expect(authHeader(client)).toBeUndefined();
+		expect(client.defaults.baseURL).toContain(`/HDBInstance/${INSTANCE_ID}/operation`);
+		expect(client.defaults.withCredentials).toBe(true);
+	});
+
+	it('ignores the token and uses the proxy when forceFabricConnect is set', () => {
+		stubAuthStore({ operationToken: 'jwt-abc', fabricConnect: true });
+
+		const client = getInstanceClient({ id: INSTANCE_ID, forceFabricConnect: true });
+
+		expect(authHeader(client)).toBeUndefined();
+		expect(client.defaults.baseURL).toContain(`/HDBInstance/${INSTANCE_ID}/operation`);
+	});
+
+	it('prefers basic auth over a stale Fabric Connect token', () => {
+		const basicAuth = { username: 'admin', password: 'pw' };
+		stubAuthStore({ operationToken: 'jwt-abc', basicAuth });
+
+		const client = getInstanceClient({ id: INSTANCE_ID });
+
+		expect(authHeader(client)).toBeUndefined();
+		expect(client.defaults.auth).toEqual(basicAuth);
+		expect(client.defaults.baseURL).toBe(DIRECT_URL);
+		expect(client.defaults.withCredentials).toBe(false);
+	});
+
+	it('falls back to cookie-based direct connect with no token, flag, or basic auth', () => {
+		stubAuthStore({});
+
+		const client = getInstanceClient({ id: INSTANCE_ID });
+
+		expect(authHeader(client)).toBeUndefined();
+		expect(client.defaults.baseURL).toBe(DIRECT_URL);
+		expect(client.defaults.withCredentials).toBe(true);
+	});
+});

--- a/src/config/getInstanceClient.ts
+++ b/src/config/getInstanceClient.ts
@@ -38,7 +38,17 @@ export function getInstanceClient(
 		}
 	}
 
-	const fabricConnect = !disableFabricConnect && (forceFabricConnect || authStore.checkForFabricConnect(id));
+	const basicAuth = authStore.checkForBasicAuth(id);
+
+	// In Fabric Connect mode we obtain a JWT via the proxy (see authStore.establishFabricConnectAuth)
+	// and then talk to the instance directly with a Bearer token instead of routing every operation
+	// through the proxy. Basic auth and explicit proxy requests (forceFabricConnect) take precedence.
+	const operationToken = forceFabricConnect || disableFabricConnect || basicAuth
+		? undefined
+		: authStore.getOperationToken(id);
+
+	const fabricConnect = !operationToken && !disableFabricConnect
+		&& (forceFabricConnect || authStore.checkForFabricConnect(id));
 	if (fabricConnect) {
 		if (id.startsWith('clu-')) {
 			baseURL = apiClient.defaults.baseURL + `/Cluster/${id}/operation`;
@@ -47,14 +57,13 @@ export function getInstanceClient(
 		}
 	}
 
-	const basicAuth = authStore.checkForBasicAuth(id);
-
 	const client = axios.create({
-		auth: fabricConnect ? undefined : basicAuth,
-		withCredentials: fabricConnect || !basicAuth,
+		auth: fabricConnect || operationToken ? undefined : basicAuth,
+		withCredentials: fabricConnect || (!basicAuth && !operationToken),
 		timeout: 60000,
 		headers: {
 			'Content-Type': 'application/json',
+			...(operationToken ? { Authorization: `Bearer ${operationToken}` } : {}),
 		},
 		baseURL,
 	});

--- a/src/config/getInstanceClient.ts
+++ b/src/config/getInstanceClient.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/config/apiClient';
 import { authStore, EntityIds, OverallAppSignIn } from '@/features/auth/store/authStore';
 import { rejectReplicationFailures } from '@/integrations/api/replication';
+import { curryRecoverExpiredOperationToken } from '@/integrations/api/retryExpiredOperationToken';
 import { curryRetryGatewayErrors } from '@/integrations/api/retryGatewayErrors';
 import axios from 'axios';
 
@@ -75,5 +76,10 @@ export function getInstanceClient(
 		rejectReplicationFailures,
 		curryRetryGatewayErrors(client),
 	);
+	// Direct-connect clients recover from a 401 (expired operation token) by minting a fresh token and
+	// replaying once. Registered after the gateway-retry handler, which passes a 401 straight through.
+	if (operationToken) {
+		client.interceptors.response.use(undefined, curryRecoverExpiredOperationToken(client, id));
+	}
 	return client;
 }

--- a/src/config/getInstanceClient.ts
+++ b/src/config/getInstanceClient.ts
@@ -19,9 +19,11 @@ export function getInstanceClient(
 		secure,
 		forceFabricConnect,
 		disableFabricConnect,
+		forceOperationToken,
 	}: InstanceClient & {
 		forceFabricConnect?: boolean;
 		disableFabricConnect?: boolean;
+		forceOperationToken?: boolean;
 	} = {},
 ) {
 	let baseURL = operationsUrl || authStore.getOperationsUrl(id);
@@ -42,8 +44,10 @@ export function getInstanceClient(
 
 	// In Fabric Connect mode we obtain a JWT via the proxy (see authStore.establishFabricConnectAuth)
 	// and then talk to the instance directly with a Bearer token instead of routing every operation
-	// through the proxy. Basic auth and explicit proxy requests (forceFabricConnect) take precedence.
-	const operationToken = forceFabricConnect || disableFabricConnect || basicAuth
+	// through the proxy. Basic auth and explicit proxy requests (forceFabricConnect) take precedence —
+	// except when forceOperationToken is set (the establish probe, which must verify the JWT it just
+	// minted even if a stale basic-auth entry exists for this id).
+	const operationToken = forceFabricConnect || disableFabricConnect || (basicAuth && !forceOperationToken)
 		? undefined
 		: authStore.getOperationToken(id);
 

--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -44,11 +44,17 @@ export function ClusterInstanceSignIn() {
 
 	const operationsUrl = useMemo(() => {
 		if (cluster) {
+			// Entering direct sign-in resets any existing Fabric Connect session for this entity. We drop
+			// the connected user (not just the Fabric Connect flag) so it isn't mislabeled as "Direct
+			// Connect" if the user leaves the form without signing in (HarperFast/studio#1333), and so the
+			// sign-in/health requests go directly to the instance rather than through the proxy.
 			if (instance) {
 				authStore.flagForFabricConnect(instance.id, false);
+				authStore.setUserForEntity(instance, null);
 				return getOperationsUrlForInstance(instance);
 			} else {
 				authStore.flagForFabricConnect(cluster.id, false);
+				authStore.setUserForEntity(cluster, null);
 				return getOperationsUrlForCluster(cluster);
 			}
 		}

--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -24,7 +24,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Navigate, useParams } from '@tanstack/react-router';
 import { cx } from 'class-variance-authority';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
 export function ClusterInstanceSignIn() {
@@ -44,22 +44,33 @@ export function ClusterInstanceSignIn() {
 
 	const operationsUrl = useMemo(() => {
 		if (cluster) {
-			// Entering direct sign-in resets any existing Fabric Connect session for this entity. We drop
-			// the connected user (not just the Fabric Connect flag) so it isn't mislabeled as "Direct
-			// Connect" if the user leaves the form without signing in (HarperFast/studio#1333), and so the
-			// sign-in/health requests go directly to the instance rather than through the proxy.
+			// Clear the Fabric Connect flag synchronously here (before the instance client is built below)
+			// so the sign-in / health requests go directly to the instance rather than through the proxy.
+			// This is idempotent, so it's safe to re-run on every render (e.g. the 10s cluster poll).
 			if (instance) {
 				authStore.flagForFabricConnect(instance.id, false);
-				authStore.setUserForEntity(instance, null);
 				return getOperationsUrlForInstance(instance);
 			} else {
 				authStore.flagForFabricConnect(cluster.id, false);
-				authStore.setUserForEntity(cluster, null);
 				return getOperationsUrlForCluster(cluster);
 			}
 		}
 		return null;
 	}, [cluster, instance]);
+
+	// Drop any existing connected user ONCE on entering the sign-in form (keyed on the stable entity id,
+	// not the poll-refreshed cluster object) so an abandoned sign-in isn't mislabeled as "Direct Connect"
+	// (HarperFast/studio#1333) — without wiping a user that a successful sign-in sets on a later poll tick.
+	const signInEntityId = instance?.id ?? cluster?.id;
+	useEffect(() => {
+		if (instance) {
+			authStore.setUserForEntity(instance, null);
+		} else if (cluster) {
+			authStore.setUserForEntity(cluster, null);
+		}
+		// Intentionally keyed on the stable id, not the entity object (which changes on every poll).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [signInEntityId]);
 
 	const instanceParams = useInstanceClientIdParams({ operationsUrl });
 	const warnAboutLocalDeviceAccess = useMemo(

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -3,6 +3,7 @@ import { getInstanceClient } from '@/config/getInstanceClient';
 import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
 import { SchemaCluster, SchemaHdbInstance } from '@/integrations/api/api.gen';
 import { Cluster, Instance, LocalUser, User } from '@/integrations/api/api.patch';
+import { createInstanceAuthenticationTokens } from '@/integrations/api/instance/auth/createInstanceAuthenticationTokens';
 import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
 import { getInstanceUserInfo } from '@/integrations/api/instance/status/getInstanceUserInfo';
 import { sleep } from '@/lib/sleep';
@@ -52,6 +53,14 @@ class AuthStore {
 	private readonly potentiallyAuthenticated: Record<EntityIds, AuthenticatedConnectionKey>;
 	private readonly checkedAuthentication: Record<EntityIds, boolean> = {};
 	private readonly allConnections: Record<EntityIds, AuthenticatedConnection> = {};
+
+	// In Fabric Connect mode, the JWT we exchange for direct access is kept in memory ONLY (never
+	// persisted) so it can't be exfiltrated from storage. `direct` means we verified a direct Bearer
+	// connection and hold its token; `proxy` means direct connect was unreachable and we fall back to
+	// routing operations through the Fabric Connect proxy. A missing entry means "not yet resolved
+	// this session" — re-resolved on the next instance navigation (see establishFabricConnectAuth).
+	private readonly fabricConnectAuth = new Map<EntityIds, { mode: 'direct'; token: string } | { mode: 'proxy' }>();
+	private readonly fabricConnectInFlight = new Map<EntityIds, Promise<LocalUser>>();
 
 	constructor() {
 		this.potentiallyAuthenticated = JSON.parse(localStorage.getItem(this.potentiallyAuthenticatedKey) || '{}');
@@ -182,6 +191,74 @@ class AuthStore {
 			localStorage.setItem(this.fabricConnectKeyPrefix + id, 'true');
 		} else {
 			localStorage.removeItem(this.fabricConnectKeyPrefix + id);
+			this.fabricConnectAuth.delete(id);
+		}
+	}
+
+	/** The in-memory Fabric Connect JWT for direct connect, or undefined if not connected directly. */
+	public getOperationToken(id: EntityIds): string | undefined {
+		const fabric = this.fabricConnectAuth.get(id);
+		return fabric?.mode === 'direct' ? fabric.token : undefined;
+	}
+
+	/** Whether Fabric Connect auth has been resolved (direct or proxy) for this id this session. */
+	public hasResolvedFabricConnect(id: EntityIds): boolean {
+		return this.fabricConnectAuth.has(id);
+	}
+
+	/**
+	 * Establishes Fabric Connect auth for an instance/cluster: grabs a JWT through the proxy, then
+	 * tries to use it to connect to the instance directly (Bearer token, no proxy). If the instance
+	 * isn't directly reachable (e.g. CORS/mixed-content from cloud Studio to a local instance), we
+	 * drop the token and fall back to routing everything through the proxy. The verified user is
+	 * recorded in the connection state either way. The JWT is held in memory only.
+	 *
+	 * Concurrent calls for the same id share one in-flight request.
+	 */
+	public establishFabricConnectAuth(
+		{ id, operationsUrl }: { id: EntityIds; operationsUrl?: string | null },
+	): Promise<LocalUser> {
+		const inFlight = this.fabricConnectInFlight.get(id);
+		if (inFlight) {
+			return inFlight;
+		}
+		const promise = this.resolveFabricConnectAuth(id, operationsUrl);
+		this.fabricConnectInFlight.set(id, promise);
+		return promise.finally(() => this.fabricConnectInFlight.delete(id));
+	}
+
+	private async resolveFabricConnectAuth(
+		id: EntityIds,
+		operationsUrl: string | null | undefined,
+	): Promise<LocalUser> {
+		try {
+			const token = await createInstanceAuthenticationTokens({
+				instanceClient: getInstanceClient({ id, forceFabricConnect: true }),
+			});
+			this.fabricConnectAuth.set(id, { mode: 'direct', token });
+
+			let user: LocalUser;
+			let key: AuthenticatedConnectionKey;
+			try {
+				const directClient = getInstanceClient({ id, operationsUrl: operationsUrl ?? undefined });
+				user = await getInstanceUserInfo({ instanceClient: directClient });
+				key = operationsUrl || directClient.defaults.baseURL!;
+			} catch (directErr) {
+				// Direct connect unreachable — fall back to the proxy for all operations.
+				console.debug('Fabric Connect direct connect unavailable; falling back to proxy', directErr);
+				this.fabricConnectAuth.set(id, { mode: 'proxy' });
+				const proxyClient = getInstanceClient({ id, forceFabricConnect: true });
+				user = await getInstanceUserInfo({ instanceClient: proxyClient });
+				key = operationsUrl || proxyClient.defaults.baseURL!;
+			}
+
+			this.flagForFabricConnect(id, true);
+			this.setUserForIdAndKey(id, key, user);
+			return user;
+		} catch (err) {
+			// Couldn't establish either mode — clear the half-resolved state so we retry next time.
+			this.fabricConnectAuth.delete(id);
+			throw err;
 		}
 	}
 
@@ -198,6 +275,7 @@ class AuthStore {
 		for (const entityId in this.potentiallyAuthenticated) {
 			this.updateConnectionIfChanged(entityId, false, null);
 			this.flagKeyAsSignedOut(entityId);
+			this.fabricConnectAuth.delete(entityId);
 			if (entityId === OverallAppSignIn) {
 				continue;
 			}

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -235,25 +235,37 @@ class AuthStore {
 			const token = await createInstanceAuthenticationTokens({
 				instanceClient: getInstanceClient({ id, forceFabricConnect: true }),
 			});
-			this.fabricConnectAuth.set(id, { mode: 'direct', token });
 
-			let user: LocalUser;
-			let key: AuthenticatedConnectionKey;
-			try {
-				const directClient = getInstanceClient({ id, operationsUrl: operationsUrl ?? undefined });
-				user = await getInstanceUserInfo({ instanceClient: directClient });
-				key = operationsUrl || directClient.defaults.baseURL!;
-			} catch (directErr) {
-				// Direct connect unreachable — fall back to the proxy for all operations.
-				console.debug('Fabric Connect direct connect unavailable; falling back to proxy', directErr);
-				this.fabricConnectAuth.set(id, { mode: 'proxy' });
-				const proxyClient = getInstanceClient({ id, forceFabricConnect: true });
-				user = await getInstanceUserInfo({ instanceClient: proxyClient });
-				key = operationsUrl || proxyClient.defaults.baseURL!;
+			// Only attempt a direct Bearer connection when we have a concrete direct operations URL.
+			// Without one, getInstanceClient would fall back to the stored connection key — which may be
+			// the proxy URL — and we'd send the instance JWT to the central-manager origin. In that case
+			// skip straight to the proxy fallback.
+			if (operationsUrl) {
+				this.fabricConnectAuth.set(id, { mode: 'direct', token });
+				try {
+					// forceOperationToken so a stale basic-auth entry for this id can't shadow the token we
+					// just minted (basic auth otherwise wins in getInstanceClient).
+					const directClient = getInstanceClient({ id, operationsUrl, forceOperationToken: true });
+					const user = await getInstanceUserInfo({ instanceClient: directClient });
+					this.flagForFabricConnect(id, true);
+					this.setUserForIdAndKey(id, operationsUrl, user);
+					return user;
+				} catch (directErr) {
+					// Direct connect unreachable — fall back to the proxy. Log only the message: the full
+					// axios error carries the Bearer token in error.config.headers.
+					console.debug(
+						'Fabric Connect direct connect unavailable; falling back to proxy',
+						directErr instanceof Error ? directErr.message : directErr,
+					);
+				}
 			}
 
+			// Proxy fallback: route every operation through the central-manager proxy.
+			this.fabricConnectAuth.set(id, { mode: 'proxy' });
+			const proxyClient = getInstanceClient({ id, forceFabricConnect: true });
+			const user = await getInstanceUserInfo({ instanceClient: proxyClient });
 			this.flagForFabricConnect(id, true);
-			this.setUserForIdAndKey(id, key, user);
+			this.setUserForIdAndKey(id, operationsUrl || proxyClient.defaults.baseURL!, user);
 			return user;
 		} catch (err) {
 			// Couldn't establish either mode — clear the half-resolved state so we retry next time.

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -3,7 +3,10 @@ import { getInstanceClient } from '@/config/getInstanceClient';
 import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
 import { SchemaCluster, SchemaHdbInstance } from '@/integrations/api/api.gen';
 import { Cluster, Instance, LocalUser, User } from '@/integrations/api/api.patch';
-import { createInstanceAuthenticationTokens } from '@/integrations/api/instance/auth/createInstanceAuthenticationTokens';
+import {
+	createInstanceAuthenticationTokens,
+	refreshInstanceOperationToken,
+} from '@/integrations/api/instance/auth/createInstanceAuthenticationTokens';
 import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
 import { getInstanceUserInfo } from '@/integrations/api/instance/status/getInstanceUserInfo';
 import { sleep } from '@/lib/sleep';
@@ -66,8 +69,12 @@ class AuthStore {
 	// connection and hold its token; `proxy` means direct connect was unreachable and we fall back to
 	// routing operations through the Fabric Connect proxy. A missing entry means "not yet resolved
 	// this session" — re-resolved on the next instance navigation (see establishFabricConnectAuth).
-	private readonly fabricConnectAuth = new Map<EntityIds, { mode: 'direct'; token: string } | { mode: 'proxy' }>();
+	private readonly fabricConnectAuth = new Map<
+		EntityIds,
+		{ mode: 'direct'; token: string; refreshToken?: string } | { mode: 'proxy' }
+	>();
 	private readonly fabricConnectInFlight = new Map<EntityIds, Promise<LocalUser>>();
+	private readonly operationTokenRefreshInFlight = new Map<EntityIds, Promise<string | null>>();
 
 	constructor() {
 		this.potentiallyAuthenticated = JSON.parse(localStorage.getItem(this.potentiallyAuthenticatedKey) || '{}');
@@ -214,6 +221,67 @@ class AuthStore {
 	}
 
 	/**
+	 * Recovers a fresh operation token for a direct-connect id whose token was rejected (typically 401
+	 * from mid-session expiry — Harper operation tokens default to ~1 day). Prefers exchanging the
+	 * refresh token directly at the instance; falls back to re-minting a fresh pair through the proxy.
+	 * Returns the new token, or null if recovery failed or the id isn't in direct mode. Concurrent
+	 * callers for the same id share one recovery.
+	 */
+	public recoverExpiredOperationToken(id: EntityIds): Promise<string | null> {
+		const fabric = this.fabricConnectAuth.get(id);
+		if (fabric?.mode !== 'direct') {
+			return Promise.resolve(null);
+		}
+		const inFlight = this.operationTokenRefreshInFlight.get(id);
+		if (inFlight) {
+			return inFlight;
+		}
+		const promise = this.mintFreshOperationToken(id, fabric.refreshToken);
+		this.operationTokenRefreshInFlight.set(id, promise);
+		return promise.finally(() => this.operationTokenRefreshInFlight.delete(id));
+	}
+
+	private async mintFreshOperationToken(id: EntityIds, refreshToken: string | undefined): Promise<string | null> {
+		// Cheap path: exchange the refresh token for a new operation token, directly at the instance.
+		// forceOperationToken keeps getInstanceClient on the direct URL (not the proxy) even if a stale
+		// basic-auth entry exists; refreshInstanceOperationToken overrides the Bearer with the refresh token.
+		if (refreshToken) {
+			try {
+				const token = await refreshInstanceOperationToken({
+					instanceClient: getInstanceClient({ id, forceOperationToken: true }),
+					refreshToken,
+				});
+				this.updateDirectOperationToken(id, token, refreshToken);
+				return token;
+			} catch (err) {
+				console.debug(
+					'Operation token refresh failed; re-minting via proxy',
+					err instanceof Error ? err.message : err,
+				);
+			}
+		}
+
+		// Fall back to minting a fresh pair through the proxy.
+		try {
+			const { operationToken, refreshToken: newRefreshToken } = await createInstanceAuthenticationTokens({
+				instanceClient: getInstanceClient({ id, forceFabricConnect: true }),
+			});
+			this.updateDirectOperationToken(id, operationToken, newRefreshToken ?? refreshToken);
+			return operationToken;
+		} catch (err) {
+			console.debug('Operation token re-mint failed', err instanceof Error ? err.message : err);
+			return null;
+		}
+	}
+
+	/** Update the in-memory direct token, but only if a concurrent logout/flag-off hasn't cleared it. */
+	private updateDirectOperationToken(id: EntityIds, token: string, refreshToken: string | undefined): void {
+		if (this.fabricConnectAuth.get(id)?.mode === 'direct') {
+			this.fabricConnectAuth.set(id, { mode: 'direct', token, refreshToken });
+		}
+	}
+
+	/**
 	 * Establishes Fabric Connect auth for an instance/cluster: grabs a JWT through the proxy, then
 	 * tries to use it to connect to the instance directly (Bearer token, no proxy). If the instance
 	 * isn't directly reachable (e.g. CORS/mixed-content from cloud Studio to a local instance), we
@@ -239,7 +307,7 @@ class AuthStore {
 		operationsUrl: string | null | undefined,
 	): Promise<LocalUser> {
 		try {
-			const token = await createInstanceAuthenticationTokens({
+			const { operationToken, refreshToken } = await createInstanceAuthenticationTokens({
 				instanceClient: getInstanceClient({ id, forceFabricConnect: true }),
 			});
 
@@ -248,7 +316,7 @@ class AuthStore {
 			// (or the passed URL) is a proxy URL we'd send the instance JWT to the central-manager origin.
 			// In that case skip straight to the proxy fallback.
 			if (isDirectOperationsUrl(operationsUrl)) {
-				this.fabricConnectAuth.set(id, { mode: 'direct', token });
+				this.fabricConnectAuth.set(id, { mode: 'direct', token: operationToken, refreshToken });
 				try {
 					// forceOperationToken so a stale basic-auth entry for this id can't shadow the token we
 					// just minted (basic auth otherwise wins in getInstanceClient).

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -40,6 +40,13 @@ type OverallAppSignInType = typeof OverallAppSignIn;
 export type EntityIds = OverallAppSignInType | Instance['id'] | Cluster['id'];
 type EntityTypes = OverallAppSignInType | Instance | Cluster | null;
 
+// The Fabric Connect proxy routes through these central-manager paths (see getInstanceClient). A
+// direct operations URL must never be one of them, or we'd send the instance Bearer JWT to the proxy
+// origin instead of the instance.
+function isDirectOperationsUrl(url: string | null | undefined): url is string {
+	return !!url && !url.includes('/HDBInstance/') && !url.includes('/Cluster/');
+}
+
 class AuthStore {
 	private readonly broadListeners: Array<(connection: AuthenticatedConnection, id: EntityIds) => void> = [];
 	private readonly specificListeners: Record<
@@ -236,11 +243,11 @@ class AuthStore {
 				instanceClient: getInstanceClient({ id, forceFabricConnect: true }),
 			});
 
-			// Only attempt a direct Bearer connection when we have a concrete direct operations URL.
-			// Without one, getInstanceClient would fall back to the stored connection key — which may be
-			// the proxy URL — and we'd send the instance JWT to the central-manager origin. In that case
-			// skip straight to the proxy fallback.
-			if (operationsUrl) {
+			// Only attempt a direct Bearer connection when we have a concrete DIRECT operations URL.
+			// Without one, getInstanceClient would fall back to the stored connection key, and if that
+			// (or the passed URL) is a proxy URL we'd send the instance JWT to the central-manager origin.
+			// In that case skip straight to the proxy fallback.
+			if (isDirectOperationsUrl(operationsUrl)) {
 				this.fabricConnectAuth.set(id, { mode: 'direct', token });
 				try {
 					// forceOperationToken so a stale basic-auth entry for this id can't shadow the token we

--- a/src/features/auth/store/establishFabricConnectAuth.test.ts
+++ b/src/features/auth/store/establishFabricConnectAuth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getInstanceClient = vi.fn();
 const createInstanceAuthenticationTokens = vi.fn();
+const refreshInstanceOperationToken = vi.fn();
 const getInstanceUserInfo = vi.fn();
 
 vi.mock('@/config/getInstanceClient', () => ({
@@ -10,6 +11,7 @@ vi.mock('@/config/getInstanceClient', () => ({
 }));
 vi.mock('@/integrations/api/instance/auth/createInstanceAuthenticationTokens', () => ({
 	createInstanceAuthenticationTokens: (...args: unknown[]) => createInstanceAuthenticationTokens(...args),
+	refreshInstanceOperationToken: (...args: unknown[]) => refreshInstanceOperationToken(...args),
 }));
 vi.mock('@/integrations/api/instance/status/getInstanceUserInfo', () => ({
 	getInstanceUserInfo: (...args: unknown[]) => getInstanceUserInfo(...args),
@@ -30,7 +32,10 @@ describe('authStore.establishFabricConnectAuth', () => {
 		getInstanceClient.mockImplementation(({ forceFabricConnect }: { forceFabricConnect?: boolean }) => ({
 			defaults: { baseURL: forceFabricConnect ? PROXY_URL : DIRECT_URL },
 		}));
-		createInstanceAuthenticationTokens.mockResolvedValue('jwt-token');
+		createInstanceAuthenticationTokens.mockResolvedValue({
+			operationToken: 'jwt-token',
+			refreshToken: 'refresh-token',
+		});
 	});
 
 	afterEach(() => {
@@ -134,5 +139,92 @@ describe('authStore.establishFabricConnectAuth', () => {
 
 		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
 		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(false);
+	});
+});
+
+describe('authStore.recoverExpiredOperationToken', () => {
+	beforeEach(() => {
+		getInstanceClient.mockImplementation(({ forceFabricConnect }: { forceFabricConnect?: boolean }) => ({
+			defaults: { baseURL: forceFabricConnect ? PROXY_URL : DIRECT_URL },
+		}));
+		createInstanceAuthenticationTokens.mockResolvedValue({
+			operationToken: 'jwt-token',
+			refreshToken: 'refresh-token',
+		});
+		getInstanceUserInfo.mockResolvedValue(directUser);
+	});
+
+	afterEach(() => {
+		authStore.flagForFabricConnect('ins-1', false);
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	// Seeds a direct-mode connection with token 'jwt-token' + refreshToken 'refresh-token'.
+	async function seedDirect() {
+		await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL });
+		expect(authStore.getOperationToken('ins-1')).toBe('jwt-token');
+	}
+
+	it('returns null and does nothing when the id is not in direct mode', async () => {
+		// No entry seeded at all.
+		const token = await authStore.recoverExpiredOperationToken('ins-1');
+		expect(token).toBeNull();
+		expect(refreshInstanceOperationToken).not.toHaveBeenCalled();
+		expect(createInstanceAuthenticationTokens).not.toHaveBeenCalled();
+	});
+
+	it('exchanges the refresh token for a fresh operation token without hitting the proxy', async () => {
+		await seedDirect();
+		refreshInstanceOperationToken.mockResolvedValue('refreshed-token');
+
+		const token = await authStore.recoverExpiredOperationToken('ins-1');
+
+		expect(token).toBe('refreshed-token');
+		expect(authStore.getOperationToken('ins-1')).toBe('refreshed-token');
+		expect(refreshInstanceOperationToken).toHaveBeenCalledTimes(1);
+		// The proxy re-mint (create_authentication_tokens) is only the seed call, not a recovery call.
+		expect(createInstanceAuthenticationTokens).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-mints a fresh pair through the proxy when the refresh token is rejected', async () => {
+		await seedDirect();
+		refreshInstanceOperationToken.mockRejectedValue(new Error('refresh expired'));
+		createInstanceAuthenticationTokens.mockResolvedValue({
+			operationToken: 'reminted-token',
+			refreshToken: 'new-refresh',
+		});
+
+		const token = await authStore.recoverExpiredOperationToken('ins-1');
+
+		expect(token).toBe('reminted-token');
+		expect(authStore.getOperationToken('ins-1')).toBe('reminted-token');
+		expect(refreshInstanceOperationToken).toHaveBeenCalledTimes(1);
+		expect(createInstanceAuthenticationTokens).toHaveBeenCalledTimes(2); // seed + recovery re-mint
+	});
+
+	it('returns null and keeps the old token when both refresh and re-mint fail', async () => {
+		await seedDirect();
+		refreshInstanceOperationToken.mockRejectedValue(new Error('refresh expired'));
+		createInstanceAuthenticationTokens.mockRejectedValue(new Error('proxy down'));
+
+		const token = await authStore.recoverExpiredOperationToken('ins-1');
+
+		expect(token).toBeNull();
+		expect(authStore.getOperationToken('ins-1')).toBe('jwt-token');
+	});
+
+	it('shares one recovery for concurrent callers', async () => {
+		await seedDirect();
+		refreshInstanceOperationToken.mockResolvedValue('refreshed-token');
+
+		const [a, b] = await Promise.all([
+			authStore.recoverExpiredOperationToken('ins-1'),
+			authStore.recoverExpiredOperationToken('ins-1'),
+		]);
+
+		expect(a).toBe('refreshed-token');
+		expect(b).toBe('refreshed-token');
+		expect(refreshInstanceOperationToken).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/features/auth/store/establishFabricConnectAuth.test.ts
+++ b/src/features/auth/store/establishFabricConnectAuth.test.ts
@@ -113,6 +113,18 @@ describe('authStore.establishFabricConnectAuth', () => {
 		expect(getInstanceUserInfo.mock.calls[0][0].instanceClient.defaults.baseURL).toBe(PROXY_URL);
 	});
 
+	it('refuses to send the Bearer token to a proxy URL and falls back to the proxy', async () => {
+		// A proxy-looking operations URL must never receive the instance JWT directly.
+		getInstanceUserInfo.mockResolvedValue(proxyUser);
+
+		const user = await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: PROXY_URL });
+
+		expect(user).toBe(proxyUser);
+		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
+		expect(getInstanceUserInfo).toHaveBeenCalledTimes(1);
+		expect(getInstanceUserInfo.mock.calls[0][0].instanceClient.defaults.baseURL).toBe(PROXY_URL);
+	});
+
 	it('drops the in-memory token when Fabric Connect is flagged off (e.g. on logout)', async () => {
 		getInstanceUserInfo.mockResolvedValue(directUser);
 		await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL });

--- a/src/features/auth/store/establishFabricConnectAuth.test.ts
+++ b/src/features/auth/store/establishFabricConnectAuth.test.ts
@@ -88,4 +88,39 @@ describe('authStore.establishFabricConnectAuth', () => {
 			.rejects.toThrow('proxy unauthorized');
 		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(false);
 	});
+
+	it('clears resolution and rethrows when both direct and proxy verification fail', async () => {
+		// Token mints, but neither the direct probe nor the proxy fallback can reach the instance — the
+		// half-resolved {mode:'proxy'} entry must be cleared so the next navigation retries.
+		getInstanceUserInfo.mockRejectedValue(new Error('unreachable'));
+
+		await expect(authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL }))
+			.rejects.toThrow('unreachable');
+		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(false);
+		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
+	});
+
+	it('skips the direct Bearer probe and uses the proxy when no direct operations URL is known', async () => {
+		// Without a concrete direct URL, a Bearer request would be sent to the stored key (possibly the
+		// proxy origin) — so it must go straight to proxy mode and never probe directly.
+		getInstanceUserInfo.mockResolvedValue(proxyUser);
+
+		const user = await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: null });
+
+		expect(user).toBe(proxyUser);
+		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
+		expect(getInstanceUserInfo).toHaveBeenCalledTimes(1);
+		expect(getInstanceUserInfo.mock.calls[0][0].instanceClient.defaults.baseURL).toBe(PROXY_URL);
+	});
+
+	it('drops the in-memory token when Fabric Connect is flagged off (e.g. on logout)', async () => {
+		getInstanceUserInfo.mockResolvedValue(directUser);
+		await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL });
+		expect(authStore.getOperationToken('ins-1')).toBe('jwt-token');
+
+		authStore.flagForFabricConnect('ins-1', false);
+
+		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
+		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(false);
+	});
 });

--- a/src/features/auth/store/establishFabricConnectAuth.test.ts
+++ b/src/features/auth/store/establishFabricConnectAuth.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getInstanceClient = vi.fn();
+const createInstanceAuthenticationTokens = vi.fn();
+const getInstanceUserInfo = vi.fn();
+
+vi.mock('@/config/getInstanceClient', () => ({
+	getInstanceClient: (...args: unknown[]) => getInstanceClient(...args),
+}));
+vi.mock('@/integrations/api/instance/auth/createInstanceAuthenticationTokens', () => ({
+	createInstanceAuthenticationTokens: (...args: unknown[]) => createInstanceAuthenticationTokens(...args),
+}));
+vi.mock('@/integrations/api/instance/status/getInstanceUserInfo', () => ({
+	getInstanceUserInfo: (...args: unknown[]) => getInstanceUserInfo(...args),
+}));
+
+const PROXY_URL = 'https://manager.example.com/HDBInstance/ins-1/operation';
+const DIRECT_URL = 'https://instance.example.com:9925/';
+const directUser = { username: 'direct-user' };
+const proxyUser = { username: 'proxy-user' };
+
+// Imported after the mocks are registered.
+const { authStore } = await import('@/features/auth/store/authStore');
+
+describe('authStore.establishFabricConnectAuth', () => {
+	beforeEach(() => {
+		// getInstanceClient is called with { forceFabricConnect: true } for the proxy client and with
+		// an operationsUrl for the direct client. Hand back objects we can tell apart by baseURL.
+		getInstanceClient.mockImplementation(({ forceFabricConnect }: { forceFabricConnect?: boolean }) => ({
+			defaults: { baseURL: forceFabricConnect ? PROXY_URL : DIRECT_URL },
+		}));
+		createInstanceAuthenticationTokens.mockResolvedValue('jwt-token');
+	});
+
+	afterEach(() => {
+		authStore.flagForFabricConnect('ins-1', false);
+		localStorage.clear();
+		vi.clearAllMocks();
+	});
+
+	it('connects directly with the JWT when the instance is reachable', async () => {
+		getInstanceUserInfo.mockResolvedValue(directUser);
+
+		const user = await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL });
+
+		expect(user).toBe(directUser);
+		expect(authStore.getOperationToken('ins-1')).toBe('jwt-token');
+		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(true);
+		expect(authStore.checkForFabricConnect('ins-1')).toBe(true);
+	});
+
+	it('drops the JWT and falls back to the proxy when direct connect is unreachable', async () => {
+		getInstanceUserInfo.mockImplementation((
+			{ instanceClient }: { instanceClient: { defaults: { baseURL: string } } },
+		) =>
+			instanceClient.defaults.baseURL === DIRECT_URL
+				? Promise.reject(new Error('CORS'))
+				: Promise.resolve(proxyUser)
+		);
+
+		const user = await authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL });
+
+		expect(user).toBe(proxyUser);
+		// No token retained in proxy mode, but the connection is still resolved.
+		expect(authStore.getOperationToken('ins-1')).toBeUndefined();
+		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(true);
+		expect(authStore.checkForFabricConnect('ins-1')).toBe(true);
+	});
+
+	it('shares one in-flight request for concurrent calls', async () => {
+		getInstanceUserInfo.mockResolvedValue(directUser);
+
+		const [a, b] = await Promise.all([
+			authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL }),
+			authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL }),
+		]);
+
+		expect(a).toBe(directUser);
+		expect(b).toBe(directUser);
+		expect(createInstanceAuthenticationTokens).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears resolution and rethrows when no token can be obtained', async () => {
+		createInstanceAuthenticationTokens.mockRejectedValue(new Error('proxy unauthorized'));
+
+		await expect(authStore.establishFabricConnectAuth({ id: 'ins-1', operationsUrl: DIRECT_URL }))
+			.rejects.toThrow('proxy unauthorized');
+		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(false);
+	});
+});

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -63,12 +63,10 @@ export function redirectAwayFromInstanceSignInIfConnected(
 		params: { clusterId: string; instanceId: string };
 	},
 ) {
-	const isFabricConnect = authStore.checkForFabricConnect(params.clusterId)
-		|| authStore.checkForFabricConnect(params.instanceId);
-	if (isFabricConnect) {
-		return;
-	}
-	if (authStore.getConnectionById(params.instanceId).user) {
+	// Key off the instance's OWN state, mirroring the cluster guard. The parent cluster's Fabric Connect
+	// flag must not suppress the redirect for an instance that is directly connected in its own right.
+	const isFabricConnect = authStore.checkForFabricConnect(params.instanceId);
+	if (authStore.getConnectionById(params.instanceId).user && !isFabricConnect) {
 		const redirectTo = location?.search?.redirect;
 		throw redirect({
 			to: redirectTo?.startsWith('/') ? redirectTo : defaultInstanceRouteUpOne,

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -37,22 +37,51 @@ const clusterDomainsRoute = createRoute({
 	component: DomainsPage,
 });
 
+// These guards intentionally read live `authStore` state rather than the `context.authentication`
+// snapshot. Clicking "Direct Sign In" clears the connection synchronously, but the router context
+// lags (authStore notifies its listeners asynchronously), so the snapshot still shows the old user
+// — which would bounce us off the sign-in form and back into Fabric Connect (HarperFast/studio#1333).
+
+export function redirectAwayFromSignInIfConnected(
+	{ location, params }: {
+		location?: { search?: { redirect?: string } };
+		params: { clusterId: string };
+	},
+) {
+	const isFabricConnect = authStore.checkForFabricConnect(params.clusterId);
+	if (authStore.getConnectionById(params.clusterId).user && !isFabricConnect) {
+		const redirectTo = location?.search?.redirect;
+		throw redirect({
+			to: redirectTo?.startsWith('/') ? redirectTo : defaultInstanceRouteUpOne,
+		});
+	}
+}
+
+export function redirectAwayFromInstanceSignInIfConnected(
+	{ location, params }: {
+		location?: { search?: { redirect?: string } };
+		params: { clusterId: string; instanceId: string };
+	},
+) {
+	const isFabricConnect = authStore.checkForFabricConnect(params.clusterId)
+		|| authStore.checkForFabricConnect(params.instanceId);
+	if (isFabricConnect) {
+		return;
+	}
+	if (authStore.getConnectionById(params.instanceId).user) {
+		const redirectTo = location?.search?.redirect;
+		throw redirect({
+			to: redirectTo?.startsWith('/') ? redirectTo : defaultInstanceRouteUpOne,
+		});
+	}
+}
+
 const clusterSignInRoute = createRoute({
 	getParentRoute: () => clusterLayoutRoute,
 	path: 'sign-in',
 	head: () => ({ meta: [{ title: 'Sign In — Harper Fabric' }] }),
 	component: ClusterInstanceSignIn,
-	beforeLoad: ({ context, location, params }) => {
-		const isFabricConnect = authStore.checkForFabricConnect(params.clusterId);
-		if (context.authentication[params.clusterId]?.user && !isFabricConnect) {
-			const search: Record<string, string> = location?.search;
-			throw redirect({
-				to: search?.redirect?.startsWith('/')
-					? search.redirect
-					: defaultInstanceRouteUpOne,
-			});
-		}
-	},
+	beforeLoad: redirectAwayFromSignInIfConnected,
 });
 
 const instanceSignInRoute = createRoute({
@@ -60,21 +89,7 @@ const instanceSignInRoute = createRoute({
 	path: 'instance/$instanceId/sign-in',
 	head: () => ({ meta: [{ title: 'Sign In — Harper Fabric' }] }),
 	component: ClusterInstanceSignIn,
-	beforeLoad: ({ context, location, params }) => {
-		const isFabricConnect = authStore.checkForFabricConnect(params.clusterId)
-			|| authStore.checkForFabricConnect(params.instanceId);
-		if (isFabricConnect) {
-			return;
-		}
-		if (context.authentication[params.instanceId]?.user) {
-			const search: Record<string, string> = location?.search;
-			throw redirect({
-				to: search?.redirect?.startsWith('/')
-					? search.redirect
-					: defaultInstanceRouteUpOne,
-			});
-		}
-	},
+	beforeLoad: redirectAwayFromInstanceSignInIfConnected,
 });
 
 const clusterFinishSetupRoute = createRoute({

--- a/src/features/cluster/signInGuards.test.ts
+++ b/src/features/cluster/signInGuards.test.ts
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+import { authStore } from '@/features/auth/store/authStore';
+import { LocalUser } from '@/integrations/api/api.patch';
+import { afterEach, describe, expect, it } from 'vitest';
+import { redirectAwayFromInstanceSignInIfConnected, redirectAwayFromSignInIfConnected } from './routes';
+
+const CLUSTER_ID = 'clu-1333';
+const INSTANCE_ID = 'ins-1333';
+const KEY = 'https://instance.example.com:9925/';
+const user = { username: 'admin' } as LocalUser;
+
+function setConnectedUser(id: string) {
+	authStore.setUserForIdAndKey(id, KEY, user);
+}
+
+function clearConnection(id: string) {
+	authStore.setUserForIdAndKey(id, KEY, null);
+	authStore.flagForFabricConnect(id, false);
+}
+
+afterEach(() => {
+	clearConnection(CLUSTER_ID);
+	clearConnection(INSTANCE_ID);
+	localStorage.clear();
+});
+
+describe('redirectAwayFromSignInIfConnected (cluster)', () => {
+	it('shows the form (no redirect) when there is no connection', () => {
+		expect(() => redirectAwayFromSignInIfConnected({ params: { clusterId: CLUSTER_ID } })).not.toThrow();
+	});
+
+	it('redirects away when already directly connected', () => {
+		setConnectedUser(CLUSTER_ID);
+		expect(() => redirectAwayFromSignInIfConnected({ params: { clusterId: CLUSTER_ID } })).toThrow();
+	});
+
+	it('shows the form when connected via Fabric Connect (so the user can sign in directly)', () => {
+		setConnectedUser(CLUSTER_ID);
+		authStore.flagForFabricConnect(CLUSTER_ID, true);
+		expect(() => redirectAwayFromSignInIfConnected({ params: { clusterId: CLUSTER_ID } })).not.toThrow();
+	});
+
+	it('reads live auth state: a synchronously-cleared user does not redirect (the #1333 race)', () => {
+		setConnectedUser(CLUSTER_ID);
+		// Simulates "Direct Sign In" clearing the connection right before navigation. The router-context
+		// snapshot would still hold the old user, but the live store does not — so we must not redirect.
+		authStore.setUserForIdAndKey(CLUSTER_ID, KEY, null);
+		expect(() => redirectAwayFromSignInIfConnected({ params: { clusterId: CLUSTER_ID } })).not.toThrow();
+	});
+
+	it('honors an absolute redirect target', () => {
+		setConnectedUser(CLUSTER_ID);
+		try {
+			redirectAwayFromSignInIfConnected({
+				params: { clusterId: CLUSTER_ID },
+				location: { search: { redirect: '/some/path' } },
+			});
+			expect.unreachable('expected a redirect');
+		} catch (thrown) {
+			expect((thrown as { options?: { to?: string } }).options?.to).toBe('/some/path');
+		}
+	});
+});
+
+describe('redirectAwayFromInstanceSignInIfConnected (instance)', () => {
+	it('shows the form (no redirect) when there is no connection', () => {
+		expect(() =>
+			redirectAwayFromInstanceSignInIfConnected({ params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID } })
+		).not.toThrow();
+	});
+
+	it('redirects away when already directly connected', () => {
+		setConnectedUser(INSTANCE_ID);
+		expect(() =>
+			redirectAwayFromInstanceSignInIfConnected({ params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID } })
+		).toThrow();
+	});
+
+	it('shows the form when Fabric Connect is flagged, even with a user', () => {
+		setConnectedUser(INSTANCE_ID);
+		authStore.flagForFabricConnect(INSTANCE_ID, true);
+		expect(() =>
+			redirectAwayFromInstanceSignInIfConnected({ params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID } })
+		).not.toThrow();
+	});
+});

--- a/src/features/cluster/signInGuards.test.ts
+++ b/src/features/cluster/signInGuards.test.ts
@@ -76,11 +76,32 @@ describe('redirectAwayFromInstanceSignInIfConnected (instance)', () => {
 		).toThrow();
 	});
 
-	it('shows the form when Fabric Connect is flagged, even with a user', () => {
+	it('shows the form when the INSTANCE is flagged for Fabric Connect, even with a user', () => {
 		setConnectedUser(INSTANCE_ID);
 		authStore.flagForFabricConnect(INSTANCE_ID, true);
 		expect(() =>
 			redirectAwayFromInstanceSignInIfConnected({ params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID } })
 		).not.toThrow();
+	});
+
+	it('redirects away for a directly-connected instance even when the parent CLUSTER is fabric-connected', () => {
+		setConnectedUser(INSTANCE_ID);
+		authStore.flagForFabricConnect(CLUSTER_ID, true); // cluster flag must not suppress the instance redirect
+		expect(() =>
+			redirectAwayFromInstanceSignInIfConnected({ params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID } })
+		).toThrow();
+	});
+
+	it('honors an absolute redirect target', () => {
+		setConnectedUser(INSTANCE_ID);
+		try {
+			redirectAwayFromInstanceSignInIfConnected({
+				params: { clusterId: CLUSTER_ID, instanceId: INSTANCE_ID },
+				location: { search: { redirect: '/some/path' } },
+			});
+			expect.unreachable('expected a redirect');
+		} catch (thrown) {
+			expect((thrown as { options?: { to?: string } }).options?.to).toBe('/some/path');
+		}
 	});
 });

--- a/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
+++ b/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+import { authStore } from '@/features/auth/store/authStore';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let permissions = { update: false } as { update: boolean };
+vi.mock('@/hooks/usePermissions', () => ({
+	getOrganizationClusterPermissions: () => permissions,
+	getOrganizationClusterInstancePermissions: () => permissions,
+}));
+
+const { checkClusterInstanceAuthenticationBeforeLoad } = await import('./instanceLayoutRoute');
+
+const CLUSTER_ID = 'clu-guard';
+const PARAMS = { organizationId: 'org-1', clusterId: CLUSTER_ID };
+// user is null because the permission helpers are mocked and ignore it; we only need isLoading: false.
+const overallAuthReady = { OverallAppSignIn: { isLoading: false, user: null } };
+
+let establishSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	permissions = { update: false };
+	vi.spyOn(authStore, 'checkForFabricConnect').mockReturnValue(false);
+	vi.spyOn(authStore, 'hasResolvedFabricConnect').mockReturnValue(false);
+	establishSpy = vi.spyOn(authStore, 'establishFabricConnectAuth').mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('checkClusterInstanceAuthenticationBeforeLoad', () => {
+	it('re-establishes on reload (flag set, not resolved) and returns without redirecting', async () => {
+		(authStore.checkForFabricConnect as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: overallAuthReady }, params: PARAMS }),
+		).resolves.toBeUndefined();
+		expect(establishSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not attempt establishment twice in one pass when the reload attempt fails (manage perms)', async () => {
+		// Reload: flag set + not resolved -> first attempt runs and fails; even with update permission the
+		// permission-gated path must NOT fire a second mint in the same beforeLoad pass.
+		(authStore.checkForFabricConnect as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		establishSpy.mockRejectedValue(new Error('proxy down'));
+		permissions = { update: true };
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: overallAuthReady }, params: PARAMS }),
+		).rejects.toMatchObject({ options: { to: expect.stringContaining('/sign-in') } });
+		expect(establishSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('auto-connects a first-time visitor with manage permission', async () => {
+		// Not flagged yet (first visit), but the user can manage -> establish once, no redirect.
+		permissions = { update: true };
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: overallAuthReady }, params: PARAMS }),
+		).resolves.toBeUndefined();
+		expect(establishSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('redirects to sign-in when not flagged and the user cannot manage', async () => {
+		permissions = { update: false };
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: overallAuthReady }, params: PARAMS }),
+		).rejects.toMatchObject({ options: { to: expect.stringContaining('/sign-in') } });
+		expect(establishSpy).not.toHaveBeenCalled();
+	});
+
+	it('waits (no redirect) while the app-level sign-in is still loading', async () => {
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({
+				context: { authentication: { OverallAppSignIn: { isLoading: true, user: null } } },
+				params: PARAMS,
+			}),
+		).resolves.toBeUndefined();
+		expect(establishSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
+++ b/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
@@ -16,11 +16,14 @@ const PARAMS = { organizationId: 'org-1', clusterId: CLUSTER_ID };
 const overallAuthReady = { OverallAppSignIn: { isLoading: false, user: null } };
 
 let establishSpy: ReturnType<typeof vi.spyOn>;
+let connectionSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
 	permissions = { update: false };
 	vi.spyOn(authStore, 'checkForFabricConnect').mockReturnValue(false);
 	vi.spyOn(authStore, 'hasResolvedFabricConnect').mockReturnValue(false);
+	// Default: no live connection for the entity (not signed in yet).
+	connectionSpy = vi.spyOn(authStore, 'getConnectionById').mockReturnValue({ isLoading: false, user: null });
 	establishSpy = vi.spyOn(authStore, 'establishFabricConnectAuth').mockResolvedValue({} as never);
 });
 
@@ -49,6 +52,22 @@ describe('checkClusterInstanceAuthenticationBeforeLoad', () => {
 			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: overallAuthReady }, params: PARAMS }),
 		).rejects.toMatchObject({ options: { to: expect.stringContaining('/sign-in') } });
 		expect(establishSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not Fabric Connect over a fresh direct sign-in (reads live auth, not the stale snapshot)', async () => {
+		// Simulates a just-completed direct sign-in: the live connection has a user (set synchronously by
+		// the sign-in success handler) even though the router-context snapshot would still be empty, and
+		// the manager has update permission. The guard must NOT auto-Fabric-Connect over the direct session.
+		permissions = { update: true };
+		connectionSpy.mockReturnValue({ isLoading: false, user: { username: 'direct-user' } as never });
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({
+				context: { authentication: { OverallAppSignIn: { isLoading: false, user: null } } },
+				params: PARAMS,
+			}),
+		).resolves.toBeUndefined();
+		expect(establishSpy).not.toHaveBeenCalled();
 	});
 
 	it('auto-connects a first-time visitor with manage permission', async () => {

--- a/src/features/instance/instanceLayoutRoute.ts
+++ b/src/features/instance/instanceLayoutRoute.ts
@@ -43,7 +43,7 @@ export function createInstanceLayoutRoute(mode: 'local' | 'cluster' | 'instance'
 	}
 }
 
-async function checkClusterInstanceAuthenticationBeforeLoad({
+export async function checkClusterInstanceAuthenticationBeforeLoad({
 	context,
 	params,
 }: {
@@ -54,7 +54,9 @@ async function checkClusterInstanceAuthenticationBeforeLoad({
 
 	// The Fabric Connect JWT lives only in memory, so after a reload we still have the persisted flag
 	// but no token. Re-establish direct connect before anything tries to talk to the instance.
+	let attemptedEstablish = false;
 	if (authStore.checkForFabricConnect(entityId) && !authStore.hasResolvedFabricConnect(entityId)) {
+		attemptedEstablish = true;
 		if (await tryEstablishFabricConnect(entityId, context.cluster, params.instanceId)) {
 			return;
 		}
@@ -73,10 +75,11 @@ async function checkClusterInstanceAuthenticationBeforeLoad({
 	}
 
 	// First visit: if the user can manage this entity, connect them via Fabric Connect automatically.
+	// Skip if we already tried above (e.g. reload with an unreachable proxy) to avoid a duplicate mint.
 	const { update } = params.instanceId
 		? getOrganizationClusterInstancePermissions(overallAuth.user, params.organizationId, params.clusterId)
 		: getOrganizationClusterPermissions(overallAuth.user, params.organizationId, params.clusterId);
-	if (update && await tryEstablishFabricConnect(entityId, context.cluster, params.instanceId)) {
+	if (!attemptedEstablish && update && await tryEstablishFabricConnect(entityId, context.cluster, params.instanceId)) {
 		return;
 	}
 

--- a/src/features/instance/instanceLayoutRoute.ts
+++ b/src/features/instance/instanceLayoutRoute.ts
@@ -1,4 +1,3 @@
-import { getInstanceClient } from '@/config/getInstanceClient';
 import {
 	AuthenticatedCloudConnection,
 	AuthenticatedConnection,
@@ -8,8 +7,10 @@ import {
 import { clusterLayoutRoute } from '@/features/cluster/clusterLayoutRoute';
 import { InstanceLayout } from '@/features/instance/InstanceLayout';
 import { getOrganizationClusterInstancePermissions, getOrganizationClusterPermissions } from '@/hooks/usePermissions';
-import { getInstanceUserInfo } from '@/integrations/api/instance/status/getInstanceUserInfo';
+import { Cluster } from '@/integrations/api/api.patch';
 import { buildRedirectInSearch } from '@/lib/urls/buildRedirectInSearch';
+import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
 import { dashboardLayout } from '@/router/dashboardRoute';
 import { createRoute, redirect } from '@tanstack/react-router';
 import { registrationInfoLoader } from './registrationInfoLoader';
@@ -46,48 +47,74 @@ async function checkClusterInstanceAuthenticationBeforeLoad({
 	context,
 	params,
 }: {
-	context: { authentication: Record<string, AuthenticatedConnection> };
+	context: { authentication: Record<string, AuthenticatedConnection>; cluster?: Cluster };
 	params: { organizationId: string; clusterId: string; instanceId?: string };
 }) {
-	// Are we already authenticated?
-	const auth = context.authentication[params.instanceId || params.clusterId];
+	const entityId = params.instanceId || params.clusterId;
+
+	// The Fabric Connect JWT lives only in memory, so after a reload we still have the persisted flag
+	// but no token. Re-establish direct connect before anything tries to talk to the instance.
+	if (authStore.checkForFabricConnect(entityId) && !authStore.hasResolvedFabricConnect(entityId)) {
+		if (await tryEstablishFabricConnect(entityId, context.cluster, params.instanceId)) {
+			return;
+		}
+	}
+
+	// Are we already authenticated (direct sign-in, basic auth, or a resolved Fabric Connect)?
+	const auth = context.authentication[entityId];
 	if (auth?.isLoading || auth?.user) {
 		return;
 	}
 
-	// See if we can Fabric Connect.
+	// Wait for the app-level sign-in to resolve before deciding whether to redirect.
 	const overallAuth = context.authentication[OverallAppSignIn] as AuthenticatedCloudConnection;
 	if (overallAuth?.isLoading) {
 		return;
 	}
+
+	// First visit: if the user can manage this entity, connect them via Fabric Connect automatically.
 	const { update } = params.instanceId
 		? getOrganizationClusterInstancePermissions(overallAuth.user, params.organizationId, params.clusterId)
 		: getOrganizationClusterPermissions(overallAuth.user, params.organizationId, params.clusterId);
-	if (update) {
-		const entityId = params.instanceId || params.clusterId;
-		const instanceClient = getInstanceClient({
-			id: entityId,
-			forceFabricConnect: true,
-		});
-		try {
-			const user = await getInstanceUserInfo({ instanceClient });
-			authStore.setUserForIdAndKey(
-				entityId,
-				instanceClient.defaults.baseURL!,
-				user,
-			);
-			authStore.flagForFabricConnect(entityId, true);
-			return;
-		} catch (err) {
-			// Expected: the instance may be down, restarting, or unauthorized. We fall
-			// through to the sign-in redirect below. Use debug so RUM doesn't forward it
-			// to Datadog as an error (RUM only forwards console.error).
-			console.debug('Fabric Connect not established', err);
-		}
+	if (update && await tryEstablishFabricConnect(entityId, context.cluster, params.instanceId)) {
+		return;
 	}
 
 	const to = `/${params.organizationId}/${params.clusterId}/`
 		+ (params.instanceId ? `instance/${params.instanceId}` : '')
 		+ `/sign-in`;
 	throw redirect({ to, search: buildRedirectInSearch() });
+}
+
+/** Establishes Fabric Connect auth, returning whether it succeeded. */
+async function tryEstablishFabricConnect(
+	entityId: string,
+	cluster: Cluster | undefined,
+	instanceId: string | undefined,
+): Promise<boolean> {
+	try {
+		await authStore.establishFabricConnectAuth({
+			id: entityId,
+			operationsUrl: resolveDirectOperationsUrl(cluster, instanceId),
+		});
+		return true;
+	} catch (err) {
+		// Expected: the instance may be down, restarting, or unauthorized. The caller falls through to
+		// the sign-in redirect. Use debug so RUM doesn't forward it to Datadog (it only forwards errors).
+		console.debug('Fabric Connect not established', err);
+		return false;
+	}
+}
+
+/**
+ * Resolves the instance's (or cluster's) direct operations URL from the cluster loaded by the parent
+ * route, so Fabric Connect can attempt a direct Bearer connection. Returns undefined when the entity
+ * can't be found, in which case establishFabricConnectAuth falls back to the proxy.
+ */
+function resolveDirectOperationsUrl(cluster: Cluster | undefined, instanceId: string | undefined): string | undefined {
+	if (instanceId) {
+		const instance = cluster?.instances?.find((candidate) => candidate.id === instanceId);
+		return instance ? getOperationsUrlForInstance(instance) : undefined;
+	}
+	return getOperationsUrlForCluster(cluster) ?? undefined;
 }

--- a/src/features/instance/instanceLayoutRoute.ts
+++ b/src/features/instance/instanceLayoutRoute.ts
@@ -63,8 +63,13 @@ export async function checkClusterInstanceAuthenticationBeforeLoad({
 	}
 
 	// Are we already authenticated (direct sign-in, basic auth, or a resolved Fabric Connect)?
-	const auth = context.authentication[entityId];
-	if (auth?.isLoading || auth?.user) {
+	// Read LIVE auth state, not the context.authentication snapshot: a direct sign-in sets the
+	// connection synchronously but the router context lags (authStore notifies listeners
+	// asynchronously), so the snapshot would miss the just-signed-in user and we'd wrongly
+	// auto-Fabric-Connect over the direct session (the user lands back on the cluster list as
+	// "Fabric Connect" instead of "Direct Connect").
+	const auth = authStore.getConnectionById(entityId);
+	if (auth.isLoading || auth.user) {
 		return;
 	}
 

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -1,23 +1,52 @@
 import { InstanceClientConfig } from '@/config/instanceClientConfig';
 import type { AxiosRequestConfig } from 'axios';
 
+export interface InstanceAuthenticationTokens {
+	/** Short-lived JWT (Harper default ~1 day) used as the direct-connect Bearer token. */
+	operationToken: string;
+	/** Longer-lived JWT (Harper default ~30 days) used to mint a fresh operation token without the proxy. */
+	refreshToken?: string;
+}
+
 /**
- * Mints a Harper operation token (a JWT) for the user the request authenticates as. This is the
- * same operation `harper login` uses. We send it through the Fabric Connect proxy (which is already
- * authenticated as the instance user on the caller's behalf) so we can obtain a token without ever
- * holding the instance's username/password, then use that token to talk to the instance directly.
- *
- * @returns the `operation_token` JWT.
+ * Mints a Harper operation token + refresh token for the user the request authenticates as. This is
+ * the same operation `harper login` uses. We send it through the Fabric Connect proxy (which is
+ * already authenticated as the instance user on the caller's behalf) so we can obtain tokens without
+ * ever holding the instance's username/password, then use the operation token to talk to the instance
+ * directly and the refresh token to renew it when it expires.
  */
 export async function createInstanceAuthenticationTokens(
 	{ instanceClient, ...config }: InstanceClientConfig & AxiosRequestConfig,
-): Promise<string> {
+): Promise<InstanceAuthenticationTokens> {
 	const { data } = await instanceClient.post('/', {
 		operation: 'create_authentication_tokens',
 	}, config);
-	const token = (data as { operation_token?: string } | undefined)?.operation_token;
-	if (!token) {
+	const { operation_token: operationToken, refresh_token: refreshToken } =
+		(data as { operation_token?: string; refresh_token?: string } | undefined) ?? {};
+	if (!operationToken) {
 		throw new Error('Fabric Connect did not return an operation token');
 	}
-	return token;
+	return { operationToken, refreshToken };
+}
+
+/**
+ * Exchanges a refresh token for a fresh operation token via Harper's `refresh_operation_token`
+ * operation, sent DIRECTLY to the instance (the refresh token is the Bearer credential). This renews
+ * an expired operation token without a proxy round-trip. Harper returns only a new operation token —
+ * the refresh token is unchanged.
+ */
+export async function refreshInstanceOperationToken(
+	{ instanceClient, refreshToken, ...config }: InstanceClientConfig & { refreshToken: string } & AxiosRequestConfig,
+): Promise<string> {
+	const { data } = await instanceClient.post('/', {
+		operation: 'refresh_operation_token',
+	}, {
+		...config,
+		headers: { ...config.headers, Authorization: `Bearer ${refreshToken}` },
+	});
+	const operationToken = (data as { operation_token?: string } | undefined)?.operation_token;
+	if (!operationToken) {
+		throw new Error('Harper did not return a refreshed operation token');
+	}
+	return operationToken;
 }

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -1,0 +1,23 @@
+import { InstanceClientConfig } from '@/config/instanceClientConfig';
+import type { AxiosRequestConfig } from 'axios';
+
+/**
+ * Mints a Harper operation token (a JWT) for the user the request authenticates as. This is the
+ * same operation `harper login` uses. We send it through the Fabric Connect proxy (which is already
+ * authenticated as the instance user on the caller's behalf) so we can obtain a token without ever
+ * holding the instance's username/password, then use that token to talk to the instance directly.
+ *
+ * @returns the `operation_token` JWT.
+ */
+export async function createInstanceAuthenticationTokens(
+	{ instanceClient, ...config }: InstanceClientConfig & AxiosRequestConfig,
+): Promise<string> {
+	const { data } = await instanceClient.post('/', {
+		operation: 'create_authentication_tokens',
+	}, config);
+	const token = (data as { operation_token?: string } | undefined)?.operation_token;
+	if (!token) {
+		throw new Error('Fabric Connect did not return an operation token');
+	}
+	return token;
+}

--- a/src/integrations/api/instance/auth/onInstanceLogoutSubmit.test.ts
+++ b/src/integrations/api/instance/auth/onInstanceLogoutSubmit.test.ts
@@ -1,0 +1,24 @@
+/** @vitest-environment jsdom */
+import { authStore } from '@/features/auth/store/authStore';
+import type { AxiosInstance } from 'axios';
+import { afterEach, expect, it, vi } from 'vitest';
+import { onInstanceLogoutSubmit } from './onInstanceLogoutSubmit';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+it('clears Fabric Connect (in-memory token + flag) and basic auth on logout', async () => {
+	const fabricSpy = vi.spyOn(authStore, 'flagForFabricConnect');
+	const basicSpy = vi.spyOn(authStore, 'flagForBasicAuth');
+	const instanceClient = {
+		post: vi.fn().mockResolvedValue({ data: { message: 'Logout successful' } }),
+	} as unknown as AxiosInstance;
+
+	const result = await onInstanceLogoutSubmit({ instanceClient, entityId: 'ins-logout' });
+
+	expect(result).toEqual({ message: 'Logout successful' });
+	// flagForFabricConnect(id, false) is what drops the in-memory JWT (fabricConnectAuth.delete).
+	expect(fabricSpy).toHaveBeenCalledWith('ins-logout', false);
+	expect(basicSpy).toHaveBeenCalledWith('ins-logout', null);
+});

--- a/src/integrations/api/instance/auth/onInstanceLogoutSubmit.ts
+++ b/src/integrations/api/instance/auth/onInstanceLogoutSubmit.ts
@@ -12,6 +12,7 @@ export async function onInstanceLogoutSubmit(
 		operation: 'logout',
 	});
 	authStore.flagForBasicAuth(entityId, null);
+	authStore.flagForFabricConnect(entityId, false);
 	if (data) {
 		return data;
 	} else {

--- a/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
+++ b/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
@@ -1,4 +1,5 @@
 import { forceBasicAuth, isLocalStudio } from '@/config/constants';
+import { getInstanceClient } from '@/config/getInstanceClient';
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { authStore } from '@/features/auth/store/authStore';
 import { LocalUser } from '@/integrations/api/api.patch';
@@ -83,6 +84,10 @@ export async function onInstanceLoginSubmit({
 	return {
 		message,
 		user,
+		// Hand back a client rebuilt from the now-established auth (Bearer-direct or proxy-routed) so
+		// callers that keep issuing operations on the returned client — e.g. the reset-password /
+		// Finish Setup flow — don't reuse the stale pre-fallback (cookie-mode) client.
+		instanceClient: getInstanceClient({ id: entityId, operationsUrl: instanceClient.defaults.baseURL }),
 	};
 }
 

--- a/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
+++ b/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
@@ -1,5 +1,4 @@
 import { forceBasicAuth, isLocalStudio } from '@/config/constants';
-import { getInstanceClient } from '@/config/getInstanceClient';
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { authStore } from '@/features/auth/store/authStore';
 import { LocalUser } from '@/integrations/api/api.patch';
@@ -73,18 +72,17 @@ export async function onInstanceLoginSubmit({
 		console.error('Failed to get user with basic auth, trying Fabric Connect', err);
 	}
 
-	const fabricInstanceClient = getInstanceClient({
+	// The user's own credentials worked for the login operation but neither session cookies nor basic
+	// auth stuck (e.g. cross-origin cookie restrictions). Fall back to Fabric Connect: grab a JWT via
+	// the proxy and connect to the instance directly with it, or proxy everything if that's not
+	// reachable either.
+	const user = await authStore.establishFabricConnectAuth({
 		id: entityId,
-		forceFabricConnect: true,
+		operationsUrl: instanceClient.defaults.baseURL,
 	});
-	const user = await getInstanceUserInfo({
-		instanceClient: fabricInstanceClient,
-	});
-	authStore.flagForFabricConnect(entityId, true);
 	return {
 		message,
 		user,
-		instanceClient: fabricInstanceClient,
 	};
 }
 

--- a/src/integrations/api/retryExpiredOperationToken.test.ts
+++ b/src/integrations/api/retryExpiredOperationToken.test.ts
@@ -1,0 +1,62 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const recoverExpiredOperationToken = vi.fn();
+vi.mock('@/features/auth/store/authStore', () => ({
+	authStore: { recoverExpiredOperationToken: (...args: unknown[]) => recoverExpiredOperationToken(...args) },
+}));
+
+const { curryRecoverExpiredOperationToken } = await import('./retryExpiredOperationToken');
+
+function error401(config: Record<string, unknown> = { headers: {} }) {
+	return { response: { status: 401 }, config };
+}
+
+describe('curryRecoverExpiredOperationToken', () => {
+	afterEach(() => vi.clearAllMocks());
+
+	it('mints a fresh token and replays the request once with the new Bearer header', async () => {
+		recoverExpiredOperationToken.mockResolvedValue('fresh-token');
+		const request = vi.fn().mockResolvedValue({ data: 'ok' });
+		const handler = curryRecoverExpiredOperationToken({ request }, 'ins-1');
+		const config = { headers: { Authorization: 'Bearer stale' } };
+
+		const result = await handler(error401(config));
+
+		expect(result).toEqual({ data: 'ok' });
+		expect(recoverExpiredOperationToken).toHaveBeenCalledWith('ins-1');
+		expect(request).toHaveBeenCalledTimes(1);
+		const replayed = request.mock.calls[0][0];
+		expect(replayed.headers.Authorization).toBe('Bearer fresh-token');
+		expect(replayed.__triedOperationTokenRefresh).toBe(true);
+	});
+
+	it('rejects (no retry) when recovery yields no token', async () => {
+		recoverExpiredOperationToken.mockResolvedValue(null);
+		const request = vi.fn();
+		const handler = curryRecoverExpiredOperationToken({ request }, 'ins-1');
+		const err = error401();
+
+		await expect(handler(err)).rejects.toBe(err);
+		expect(request).not.toHaveBeenCalled();
+	});
+
+	it('does not recover a non-401 error', async () => {
+		const request = vi.fn();
+		const handler = curryRecoverExpiredOperationToken({ request }, 'ins-1');
+		const err = { response: { status: 500 }, config: { headers: {} } };
+
+		await expect(handler(err)).rejects.toBe(err);
+		expect(recoverExpiredOperationToken).not.toHaveBeenCalled();
+	});
+
+	it('does not retry twice (guards against a loop when the fresh token is also rejected)', async () => {
+		const request = vi.fn();
+		const handler = curryRecoverExpiredOperationToken({ request }, 'ins-1');
+		const err = error401({ headers: {}, __triedOperationTokenRefresh: true });
+
+		await expect(handler(err)).rejects.toBe(err);
+		expect(recoverExpiredOperationToken).not.toHaveBeenCalled();
+		expect(request).not.toHaveBeenCalled();
+	});
+});

--- a/src/integrations/api/retryExpiredOperationToken.ts
+++ b/src/integrations/api/retryExpiredOperationToken.ts
@@ -1,0 +1,28 @@
+import { authStore, EntityIds } from '@/features/auth/store/authStore';
+import { AxiosInstance } from 'axios';
+
+/**
+ * Response-error interceptor for direct-connect (Fabric Connect Bearer) clients. On a 401 the
+ * operation token has most likely expired mid-session; recover a fresh one (via the refresh token,
+ * falling back to a proxy re-mint) and replay the request once with the new Bearer token. A per-request
+ * flag caps this at a single retry so a still-rejected token can't loop.
+ */
+export function curryRecoverExpiredOperationToken(client: Pick<AxiosInstance, 'request'>, id: EntityIds) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return async (error: any) => {
+		const status = error?.response?.status as number | undefined;
+		const config = error?.config;
+		if (status !== 401 || !config || config.__triedOperationTokenRefresh) {
+			return Promise.reject(error);
+		}
+
+		const token = await authStore.recoverExpiredOperationToken(id);
+		if (!token) {
+			return Promise.reject(error);
+		}
+
+		config.__triedOperationTokenRefresh = true;
+		config.headers = { ...config.headers, Authorization: `Bearer ${token}` };
+		return client.request(config);
+	};
+}


### PR DESCRIPTION
## What & why

**#1398 — direct-connect via JWT.** Instead of routing **every** operation through the Fabric Connect proxy, Studio now:
1. Mints a JWT (+ refresh token) via the proxy (`create_authentication_tokens`, the op `harper login` uses).
2. Talks to the instance **directly** with `Authorization: Bearer <jwt>`.
3. Holds the tokens **in memory only** — re-fetched via the proxy after a reload.
4. **Falls back to full proxy mode** when direct connect isn't reachable (CORS / mixed-content / Safari-cloud-to-local). Because the JWT is a header (not a cookie), this also sidesteps the Safari cross-localhost cookie limitation.
5. **Recovers from mid-session token expiry:** a 401 on a direct request exchanges the refresh token for a new operation token directly at the instance (`refresh_operation_token`, no proxy round-trip), falling back to a fresh proxy mint, then replays the request once.

> Harper 5.1.14 has no token→cookie login, so the issue's "drop the JWT, keep only an httpOnly cookie" ideal would need a coordinated Harper server change. This implements the in-memory-JWT variant, structured so a future cookie swap stays localized.

**#1333 — Direct Sign In no longer falls back to Fabric Connect too aggressively.** The cluster sign-in guard read the `context.authentication` router snapshot, which lags the live authStore (listeners notify asynchronously); right after "Direct Sign In" cleared the connection, the snapshot still showed the old user → bounced off the form → auto-Fabric-Connected. Both sign-in guards now read live authStore state, and the sign-in page resets the connected user (not just the flag) so an abandoned sign-in isn't mislabeled as "Direct Connect".

## Adversarial review

Ran a multi-agent adversarial review (6 lenses → skeptic verification); 15 confirmed findings, all addressed. Highlights:
- **HIGH:** reset-password / Finish Setup broke in the Fabric Connect fallback (stale client) — the fallback now returns a client rebuilt from the established auth.
- **MED:** sign-in page cleared the user inside a render-phase `useMemo` keyed on the 10s-polled cluster object (could wipe a just-signed-in user) — moved to a once-per-id effect.
- **Security (low):** never send the Bearer JWT to the central-manager origin (only go direct with a concrete direct URL, and reject proxy-looking URLs via `isDirectOperationsUrl`); stop logging the raw axios error (carried the token in `error.config.headers`).
- The establish probe forces the token so a stale basic-auth entry can't shadow it; the instance sign-in guard keys off the instance's own state; no double-establish in one `beforeLoad` pass.

Both automated (Gemini) review threads were addressed and resolved.

## Tests
~40 new tests: routing precedence (Bearer/proxy/basic/cookie/disableFabricConnect/cluster-proxy/forceOperationToken), establish direct/proxy-fallback/no-direct-URL/proxy-URL-guard/both-fail-cleanup/in-flight-dedupe, token recovery (refresh / proxy re-mint / both-fail / non-direct / dedupe) and the 401 interceptor (replay-once / no-token / non-401 / loop-guard), logout token cleanup, sign-in guards (live-state race + cluster-flag case + redirect target), and route-guard orchestration. Full suite green (1035 passing).

## Verification & risk
Verified via typecheck + unit tests. Not browser-verified (needs a live cluster + Fabric Connect session). **Main runtime assumption to confirm against a real cluster:** the central-manager proxy forwards `create_authentication_tokens` / `refresh_operation_token` and returns the tokens. If an op allowlist excludes them, step 1 fails and we silently fall back to proxy mode (functional, just not the new direct path).

Fixes HarperFast/studio#1333
Refs HarperFast/studio#1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)