### PR TITLE
feat(secrets): cluster secrets page on the hdb_secret store

### DIFF
--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -8,7 +8,7 @@ import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Outlet, useLoaderData, useParams } from '@tanstack/react-router';
-import { GlobeIcon, HandshakeIcon, KeyIcon, PieChartIcon, RocketIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
+import { GlobeIcon, HandshakeIcon, KeyIcon, LockIcon, PieChartIcon, RocketIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
 import { ReactNode, Suspense } from 'react';
 
 const sharedClasses = 'flex items-center p-2 rounded-lg group';
@@ -24,6 +24,9 @@ export function ConfigIndex() {
 	const { version }: RegistrationInfoResponse = useLoaderData({ strict: false });
 	const certsAvailable = wasAReleasedBeforeB('4.6.0', version);
 	const deploymentsAvailable = wasAReleasedBeforeB('5.1.0', version);
+	// The hdb_secret store and its operations (list_secrets / set_secret / …) ship in Harper 5.2
+	// (harper#1554's upgrade directive is tagged 5.2.0 — revisit if it ships in a different release).
+	const secretsSupported = wasAReleasedBeforeB('5.2.0', version);
 
 	const { clusterId } = params;
 	const canManage = useInstanceManagePermission();
@@ -99,6 +102,22 @@ export function ConfigIndex() {
 						activeProps={activeProps}
 					>
 						<KeyIcon className="hidden md:inline-block" /> <span className="ms-3">SSH Keys</span>
+					</Link>
+				</li>
+			)}
+			{
+				/* Secrets (the replicated hdb_secret store): any instance or cluster on a supported
+			    version — key custody may be file-based (self-hosted) or injected (Fabric). */
+			}
+			{secretsSupported && (
+				<li>
+					<Link
+						to={buildAbsoluteLinkToPage(params, 'config/secrets')}
+						className={sharedClasses}
+						inactiveProps={inactiveProps}
+						activeProps={activeProps}
+					>
+						<LockIcon className="hidden md:inline-block" /> <span className="ms-3">Secrets</span>
 					</Link>
 				</li>
 			)}

--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -8,7 +8,16 @@ import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Outlet, useLoaderData, useParams } from '@tanstack/react-router';
-import { GlobeIcon, HandshakeIcon, KeyIcon, LockIcon, PieChartIcon, RocketIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
+import {
+	GlobeIcon,
+	HandshakeIcon,
+	KeyIcon,
+	LockIcon,
+	PieChartIcon,
+	RocketIcon,
+	ShieldCheckIcon,
+	UsersIcon,
+} from 'lucide-react';
 import { ReactNode, Suspense } from 'react';
 
 const sharedClasses = 'flex items-center p-2 rounded-lg group';
@@ -25,8 +34,9 @@ export function ConfigIndex() {
 	const certsAvailable = wasAReleasedBeforeB('4.6.0', version);
 	const deploymentsAvailable = wasAReleasedBeforeB('5.1.0', version);
 	// The hdb_secret store and its operations (list_secrets / set_secret / …) ship in Harper 5.2
-	// (harper#1554's upgrade directive is tagged 5.2.0 — revisit if it ships in a different release).
-	const secretsSupported = wasAReleasedBeforeB('5.2.0', version);
+	// (harper#1554). Floor at the earliest 5.2 prerelease so alpha/beta dev builds pass too — a
+	// plain '5.2.0' gate would exclude every prerelease (SemVer ranks prereleases below the release).
+	const secretsSupported = wasAReleasedBeforeB('5.2.0-alpha.1', version);
 
 	const { clusterId } = params;
 	const canManage = useInstanceManagePermission();

--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -117,7 +117,9 @@ export function ConfigIndex() {
 			)}
 			{
 				/* Secrets (the replicated hdb_secret store): any instance or cluster on a supported
-			    version — key custody may be file-based (self-hosted) or injected (Fabric). */
+			    version — key custody may be file-based (self-hosted) or injected (Fabric). Manage-gated
+			    like every entry here (it lives under the `canManage` block above); the secret operations
+			    are additionally super_user-only server-side, so a deep-link by a lesser role lists nothing. */
 			}
 			{secretsSupported && (
 				<li>

--- a/src/features/instance/config/routes.ts
+++ b/src/features/instance/config/routes.ts
@@ -4,6 +4,7 @@ import { ConfigDomainsIndex } from '@/features/instance/config/domains';
 import { ConfigIndex } from '@/features/instance/config/index';
 import { ConfigOverviewIndex } from '@/features/instance/config/overview';
 import { ConfigRolesIndex } from '@/features/instance/config/roles';
+import { ConfigSecretsIndex } from '@/features/instance/config/secrets';
 import { ConfigSSHKeysIndex } from '@/features/instance/config/sshKeys';
 import { ConfigUsersIndex } from '@/features/instance/config/users';
 import { createInstanceLayoutRoute } from '@/features/instance/instanceLayoutRoute';
@@ -85,6 +86,19 @@ export function createConfigRouteTree(instanceLayoutRoute: ReturnType<typeof cre
 		component: ConfigDeploymentsIndex,
 	});
 
+	const instanceConfigSecretsRoute = createRoute({
+		getParentRoute: () => instanceConfigRoute,
+		path: 'secrets',
+		head: () => ({ meta: [{ title: 'Secrets — Harper Fabric' }] }),
+		component: ConfigSecretsIndex,
+	});
+	const instanceConfigSecretRoute = createRoute({
+		getParentRoute: () => instanceConfigRoute,
+		path: 'secrets/$secretName',
+		head: () => ({ meta: [{ title: 'Secrets — Harper Fabric' }] }),
+		component: ConfigSecretsIndex,
+	});
+
 	const instanceConfigCertificatesRoute = createRoute({
 		getParentRoute: () => instanceConfigRoute,
 		path: 'certificates',
@@ -114,6 +128,9 @@ export function createConfigRouteTree(instanceLayoutRoute: ReturnType<typeof cre
 
 		instanceConfigSSHKeysRoute,
 		instanceConfigSSHKeyRoute,
+
+		instanceConfigSecretsRoute,
+		instanceConfigSecretRoute,
 
 		instanceConfigCertificatesRoute,
 		instanceConfigCertificateRoute,

--- a/src/features/instance/config/secrets/SecretGrantsEditor.tsx
+++ b/src/features/instance/config/secrets/SecretGrantsEditor.tsx
@@ -69,7 +69,8 @@ export function SecretGrantsEditor({
 		<div className="grid gap-2">
 			<span className="text-sm font-medium">Granted applications</span>
 			<p className="text-sm text-muted-foreground">
-				Only granted applications receive this secret in their environment. Changes apply immediately.
+				Only granted applications can read this secret through the <code className="font-mono">secrets</code>{' '}
+				accessor. Changes apply immediately.
 			</p>
 			{grants.length > 0 && (
 				<div className="flex flex-wrap gap-1">

--- a/src/features/instance/config/secrets/SecretGrantsEditor.tsx
+++ b/src/features/instance/config/secrets/SecretGrantsEditor.tsx
@@ -1,0 +1,115 @@
+/**
+ * Grants editor for one secret, shown inside the edit dialog. A secret is only materialized into
+ * the environment of components listed in its grants, so this is where a stored secret actually
+ * gets scoped to applications. Grant/revoke apply immediately (they are their own operations, not
+ * part of the value form).
+ */
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useGrantSecret, useRevokeSecret } from '@/integrations/api/instance/secrets/secrets';
+import { PlusIcon, XIcon } from 'lucide-react';
+import { KeyboardEvent, useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+export function SecretGrantsEditor({
+	name,
+	initialGrants,
+	onChanged,
+}: {
+	name: string;
+	initialGrants: string[];
+	/** Called after a successful grant/revoke so the list view can refresh its metadata. */
+	onChanged?: () => void;
+}) {
+	const instanceParams = useInstanceClientIdParams();
+	const { mutateAsync: grantSecret, isPending: isGranting } = useGrantSecret();
+	const { mutateAsync: revokeSecret, isPending: isRevoking } = useRevokeSecret();
+	const busy = isGranting || isRevoking;
+
+	// The mutation responses carry the resulting grants, so the chips track server truth.
+	const [grants, setGrants] = useState(initialGrants);
+	const [component, setComponent] = useState('');
+
+	const onGrantClick = useCallback(async () => {
+		const target = component.trim();
+		if (!target) {
+			return;
+		}
+		try {
+			const response = await grantSecret({ ...instanceParams, name, component: target });
+			setGrants(response.grants);
+			setComponent('');
+			onChanged?.();
+		} catch (error) {
+			toast.error(String(error));
+		}
+	}, [component, grantSecret, instanceParams, name, onChanged]);
+
+	const onRevokeClick = useCallback(async (target: string) => {
+		try {
+			const response = await revokeSecret({ ...instanceParams, name, component: target });
+			setGrants(response.grants);
+			onChanged?.();
+		} catch (error) {
+			toast.error(String(error));
+		}
+	}, [revokeSecret, instanceParams, name, onChanged]);
+
+	// This editor lives inside the value form — Enter must grant, not submit a value replacement.
+	const onComponentKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			void onGrantClick();
+		}
+	}, [onGrantClick]);
+
+	return (
+		<div className="grid gap-2">
+			<span className="text-sm font-medium">Granted applications</span>
+			<p className="text-sm text-muted-foreground">
+				Only granted applications receive this secret in their environment. Changes apply immediately.
+			</p>
+			{grants.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{grants.map((granted) => (
+						<Badge key={granted} variant="secondary">
+							{granted}
+							<button
+								type="button"
+								onClick={() => void onRevokeClick(granted)}
+								disabled={busy}
+								title={`Revoke ${granted}`}
+								className="cursor-pointer disabled:cursor-default"
+							>
+								<XIcon />
+								<span className="sr-only">Revoke {granted}</span>
+							</button>
+						</Badge>
+					))}
+				</div>
+			)}
+			<div className="flex gap-2">
+				<Input
+					type="text"
+					autoComplete="off"
+					autoCapitalize="off"
+					placeholder="application name"
+					value={component}
+					onChange={(event) => setComponent(event.target.value)}
+					onKeyDown={onComponentKeyDown}
+					disabled={busy}
+				/>
+				<Button
+					type="button"
+					variant="positiveOutline"
+					onClick={() => void onGrantClick()}
+					disabled={busy || !component.trim()}
+				>
+					<PlusIcon /> Grant
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -34,15 +34,23 @@ export function ConfigSecretsIndex() {
 	const managedClusterId = !isSelfManaged ? clusterId : undefined;
 	const keySource = useMemo(() => ({ ...instanceParams, managedClusterId }), [instanceParams, managedClusterId]);
 
-	// Without a secrets key (no custody registered, or CM unreachable) nothing can be encrypted,
-	// so the store is browsable read-only. Wait for the cluster lookup to settle before fetching:
-	// until it does, `cluster` is undefined ⇒ we'd assume self-managed and fetch the key from the
-	// node, which fails on a CM-custody cluster and flashes the read-only banner until the lookup
-	// resolves. When there's no clusterId (local Studio) the node is the right target immediately.
+	// The key source (node vs central-manager) depends on the cluster tier, so it isn't known until
+	// the cluster lookup SUCCEEDS. `cluster === undefined` covers both the load window and a failed
+	// fetch (getClusterInfoQuery has retry:false, so `data` stays undefined on error) — treating
+	// either as self-managed would route a managed cluster to the node key: a transient banner flash
+	// while loading, and a non-self-healing mis-route on error (set_secret would then encrypt against
+	// the wrong key and fail a kid mismatch the retry can't heal). So gate the fetch on isSuccess,
+	// and only skip the gate when there's no clusterId (local Studio — the node is always right).
+	const clusterTierKnown = !clusterId || clusterQuery.isSuccess;
+	// Without a secrets key (no custody registered, or CM unreachable) nothing can be encrypted, so
+	// the store stays browsable read-only.
 	const publicKeyQuery = useQuery({
 		...secretsPublicKeyQueryOptions(keySource),
-		enabled: !clusterId || !clusterQuery.isPending,
+		enabled: clusterTierKnown,
 	});
+	// A failed cluster lookup is a distinct degraded state from "no secrets key" — surface it as such
+	// instead of leaving the page silently read-only (or, worse, guessing the wrong custody).
+	const clusterInfoUnavailable = !!clusterId && clusterQuery.isError;
 
 	const secrets = data?.secrets;
 	const rows = useMemo<SecretRow[]>(
@@ -87,15 +95,25 @@ export function ConfigSecretsIndex() {
 
 	return (
 		<>
-			{publicKeyQuery.isError && (
-				<p className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3 mb-4">
-					<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
-					<span>
-						Secrets are read-only right now: this cluster has no secrets key, so values can't be encrypted. Key custody
-						is provided by the Harper secret-custody component — once it's active, refresh this page.
-					</span>
-				</p>
-			)}
+			{clusterInfoUnavailable
+				? (
+					<p className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3 mb-4">
+						<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
+						<span>
+							Secrets are read-only right now: this cluster's info couldn't be loaded, so its secret custody is unknown.
+							Refresh once cluster info is available.
+						</span>
+					</p>
+				)
+				: publicKeyQuery.isError && (
+					<p className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3 mb-4">
+						<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
+						<span>
+							Secrets are read-only right now: this cluster has no secrets key, so values can't be encrypted. Key
+							custody is provided by the Harper secret-custody component — once it's active, refresh this page.
+						</span>
+					</p>
+				)}
 			<SecretsManager
 				rows={rows}
 				isFetching={isFetching}

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -1,6 +1,8 @@
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { SecretGrantsEditor } from '@/features/instance/config/secrets/SecretGrantsEditor';
 import { SecretRow, SecretsManager } from '@/features/instance/secrets/SecretsManager';
+import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import {
 	listSecretsQueryOptions,
 	SecretMetadata,
@@ -20,12 +22,20 @@ import { useCallback, useMemo } from 'react';
  */
 export function ConfigSecretsIndex() {
 	const navigate = useNavigate();
-	const { secretName }: { secretName?: string } = useParams({ strict: false });
+	const { secretName, clusterId }: { secretName?: string; clusterId?: string } = useParams({ strict: false });
 	const instanceParams = useInstanceClientIdParams();
 	const { data, refetch, isFetching } = useQuery(listSecretsQueryOptions(instanceParams));
-	// Without registered key custody (the Pro secretCustody component) the node has no secrets
-	// key: nothing can be encrypted, so the store is browsable read-only.
-	const publicKeyQuery = useQuery(secretsPublicKeyQueryOptions(instanceParams));
+
+	// Fabric-managed clusters get their public key from central-manager (the custodian — it mints
+	// the keypair on first use, central-manager#409); self-hosted/local nodes serve their own.
+	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId, false));
+	const isSelfManaged = cluster === undefined || clusterIsSelfManaged(cluster);
+	const managedClusterId = !isSelfManaged ? clusterId : undefined;
+	const keySource = useMemo(() => ({ ...instanceParams, managedClusterId }), [instanceParams, managedClusterId]);
+
+	// Without a secrets key (no custody registered, or CM unreachable) nothing can be encrypted,
+	// so the store is browsable read-only.
+	const publicKeyQuery = useQuery(secretsPublicKeyQueryOptions(keySource));
 
 	const secrets = data?.secrets;
 	const rows = useMemo<SecretRow[]>(
@@ -46,9 +56,9 @@ export function ConfigSecretsIndex() {
 	const { mutateAsync: deleteSecret } = useDeleteSecret();
 
 	const onSet = useCallback(async (name: string, value: string) => {
-		await setSecret({ ...instanceParams, name, value });
+		await setSecret({ ...keySource, name, value });
 		await refetch();
-	}, [setSecret, instanceParams, refetch]);
+	}, [setSecret, keySource, refetch]);
 
 	const onDelete = useCallback(async (name: string) => {
 		await deleteSecret({ ...instanceParams, name });

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -1,0 +1,113 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { SecretGrantsEditor } from '@/features/instance/config/secrets/SecretGrantsEditor';
+import { SecretRow, SecretsManager } from '@/features/instance/secrets/SecretsManager';
+import {
+	listSecretsQueryOptions,
+	SecretMetadata,
+	secretsPublicKeyQueryOptions,
+	useDeleteSecret,
+	useSetSecret,
+} from '@/integrations/api/instance/secrets/secrets';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { TriangleAlertIcon } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+
+/**
+ * Cluster secrets (the replicated `system.hdb_secret` store, harper#1554 / harper-pro#166):
+ * named, envelope-encrypted values managed through the instance operations API and scoped to
+ * applications via grants. Values are encrypted in the browser and can never be read back.
+ */
+export function ConfigSecretsIndex() {
+	const navigate = useNavigate();
+	const { secretName }: { secretName?: string } = useParams({ strict: false });
+	const instanceParams = useInstanceClientIdParams();
+	const { data, refetch, isFetching } = useQuery(listSecretsQueryOptions(instanceParams));
+	// Without registered key custody (the Pro secretCustody component) the node has no secrets
+	// key: nothing can be encrypted, so the store is browsable read-only.
+	const publicKeyQuery = useQuery(secretsPublicKeyQueryOptions(instanceParams));
+
+	const secrets = data?.secrets;
+	const rows = useMemo<SecretRow[]>(
+		() => (secrets ?? []).map((secret) => ({ name: secret.name, warning: warningFor(secret, data) })),
+		[secrets, data],
+	);
+	const selectedName = useMemo(() => secrets?.find((s) => s.name === secretName)?.name, [secrets, secretName]);
+
+	const onSelectName = useCallback(
+		(next: string | undefined) => {
+			const parts = [secretName ? '..' : '', next].filter(Boolean);
+			void navigate({ to: parts.join('/') });
+		},
+		[navigate, secretName],
+	);
+
+	const { mutateAsync: setSecret } = useSetSecret();
+	const { mutateAsync: deleteSecret } = useDeleteSecret();
+
+	const onSet = useCallback(async (name: string, value: string) => {
+		await setSecret({ ...instanceParams, name, value });
+		await refetch();
+	}, [setSecret, instanceParams, refetch]);
+
+	const onDelete = useCallback(async (name: string) => {
+		await deleteSecret({ ...instanceParams, name });
+		await refetch();
+	}, [deleteSecret, instanceParams, refetch]);
+
+	return (
+		<>
+			{publicKeyQuery.isError && (
+				<p className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3 mb-4">
+					<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
+					<span>
+						Secrets are read-only right now: this cluster has no secrets key, so values can't be encrypted. Key custody
+						is provided by the Harper secret-custody component — once it's active, refresh this page.
+					</span>
+				</p>
+			)}
+			<SecretsManager
+				rows={rows}
+				isFetching={isFetching}
+				onRefresh={refetch}
+				canManage={publicKeyQuery.isSuccess}
+				selectedName={selectedName}
+				onSelectName={onSelectName}
+				nameHeader="Secret"
+				addDescription="The value is encrypted in your browser against the cluster's secrets key — plaintext never reaches the API, the operation log, or disk. It can be replaced or deleted, but never read back."
+				editDescription="The current value can't be shown — it's stored encrypted. Enter a new value to replace it, adjust which applications receive it, or delete the secret."
+				valueDescription="Encrypted client-side before it leaves this page."
+				onSet={onSet}
+				onDelete={onDelete}
+				renderEditExtras={(name) => {
+					const secret = secrets?.find((s) => s.name === name);
+					return (
+						secret && (
+							<SecretGrantsEditor
+								key={secret.name}
+								name={secret.name}
+								initialGrants={secret.grants}
+								onChanged={() => void refetch()}
+							/>
+						)
+					);
+				}}
+			/>
+		</>
+	);
+}
+
+/** A per-row caution for stored secrets that may not decrypt at load time. */
+function warningFor(secret: SecretMetadata, data: { custody_fingerprint: string | null } | undefined) {
+	// Without custody there is no key identity to compare against — every row would "mismatch".
+	if (!data?.custody_fingerprint) {
+		return undefined;
+	}
+	if (!secret.kid_matches_custody) {
+		return "Encrypted under a different key than the cluster's current secrets key — it may fail to decrypt at load time. Set a new value to re-encrypt.";
+	}
+	if (secret.unverified) {
+		return 'Stored without key-identity verification.';
+	}
+	return undefined;
+}

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -39,7 +39,12 @@ export function ConfigSecretsIndex() {
 
 	const secrets = data?.secrets;
 	const rows = useMemo<SecretRow[]>(
-		() => (secrets ?? []).map((secret) => ({ name: secret.name, warning: warningFor(secret, data) })),
+		() =>
+			(secrets ?? []).map((secret) => ({
+				name: secret.name,
+				processEnv: secret.processEnv,
+				warning: warningFor(secret, data),
+			})),
 		[secrets, data],
 	);
 	const selectedName = useMemo(() => secrets?.find((s) => s.name === secretName)?.name, [secrets, secretName]);
@@ -55,10 +60,13 @@ export function ConfigSecretsIndex() {
 	const { mutateAsync: setSecret } = useSetSecret();
 	const { mutateAsync: deleteSecret } = useDeleteSecret();
 
-	const onSet = useCallback(async (name: string, value: string) => {
-		await setSecret({ ...keySource, name, value });
-		await refetch();
-	}, [setSecret, keySource, refetch]);
+	const onSet = useCallback(
+		async (name: string, value: string, options?: { processEnv?: boolean; grants?: string[] }) => {
+			await setSecret({ ...keySource, name, value, processEnv: options?.processEnv, grants: options?.grants });
+			await refetch();
+		},
+		[setSecret, keySource, refetch],
+	);
 
 	const onDelete = useCallback(async (name: string) => {
 		await deleteSecret({ ...instanceParams, name });
@@ -84,8 +92,9 @@ export function ConfigSecretsIndex() {
 				selectedName={selectedName}
 				onSelectName={onSelectName}
 				nameHeader="Secret"
+				delivery={true}
 				addDescription="The value is encrypted in your browser against the cluster's secrets key — plaintext never reaches the API, the operation log, or disk. It can be replaced or deleted, but never read back."
-				editDescription="The current value can't be shown — it's stored encrypted. Enter a new value to replace it, adjust which applications receive it, or delete the secret."
+				editDescription="The current value can't be shown — it's stored encrypted. Enter a new value to replace it, adjust how applications read it, or delete the secret."
 				valueDescription="Encrypted client-side before it leaves this page."
 				onSet={onSet}
 				onDelete={onDelete}

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -28,14 +28,21 @@ export function ConfigSecretsIndex() {
 
 	// Fabric-managed clusters get their public key from central-manager (the custodian — it mints
 	// the keypair on first use, central-manager#409); self-hosted/local nodes serve their own.
-	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId, false));
+	const clusterQuery = useQuery(getClusterInfoQueryOptions(clusterId, false));
+	const cluster = clusterQuery.data;
 	const isSelfManaged = cluster === undefined || clusterIsSelfManaged(cluster);
 	const managedClusterId = !isSelfManaged ? clusterId : undefined;
 	const keySource = useMemo(() => ({ ...instanceParams, managedClusterId }), [instanceParams, managedClusterId]);
 
 	// Without a secrets key (no custody registered, or CM unreachable) nothing can be encrypted,
-	// so the store is browsable read-only.
-	const publicKeyQuery = useQuery(secretsPublicKeyQueryOptions(keySource));
+	// so the store is browsable read-only. Wait for the cluster lookup to settle before fetching:
+	// until it does, `cluster` is undefined ⇒ we'd assume self-managed and fetch the key from the
+	// node, which fails on a CM-custody cluster and flashes the read-only banner until the lookup
+	// resolves. When there's no clusterId (local Studio) the node is the right target immediately.
+	const publicKeyQuery = useQuery({
+		...secretsPublicKeyQueryOptions(keySource),
+		enabled: !clusterId || !clusterQuery.isPending,
+	});
 
 	const secrets = data?.secrets;
 	const rows = useMemo<SecretRow[]>(
@@ -57,15 +64,20 @@ export function ConfigSecretsIndex() {
 		[navigate, secretName],
 	);
 
-	const { mutateAsync: setSecret } = useSetSecret();
+	const { mutateAsync: setSecret, reset: resetSetSecret } = useSetSecret();
 	const { mutateAsync: deleteSecret } = useDeleteSecret();
 
 	const onSet = useCallback(
 		async (name: string, value: string, options?: { processEnv?: boolean; grants?: string[] }) => {
-			await setSecret({ ...keySource, name, value, processEnv: options?.processEnv, grants: options?.grants });
+			try {
+				await setSecret({ ...keySource, name, value, processEnv: options?.processEnv, grants: options?.grants });
+			} finally {
+				// Drop the plaintext `value` that lingers in the mutation's `variables` after the call.
+				resetSetSecret();
+			}
 			await refetch();
 		},
-		[setSecret, keySource, refetch],
+		[setSecret, resetSetSecret, keySource, refetch],
 	);
 
 	const onDelete = useCallback(async (name: string) => {

--- a/src/features/instance/secrets/PendingGrantsInput.tsx
+++ b/src/features/instance/secrets/PendingGrantsInput.tsx
@@ -1,0 +1,95 @@
+/**
+ * A local, API-free grants collector for the Add-secret flow: the secret doesn't exist yet, so
+ * grants can't be persisted with grant_secret (as the edit flow's live SecretGrantsEditor does) —
+ * they're gathered here and submitted in the initial set_secret call. Chip UI mirrors
+ * SecretGrantsEditor so the two read the same.
+ */
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { PlusIcon, XIcon } from 'lucide-react';
+import { KeyboardEvent, useCallback, useState } from 'react';
+
+export function PendingGrantsInput({
+	grants,
+	onChange,
+	disabled,
+}: {
+	grants: string[];
+	onChange: (next: string[]) => void;
+	disabled?: boolean;
+}) {
+	const [component, setComponent] = useState('');
+
+	const add = useCallback(() => {
+		const target = component.trim();
+		if (!target) {
+			return;
+		}
+		if (!grants.includes(target)) {
+			onChange([...grants, target]);
+		}
+		setComponent('');
+	}, [component, grants, onChange]);
+
+	const remove = useCallback((target: string) => {
+		onChange(grants.filter((granted) => granted !== target));
+	}, [grants, onChange]);
+
+	// This input lives inside the add form — Enter must add a grant, not submit the secret.
+	const onKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			add();
+		}
+	}, [add]);
+
+	return (
+		<div className="grid gap-2">
+			<span className="text-sm font-medium">Granted applications</span>
+			<p className="text-sm text-muted-foreground">
+				Only these applications will be able to read the secret. You can grant more later — leave it empty to add grants
+				after creating the secret.
+			</p>
+			{grants.length > 0 && (
+				<div className="flex flex-wrap gap-1">
+					{grants.map((granted) => (
+						<Badge key={granted} variant="secondary">
+							{granted}
+							<button
+								type="button"
+								onClick={() => remove(granted)}
+								disabled={disabled}
+								title={`Remove ${granted}`}
+								className="cursor-pointer disabled:cursor-default"
+							>
+								<XIcon />
+								<span className="sr-only">Remove {granted}</span>
+							</button>
+						</Badge>
+					))}
+				</div>
+			)}
+			<div className="flex gap-2">
+				<Input
+					type="text"
+					autoComplete="off"
+					autoCapitalize="off"
+					placeholder="application name"
+					value={component}
+					onChange={(event) => setComponent(event.target.value)}
+					onKeyDown={onKeyDown}
+					disabled={disabled}
+				/>
+				<Button
+					type="button"
+					variant="positiveOutline"
+					onClick={add}
+					disabled={disabled || !component.trim()}
+				>
+					<PlusIcon /> Add
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/features/instance/secrets/PendingGrantsInput.tsx
+++ b/src/features/instance/secrets/PendingGrantsInput.tsx
@@ -79,6 +79,9 @@ export function PendingGrantsInput({
 					value={component}
 					onChange={(event) => setComponent(event.target.value)}
 					onKeyDown={onKeyDown}
+					// Commit a typed-but-not-added name on blur too, so submitting the Add-secret form (which
+					// blurs this field first) doesn't silently drop it. add() no-ops on empty/duplicate.
+					onBlur={add}
 					disabled={disabled}
 				/>
 				<Button

--- a/src/features/instance/secrets/SecretAccessExample.tsx
+++ b/src/features/instance/secrets/SecretAccessExample.tsx
@@ -1,0 +1,47 @@
+/**
+ * A copyable, syntax-free code snippet showing how a component reads a secret of a given delivery
+ * tier. The example is name-aware (dot vs bracket access) — see {@link buildSecretAccessExample}.
+ */
+import { Button } from '@/components/ui/button';
+import { writeToClipboard } from '@/hooks/useCopyToClipboard';
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildSecretAccessExample, SecretTier } from './accessExample';
+
+export function SecretAccessExample({ name, tier }: { name: string; tier: SecretTier }) {
+	const code = buildSecretAccessExample(name, tier);
+
+	const [copied, setCopied] = useState(false);
+	const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+	useEffect(() => () => clearTimeout(resetTimer.current), []);
+
+	const onCopy = useCallback(() => {
+		void writeToClipboard(code).then((ok) => {
+			if (!ok) {
+				return;
+			}
+			setCopied(true);
+			clearTimeout(resetTimer.current);
+			resetTimer.current = setTimeout(() => setCopied(false), 1200);
+		});
+	}, [code]);
+
+	return (
+		<div className="relative">
+			<pre className="overflow-x-auto rounded-md border border-border bg-muted/50 p-3 pr-10 text-xs leading-relaxed">
+				<code className="font-mono text-foreground">{code}</code>
+			</pre>
+			<Button
+				type="button"
+				variant="ghost"
+				size="sm"
+				className="absolute top-1.5 right-1.5 px-1"
+				onClick={onCopy}
+				title="Copy example"
+			>
+				{copied ? <CheckIcon className="text-green-500" /> : <CopyIcon />}
+				<span className="sr-only">Copy example</span>
+			</Button>
+		</div>
+	);
+}

--- a/src/features/instance/secrets/SecretDeliveryPicker.tsx
+++ b/src/features/instance/secrets/SecretDeliveryPicker.tsx
@@ -1,0 +1,67 @@
+/**
+ * The delivery-tier chooser shown in the add/edit secret dialogs: pick whether a secret is exposed
+ * as a global environment variable (`process.env.NAME`) or scoped to specific apps through the
+ * `secrets` accessor (`secrets.NAME`), and see the exact code to read it either way. The two tiers
+ * are mutually exclusive server-side (harper#1554), so the grants slot only renders when scoped.
+ */
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radioGroup';
+import { ReactNode } from 'react';
+import { SecretTier } from './accessExample';
+import { SecretAccessExample } from './SecretAccessExample';
+
+export function SecretDeliveryPicker({
+	name,
+	tier,
+	onTierChange,
+	disabled,
+	grantsSlot,
+}: {
+	/** The secret name, used to render a copy-paste-correct access example. */
+	name: string;
+	tier: SecretTier;
+	onTierChange: (tier: SecretTier) => void;
+	disabled?: boolean;
+	/** Grants editor to show under the scoped option (pending-grants on add, live editor on edit). */
+	grantsSlot?: ReactNode;
+}) {
+	return (
+		<div className="grid gap-3">
+			<span className="text-sm font-medium">How should applications read this secret?</span>
+			<RadioGroup
+				value={tier}
+				onValueChange={(value) => onTierChange(value as SecretTier)}
+				disabled={disabled}
+			>
+				<label className="flex items-start gap-2 cursor-pointer">
+					<RadioGroupItem value="scoped" className="mt-0.5" />
+					<div className="grid gap-0.5">
+						<span className="text-sm font-medium">Scoped to specific apps</span>
+						<span className="text-sm text-muted-foreground">
+							Exposed only to the applications you grant, through the <code className="font-mono">secrets</code>{' '}
+							accessor. Never placed on <code className="font-mono">process.env</code>.
+						</span>
+					</div>
+				</label>
+				<label className="flex items-start gap-2 cursor-pointer">
+					<RadioGroupItem value="processEnv" className="mt-0.5" />
+					<div className="grid gap-0.5">
+						<span className="text-sm font-medium">Environment variable</span>
+						<span className="text-sm text-muted-foreground">
+							Materialized onto <code className="font-mono">process.env</code>{' '}
+							for every component (and child processes). Global — it can't be scoped to specific apps.
+						</span>
+					</div>
+				</label>
+			</RadioGroup>
+
+			{tier === 'scoped' && grantsSlot}
+
+			<div className="grid gap-1">
+				<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+					How to read it in your component
+				</span>
+				<SecretAccessExample name={name} tier={tier} />
+			</div>
+		</div>
+	);
+}

--- a/src/features/instance/secrets/SecretModals.tsx
+++ b/src/features/instance/secrets/SecretModals.tsx
@@ -339,7 +339,16 @@ export function EditSecretModal({
 										disabled={busy}
 										// The live grants editor (grant_secret/revoke_secret) only applies to scoped
 										// secrets — the picker shows it under the scoped option and hides it for env vars.
-										grantsSlot={children}
+										// On an *unsaved* switch to scoped the secret is still processEnv server-side, so
+										// grant_secret would be rejected: show a hint until the scoped save lands, rather than
+										// a live editor that fires a doomed request.
+										grantsSlot={tierChanged
+											? (
+												<p className="text-sm text-muted-foreground">
+													Save this as a scoped secret first, then you can grant applications.
+												</p>
+											)
+											: children}
 									/>
 									{tierChanged && !isDirty && (
 										<p className="text-sm text-amber-600 dark:text-amber-500">

--- a/src/features/instance/secrets/SecretModals.tsx
+++ b/src/features/instance/secrets/SecretModals.tsx
@@ -30,6 +30,17 @@ import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
+import { SecretTier } from './accessExample';
+import { PendingGrantsInput } from './PendingGrantsInput';
+import { SecretDeliveryPicker } from './SecretDeliveryPicker';
+
+/** What the add/edit dialogs report back on submit, beyond the key/value pair. */
+export interface SecretDeliveryOptions {
+	/** true → global (`process.env`); false → scoped; undefined → preserve the stored tier. */
+	processEnv?: boolean;
+	/** Initial grants for a scoped secret (add flow only; edit manages grants live). */
+	grants?: string[];
+}
 
 const secretKeySchema = z
 	.string()
@@ -44,15 +55,21 @@ export function AddSecretModal({
 	onSubmit,
 	isModalOpen,
 	setIsModalOpen,
+	delivery = false,
+	defaultTier = 'scoped',
 }: {
 	description: ReactNode;
 	valueDescription?: ReactNode;
 	/** Keys that already exist — adding one of these is rejected (edit it instead). */
 	existingKeys?: string[];
 	/** Persist the new secret; reject to keep the dialog open and surface the error. */
-	onSubmit: (data: { key: string; value: string }) => Promise<unknown>;
+	onSubmit: (data: { key: string; value: string } & SecretDeliveryOptions) => Promise<unknown>;
 	isModalOpen: boolean;
 	setIsModalOpen: (open: boolean) => void;
+	/** Show the delivery-tier chooser (process.env vs scoped) + grants + a live access example. */
+	delivery?: boolean;
+	/** Tier pre-selected when the dialog opens (defaults to the safer scoped tier). */
+	defaultTier?: SecretTier;
 }) {
 	const schema = useMemo(
 		() =>
@@ -71,24 +88,40 @@ export function AddSecretModal({
 	// Destructured unconditionally so react-hook-form tracks all three (see EditSecretModal).
 	const { isDirty, isValid, isSubmitting: isPending } = form.formState;
 
+	// Delivery tier + initial grants live outside the value form (they aren't validated fields).
+	const [tier, setTier] = useState<SecretTier>(defaultTier);
+	const [grants, setGrants] = useState<string[]>([]);
+	const liveName = form.watch('key');
+
+	const resetDelivery = useCallback(() => {
+		setTier(defaultTier);
+		setGrants([]);
+	}, [defaultTier]);
+
 	const onSubmitClick = useCallback(
 		async (formData: z.infer<typeof schema>) => {
+			// Scoped is the default tier server-side; only send delivery fields when the chooser is on.
+			const deliveryFields: SecretDeliveryOptions = delivery
+				? { processEnv: tier === 'processEnv', grants: tier === 'scoped' ? grants : undefined }
+				: {};
 			try {
-				await onSubmit(formData);
+				await onSubmit({ ...formData, ...deliveryFields });
 				form.reset();
+				resetDelivery();
 				toast.success(`Secret "${formData.key}" saved.`);
 				setIsModalOpen(false);
 			} catch (error) {
 				toast.error(String(error));
 			}
 		},
-		[onSubmit, form, setIsModalOpen],
+		[onSubmit, form, setIsModalOpen, delivery, tier, grants, resetDelivery],
 	);
 
 	const onClickCancel = useCallback(() => {
 		form.reset();
+		resetDelivery();
 		setIsModalOpen(false);
-	}, [form, setIsModalOpen]);
+	}, [form, setIsModalOpen, resetDelivery]);
 
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
@@ -134,6 +167,16 @@ export function AddSecretModal({
 							)}
 						/>
 
+						{delivery && (
+							<SecretDeliveryPicker
+								name={liveName}
+								tier={tier}
+								onTierChange={setTier}
+								disabled={isPending}
+								grantsSlot={<PendingGrantsInput grants={grants} onChange={setGrants} disabled={isPending} />}
+							/>
+						)}
+
 						<DialogFooter>
 							<div className="flex justify-between w-full">
 								<Button
@@ -171,6 +214,8 @@ export function EditSecretModal({
 	onDelete,
 	closeModal,
 	children,
+	delivery = false,
+	currentTier = 'scoped',
 }: {
 	name: string;
 	description: ReactNode;
@@ -182,12 +227,16 @@ export function EditSecretModal({
 	 */
 	currentValue?: string;
 	/** Persist the replacement value; reject to keep the dialog open and surface the error. */
-	onSave: (value: string) => Promise<unknown>;
+	onSave: (value: string, options?: SecretDeliveryOptions) => Promise<unknown>;
 	/** Remove the secret entirely (second click confirms). Omit to hide the delete button. */
 	onDelete?: () => Promise<unknown>;
 	closeModal: () => void;
-	/** Extra content rendered between the value field and the footer (e.g. a grants editor). */
+	/** Extra content rendered between the value field and the footer (e.g. a live grants editor). */
 	children?: ReactNode;
+	/** Show the delivery-tier chooser + access example; `children` becomes the scoped grants slot. */
+	delivery?: boolean;
+	/** The secret's stored tier, pre-selected in the chooser. */
+	currentTier?: SecretTier;
 }) {
 	const form = useForm({ resolver: zodResolver(EditSecretSchema), defaultValues: { value: '' } });
 	// Destructured unconditionally: react-hook-form only tracks formState fields that are actually
@@ -197,6 +246,11 @@ export function EditSecretModal({
 	const { isDirty, isValid, isSubmitting } = form.formState;
 	const [isDeleting, setIsDeleting] = useState(false);
 	const busy = isSubmitting || isDeleting;
+
+	// The stored tier can be changed here, but only by re-supplying the value: set_secret always
+	// re-writes the envelope, and an encrypted value can't be read back to re-encrypt automatically.
+	const [tier, setTier] = useState<SecretTier>(currentTier);
+	const tierChanged = delivery && tier !== currentTier;
 
 	// Revealing fills the field with the current value without marking the form dirty, so Save
 	// stays disabled until the user actually changes something.
@@ -209,14 +263,14 @@ export function EditSecretModal({
 	const onSubmitClick = useCallback(
 		async (formData: z.infer<typeof EditSecretSchema>) => {
 			try {
-				await onSave(formData.value);
+				await onSave(formData.value, delivery ? { processEnv: tier === 'processEnv' } : undefined);
 				toast.success(`Secret "${name}" updated.`);
 				closeModal();
 			} catch (error) {
 				toast.error(String(error));
 			}
 		},
-		[onSave, name, closeModal],
+		[onSave, name, closeModal, delivery, tier],
 	);
 
 	// Deleting a secret can break running applications, so require a second click to confirm.
@@ -275,7 +329,27 @@ export function EditSecretModal({
 							)}
 						/>
 
-						{children}
+						{delivery
+							? (
+								<>
+									<SecretDeliveryPicker
+										name={name}
+										tier={tier}
+										onTierChange={setTier}
+										disabled={busy}
+										// The live grants editor (grant_secret/revoke_secret) only applies to scoped
+										// secrets — the picker shows it under the scoped option and hides it for env vars.
+										grantsSlot={children}
+									/>
+									{tierChanged && !isDirty && (
+										<p className="text-sm text-amber-600 dark:text-amber-500">
+											Re-enter the value above to save this change — a stored secret can’t be read back to re-encrypt
+											automatically.
+										</p>
+									)}
+								</>
+							)
+							: children}
 
 						<DialogFooter>
 							<div className="flex justify-between w-full">

--- a/src/features/instance/secrets/SecretsManager.delivery.test.tsx
+++ b/src/features/instance/secrets/SecretsManager.delivery.test.tsx
@@ -119,11 +119,32 @@ describe('SecretsManager delivery tier — Edit', () => {
 		expect(onSet).toHaveBeenCalledWith('TOKEN', 'rotated', { processEnv: true });
 	});
 
-	it('a scoped row shows the accessor example', async () => {
+	it('a scoped row shows the accessor example and the live grants editor', async () => {
 		renderManager({
 			rows: [{ name: 'DB_PASSWORD', processEnv: false }],
 			selectedName: 'DB_PASSWORD',
+			renderEditExtras: () => <div data-testid="live-grants">grants</div>,
 		});
 		await waitFor(() => expect(exampleText()).toContain('const { DB_PASSWORD } = secrets;'));
+		// Tier matches what's stored (scoped, unchanged), so the live grant_secret editor is safe.
+		expect(screen.getByTestId('live-grants')).toBeTruthy();
+	});
+
+	it('hides the live grants editor on an unsaved switch from processEnv to scoped', async () => {
+		renderManager({
+			rows: [{ name: 'TOKEN', processEnv: true }],
+			selectedName: 'TOKEN',
+			renderEditExtras: () => <div data-testid="live-grants">grants</div>,
+		});
+		await waitFor(() => expect(exampleText()).toContain('process.env.TOKEN'));
+		// processEnv secret: no scoped grants slot at all.
+		expect(screen.queryByTestId('live-grants')).toBeNull();
+
+		// Flip to scoped without saving: the secret is still processEnv server-side, so a live
+		// grant_secret would be rejected — show the "save first" hint instead of the editor.
+		fireEvent.click(screen.getAllByRole('radio')[0]);
+		await waitFor(() => expect(exampleText()).toContain('const { TOKEN } = secrets;'));
+		expect(screen.queryByTestId('live-grants')).toBeNull();
+		expect(screen.getByText(/save this as a scoped secret first/i)).toBeTruthy();
 	});
 });

--- a/src/features/instance/secrets/SecretsManager.delivery.test.tsx
+++ b/src/features/instance/secrets/SecretsManager.delivery.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+/*
+ The delivery-tier flow on the shared secrets dialogs (enabled by `delivery`): picking
+ process.env vs scoped, seeing the matching access example, and reporting the choice through
+ onSet. Uses fireEvent (no @testing-library/user-event in this repo) and the Radix DOM polyfills.
+*/
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { SecretRow, SecretsManager } from './SecretsManager';
+
+beforeAll(() => {
+	Element.prototype.hasPointerCapture ??= () => false;
+	Element.prototype.setPointerCapture ??= () => undefined;
+	Element.prototype.releasePointerCapture ??= () => undefined;
+	Element.prototype.scrollIntoView ??= () => undefined;
+	if (typeof window.PointerEvent === 'undefined') {
+		window.PointerEvent = class extends MouseEvent {} as typeof PointerEvent;
+	}
+});
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+function renderManager(overrides: Partial<Parameters<typeof SecretsManager>[0]> = {}) {
+	const onSet = vi.fn().mockResolvedValue(undefined);
+	const rows: SecretRow[] = overrides.rows ?? [];
+	render(
+		<SecretsManager
+			rows={rows}
+			onSelectName={vi.fn()}
+			addDescription="add"
+			editDescription="edit"
+			onSet={onSet}
+			delivery={true}
+			{...overrides}
+		/>,
+	);
+	return { onSet };
+}
+
+/** The rendered access example (the only <pre><code> on screen at a time). */
+function exampleText(): string {
+	return document.querySelector('pre code')?.textContent ?? '';
+}
+
+describe('SecretsManager delivery tier — Add', () => {
+	async function openAddWithKeyValue() {
+		fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		fireEvent.change(await screen.findByLabelText('Key'), { target: { value: 'NEW_KEY' } });
+		fireEvent.change(screen.getByLabelText('Value'), { target: { value: 'a value' } });
+	}
+
+	it('defaults to scoped and shows the secrets-accessor example', async () => {
+		renderManager();
+		await openAddWithKeyValue();
+
+		// Scoped is the default: the example destructures the accessor, never touches process.env.
+		expect(exampleText()).toContain("import { secrets } from 'harper';");
+		expect(exampleText()).toContain('const { NEW_KEY } = secrets;');
+		expect(exampleText()).not.toContain('process.env');
+	});
+
+	it('submits a scoped secret with its pending grants', async () => {
+		const { onSet } = renderManager();
+		await openAddWithKeyValue();
+
+		// Add one grant (the PendingGrantsInput "Add" button, distinct from "Add Secret").
+		fireEvent.change(screen.getByPlaceholderText('application name'), { target: { value: 'my-app' } });
+		fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+		expect(screen.getByText('my-app')).toBeTruthy();
+
+		const submit = screen.getByRole('button', { name: /add secret/i });
+		await waitFor(() => expect(submit.hasAttribute('disabled')).toBe(false));
+		fireEvent.click(submit);
+
+		await waitFor(() => expect(onSet).toHaveBeenCalledTimes(1));
+		expect(onSet).toHaveBeenCalledWith('NEW_KEY', 'a value', { processEnv: false, grants: ['my-app'] });
+	});
+
+	it('switching to environment variable swaps the example and submits processEnv', async () => {
+		const { onSet } = renderManager();
+		await openAddWithKeyValue();
+
+		// [scoped, processEnv] in DOM order; select the second.
+		fireEvent.click(screen.getAllByRole('radio')[1]);
+		await waitFor(() => expect(exampleText()).toContain('process.env.NEW_KEY'));
+		expect(exampleText()).not.toContain('secrets');
+
+		const submit = screen.getByRole('button', { name: /add secret/i });
+		await waitFor(() => expect(submit.hasAttribute('disabled')).toBe(false));
+		fireEvent.click(submit);
+
+		await waitFor(() => expect(onSet).toHaveBeenCalledTimes(1));
+		expect(onSet).toHaveBeenCalledWith('NEW_KEY', 'a value', { processEnv: true, grants: undefined });
+	});
+});
+
+describe('SecretsManager delivery tier — Edit', () => {
+	it('preselects a processEnv row and re-saves it as processEnv', async () => {
+		const { onSet } = renderManager({
+			rows: [{ name: 'TOKEN', processEnv: true }],
+			selectedName: 'TOKEN',
+		});
+
+		// The edit dialog opens for the selected row; a process.env secret shows that example.
+		await waitFor(() => expect(exampleText()).toContain('process.env.TOKEN'));
+		expect(exampleText()).not.toContain('import { secrets }');
+
+		fireEvent.change(await screen.findByLabelText('New value'), { target: { value: 'rotated' } });
+		const save = screen.getByRole('button', { name: /^save$/i });
+		await waitFor(() => expect(save.hasAttribute('disabled')).toBe(false));
+		fireEvent.click(save);
+
+		await waitFor(() => expect(onSet).toHaveBeenCalledTimes(1));
+		expect(onSet).toHaveBeenCalledWith('TOKEN', 'rotated', { processEnv: true });
+	});
+
+	it('a scoped row shows the accessor example', async () => {
+		renderManager({
+			rows: [{ name: 'DB_PASSWORD', processEnv: false }],
+			selectedName: 'DB_PASSWORD',
+		});
+		await waitFor(() => expect(exampleText()).toContain('const { DB_PASSWORD } = secrets;'));
+	});
+});

--- a/src/features/instance/secrets/SecretsManager.tsx
+++ b/src/features/instance/secrets/SecretsManager.tsx
@@ -11,7 +11,8 @@ import { ENV_VALUE_MASK } from '@/lib/env/envFile';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import { EyeIcon, EyeOffIcon, PlusIcon, RefreshCwIcon, TriangleAlertIcon } from 'lucide-react';
 import { MouseEvent, ReactNode, useCallback, useMemo, useState } from 'react';
-import { AddSecretModal, EditSecretModal } from './SecretModals';
+import { SecretTier } from './accessExample';
+import { AddSecretModal, EditSecretModal, SecretDeliveryOptions } from './SecretModals';
 
 export interface SecretRow {
 	name: string;
@@ -23,6 +24,12 @@ export interface SecretRow {
 	value?: string;
 	/** A per-row caution (e.g. "encrypted under a stale key"), shown as an alert icon. */
 	warning?: string;
+	/**
+	 * The row's delivery tier, when the store supports one (the cluster hdb_secret store): true =
+	 * materialized onto `process.env` (global), false/undefined = scoped to granted apps. Only read
+	 * when `delivery` is enabled.
+	 */
+	processEnv?: boolean;
 }
 
 export function SecretsManager({
@@ -40,6 +47,8 @@ export function SecretsManager({
 	onDelete,
 	renderEditExtras,
 	children,
+	delivery = false,
+	deliveryDefaultTier = 'scoped',
 }: {
 	rows: SecretRow[];
 	isFetching?: boolean;
@@ -54,14 +63,21 @@ export function SecretsManager({
 	addDescription: ReactNode;
 	editDescription: ReactNode;
 	valueDescription?: ReactNode;
-	/** Persist a key/value pair — both adding a new secret and replacing an existing value. */
-	onSet: (key: string, value: string) => Promise<unknown>;
+	/**
+	 * Persist a key/value pair — both adding a new secret and replacing an existing value. The
+	 * third argument carries delivery-tier choices when `delivery` is enabled (ignored otherwise).
+	 */
+	onSet: (key: string, value: string, options?: SecretDeliveryOptions) => Promise<unknown>;
 	/** Remove a secret by key. Omit to hide the delete affordance. */
 	onDelete?: (key: string) => Promise<unknown>;
-	/** Extra per-secret content for the edit dialog (e.g. a grants editor). */
+	/** Extra per-secret content for the edit dialog (e.g. a live grants editor). */
 	renderEditExtras?: (name: string) => ReactNode;
 	/** Extra toolbar actions, rendered after Refresh/Add. */
 	children?: ReactNode;
+	/** Enable the delivery-tier chooser (process.env vs scoped) + access examples in the dialogs. */
+	delivery?: boolean;
+	/** Tier pre-selected in the Add dialog (defaults to the safer scoped tier). */
+	deliveryDefaultTier?: SecretTier;
 }) {
 	const columns = useMemo<Array<ColumnDef<SecretRow>>>(() => [
 		{
@@ -131,7 +147,9 @@ export function SecretsManager({
 					description={addDescription}
 					valueDescription={valueDescription}
 					existingKeys={existingKeys}
-					onSubmit={({ key, value }) => onSet(key, value)}
+					delivery={delivery}
+					defaultTier={deliveryDefaultTier}
+					onSubmit={({ key, value, ...options }) => onSet(key, value, options)}
 				/>
 			)}
 			{selectedName && selectedRow && (
@@ -141,7 +159,9 @@ export function SecretsManager({
 					description={editDescription}
 					valueDescription={valueDescription}
 					currentValue={selectedRow.value}
-					onSave={(value) => onSet(selectedRow.name, value)}
+					delivery={delivery}
+					currentTier={selectedRow.processEnv ? 'processEnv' : 'scoped'}
+					onSave={(value, options) => onSet(selectedRow.name, value, options)}
 					onDelete={onDelete && (() => onDelete(selectedRow.name))}
 					closeModal={() => onSelectName(undefined)}
 				>

--- a/src/features/instance/secrets/accessExample.test.ts
+++ b/src/features/instance/secrets/accessExample.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { buildSecretAccessExample, isJsIdentifier, SECRET_NAME_PLACEHOLDER } from './accessExample';
+
+describe('isJsIdentifier', () => {
+	it('accepts bare identifiers', () => {
+		expect(isJsIdentifier('MY_KEY')).toBe(true);
+		expect(isJsIdentifier('_private')).toBe(true);
+		expect(isJsIdentifier('$ref')).toBe(true);
+		expect(isJsIdentifier('token2')).toBe(true);
+	});
+
+	it('rejects names that need bracket access', () => {
+		expect(isJsIdentifier('my.key')).toBe(false); // dot
+		expect(isJsIdentifier('my-key')).toBe(false); // dash
+		expect(isJsIdentifier('2fa')).toBe(false); // leading digit
+		expect(isJsIdentifier('')).toBe(false);
+	});
+});
+
+describe('buildSecretAccessExample', () => {
+	it('processEnv uses process.env dot access for identifier names', () => {
+		const code = buildSecretAccessExample('API_KEY', 'processEnv');
+		expect(code).toContain('const value = process.env.API_KEY;');
+		expect(code).toContain('process.env for every component');
+		expect(code).not.toContain('import { secrets }');
+	});
+
+	it('processEnv uses bracket access for non-identifier names', () => {
+		expect(buildSecretAccessExample('my.key', 'processEnv')).toContain("const value = process.env['my.key'];");
+		expect(buildSecretAccessExample('my-key', 'processEnv')).toContain("const value = process.env['my-key'];");
+	});
+
+	it('scoped destructures the secrets accessor for identifier names', () => {
+		const code = buildSecretAccessExample('DB_PASSWORD', 'scoped');
+		expect(code).toContain("import { secrets } from 'harper';");
+		expect(code).toContain('const { DB_PASSWORD } = secrets;');
+		expect(code).toContain('top level'); // the module-top-level guidance
+		expect(code).not.toContain('process.env');
+	});
+
+	it('scoped uses bracket access for non-identifier names', () => {
+		const code = buildSecretAccessExample('my.key', 'scoped');
+		expect(code).toContain("const value = secrets['my.key'];");
+		expect(code).not.toContain('const { my.key }');
+	});
+
+	it('falls back to a placeholder name when empty or whitespace', () => {
+		expect(buildSecretAccessExample('', 'scoped')).toContain(`const { ${SECRET_NAME_PLACEHOLDER} } = secrets;`);
+		expect(buildSecretAccessExample('   ', 'processEnv')).toContain(`process.env.${SECRET_NAME_PLACEHOLDER}`);
+	});
+
+	it('escapes single quotes in bracketed names', () => {
+		expect(buildSecretAccessExample("a'b", 'processEnv')).toContain("process.env['a\\'b']");
+	});
+});

--- a/src/features/instance/secrets/accessExample.ts
+++ b/src/features/instance/secrets/accessExample.ts
@@ -1,0 +1,61 @@
+/**
+ * Inline "how do I read this secret?" code examples for the two hdb_secret delivery tiers
+ * (harper#1554 / harper#1559). The tier a secret is stored under decides how component code reads
+ * it, so the UI shows the matching snippet as soon as the tier is picked:
+ *
+ *  - 'processEnv' — the value is materialized into the real `process.env` at component load and
+ *    inherited by child processes (global, `.env` semantics). Read it as `process.env.NAME`.
+ *  - 'scoped'     — never placed on `process.env`; exposed only to granted components through the
+ *    `secrets` accessor (`import { secrets } from 'harper'`), read at module top level.
+ *
+ * The two tiers are mutually exclusive server-side (a processEnv secret is global, so scoping it
+ * with grants is rejected). The secret-name grammar (`[\w.-]+`) permits `.` and `-`, which aren't
+ * valid JS identifiers, so the examples switch between dot/destructure and bracket notation per
+ * name to stay copy-paste-correct.
+ */
+
+export type SecretTier = 'processEnv' | 'scoped';
+
+/** Shown in the example while the user hasn't typed a name yet. */
+export const SECRET_NAME_PLACEHOLDER = 'MY_SECRET';
+
+/** True when `name` can be used as a bare JS identifier (so `secrets.NAME` / `const { NAME }` is valid). */
+export function isJsIdentifier(name: string): boolean {
+	return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name);
+}
+
+/** A single-quoted JS string literal for a name that can't be a bare identifier. */
+function quote(name: string): string {
+	return `'${name.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/**
+ * The code a component uses to read a secret of the given tier. `name` is the stored secret name;
+ * an empty/whitespace name falls back to {@link SECRET_NAME_PLACEHOLDER} so the example still reads
+ * sensibly while the user is typing.
+ */
+export function buildSecretAccessExample(name: string, tier: SecretTier): string {
+	const key = name.trim() || SECRET_NAME_PLACEHOLDER;
+	const identifier = isJsIdentifier(key);
+
+	if (tier === 'processEnv') {
+		const access = identifier ? `process.env.${key}` : `process.env[${quote(key)}]`;
+		return [
+			'// Exposed on process.env for every component (and child processes).',
+			`const value = ${access};`,
+		].join('\n');
+	}
+
+	// Scoped: the `secrets` accessor is bound to the loading component, so it must be read at module
+	// top level (during load) — reading it inside a request handler throws.
+	const read = identifier
+		? `const { ${key} } = secrets;`
+		: `const value = secrets[${quote(key)}];`;
+	return [
+		"import { secrets } from 'harper';",
+		'',
+		'// Read granted secrets at the top level of your component module',
+		'// (the accessor is bound during load, not inside request handlers).',
+		read,
+	].join('\n');
+}

--- a/src/integrations/api/instance/secrets/secrets.test.tsx
+++ b/src/integrations/api/instance/secrets/secrets.test.tsx
@@ -17,6 +17,11 @@ import { secretsPublicKeyQueryOptions, useDeleteSecret, useSetSecret } from './s
  our cached copy) must refetch the key and re-encrypt exactly once.
  */
 
+// Managed clusters fetch the public key from central-manager's apiClient; keep the real module
+// (and its env expectations) out of the test.
+const { cmPost } = vi.hoisted(() => ({ cmPost: vi.fn() }));
+vi.mock('@/config/apiClient', () => ({ apiClient: { post: cmPost } }));
+
 // jsdom has no SubtleCrypto; Node's WebCrypto implements the same interface.
 beforeAll(() => {
 	if (!globalThis.crypto?.subtle) {
@@ -132,6 +137,32 @@ describe('useSetSecret', () => {
 		await expect(result.current.mutateAsync({ ...params, name: 'API_KEY', value: 'x' })).rejects.toThrow(
 			'secrets custody is not initialized on this node',
 		);
+	});
+
+	it('fetches the key from central-manager for managed clusters (central-manager#409)', async () => {
+		const { post, wrapper, params } = harness();
+		const key = await generateKey();
+		cmPost.mockResolvedValue({
+			data: { publicKey: key.pem, fingerprint: key.fingerprint, scheme: 'enc:v1', algorithm: 'RSA-OAEP-256' },
+		});
+		post.mockImplementation((_url: string, body: { operation: string }) =>
+			body.operation === 'set_secret'
+				? Promise.resolve({ data: { name: 'API_KEY', kid: key.fingerprint, created: true } })
+				: Promise.reject(new Error(`Unexpected operation ${body.operation}`))
+		);
+
+		const { result } = renderHook(() => useSetSecret(), { wrapper });
+		await result.current.mutateAsync({ ...params, managedClusterId: 'clu-123', name: 'API_KEY', value: 'v' });
+
+		expect(cmPost).toHaveBeenCalledWith('/ClusterSecrets', {
+			operation: 'get_secrets_public_key',
+			clusterId: 'clu-123',
+		});
+		// The node op is never used for the key; the envelope targets CM's key; the write still
+		// goes to the cluster itself.
+		expect(post.mock.calls.filter(([, body]) => body.operation === 'get_secrets_public_key')).toHaveLength(0);
+		const setCall = post.mock.calls.find(([, body]) => body.operation === 'set_secret');
+		expect(decodeEnvelope(setCall![1].envelope).kid).toBe(key.fingerprint);
 	});
 
 	it('caches the public key between writes', async () => {

--- a/src/integrations/api/instance/secrets/secrets.test.tsx
+++ b/src/integrations/api/instance/secrets/secrets.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { EntityIds } from '@/features/auth/store/authStore';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { AxiosInstance } from 'axios';
+import { webcrypto } from 'node:crypto';
+import { PropsWithChildren } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { secretsPublicKeyQueryOptions, useDeleteSecret, useSetSecret } from './secrets';
+
+/*
+ Exercises the hdb_secret client flow against a mocked operations client and a REAL RSA keypair:
+ set_secret must carry an `enc:v1:` envelope whose sealed kid matches the served fingerprint (the
+ plaintext never appears in the request), and a kid-mismatch rejection (custody key rotated under
+ our cached copy) must refetch the key and re-encrypt exactly once.
+ */
+
+// jsdom has no SubtleCrypto; Node's WebCrypto implements the same interface.
+beforeAll(() => {
+	if (!globalThis.crypto?.subtle) {
+		Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+	}
+});
+
+afterEach(() => vi.clearAllMocks());
+
+async function generateKey() {
+	const keyPair = await webcrypto.subtle.generateKey(
+		{ name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+		true,
+		['encrypt', 'decrypt'],
+	);
+	const der = new Uint8Array(await webcrypto.subtle.exportKey('spki', keyPair.publicKey));
+	const b64 = btoa(String.fromCharCode(...der));
+	const pem = `-----BEGIN PUBLIC KEY-----\n${b64.replace(/(.{64})/g, '$1\n')}\n-----END PUBLIC KEY-----\n`;
+	const fingerprintBytes = new Uint8Array(await webcrypto.subtle.digest('SHA-256', der));
+	const fingerprint = Array.from(fingerprintBytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+	return { pem, fingerprint };
+}
+
+function decodeEnvelope(envelope: string): { kid: string } {
+	expect(envelope.startsWith('enc:v1:')).toBe(true);
+	const b64 = envelope.slice('enc:v1:'.length).replace(/-/g, '+').replace(/_/g, '/');
+	return JSON.parse(atob(b64));
+}
+
+function harness() {
+	const post = vi.fn();
+	const instanceClient = { post } as unknown as AxiosInstance;
+	const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: PropsWithChildren) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	const params = { instanceClient, entityId: 'test-cluster' as EntityIds };
+	return { post, queryClient, wrapper, params };
+}
+
+describe('useSetSecret', () => {
+	it('encrypts client-side and posts an envelope sealed with the served key', async () => {
+		const { post, wrapper, params } = harness();
+		const key = await generateKey();
+		post.mockImplementation((_url: string, body: { operation: string }) => {
+			if (body.operation === 'get_secrets_public_key') {
+				return Promise.resolve({ data: { public_key: key.pem, fingerprint: key.fingerprint } });
+			}
+			if (body.operation === 'set_secret') {
+				return Promise.resolve({ data: { name: 'API_KEY', kid: key.fingerprint, created: true } });
+			}
+			return Promise.reject(new Error(`Unexpected operation ${body.operation}`));
+		});
+
+		const { result } = renderHook(() => useSetSecret(), { wrapper });
+		const response = await result.current.mutateAsync({ ...params, name: 'API_KEY', value: 'hunter2' });
+
+		expect(response.created).toBe(true);
+		const setCalls = post.mock.calls.filter(([, body]) => body.operation === 'set_secret');
+		expect(setCalls).toHaveLength(1);
+		const [, setBody] = setCalls[0];
+		expect(setBody.name).toBe('API_KEY');
+		expect(setBody.value).toBeUndefined(); // plaintext never leaves the browser
+		expect(JSON.stringify(setBody)).not.toContain('hunter2');
+		expect(decodeEnvelope(setBody.envelope).kid).toBe(key.fingerprint);
+	});
+
+	it('refetches the public key and re-encrypts once on a kid mismatch (key rotation)', async () => {
+		const { post, wrapper, params } = harness();
+		const staleKey = await generateKey();
+		const activeKey = await generateKey();
+		let servedKey = staleKey;
+		post.mockImplementation((_url: string, body: { operation: string; envelope?: string }) => {
+			if (body.operation === 'get_secrets_public_key') {
+				return Promise.resolve({ data: { public_key: servedKey.pem, fingerprint: servedKey.fingerprint } });
+			}
+			if (body.operation === 'set_secret') {
+				const { kid } = decodeEnvelope(body.envelope!);
+				if (kid !== activeKey.fingerprint) {
+					// The moment the stale envelope is rejected, the node serves the rotated key.
+					servedKey = activeKey;
+					return Promise.reject({
+						response: {
+							data: { error: `Secret envelope kid '${kid}' does not match this cluster's secrets key` },
+						},
+					});
+				}
+				return Promise.resolve({ data: { name: 'API_KEY', kid, created: false } });
+			}
+			return Promise.reject(new Error(`Unexpected operation ${body.operation}`));
+		});
+
+		const { result } = renderHook(() => useSetSecret(), { wrapper });
+		const response = await result.current.mutateAsync({ ...params, name: 'API_KEY', value: 'rotated' });
+
+		expect(response.kid).toBe(activeKey.fingerprint);
+		const setCalls = post.mock.calls.filter(([, body]) => body.operation === 'set_secret');
+		expect(setCalls).toHaveLength(2); // stale attempt + one re-encrypted retry
+		expect(decodeEnvelope(setCalls[1][1].envelope).kid).toBe(activeKey.fingerprint);
+	});
+
+	it('surfaces the operation error message (not Axios noise) when the retry also fails', async () => {
+		const { post, wrapper, params } = harness();
+		const key = await generateKey();
+		post.mockImplementation((_url: string, body: { operation: string }) => {
+			if (body.operation === 'get_secrets_public_key') {
+				return Promise.resolve({ data: { public_key: key.pem, fingerprint: key.fingerprint } });
+			}
+			return Promise.reject({ response: { data: { error: 'secrets custody is not initialized on this node' } } });
+		});
+
+		const { result } = renderHook(() => useSetSecret(), { wrapper });
+		await expect(result.current.mutateAsync({ ...params, name: 'API_KEY', value: 'x' })).rejects.toThrow(
+			'secrets custody is not initialized on this node',
+		);
+	});
+
+	it('caches the public key between writes', async () => {
+		const { post, wrapper, params, queryClient } = harness();
+		const key = await generateKey();
+		post.mockImplementation((_url: string, body: { operation: string }) => {
+			if (body.operation === 'get_secrets_public_key') {
+				return Promise.resolve({ data: { public_key: key.pem, fingerprint: key.fingerprint } });
+			}
+			return Promise.resolve({ data: { name: 'X', kid: key.fingerprint, created: true } });
+		});
+
+		const { result } = renderHook(() => useSetSecret(), { wrapper });
+		await result.current.mutateAsync({ ...params, name: 'A', value: '1' });
+		await result.current.mutateAsync({ ...params, name: 'B', value: '2' });
+
+		const keyFetches = post.mock.calls.filter(([, body]) => body.operation === 'get_secrets_public_key');
+		expect(keyFetches).toHaveLength(1);
+		// And the cached entry is the one ensureQueryData used.
+		await waitFor(() => expect(queryClient.getQueryData(secretsPublicKeyQueryOptions(params).queryKey)).toBeTruthy());
+	});
+});
+
+describe('useDeleteSecret', () => {
+	it('posts delete_secret and surfaces the body error message on failure', async () => {
+		const { post, wrapper, params } = harness();
+		post.mockResolvedValueOnce({ data: { message: "Successfully deleted secret 'API_KEY'" } });
+
+		const { result } = renderHook(() => useDeleteSecret(), { wrapper });
+		await result.current.mutateAsync({ ...params, name: 'API_KEY' });
+		expect(post).toHaveBeenCalledWith('/', { operation: 'delete_secret', name: 'API_KEY' });
+
+		post.mockRejectedValueOnce({ response: { data: { error: "No secret found with name 'NOPE'" } } });
+		await expect(result.current.mutateAsync({ ...params, name: 'NOPE' })).rejects.toThrow(
+			"No secret found with name 'NOPE'",
+		);
+	});
+});

--- a/src/integrations/api/instance/secrets/secrets.ts
+++ b/src/integrations/api/instance/secrets/secrets.ts
@@ -1,0 +1,170 @@
+/**
+ * Cluster secrets — the replicated `system.hdb_secret` store (harper#1554; key custody in
+ * harper-pro#512, tracked by harper-pro#166).
+ *
+ * Secrets are named, envelope-encrypted rows on the cluster itself, managed through the ordinary
+ * per-instance operations API. Values are encrypted **in the browser** (`enc:v1` envelope against
+ * the cluster secrets public key) before they leave, so plaintext never reaches the operations
+ * API, the operation log, or disk — and can never be read back. Rows replicate to every node via
+ * normal system-table replication; at load time core materializes a secret only into components
+ * listed in its `grants`.
+ *
+ * Without a registered key custody provider (the Pro secretCustody component), the node has no
+ * public key — `get_secrets_public_key` fails with a clean error and nothing can be encrypted.
+ * `list_secrets` still works, so the store is browsable read-only in that state.
+ */
+import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { encryptEnvelope } from '@/lib/crypto/envSecret';
+import { QueryClient, queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+/** `get_secrets_public_key` — the cluster key clients encrypt against. */
+export interface SecretsPublicKey {
+	public_key: string;
+	fingerprint: string;
+}
+
+/** One `list_secrets` row: metadata only — never envelopes, never values. */
+export interface SecretMetadata {
+	name: string;
+	/** Fingerprint of the key the stored envelope was encrypted under (null for kid-less rows). */
+	kid: string | null;
+	/** Component names allowed to receive this secret at load time. */
+	grants: string[];
+	metadata: Record<string, unknown>;
+	/** Stored without key-identity verification (kid-less envelope, or no custody at write time). */
+	unverified: boolean;
+	updated_by: string | null;
+	__createdtime__: number;
+	__updatedtime__: number;
+	/** False when the row was encrypted under a different key than the node's current one. */
+	kid_matches_custody: boolean;
+}
+
+export interface ListSecretsResponse {
+	secrets: SecretMetadata[];
+	/** The node's current custody key fingerprint; null when no custody is registered. */
+	custody_fingerprint: string | null;
+}
+
+/** Operations API errors carry the message in the response body; surface that, not the Axios noise. */
+function operationErrorMessage(error: unknown): string {
+	const body = (error as { response?: { data?: { error?: string; message?: string } } })?.response?.data;
+	return body?.error ?? body?.message ?? String(error);
+}
+
+async function getSecretsPublicKey({ instanceClient }: InstanceClientIdConfig): Promise<SecretsPublicKey> {
+	const { data } = await instanceClient.post<SecretsPublicKey>('/', { operation: 'get_secrets_public_key' });
+	return data;
+}
+
+export function secretsPublicKeyQueryOptions(params: InstanceClientIdConfig) {
+	return queryOptions({
+		queryKey: [params.entityId, 'get_secrets_public_key'] as const,
+		queryFn: () => getSecretsPublicKey(params),
+		// The custody key can rotate (kid map), so refresh periodically instead of caching forever.
+		// Failure is a state, not a blip: without custody the node simply has no key.
+		staleTime: 5 * 60_000,
+		retry: false,
+	});
+}
+
+async function listSecrets({ instanceClient }: InstanceClientIdConfig): Promise<ListSecretsResponse> {
+	const { data } = await instanceClient.post<ListSecretsResponse>('/', { operation: 'list_secrets' });
+	return data;
+}
+
+export function listSecretsQueryOptions(params: InstanceClientIdConfig) {
+	return queryOptions({
+		queryKey: [params.entityId, 'list_secrets'] as const,
+		queryFn: () => listSecrets(params),
+	});
+}
+
+export interface SetSecretArgs extends InstanceClientIdConfig {
+	name: string;
+	value: string;
+}
+
+async function encryptAndSetSecret(queryClient: QueryClient, args: SetSecretArgs, isRetry: boolean): Promise<{
+	name: string;
+	kid: string | null;
+	created: boolean;
+}> {
+	// Encrypt against the cluster public key so the plaintext value never leaves the browser. The
+	// envelope's sealed kid tells the cluster which key it was encrypted under.
+	const { public_key, fingerprint } = await queryClient.ensureQueryData(secretsPublicKeyQueryOptions(args));
+	const envelope = await encryptEnvelope(args.value, public_key, fingerprint);
+	try {
+		const { data } = await args.instanceClient.post('/', {
+			operation: 'set_secret',
+			name: args.name,
+			envelope,
+		});
+		return data;
+	} catch (error) {
+		const message = operationErrorMessage(error);
+		// A kid mismatch means our cached public key is stale (the custody key rotated). Drop the
+		// cached key (ensureQueryData returns stale entries, so invalidation isn't enough) and
+		// re-encrypt once; anything else (or a second mismatch) surfaces to the caller.
+		if (!isRetry && message.includes('does not match')) {
+			queryClient.removeQueries({ queryKey: secretsPublicKeyQueryOptions(args).queryKey });
+			return encryptAndSetSecret(queryClient, args, true);
+		}
+		throw new Error(message);
+	}
+}
+
+export function useSetSecret() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (args: SetSecretArgs) => encryptAndSetSecret(queryClient, args, false),
+	});
+}
+
+export interface DeleteSecretArgs extends InstanceClientIdConfig {
+	name: string;
+}
+
+async function deleteSecret({ instanceClient, name }: DeleteSecretArgs): Promise<{ message: string }> {
+	try {
+		const { data } = await instanceClient.post('/', { operation: 'delete_secret', name });
+		return data;
+	} catch (error) {
+		throw new Error(operationErrorMessage(error));
+	}
+}
+
+export function useDeleteSecret() {
+	return useMutation({ mutationFn: deleteSecret });
+}
+
+export interface GrantSecretArgs extends InstanceClientIdConfig {
+	name: string;
+	component: string;
+}
+
+export interface GrantSecretResponse {
+	name: string;
+	grants: string[];
+	changed: boolean;
+}
+
+async function mutateGrant(
+	operation: 'grant_secret' | 'revoke_secret',
+	{ instanceClient, name, component }: GrantSecretArgs,
+): Promise<GrantSecretResponse> {
+	try {
+		const { data } = await instanceClient.post<GrantSecretResponse>('/', { operation, name, component });
+		return data;
+	} catch (error) {
+		throw new Error(operationErrorMessage(error));
+	}
+}
+
+export function useGrantSecret() {
+	return useMutation({ mutationFn: (args: GrantSecretArgs) => mutateGrant('grant_secret', args) });
+}
+
+export function useRevokeSecret() {
+	return useMutation({ mutationFn: (args: GrantSecretArgs) => mutateGrant('revoke_secret', args) });
+}

--- a/src/integrations/api/instance/secrets/secrets.ts
+++ b/src/integrations/api/instance/secrets/secrets.ts
@@ -36,6 +36,8 @@ export interface SecretMetadata {
 	kid: string | null;
 	/** Component names allowed to receive this secret at load time. */
 	grants: string[];
+	/** Materialize into every component's process.env instead of per-component grants (mutually exclusive with grants). */
+	processEnv?: boolean;
 	metadata: Record<string, unknown>;
 	/** Stored without key-identity verification (kid-less envelope, or no custody at write time). */
 	unverified: boolean;

--- a/src/integrations/api/instance/secrets/secrets.ts
+++ b/src/integrations/api/instance/secrets/secrets.ts
@@ -9,17 +9,23 @@
  * normal system-table replication; at load time core materializes a secret only into components
  * listed in its `grants`.
  *
- * Without a registered key custody provider (the Pro secretCustody component), the node has no
- * public key — `get_secrets_public_key` fails with a clean error and nothing can be encrypted.
- * `list_secrets` still works, so the store is browsable read-only in that state.
+ * The public key has two sources depending on who holds custody (normalized here to one shape):
+ * Fabric-managed clusters fetch it from central-manager (`POST /ClusterSecrets`,
+ * central-manager#409 — CM mints the per-cluster keypair on first use and delivers the private
+ * key to hosts), while self-hosted/local nodes serve their own file-tier key via the
+ * `get_secrets_public_key` operation. Without custody the node has no key — the fetch fails with
+ * a clean error and nothing can be encrypted; `list_secrets` still works, so the store is
+ * browsable read-only in that state.
  */
+import { apiClient } from '@/config/apiClient';
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { encryptEnvelope } from '@/lib/crypto/envSecret';
 import { QueryClient, queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
 
-/** `get_secrets_public_key` — the cluster key clients encrypt against. */
+/** The cluster key clients encrypt against, normalized across the two sources (see below). */
 export interface SecretsPublicKey {
-	public_key: string;
+	publicKey: string;
 	fingerprint: string;
 }
 
@@ -52,15 +58,43 @@ function operationErrorMessage(error: unknown): string {
 	return body?.error ?? body?.message ?? String(error);
 }
 
-async function getSecretsPublicKey({ instanceClient }: InstanceClientIdConfig): Promise<SecretsPublicKey> {
-	const { data } = await instanceClient.post<SecretsPublicKey>('/', { operation: 'get_secrets_public_key' });
-	return data;
+async function getSecretsPublicKeyFromNode({ instanceClient }: InstanceClientIdConfig): Promise<SecretsPublicKey> {
+	const { data } = await instanceClient.post<{ public_key: string; fingerprint: string }>('/', {
+		operation: 'get_secrets_public_key',
+	});
+	return { publicKey: data.public_key, fingerprint: data.fingerprint };
 }
 
-export function secretsPublicKeyQueryOptions(params: InstanceClientIdConfig) {
+// `apiClient` is a TypedAxios bound to the generated OpenAPI spec; `/ClusterSecrets` isn't in the
+// spec yet, so use the plain Axios view. (Regenerate the SDK to type this once the endpoint ships.)
+const cm = apiClient as unknown as AxiosInstance;
+
+async function getSecretsPublicKeyFromClusterManager(clusterId: string): Promise<SecretsPublicKey> {
+	const { data } = await cm.post<{ publicKey: string; fingerprint: string }>('/ClusterSecrets', {
+		operation: 'get_secrets_public_key',
+		clusterId,
+	});
+	return { publicKey: data.publicKey, fingerprint: data.fingerprint };
+}
+
+export interface SecretsPublicKeySource extends InstanceClientIdConfig {
+	/**
+	 * For Fabric-managed clusters, the clusterId to fetch the key from central-manager
+	 * (central-manager#409): CM is the custodian there — it mints the keypair on first use and
+	 * delivers the private key to hosts, so the key exists (and is authoritative) even before any
+	 * node has custody registered. Omit for self-hosted/local, where the node mints its own
+	 * file-tier key and serves it via the `get_secrets_public_key` operation.
+	 */
+	managedClusterId?: string;
+}
+
+export function secretsPublicKeyQueryOptions(params: SecretsPublicKeySource) {
 	return queryOptions({
-		queryKey: [params.entityId, 'get_secrets_public_key'] as const,
-		queryFn: () => getSecretsPublicKey(params),
+		queryKey: [params.entityId, 'get_secrets_public_key', params.managedClusterId ?? 'node'] as const,
+		queryFn: () =>
+			params.managedClusterId
+				? getSecretsPublicKeyFromClusterManager(params.managedClusterId)
+				: getSecretsPublicKeyFromNode(params),
 		// The custody key can rotate (kid map), so refresh periodically instead of caching forever.
 		// Failure is a state, not a blip: without custody the node simply has no key.
 		staleTime: 5 * 60_000,
@@ -80,7 +114,7 @@ export function listSecretsQueryOptions(params: InstanceClientIdConfig) {
 	});
 }
 
-export interface SetSecretArgs extends InstanceClientIdConfig {
+export interface SetSecretArgs extends SecretsPublicKeySource {
 	name: string;
 	value: string;
 }
@@ -92,8 +126,8 @@ async function encryptAndSetSecret(queryClient: QueryClient, args: SetSecretArgs
 }> {
 	// Encrypt against the cluster public key so the plaintext value never leaves the browser. The
 	// envelope's sealed kid tells the cluster which key it was encrypted under.
-	const { public_key, fingerprint } = await queryClient.ensureQueryData(secretsPublicKeyQueryOptions(args));
-	const envelope = await encryptEnvelope(args.value, public_key, fingerprint);
+	const { publicKey, fingerprint } = await queryClient.ensureQueryData(secretsPublicKeyQueryOptions(args));
+	const envelope = await encryptEnvelope(args.value, publicKey, fingerprint);
 	try {
 		const { data } = await args.instanceClient.post('/', {
 			operation: 'set_secret',

--- a/src/integrations/api/instance/secrets/secrets.ts
+++ b/src/integrations/api/instance/secrets/secrets.ts
@@ -119,6 +119,15 @@ export function listSecretsQueryOptions(params: InstanceClientIdConfig) {
 export interface SetSecretArgs extends SecretsPublicKeySource {
 	name: string;
 	value: string;
+	/**
+	 * Delivery tier. true → materialized onto `process.env` for every component (global); false →
+	 * scoped, exposed only to granted components via the `secrets` accessor. Omit to preserve the
+	 * stored tier (the backend defaults a brand-new secret to scoped). processEnv and grants are
+	 * mutually exclusive — a processEnv secret is global, so it rejects grants.
+	 */
+	processEnv?: boolean;
+	/** Initial grants for a scoped secret (the add flow; edit manages grants via grant/revoke). */
+	grants?: string[];
 }
 
 async function encryptAndSetSecret(queryClient: QueryClient, args: SetSecretArgs, isRetry: boolean): Promise<{
@@ -135,6 +144,10 @@ async function encryptAndSetSecret(queryClient: QueryClient, args: SetSecretArgs
 			operation: 'set_secret',
 			name: args.name,
 			envelope,
+			// Only send the tier fields when the caller set them, so a plain value rotation preserves
+			// the stored tier (the backend falls back to the existing row otherwise).
+			...(args.processEnv !== undefined ? { processEnv: args.processEnv } : {}),
+			...(args.grants !== undefined ? { grants: args.grants } : {}),
 		});
 		return data;
 	} catch (error) {

--- a/src/integrations/api/instance/secrets/secrets.ts
+++ b/src/integrations/api/instance/secrets/secrets.ts
@@ -60,6 +60,18 @@ function operationErrorMessage(error: unknown): string {
 	return body?.error ?? body?.message ?? String(error);
 }
 
+/**
+ * CROSS-REPO CONTRACT with harper#1554: set_secret rejects an envelope whose sealed kid doesn't
+ * match the cluster's current secrets key with a message containing this phrase. The rotation
+ * self-heal below keys off it, so it's pinned here in one place rather than inlined — if harper
+ * rewords the message this is the single line to update. harper#1554 does not (yet) expose a
+ * stable error `code`; switch this to a code check the moment it does, and this substring can go.
+ */
+const KID_MISMATCH_ERROR_PHRASE = 'does not match';
+function isKidMismatchError(message: string): boolean {
+	return message.includes(KID_MISMATCH_ERROR_PHRASE);
+}
+
 async function getSecretsPublicKeyFromNode({ instanceClient }: InstanceClientIdConfig): Promise<SecretsPublicKey> {
 	const { data } = await instanceClient.post<{ public_key: string; fingerprint: string }>('/', {
 		operation: 'get_secrets_public_key',
@@ -155,7 +167,7 @@ async function encryptAndSetSecret(queryClient: QueryClient, args: SetSecretArgs
 		// A kid mismatch means our cached public key is stale (the custody key rotated). Drop the
 		// cached key (ensureQueryData returns stale entries, so invalidation isn't enough) and
 		// re-encrypt once; anything else (or a second mismatch) surfaces to the caller.
-		if (!isRetry && message.includes('does not match')) {
+		if (!isRetry && isKidMismatchError(message)) {
 			queryClient.removeQueries({ queryKey: secretsPublicKeyQueryOptions(args).queryKey });
 			return encryptAndSetSecret(queryClient, args, true);
 		}

--- a/src/lib/crypto/envSecret.test.ts
+++ b/src/lib/crypto/envSecret.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+// Runs in the node env so Web Crypto (globalThis.crypto.subtle, used by envSecret.ts) and node:crypto
+// (used here to stand in for the backend decrypt) are both available.
+import {
+	constants,
+	createDecipheriv,
+	createHash,
+	createPublicKey,
+	generateKeyPairSync,
+	privateDecrypt,
+} from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { encryptEnvelope, ENV_ENCRYPTED_PREFIX, fingerprintOf, isEncryptedEnvValue } from './envSecret';
+
+// Mirrors the backend enc:v1 decrypt (harper-pro envSecretCrypto / central-manager deploymentSecrets):
+// RSA-OAEP(SHA-256) unwraps the AES key, AES-256-GCM decrypts the value.
+function backendDecrypt(value: string, privateKeyPem: string): string {
+	const env = JSON.parse(Buffer.from(value.slice(ENV_ENCRYPTED_PREFIX.length), 'base64url').toString('utf8'));
+	const aesKey = privateDecrypt(
+		{ key: privateKeyPem, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: 'sha256' },
+		Buffer.from(env.k, 'base64'),
+	);
+	const decipher = createDecipheriv('aes-256-gcm', aesKey, Buffer.from(env.iv, 'base64'));
+	decipher.setAuthTag(Buffer.from(env.tag, 'base64'));
+	return Buffer.concat([decipher.update(Buffer.from(env.ct, 'base64')), decipher.final()]).toString('utf8');
+}
+
+// 2048-bit key keeps the test fast; the envelope code paths are identical at any RSA size.
+const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: 'spki', format: 'pem' },
+	privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+const publicKeyPem = publicKey as unknown as string;
+
+describe('envSecret (browser enc:v1)', () => {
+	it('fingerprintOf matches the backend (sha256 of DER SPKI)', async () => {
+		const der = createPublicKey(publicKeyPem).export({ type: 'spki', format: 'der' });
+		const expected = createHash('sha256').update(der).digest('hex');
+		expect(await fingerprintOf(publicKeyPem)).toBe(expected);
+	});
+
+	it('encrypts values the backend can decrypt (round-trip interop)', async () => {
+		const kid = await fingerprintOf(publicKeyPem);
+		const samples = [
+			'sk-1234567890',
+			'p@ss w#rd"with\'quotes',
+			'multi\nline\nvalue',
+			'unicode: café 🔐 日本語',
+			'-----BEGIN PRIVATE KEY-----\n' + 'A'.repeat(1500) + '\n-----END PRIVATE KEY-----\n',
+			'',
+		];
+		for (const value of samples) {
+			const envelope = await encryptEnvelope(value, publicKeyPem, kid);
+			expect(isEncryptedEnvValue(envelope)).toBe(true);
+			expect(backendDecrypt(envelope, privateKey as unknown as string)).toBe(value);
+		}
+	});
+
+	it('produces a fresh iv/key each call (no nonce reuse)', async () => {
+		const kid = await fingerprintOf(publicKeyPem);
+		const a = await encryptEnvelope('same', publicKeyPem, kid);
+		const b = await encryptEnvelope('same', publicKeyPem, kid);
+		expect(a).not.toBe(b);
+	});
+
+	it('isEncryptedEnvValue only matches the enc:v1 prefix', () => {
+		expect(isEncryptedEnvValue('plain')).toBe(false);
+		expect(isEncryptedEnvValue('enc:v2:x')).toBe(false);
+		expect(isEncryptedEnvValue(undefined)).toBe(false);
+	});
+});

--- a/src/lib/crypto/envSecret.ts
+++ b/src/lib/crypto/envSecret.ts
@@ -1,0 +1,107 @@
+/**
+ * Client-side `enc:v1:` envelope encryption using the Web Crypto API, matching the backend contract
+ * in core/docs/env-secret-encryption.md. Hybrid: AES-256-GCM encrypts the value, RSA-OAEP(SHA-256)
+ * wraps the AES key. Secret values are encrypted in the browser and never leave it in plaintext.
+ *
+ *   enc:v1:<base64url(JSON{ kid, k, iv, ct, tag })>
+ */
+
+export const ENV_ENCRYPTED_PREFIX = 'enc:v1:';
+
+function pemToDer(pem: string): Uint8Array {
+	const b64 = pem
+		.replace(/-----BEGIN [^-]+-----/, '')
+		.replace(/-----END [^-]+-----/, '')
+		.replace(/\s+/g, '');
+	const bin = atob(b64);
+	const bytes = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) { bytes[i] = bin.charCodeAt(i); }
+	return bytes;
+}
+
+function toBase64(bytes: Uint8Array): string {
+	let s = '';
+	for (let i = 0; i < bytes.length; i++) { s += String.fromCharCode(bytes[i]); }
+	return btoa(s);
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+	return toBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function toHex(buffer: ArrayBuffer): string {
+	return Array.from(new Uint8Array(buffer))
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+// Web Crypto's BufferSource typing (TS 5.7+) rejects Uint8Array<ArrayBufferLike>; hand it a plain
+// ArrayBuffer copy of the bytes.
+function ab(bytes: Uint8Array): ArrayBuffer {
+	// Avoid a copy when the view already spans its whole buffer (the common case here).
+	if (bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength) {
+		return bytes.buffer as ArrayBuffer;
+	}
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+// Web Crypto's SubtleCrypto is only available in secure contexts (HTTPS or localhost). Fail with a
+// clear message rather than a cryptic `undefined` access when the app is served over plain HTTP.
+function requireSubtle(): SubtleCrypto {
+	if (typeof crypto === 'undefined' || !crypto.subtle) {
+		throw new Error('Secret encryption requires a secure context (HTTPS or localhost).');
+	}
+	return crypto.subtle;
+}
+
+/** True if a value is an `enc:v1:` envelope rather than a plaintext value. */
+export function isEncryptedEnvValue(value: unknown): value is string {
+	return typeof value === 'string' && value.startsWith(ENV_ENCRYPTED_PREFIX);
+}
+
+/**
+ * SHA-256 (hex) of the DER SPKI public key — the envelope `kid`. Matches the backend `fingerprintOf`
+ * so a value encrypted here targets the right key during rotation.
+ */
+export async function fingerprintOf(publicKeyPem: string): Promise<string> {
+	const subtle = requireSubtle();
+	const der = pemToDer(publicKeyPem);
+	return toHex(await subtle.digest('SHA-256', ab(der)));
+}
+
+/**
+ * Encrypt a value into an `enc:v1:` envelope for the given public key. `kid` should be
+ * `fingerprintOf(publicKeyPem)` (the server returns it alongside the key).
+ */
+export async function encryptEnvelope(plaintext: string, publicKeyPem: string, kid: string): Promise<string> {
+	const subtle = requireSubtle();
+	const der = pemToDer(publicKeyPem);
+	const rsaKey = await subtle.importKey('spki', ab(der), { name: 'RSA-OAEP', hash: 'SHA-256' }, false, [
+		'encrypt',
+	]);
+
+	const aesKeyBytes = crypto.getRandomValues(new Uint8Array(32));
+	const iv = crypto.getRandomValues(new Uint8Array(12));
+	const aesKey = await subtle.importKey('raw', ab(aesKeyBytes), { name: 'AES-GCM' }, false, ['encrypt']);
+
+	const sealed = new Uint8Array(
+		await subtle.encrypt(
+			{ name: 'AES-GCM', iv: ab(iv), tagLength: 128 },
+			aesKey,
+			ab(new TextEncoder().encode(plaintext)),
+		),
+	);
+	// Web Crypto appends the 16-byte GCM tag to the ciphertext; the backend expects them separate.
+	const ct = sealed.slice(0, sealed.length - 16);
+	const tag = sealed.slice(sealed.length - 16);
+	const wrappedKey = new Uint8Array(await subtle.encrypt({ name: 'RSA-OAEP' }, rsaKey, ab(aesKeyBytes)));
+
+	const envelope = {
+		kid,
+		k: toBase64(wrappedKey),
+		iv: toBase64(iv),
+		ct: toBase64(ct),
+		tag: toBase64(tag),
+	};
+	return ENV_ENCRYPTED_PREFIX + toBase64Url(new TextEncoder().encode(JSON.stringify(envelope)));
+}

--- a/src/lib/string/wasAReleasedBeforeB.test.ts
+++ b/src/lib/string/wasAReleasedBeforeB.test.ts
@@ -43,6 +43,23 @@ describe('wasAReleasedBeforeB (b >= a)', () => {
 		expect(wasAReleasedBeforeB('3.4.5', '3.4.5')).toBe(true);
 		expect(wasAReleasedBeforeB('3.4.5-beta.2', '3.4.5-beta.2')).toBe(true);
 	});
+
+	// The Secrets nav gate (src/features/instance/config/index.tsx) floors at '5.2.0-alpha.1' rather
+	// than '5.2.0' so the harper#1554 alpha/beta dev builds pass it too. Guard that intent: a plain
+	// '5.2.0' floor would header-exclude every prerelease, hiding the page on the very builds it ships in.
+	it('5.2.0-alpha.1 secrets gate admits 5.2 prereleases/rc/final but not pre-5.2 builds', () => {
+		const gate = '5.2.0-alpha.1';
+		expect(wasAReleasedBeforeB(gate, '5.1.15')).toBe(false); // current stage line — hidden
+		expect(wasAReleasedBeforeB(gate, '5.2.0-alpha.1')).toBe(true); // earliest 5.2 prerelease — shown
+		expect(wasAReleasedBeforeB(gate, '5.2.0-alpha.2')).toBe(true);
+		expect(wasAReleasedBeforeB(gate, '5.2.0-beta.1')).toBe(true); // the shipping beta — shown
+		expect(wasAReleasedBeforeB(gate, '5.2.0-rc.1')).toBe(true);
+		expect(wasAReleasedBeforeB(gate, '5.2.0')).toBe(true); // final release — shown
+		expect(wasAReleasedBeforeB(gate, '5.2.1')).toBe(true);
+		expect(wasAReleasedBeforeB(gate, '5.2.0-alpha.1+abcdef')).toBe(true); // build metadata ignored
+		// A plain '5.2.0' floor would wrongly hide the shipping prereleases — the bug this gate avoids:
+		expect(wasAReleasedBeforeB('5.2.0', '5.2.0-alpha.1')).toBe(false);
+	});
 });
 
 import { compareVersions } from './wasAReleasedBeforeB';


### PR DESCRIPTION
> Built on the shared secrets components from #1409 (merged). The backends it consumes have landed — core's `hdb_secret` store (harper#1554), the Pro key-custody layer (harper-pro#512, tracking issue harper-pro#166), and central-manager's custody keypair endpoints (central-manager#409); only host-manager#130 (key delivery into Fabric containers) is still in flight, which affects runtime decrypt on managed clusters, not this UI. Version-gated to Harper ≥ 5.2 (`5.2.0-alpha.1`), so it's invisible until a cluster opts into 5.2 — safe to merge when ready.

## What

**Config → Secrets** manages the replicated `system.hdb_secret` store: named, envelope-encrypted rows on the cluster itself, edited through the per-instance operations API and scoped to applications via grants. Built on the shared `SecretsManager` / `SecretModals` components from #1409.

- **`integrations/api/instance/secrets/secrets.ts`** — hooks for `list_secrets` / `set_secret` / `delete_secret` / `grant_secret` / `revoke_secret`, plus public-key resolution:
  - **Managed clusters** fetch the public key from central-manager (`POST /ClusterSecrets`, per central-manager#409) — CM is the custodian there, and Studio's key fetch is what triggers the first-use mint. Requires cluster-update rights on first use (the mint stamps fingerprints onto instances). The fetch waits for the cluster lookup to succeed before choosing node-vs-CM, so a managed cluster is never mis-routed to the node key (even on a failed lookup).
  - **Self-hosted / local** instances use the node's `get_secrets_public_key` operation (file-tier custody mints its own key).
  - Both shapes (camelCase vs snake_case) normalize to one interface.
- **Client-side encryption** (`lib/crypto/envSecret.ts`, the `enc:v1` codec harper#1554 ported into core): values are encrypted in the browser and submitted as envelopes to the cluster's own `set_secret` — plaintext never reaches the operations API, the operation log, disk, or CM, and can never be read back.
- **Delivery tier + access examples**: each secret is either **scoped** (read via the `secrets` accessor — `const { NAME } = secrets` — by the apps you grant) or a global **environment variable** (`process.env.NAME`, every component and its child processes). The add/edit dialogs let you pick the tier and show a copy-paste-correct, name-aware code example for reading it; the two tiers are mutually exclusive server-side (a global secret can't be scoped).
- **Rotation/race-aware**: the public key is cached for minutes (not forever); a kid-mismatch rejection drops the cached key, re-encrypts against the freshly served key, and retries once. This is also the documented heal for CM's transient first-mint race (two CM workers minting concurrently — the loser's envelopes kid-mismatch, re-encrypting fixes them).
- **Grants editor** in the edit dialog: for scoped secrets, grant/revoke apply immediately; env-var secrets hide the grants editor (they're global), and flipping a saved env-var secret to scoped prompts a save first so a doomed `grant_secret` never fires. Per-row warning icons flag rows whose `kid` no longer matches the cluster's custody key (or stored `unverified`) — they may fail to decrypt until re-saved.
- **Custody-aware degradation**: without a secrets key (no custody registered, CM unreachable, or pre-#409 CM) the list stays browsable, a banner explains why, and add/edit is disabled. A failed cluster lookup gets its own distinct read-only banner rather than the misleading "no key" one.
- **Gating**: nav entry is version-gated (`>= 5.2.0-alpha.1`, so 5.2 beta/prerelease builds pass too) and manage-gated like every other Config entry; the secret operations are super_user-only server-side. The store ships in core, so it isn't restricted to Fabric-managed clusters.

## Verification
- `tsc`, `oxlint`, `dprint` clean; full suite green (1289 tests). Secrets-hook tests run **real WebCrypto RSA keys**, asserting plaintext never appears in a request body, the CM-vs-node key routing, and the rotation retry re-encrypting under the newly served key; jsdom tests drive the delivery-tier dialog end-to-end (the `process.env` vs `secrets` example swap, the submitted `{ processEnv, grants }`, and the grant-scoping guard on an unsaved tier switch).
- **Click-tested live** on stage (Harper 5.1.14, CM without #409): the version gate correctly hides the nav entry, and direct navigation shows the degraded state (banner, read-only, empty list) with the key fetch correctly routed to CM's `/ClusterSecrets` for the managed cluster.
- The full write path (set/grant/delete) needs a Harper build with #1554 and a CM with #409 — covered by the hook tests until then.

## Notes / open items
- The version gate floors at `5.2.0-alpha.1` (matching harper#1554's upgrade directive, tagged 5.2.0) so alpha/beta prerelease builds pass too; retag if it ships in a different release.
- `/ClusterSecrets` isn't in central-manager's generated OpenAPI spec (the generator only emits method-level `@path` JSDoc, and these resources carry class-level docs), so regenerating the SDK won't type it — the plain-Axios view is the standing approach, not a stopgap.
- The rotation retry keys off harper#1554's error phrase (`does not match`), centralized in one documented constant as a cross-repo contract; swap for a stable error `code` once the backend exposes one.
- Grant names are free text (grants may precede a deploy, matching the backend's stance); a picker fed by `get_components` would be a nice follow-up.
- History: the first cut posted to the central-manager `ClusterSecrets` store from central-manager#405 (control-plane values + host-manager value injection). That model was superseded by the two-key custody plan (harper-pro#166 / central-manager#409: CM keeps the *key*, the cluster keeps the *ciphertext*), and this page was retargeted accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Related PRs — secrets management

One `enc:v1:` client contract everywhere (public key + envelope; values encrypted before they leave the client):

- **Core (Apache):**
  - HarperFast/harper#1527 — `.env` protection in the operations API — merged (consumed by #1409)
  - HarperFast/harper#1528 — dormant `enc:v1:` decrypt hook + envelope contract — merged
  - HarperFast/harper#1554 — `hdb_secret` store with grant-scoped secret operations + `get_secrets_public_key` — merged
  - HarperFast/harper#1559 — workerData providers + deferred decrypt replay — merged
- **Pro key custody (tracked by HarperFast/harper-pro#166):**
  - HarperFast/harper-pro#512 — KeyCustody seam: `file` (self-hosted) + `injected` (Fabric) providers; supersedes harper-pro#505 — merged
- **Fabric control plane:**
  - HarperFast/central-manager#409 — per-cluster custody keypair: eager keygen, pull delivery, public-key endpoints; supersedes the CM half of central-manager#405 — merged
  - HarperFast/host-manager#130 — key delivery into containers; supersedes host-manager#128 — open (runtime decrypt on managed clusters; not required by this UI)
- **UI (this stack):**
  - HarperFast/studio#1409 — application-editor `.env` panel — merged
  - HarperFast/studio#1402 — this PR: cluster Secrets page (built on #1409)
