### PR TITLE
feat(cluster): explicit cluster home for connecting

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,23 +10,10 @@ import { Version } from '@/components/Version';
 import { defaultInstanceRoute, isLocalStudio } from '@/config/constants';
 import { useLogoutMutation } from '@/features/auth/hooks/useLogout';
 import { useOverallAuth } from '@/hooks/useAuth';
-import { useOrganizationPermissions, useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
-import { Link, useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import {
-	BookOpenTextIcon,
-	BugIcon,
-	BuildingIcon,
-	HandshakeIcon,
-	LogInIcon,
-	LogOutIcon,
-	Menu,
-	ReceiptIcon,
-	UserIcon,
-	UsersIcon,
-	X,
-} from 'lucide-react';
+import { Link, useNavigate, useRouter } from '@tanstack/react-router';
+import { BookOpenTextIcon, BugIcon, LogInIcon, LogOutIcon, Menu, UserIcon, X } from 'lucide-react';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -37,10 +24,6 @@ export function Navbar() {
 	const navigate = useNavigate();
 	const { user } = useOverallAuth();
 	const router = useRouter();
-	const { organizationId }: { organizationId: string } = useParams({ strict: false });
-	const { update: canUpdateOrganization } = useOrganizationPermissions(organizationId);
-	const { view: showOrgUsersAndRoles } = useOrganizationRolePermissions(organizationId);
-	const showBilling = canUpdateOrganization;
 
 	const handleSignOut = useCallback(() => {
 		signOut(undefined, {
@@ -61,35 +44,8 @@ export function Navbar() {
 	const menuItems: Array<MenuGroup | MenuItem> = useMemo(
 		() =>
 			[
-				!isLocalStudio && {
-					to: '/',
-					icon: <BuildingIcon />,
-					text: 'Organizations',
-					textBreakpoint: 'xl',
-				},
-				!isLocalStudio && {
-					text: 'SubOrganizations',
-					items: [
-						showOrgUsersAndRoles && {
-							to: `/${organizationId}/roles`,
-							icon: <HandshakeIcon />,
-							text: 'Roles',
-							textBreakpoint: 'lg',
-						},
-						showOrgUsersAndRoles && {
-							to: `/${organizationId}/users`,
-							icon: <UsersIcon />,
-							text: 'Users',
-							textBreakpoint: 'lg',
-						},
-						showBilling && {
-							to: `/${organizationId}/billing`,
-							icon: <ReceiptIcon />,
-							text: 'Billing',
-							textBreakpoint: 'xl',
-						},
-					].filter(excludeFalsy),
-				},
+				// Organizations lives in the breadcrumbs; Roles / Users / Billing moved into the org page's
+				// sub-nav (OrgPageLayout), so they're no longer in the global header.
 				!isLocalStudio && {
 					to: '/profile',
 					icon: <UserIcon />,
@@ -124,7 +80,7 @@ export function Navbar() {
 					textBreakpoint: isLocalStudio ? 'md' : 'xl',
 				},
 			].filter(excludeFalsy) satisfies Array<MenuGroup | MenuItem>,
-		[organizationId, showBilling, showOrgUsersAndRoles, handleSignOut],
+		[handleSignOut],
 	);
 
 	if (!user) {

--- a/src/components/SubNavRail.tsx
+++ b/src/components/SubNavRail.tsx
@@ -1,0 +1,112 @@
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
+import { Link, useLocation } from '@tanstack/react-router';
+import { ChevronDown } from 'lucide-react';
+import { ComponentType } from 'react';
+
+export interface SubNavSubItem {
+	to: string;
+	label: string;
+	exact?: boolean;
+}
+
+export interface SubNavItem {
+	to: string;
+	label: string;
+	icon: ComponentType<{ className?: string }>;
+	exact?: boolean;
+	children?: SubNavSubItem[];
+}
+
+const linkClasses = 'flex items-center gap-3 p-2 rounded-lg text-sm transition-colors';
+const subLinkClasses = 'block p-2 rounded-lg text-sm transition-colors';
+const inactiveProps = { className: 'text-foreground hover:bg-accent dark:text-white dark:hover:bg-grey-700' };
+const activeProps = { className: 'font-medium text-primary bg-primary/10 dark:text-white dark:bg-white/10' };
+
+/**
+ * Responsive section rail shared by the org and cluster page layouts: a vertical left rail when
+ * there's room, a dropdown when small. A section with sub-items expands them underneath when it's the
+ * active section (desktop) or as indented items in the dropdown (small).
+ */
+export function SubNavRail({ items, ariaLabel }: { items: SubNavItem[]; ariaLabel: string }) {
+	const { pathname } = useLocation();
+	const isSectionActive = (item: SubNavItem) => item.exact ? pathname === item.to : pathname.startsWith(item.to);
+	const active = items.find(isSectionActive) ?? items[0];
+	const ActiveIcon = active.icon;
+
+	return (
+		<>
+			<nav className="hidden md:flex flex-col gap-1" aria-label={ariaLabel}>
+				{items.map((item) => {
+					const Icon = item.icon;
+					return (
+						<div key={item.to}>
+							<Link
+								to={item.to}
+								className={linkClasses}
+								activeOptions={{ exact: !!item.exact }}
+								activeProps={activeProps}
+								inactiveProps={inactiveProps}
+							>
+								<Icon className="size-4 shrink-0" />
+								{item.label}
+							</Link>
+							{item.children && isSectionActive(item) && (
+								<div className="mt-1 ml-4 flex flex-col gap-1 border-l border-border pl-3">
+									{item.children.map((child) => (
+										<Link
+											key={child.to}
+											to={child.to}
+											className={subLinkClasses}
+											activeOptions={{ exact: !!child.exact }}
+											activeProps={activeProps}
+											inactiveProps={inactiveProps}
+										>
+											{child.label}
+										</Link>
+									))}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</nav>
+
+			<div className="md:hidden">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button variant="outline" className="w-full justify-between">
+							<span className="flex items-center gap-2">
+								<ActiveIcon className="size-4" />
+								{active.label}
+							</span>
+							<ChevronDown className="size-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
+						{items.map((item) => {
+							const Icon = item.icon;
+							return [
+								<DropdownMenuItem key={item.to} asChild>
+									<Link to={item.to} className="flex items-center gap-2">
+										<Icon className="size-4" />
+										{item.label}
+									</Link>
+								</DropdownMenuItem>,
+								...(item.children && isSectionActive(item)
+									? item.children.map((child) => (
+										<DropdownMenuItem key={child.to} asChild>
+											<Link to={child.to} className="flex items-center gap-2 pl-8">
+												{child.label}
+											</Link>
+										</DropdownMenuItem>
+									))
+									: []),
+							];
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		</>
+	);
+}

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -60,6 +60,7 @@ class AuthStore {
 	private readonly potentiallyAuthenticatedKey = 'Studio:PotentiallyAuthenticated';
 	private readonly basicAuthKeyPrefix = 'Studio:BasicAuth:';
 	private readonly fabricConnectKeyPrefix = 'Studio:FabricConnect:';
+	private readonly lastConnectModeKeyPrefix = 'Studio:LastConnectMode:';
 	private readonly potentiallyAuthenticated: Record<EntityIds, AuthenticatedConnectionKey>;
 	private readonly checkedAuthentication: Record<EntityIds, boolean> = {};
 	private readonly allConnections: Record<EntityIds, AuthenticatedConnection> = {};
@@ -209,6 +210,20 @@ class AuthStore {
 		}
 	}
 
+	/**
+	 * Remembers which connection mode the user last chose for an entity, so the cluster landing page
+	 * can highlight it with a "Last used" pill. Persisted (unlike the JWT) — it's a preference, not a
+	 * secret.
+	 */
+	public setLastConnectMode(id: EntityIds, mode: 'fabric' | 'direct') {
+		localStorage.setItem(this.lastConnectModeKeyPrefix + id, mode);
+	}
+
+	public getLastConnectMode(id: EntityIds): 'fabric' | 'direct' | undefined {
+		const value = localStorage.getItem(this.lastConnectModeKeyPrefix + id);
+		return value === 'fabric' || value === 'direct' ? value : undefined;
+	}
+
 	/** The in-memory Fabric Connect JWT for direct connect, or undefined if not connected directly. */
 	public getOperationToken(id: EntityIds): string | undefined {
 		const fabric = this.fabricConnectAuth.get(id);
@@ -323,6 +338,7 @@ class AuthStore {
 					const directClient = getInstanceClient({ id, operationsUrl, forceOperationToken: true });
 					const user = await getInstanceUserInfo({ instanceClient: directClient });
 					this.flagForFabricConnect(id, true);
+					this.setLastConnectMode(id, 'fabric');
 					this.setUserForIdAndKey(id, operationsUrl, user);
 					return user;
 				} catch (directErr) {
@@ -340,6 +356,7 @@ class AuthStore {
 			const proxyClient = getInstanceClient({ id, forceFabricConnect: true });
 			const user = await getInstanceUserInfo({ instanceClient: proxyClient });
 			this.flagForFabricConnect(id, true);
+			this.setLastConnectMode(id, 'fabric');
 			this.setUserForIdAndKey(id, operationsUrl || proxyClient.defaults.baseURL!, user);
 			return user;
 		} catch (err) {

--- a/src/features/auth/store/establishFabricConnectAuth.test.ts
+++ b/src/features/auth/store/establishFabricConnectAuth.test.ts
@@ -53,6 +53,8 @@ describe('authStore.establishFabricConnectAuth', () => {
 		expect(authStore.getOperationToken('ins-1')).toBe('jwt-token');
 		expect(authStore.hasResolvedFabricConnect('ins-1')).toBe(true);
 		expect(authStore.checkForFabricConnect('ins-1')).toBe(true);
+		// Remembered for the cluster landing page's "Last used" pill.
+		expect(authStore.getLastConnectMode('ins-1')).toBe('fabric');
 	});
 
 	it('drops the JWT and falls back to the proxy when direct connect is unreachable', async () => {

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,7 +1,7 @@
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
-import { activeClusterStatuses } from '@/config/clusterStatuses';
+import { activeClusterStatuses, deletedClusterStatuses } from '@/config/clusterStatuses';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
 import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
@@ -9,13 +9,16 @@ import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getCluste
 import { useInstanceAuth } from '@/hooks/useAuth';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
+import { Cluster } from '@/integrations/api/api.patch';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
+import { byInstanceFqdnThenPort } from '@/lib/arrays/sort/byInstanceFqdnThenPort';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Navigate, useNavigate, useParams, useRouter } from '@tanstack/react-router';
 import { ArrowRight, CircleCheck, Copy, ExternalLink, KeyRound, Loader2, Rocket, Server, Zap } from 'lucide-react';
-import { ComponentType, ReactNode, useCallback, useState } from 'react';
+import { ComponentType, ReactNode, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 export function ClusterHome() {
@@ -82,6 +85,9 @@ export function ClusterHome() {
 	}
 	if (!view) {
 		return <Navigate to={`/${cluster.organizationId}`} replace />;
+	}
+	if (clusterIsSelfManaged(cluster)) {
+		return <SelfHostedClusterHome cluster={cluster} />;
 	}
 	if (!cluster.fqdn) {
 		return <Navigate to={`${base}/instances`} replace />;
@@ -230,6 +236,133 @@ export function ClusterHome() {
 	);
 }
 
+// The self-hosted overview: no managed-cluster status, FQDN, or Fabric Connect — connections are made
+// directly to the registered instances, so this connects to (and enters through) the first instance.
+function SelfHostedClusterHome({ cluster }: { cluster: Cluster }) {
+	const router = useRouter();
+	const navigate = useNavigate();
+	const base = `/${cluster.organizationId}/${cluster.id}`;
+
+	const instances = useMemo(
+		() =>
+			(cluster.instances ?? [])
+				.filter((instance) => instance.status && !deletedClusterStatuses.includes(instance.status))
+				.sort(byInstanceFqdnThenPort),
+		[cluster.instances],
+	);
+	const firstInstance = instances.at(0);
+	const { user, isLoading } = useInstanceAuth(firstInstance?.id);
+	const connected = !!firstInstance && !!user;
+
+	const onDirectSignIn = useCallback(() => {
+		if (!firstInstance) { return; }
+		void navigate({ to: `${base}/instance/${firstInstance.id}/sign-in` });
+	}, [base, firstInstance, navigate]);
+
+	const onDisconnect = useCallback(async () => {
+		if (!firstInstance) { return; }
+		try {
+			await onInstanceLogoutSubmit({
+				instanceClient: getInstanceClient({
+					id: firstInstance.id,
+					operationsUrl: getOperationsUrlForInstance(firstInstance),
+				}),
+				entityId: firstInstance.id,
+			});
+		} catch {
+			// Ignore: we're clearing local state regardless of the server response.
+		}
+		authStore.setUserForEntity(firstInstance, null);
+		authStore.flagForBasicAuth(firstInstance.id, null);
+		await router.invalidate();
+	}, [firstInstance, router]);
+
+	return (
+		<ClusterHomeShell>
+			<div className="flex items-start gap-4 mb-6">
+				<div className="flex items-center justify-center size-12 rounded-xl bg-violet-50 text-primary dark:bg-grey-700 dark:text-violet-300 shrink-0">
+					<Server className="size-6" />
+				</div>
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-3 flex-wrap">
+						<h1 className="text-2xl font-light text-foreground">{cluster.name}</h1>
+						<span className="inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full text-muted-foreground bg-muted">
+							Self-Hosted
+						</span>
+					</div>
+					<div className="mt-1 text-sm text-muted-foreground">
+						<Link to={`${base}/instances`} className="hover:text-foreground hover:underline">
+							{instances.length} {instances.length === 1 ? 'instance' : 'instances'}
+						</Link>
+					</div>
+				</div>
+			</div>
+
+			{!firstInstance
+				? (
+					<p className="text-sm text-muted-foreground">
+						This cluster has no instances yet. Register one from the{' '}
+						<Link to={`${base}/instances`} className="underline hover:text-foreground">Instances</Link> page.
+					</p>
+				)
+				: isLoading
+				? <Spinner />
+				: connected
+				? (
+					<div>
+						<div className="flex items-center gap-2 mb-4 text-sm">
+							<CircleCheck className="size-4 text-green shrink-0" />
+							<span className="font-medium text-green">Signed in directly</span>
+							<span className="text-xs text-muted-foreground">
+								· {firstInstance.name || firstInstance.instanceFqdn}
+							</span>
+						</div>
+
+						<Link
+							to={`${base}/instance/${firstInstance.id}/`}
+							className="group flex items-center gap-4 rounded-2xl border-2 border-primary/30 bg-primary/5 p-6 transition-all hover:border-primary hover:bg-primary/10 dark:border-violet-400/30 dark:bg-violet-400/5 dark:hover:border-violet-400 dark:hover:bg-violet-400/10"
+						>
+							<div className="flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary shrink-0 dark:bg-violet-400/15 dark:text-violet-300">
+								<Rocket className="size-6" />
+							</div>
+							<div className="flex-1 min-w-0">
+								<div className="text-lg font-medium text-foreground">Enter cluster</div>
+								<div className="text-sm text-muted-foreground">
+									Open the studio — apps, databases, APIs, logs, and config.
+								</div>
+							</div>
+							<ArrowRight className="size-5 text-muted-foreground transition-transform group-hover:translate-x-1" />
+						</Link>
+
+						<div className="mt-4 flex flex-wrap gap-4 text-sm">
+							<button
+								type="button"
+								onClick={() => void onDisconnect()}
+								className="text-muted-foreground hover:text-destructive transition-colors"
+							>
+								Direct sign out
+							</button>
+						</div>
+					</div>
+				)
+				: (
+					<div>
+						<h2 className="text-sm font-medium text-foreground mb-3">Connect to this cluster</h2>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+							<ConnectOption
+								icon={KeyRound}
+								title="Direct sign-in"
+								description="Sign in with this instance's Harper username and password."
+							>
+								<Button className="w-full" variant="outline" onClick={onDirectSignIn}>Direct sign-in</Button>
+							</ConnectOption>
+						</div>
+					</div>
+				)}
+		</ClusterHomeShell>
+	);
+}
+
 function ClusterHomeShell({ children }: { children: ReactNode }) {
 	return (
 		<>
@@ -283,15 +416,18 @@ function ConnectOption(
 			}`}
 		>
 			{pill && (
-				<span
-					className={`absolute -top-2.5 left-4 inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full ${
-						pill === 'last'
-							? 'text-green bg-green/15'
-							: 'text-primary bg-violet-50 dark:text-violet-300 dark:bg-grey-700'
-					}`}
-				>
-					{pill === 'last' && <span className="size-1.5 rounded-full bg-current" />}
-					{pill === 'last' ? 'Last used' : 'Recommended'}
+				// Solid backdrop so the card's border doesn't show through the translucent pill color.
+				<span className="absolute -top-2.5 left-4 rounded-full bg-card">
+					<span
+						className={`inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full ${
+							pill === 'last'
+								? 'text-green bg-green/15'
+								: 'text-primary bg-violet-50 dark:text-violet-300 dark:bg-grey-700'
+						}`}
+					>
+						{pill === 'last' && <span className="size-1.5 rounded-full bg-current" />}
+						{pill === 'last' ? 'Last used' : 'Recommended'}
+					</span>
 				</span>
 			)}
 			<Icon className="size-6 text-primary dark:text-violet-300 mb-2" />

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,3 +1,4 @@
+import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { Button } from '@/components/ui/button';
 import { activeClusterStatuses } from '@/config/clusterStatuses';
 import { defaultInstanceRoute } from '@/config/constants';
@@ -195,7 +196,14 @@ export function ClusterHome() {
 }
 
 function ClusterHomeShell({ children }: { children: ReactNode }) {
-	return <div className="max-w-3xl mx-auto px-4 md:px-6 py-8">{children}</div>;
+	return (
+		<>
+			<nav className="fixed top-20 w-full h-12 z-39 px-4 md:px-12 bg-violet-50 border-b border-violet-100 dark:bg-grey-700 dark:border-none flex items-center">
+				<Breadcrumbs />
+			</nav>
+			<div className="mt-32 max-w-3xl mx-auto px-4 md:px-6 pb-10">{children}</div>
+		</>
+	);
 }
 
 function Spinner() {

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,8 +1,9 @@
-import { Breadcrumbs } from '@/components/Breadcrumbs';
+import { SubNavMenu } from '@/components/SubNavMenu';
 import { Button } from '@/components/ui/button';
 import { activeClusterStatuses } from '@/config/clusterStatuses';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
+import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { useInstanceAuth } from '@/hooks/useAuth';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
@@ -11,7 +12,7 @@ import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInsta
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Navigate, useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import { ArrowRight, CircleCheck, Database, Gauge, Globe, KeyRound, Loader2, Server, Zap } from 'lucide-react';
+import { ArrowRight, CircleCheck, KeyRound, Loader2, Server, Zap } from 'lucide-react';
 import { ComponentType, ReactNode, useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -155,41 +156,6 @@ export function ClusterHome() {
 						</div>
 					</div>
 				)}
-
-			<div className="mt-7 pt-5 border-t border-border">
-				<div className="text-xs text-muted-foreground mb-3">Manage</div>
-				<div className="grid grid-cols-2 md:grid-cols-3 gap-2.5">
-					<ManageTile
-						to={`${base}/instances`}
-						icon={Server}
-						label="Instances"
-						hint={`${cluster.instances?.length ?? 0} running`}
-						enabled={connected}
-					/>
-					<ManageTile
-						to={`${base}/databases`}
-						icon={Database}
-						label="Databases"
-						hint="Browse and query"
-						enabled={connected}
-					/>
-					<ManageTile
-						to={`${base}/scaling`}
-						icon={Gauge}
-						label="Scaling"
-						hint="Size and replicas"
-						enabled={connected && update}
-					/>
-					<ManageTile
-						to={`${base}/domains`}
-						icon={Globe}
-						label="Domains"
-						hint="Custom domains"
-						enabled={connected && update}
-					/>
-				</div>
-				<div className="mt-3.5 text-xs text-muted-foreground">Scaling and domains require manage permission.</div>
-			</div>
 		</ClusterHomeShell>
 	);
 }
@@ -197,10 +163,10 @@ export function ClusterHome() {
 function ClusterHomeShell({ children }: { children: ReactNode }) {
 	return (
 		<>
-			<nav className="fixed top-20 w-full h-12 z-39 px-4 md:px-12 bg-violet-50 border-b border-violet-100 dark:bg-grey-700 dark:border-none flex items-center">
-				<Breadcrumbs />
-			</nav>
-			<div className="mt-40 max-w-3xl mx-auto px-4 md:px-6 pb-10">{children}</div>
+			<SubNavMenu />
+			<ClusterPageLayout>
+				<div className="max-w-3xl">{children}</div>
+			</ClusterPageLayout>
 		</>
 	);
 }
@@ -263,38 +229,5 @@ function ConnectOption(
 			<p className="text-[13px] text-muted-foreground leading-normal mb-4">{description}</p>
 			{children}
 		</div>
-	);
-}
-
-function ManageTile(
-	{ to, icon: Icon, label, hint, enabled }: {
-		to: string;
-		icon: ComponentType<{ className?: string }>;
-		label: string;
-		hint: string;
-		enabled: boolean;
-	},
-) {
-	const body = (
-		<>
-			<Icon className="size-5 text-primary dark:text-violet-300 shrink-0" />
-			<div className="min-w-0">
-				<div className="text-[13px] font-medium text-foreground truncate">{label}</div>
-				<div className="text-[11px] text-muted-foreground truncate">{hint}</div>
-			</div>
-		</>
-	);
-	const className =
-		'flex items-center gap-3 p-3 rounded-xl border border-border bg-card transition-[transform,border-color,background-color] duration-150';
-	if (!enabled) {
-		return <div className={`${className} opacity-50`} aria-disabled>{body}</div>;
-	}
-	return (
-		<Link
-			to={to}
-			className={`${className} hover:scale-[1.02] hover:bg-accent/60 hover:border-primary/50 dark:hover:border-violet-400/60`}
-		>
-			{body}
-		</Link>
 	);
 }

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -200,7 +200,7 @@ function ClusterHomeShell({ children }: { children: ReactNode }) {
 			<nav className="fixed top-20 w-full h-12 z-39 px-4 md:px-12 bg-violet-50 border-b border-violet-100 dark:bg-grey-700 dark:border-none flex items-center">
 				<Breadcrumbs />
 			</nav>
-			<div className="mt-32 max-w-3xl mx-auto px-4 md:px-6 pb-10">{children}</div>
+			<div className="mt-40 max-w-3xl mx-auto px-4 md:px-6 pb-10">{children}</div>
 		</>
 	);
 }

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -88,7 +88,7 @@ export function ClusterHome() {
 	return (
 		<ClusterHomeShell>
 			<div className="flex items-start gap-4 mb-6">
-				<div className="flex items-center justify-center size-12 rounded-xl bg-violet-50 text-primary dark:bg-grey-700 shrink-0">
+				<div className="flex items-center justify-center size-12 rounded-xl bg-violet-50 text-primary dark:bg-grey-700 dark:text-violet-300 shrink-0">
 					<Server className="size-6" />
 				</div>
 				<div className="flex-1 min-w-0">
@@ -243,21 +243,23 @@ function ConnectOption(
 				pill === 'last'
 					? 'border-2 border-green'
 					: pill === 'recommended'
-					? 'border-2 border-primary'
+					? 'border-2 border-primary dark:border-violet-400'
 					: 'border-border'
 			}`}
 		>
 			{pill && (
 				<span
 					className={`absolute -top-2.5 left-4 inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full ${
-						pill === 'last' ? 'text-green bg-green/15' : 'text-primary bg-violet-50 dark:bg-grey-700'
+						pill === 'last'
+							? 'text-green bg-green/15'
+							: 'text-primary bg-violet-50 dark:text-violet-300 dark:bg-grey-700'
 					}`}
 				>
 					{pill === 'last' && <span className="size-1.5 rounded-full bg-current" />}
 					{pill === 'last' ? 'Last used' : 'Recommended'}
 				</span>
 			)}
-			<Icon className="size-6 text-primary mb-2" />
+			<Icon className="size-6 text-primary dark:text-violet-300 mb-2" />
 			<div className="text-[15px] font-medium text-foreground mb-1">{title}</div>
 			<p className="text-[13px] text-muted-foreground leading-normal mb-4">{description}</p>
 			{children}
@@ -276,7 +278,7 @@ function ManageTile(
 ) {
 	const body = (
 		<>
-			<Icon className="size-5 text-primary shrink-0" />
+			<Icon className="size-5 text-primary dark:text-violet-300 shrink-0" />
 			<div className="min-w-0">
 				<div className="text-[13px] font-medium text-foreground truncate">{label}</div>
 				<div className="text-[11px] text-muted-foreground truncate">{hint}</div>

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -65,6 +65,11 @@ export function ClusterHome() {
 			// Ignore: we're clearing local state regardless of the server response.
 		}
 		authStore.setUserForEntity(cluster, null);
+		// Clear the persisted connection flags too, and do it even if the logout POST above failed —
+		// onInstanceLogoutSubmit clears them on success, but a swallowed error would otherwise leave the
+		// Fabric Connect flag and Basic Auth credentials behind in localStorage.
+		authStore.flagForFabricConnect(cluster.id, false);
+		authStore.flagForBasicAuth(cluster.id, null);
 		await router.invalidate();
 	}, [cluster, router]);
 
@@ -82,6 +87,22 @@ export function ClusterHome() {
 		return <Navigate to={`${base}/instances`} replace />;
 	}
 	if (cluster.resetPassword) {
+		// Only an admin (update) can finish setup / set the password. Match ClusterCardAction: send
+		// updaters into the setup flow, but show view-only members a "pending" message instead of
+		// redirecting them to a page they can't act on.
+		if (!update) {
+			return (
+				<ClusterHomeShell>
+					<div className="text-center py-12">
+						<Server className="size-12 text-muted-foreground mx-auto mb-4" />
+						<h1 className="text-xl font-medium mb-2 text-foreground">Pending Owner Setup</h1>
+						<p className="text-sm text-muted-foreground max-w-md mx-auto">
+							This cluster needs an administrator to finish setup before it can be used.
+						</p>
+					</div>
+				</ClusterHomeShell>
+			);
+		}
 		const isActive = cluster.status && activeClusterStatuses.includes(cluster.status);
 		return <Navigate to={`${base}/${isActive ? 'finish-setup' : 'starting-up'}`} replace />;
 	}

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { Button } from '@/components/ui/button';
 import { activeClusterStatuses } from '@/config/clusterStatuses';
-import { defaultInstanceRoute } from '@/config/constants';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
@@ -117,7 +116,7 @@ export function ClusterHome() {
 							</div>
 						</div>
 						<div className="flex gap-2 flex-wrap">
-							<Link to={`${base}${defaultInstanceRoute}`}>
+							<Link to={`${base}/apps`}>
 								<Button>
 									Enter cluster <ArrowRight />
 								</Button>
@@ -168,7 +167,7 @@ export function ClusterHome() {
 						enabled={connected}
 					/>
 					<ManageTile
-						to={`${base}${defaultInstanceRoute}`}
+						to={`${base}/databases`}
 						icon={Database}
 						label="Databases"
 						hint="Browse and query"
@@ -285,9 +284,17 @@ function ManageTile(
 			</div>
 		</>
 	);
-	const className = 'flex items-center gap-3 p-3 rounded-xl border border-border bg-card';
+	const className =
+		'flex items-center gap-3 p-3 rounded-xl border border-border bg-card transition-[transform,border-color,background-color] duration-150';
 	if (!enabled) {
 		return <div className={`${className} opacity-50`} aria-disabled>{body}</div>;
 	}
-	return <Link to={to} className={`${className} hover:border-primary/40 hover:bg-accent/60`}>{body}</Link>;
+	return (
+		<Link
+			to={to}
+			className={`${className} hover:scale-[1.02] hover:bg-accent/60 hover:border-primary/50 dark:hover:border-violet-400/60`}
+		>
+			{body}
+		</Link>
+	);
 }

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,18 +1,20 @@
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
 import { activeClusterStatuses } from '@/config/clusterStatuses';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
 import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { useInstanceAuth } from '@/hooks/useAuth';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Navigate, useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import { ArrowRight, CircleCheck, KeyRound, Loader2, Rocket, Server, Zap } from 'lucide-react';
+import { ArrowRight, CircleCheck, Copy, ExternalLink, KeyRound, Loader2, Rocket, Server, Zap } from 'lucide-react';
 import { ComponentType, ReactNode, useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -25,6 +27,9 @@ export function ClusterHome() {
 	const { user, isLoading } = useInstanceAuth(clusterId);
 	const { view, update } = useOrganizationClusterPermissions(cluster?.organizationId, cluster?.id);
 	const [isConnecting, setIsConnecting] = useState(false);
+
+	const clusterHost = cluster?.domains?.[0]?.domain || cluster?.fqdn || '';
+	const [copyHostName, copyApiUrl] = useCopyToClipboard(clusterHost, clusterHost ? `https://${clusterHost}` : '');
 
 	const base = cluster ? `/${cluster.organizationId}/${cluster.id}` : '';
 
@@ -96,8 +101,30 @@ export function ClusterHome() {
 						<h1 className="text-2xl font-light text-foreground">{cluster.name}</h1>
 						<StatusPill status={cluster.status} />
 					</div>
-					<div className="mt-1 text-sm text-muted-foreground">
-						{cluster.instances?.length ?? 0} instances · {cluster.fqdn}
+					<div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+						<span>{cluster.instances?.length ?? 0} instances</span>
+						<span aria-hidden="true">·</span>
+						<a
+							href={`https://${clusterHost}`}
+							target="_blank"
+							rel="noreferrer"
+							className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+						>
+							{clusterHost}
+							<ExternalLink className="size-3" />
+						</a>
+						<DropdownMenu>
+							<DropdownMenuTrigger
+								aria-label="Copy cluster URLs"
+								className="rounded-md p-1 -m-1 hover:bg-accent/60 hover:text-foreground"
+							>
+								<Copy className="size-3.5" />
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="start">
+								<DropdownMenuItem onClick={copyHostName}>Copy host name</DropdownMenuItem>
+								<DropdownMenuItem onClick={copyApiUrl}>Copy API URL</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
 					</div>
 				</div>
 			</div>

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -1,0 +1,283 @@
+import { Button } from '@/components/ui/button';
+import { activeClusterStatuses } from '@/config/clusterStatuses';
+import { defaultInstanceRoute } from '@/config/constants';
+import { getInstanceClient } from '@/config/getInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { useInstanceAuth } from '@/hooks/useAuth';
+import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
+import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
+import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
+import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
+import { useQuery } from '@tanstack/react-query';
+import { Link, Navigate, useNavigate, useParams, useRouter } from '@tanstack/react-router';
+import { ArrowRight, CircleCheck, Database, Gauge, Globe, KeyRound, Loader2, Server, Zap } from 'lucide-react';
+import { ComponentType, ReactNode, useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+export function ClusterHome() {
+	const { clusterId } = useParams({ strict: false }) as { clusterId?: string };
+	const router = useRouter();
+	const navigate = useNavigate();
+	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId, true));
+
+	const { user, isLoading } = useInstanceAuth(clusterId);
+	const { view, update } = useOrganizationClusterPermissions(cluster?.organizationId, cluster?.id);
+	const [isConnecting, setIsConnecting] = useState(false);
+
+	const base = cluster ? `/${cluster.organizationId}/${cluster.id}` : '';
+
+	const onFabricConnect = useCallback(async () => {
+		if (!cluster) { return; }
+		setIsConnecting(true);
+		try {
+			await authStore.establishFabricConnectAuth({
+				id: cluster.id,
+				operationsUrl: getOperationsUrlForCluster(cluster),
+			});
+			await router.invalidate();
+		} catch {
+			toast.error('Could not connect to this cluster through Fabric Connect.');
+		} finally {
+			setIsConnecting(false);
+		}
+	}, [cluster, router]);
+
+	const onDirectSignIn = useCallback(() => {
+		if (cluster) {
+			authStore.setUserForEntity(cluster, null);
+			authStore.flagForFabricConnect(cluster.id, false);
+		}
+		void navigate({ to: `${base}/sign-in` });
+	}, [base, cluster, navigate]);
+
+	const onDisconnect = useCallback(async () => {
+		if (!cluster) { return; }
+		try {
+			await onInstanceLogoutSubmit({ instanceClient: getInstanceClient({ id: cluster.id }), entityId: cluster.id });
+		} catch {
+			// Ignore: we're clearing local state regardless of the server response.
+		}
+		authStore.setUserForEntity(cluster, null);
+		await router.invalidate();
+	}, [cluster, router]);
+
+	if (!cluster) {
+		return (
+			<ClusterHomeShell>
+				<Spinner />
+			</ClusterHomeShell>
+		);
+	}
+	if (!view) {
+		return <Navigate to={`/${cluster.organizationId}`} replace />;
+	}
+	if (!cluster.fqdn) {
+		return <Navigate to={`${base}/instances`} replace />;
+	}
+	if (cluster.resetPassword) {
+		const isActive = cluster.status && activeClusterStatuses.includes(cluster.status);
+		return <Navigate to={`${base}/${isActive ? 'finish-setup' : 'starting-up'}`} replace />;
+	}
+
+	const isFabricConnect = authStore.checkForFabricConnect(cluster.id);
+	const connected = !!user;
+	const lastMode = authStore.getLastConnectMode(cluster.id);
+
+	return (
+		<ClusterHomeShell>
+			<div className="flex items-start gap-4 mb-6">
+				<div className="flex items-center justify-center size-12 rounded-xl bg-violet-50 text-primary dark:bg-grey-700 shrink-0">
+					<Server className="size-6" />
+				</div>
+				<div className="flex-1 min-w-0">
+					<div className="flex items-center gap-3 flex-wrap">
+						<h1 className="text-2xl font-light text-foreground">{cluster.name}</h1>
+						<StatusPill status={cluster.status} />
+					</div>
+					<div className="mt-1 text-sm text-muted-foreground">
+						{cluster.instances?.length ?? 0} instances · {cluster.fqdn}
+					</div>
+				</div>
+			</div>
+
+			{isLoading ? <Spinner /> : connected
+				? (
+					<div>
+						<div className="flex items-center gap-3 p-4 rounded-xl bg-green/10 mb-3">
+							<CircleCheck className="size-5 text-green" />
+							<div className="flex-1">
+								<div className="text-sm font-medium text-green">
+									{isFabricConnect ? 'Connected via Fabric Connect' : 'Signed in directly'}
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{isFabricConnect ? 'Through your Harper account' : 'Session cookie'}
+								</div>
+							</div>
+						</div>
+						<div className="flex gap-2 flex-wrap">
+							<Link to={`${base}${defaultInstanceRoute}`}>
+								<Button>
+									Enter cluster <ArrowRight />
+								</Button>
+							</Link>
+							{isFabricConnect && <Button variant="outline" onClick={onDirectSignIn}>Switch to direct sign-in</Button>}
+							<Button variant="destructiveOutline" onClick={() => void onDisconnect()}>
+								{isFabricConnect ? 'Disconnect' : 'Direct sign out'}
+							</Button>
+						</div>
+					</div>
+				)
+				: (
+					<div>
+						<h2 className="text-sm font-medium text-foreground mb-3">Connect to this cluster</h2>
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-3.5">
+							{update && !clusterIsSelfManaged(cluster) && (
+								<ConnectOption
+									icon={Zap}
+									title="Fabric Connect"
+									description="Connect through your Harper account. No cluster credentials needed."
+									pill={lastMode === 'fabric' ? 'last' : lastMode ? undefined : 'recommended'}
+								>
+									<Button className="w-full" disabled={isConnecting} onClick={() => void onFabricConnect()}>
+										{isConnecting ? <Loader2 className="animate-spin" /> : 'Fabric Connect'}
+									</Button>
+								</ConnectOption>
+							)}
+							<ConnectOption
+								icon={KeyRound}
+								title="Direct sign-in"
+								description="Sign in with this cluster's Harper username and password."
+								pill={lastMode === 'direct' ? 'last' : undefined}
+							>
+								<Button className="w-full" variant="outline" onClick={onDirectSignIn}>Direct sign-in</Button>
+							</ConnectOption>
+						</div>
+					</div>
+				)}
+
+			<div className="mt-7 pt-5 border-t border-border">
+				<div className="text-xs text-muted-foreground mb-3">Manage</div>
+				<div className="grid grid-cols-2 md:grid-cols-3 gap-2.5">
+					<ManageTile
+						to={`${base}/instances`}
+						icon={Server}
+						label="Instances"
+						hint={`${cluster.instances?.length ?? 0} running`}
+						enabled={connected}
+					/>
+					<ManageTile
+						to={`${base}${defaultInstanceRoute}`}
+						icon={Database}
+						label="Databases"
+						hint="Browse and query"
+						enabled={connected}
+					/>
+					<ManageTile
+						to={`${base}/scaling`}
+						icon={Gauge}
+						label="Scaling"
+						hint="Size and replicas"
+						enabled={connected && update}
+					/>
+					<ManageTile
+						to={`${base}/domains`}
+						icon={Globe}
+						label="Domains"
+						hint="Custom domains"
+						enabled={connected && update}
+					/>
+				</div>
+				<div className="mt-3.5 text-xs text-muted-foreground">Scaling and domains require manage permission.</div>
+			</div>
+		</ClusterHomeShell>
+	);
+}
+
+function ClusterHomeShell({ children }: { children: ReactNode }) {
+	return <div className="max-w-3xl mx-auto px-4 md:px-6 py-8">{children}</div>;
+}
+
+function Spinner() {
+	return (
+		<div className="flex justify-center py-10 text-muted-foreground">
+			<Loader2 className="size-6 animate-spin" />
+		</div>
+	);
+}
+
+function StatusPill({ status }: { status?: string }) {
+	const active = status && activeClusterStatuses.includes(status);
+	return (
+		<span
+			className={`inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full ${
+				active ? 'text-green bg-green/10' : 'text-muted-foreground bg-muted'
+			}`}
+		>
+			<span className="size-1.5 rounded-full bg-current" />
+			{status ? status.charAt(0) + status.slice(1).toLowerCase() : 'Unknown'}
+		</span>
+	);
+}
+
+function ConnectOption(
+	{ icon: Icon, title, description, pill, children }: {
+		icon: ComponentType<{ className?: string }>;
+		title: string;
+		description: string;
+		pill?: 'recommended' | 'last';
+		children: ReactNode;
+	},
+) {
+	return (
+		<div
+			className={`relative rounded-xl p-4.5 bg-card border ${
+				pill === 'last'
+					? 'border-2 border-green'
+					: pill === 'recommended'
+					? 'border-2 border-primary'
+					: 'border-border'
+			}`}
+		>
+			{pill && (
+				<span
+					className={`absolute -top-2.5 left-4 inline-flex items-center gap-1.5 text-xs px-2.5 py-0.5 rounded-full ${
+						pill === 'last' ? 'text-green bg-green/15' : 'text-primary bg-violet-50 dark:bg-grey-700'
+					}`}
+				>
+					{pill === 'last' && <span className="size-1.5 rounded-full bg-current" />}
+					{pill === 'last' ? 'Last used' : 'Recommended'}
+				</span>
+			)}
+			<Icon className="size-6 text-primary mb-2" />
+			<div className="text-[15px] font-medium text-foreground mb-1">{title}</div>
+			<p className="text-[13px] text-muted-foreground leading-normal mb-4">{description}</p>
+			{children}
+		</div>
+	);
+}
+
+function ManageTile(
+	{ to, icon: Icon, label, hint, enabled }: {
+		to: string;
+		icon: ComponentType<{ className?: string }>;
+		label: string;
+		hint: string;
+		enabled: boolean;
+	},
+) {
+	const body = (
+		<>
+			<Icon className="size-5 text-primary shrink-0" />
+			<div className="min-w-0">
+				<div className="text-[13px] font-medium text-foreground truncate">{label}</div>
+				<div className="text-[11px] text-muted-foreground truncate">{hint}</div>
+			</div>
+		</>
+	);
+	const className = 'flex items-center gap-3 p-3 rounded-xl border border-border bg-card';
+	if (!enabled) {
+		return <div className={`${className} opacity-50`} aria-disabled>{body}</div>;
+	}
+	return <Link to={to} className={`${className} hover:border-primary/40 hover:bg-accent/60`}>{body}</Link>;
+}

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -12,7 +12,7 @@ import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInsta
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useQuery } from '@tanstack/react-query';
 import { Link, Navigate, useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import { ArrowRight, CircleCheck, KeyRound, Loader2, Server, Zap } from 'lucide-react';
+import { ArrowRight, CircleCheck, KeyRound, Loader2, Rocket, Server, Zap } from 'lucide-react';
 import { ComponentType, ReactNode, useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -105,27 +105,49 @@ export function ClusterHome() {
 			{isLoading ? <Spinner /> : connected
 				? (
 					<div>
-						<div className="flex items-center gap-3 p-4 rounded-xl bg-green/10 mb-3">
-							<CircleCheck className="size-5 text-green" />
-							<div className="flex-1">
-								<div className="text-sm font-medium text-green">
-									{isFabricConnect ? 'Connected via Fabric Connect' : 'Signed in directly'}
-								</div>
-								<div className="text-xs text-muted-foreground">
-									{isFabricConnect ? 'Through your Harper account' : 'Session cookie'}
+						<div className="flex items-center gap-2 mb-4 text-sm">
+							<CircleCheck className="size-4 text-green shrink-0" />
+							<span className="font-medium text-green">
+								{isFabricConnect ? 'Connected via Fabric Connect' : 'Signed in directly'}
+							</span>
+							<span className="text-xs text-muted-foreground">
+								· {isFabricConnect ? 'through your Harper account' : 'session cookie'}
+							</span>
+						</div>
+
+						<Link
+							to={`${base}/apps`}
+							className="group flex items-center gap-4 rounded-2xl border-2 border-primary/30 bg-primary/5 p-6 transition-all hover:border-primary hover:bg-primary/10 dark:border-violet-400/30 dark:bg-violet-400/5 dark:hover:border-violet-400 dark:hover:bg-violet-400/10"
+						>
+							<div className="flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary shrink-0 dark:bg-violet-400/15 dark:text-violet-300">
+								<Rocket className="size-6" />
+							</div>
+							<div className="flex-1 min-w-0">
+								<div className="text-lg font-medium text-foreground">Enter cluster</div>
+								<div className="text-sm text-muted-foreground">
+									Open the studio — apps, databases, APIs, logs, and config.
 								</div>
 							</div>
-						</div>
-						<div className="flex gap-2 flex-wrap">
-							<Link to={`${base}/apps`}>
-								<Button>
-									Enter cluster <ArrowRight />
-								</Button>
-							</Link>
-							{isFabricConnect && <Button variant="outline" onClick={onDirectSignIn}>Switch to direct sign-in</Button>}
-							<Button variant="destructiveOutline" onClick={() => void onDisconnect()}>
+							<ArrowRight className="size-5 text-muted-foreground transition-transform group-hover:translate-x-1" />
+						</Link>
+
+						<div className="mt-4 flex flex-wrap gap-4 text-sm">
+							{isFabricConnect && (
+								<button
+									type="button"
+									onClick={onDirectSignIn}
+									className="text-muted-foreground hover:text-foreground transition-colors"
+								>
+									Switch to direct sign-in
+								</button>
+							)}
+							<button
+								type="button"
+								onClick={() => void onDisconnect()}
+								className="text-muted-foreground hover:text-destructive transition-colors"
+							>
 								{isFabricConnect ? 'Disconnect' : 'Direct sign out'}
-							</Button>
+							</button>
 						</div>
 					</div>
 				)

--- a/src/features/cluster/Instances.tsx
+++ b/src/features/cluster/Instances.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { renderBadgeStatusVariant } from '@/components/ui/utils/badgeStatus';
 import { deletedClusterStatuses } from '@/config/clusterStatuses';
+import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
 import { calculateInstanceFQDN } from '@/features/clusters/upsert/lib/calculateInstanceFQDN';
 import { Instance } from '@/integrations/api/api.patch';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
@@ -146,8 +147,8 @@ export function Instances() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
-				<Card className="p-0 mt-4 min-h-96">
+			<ClusterPageLayout>
+				<Card className="p-0 min-h-96">
 					<CardContent className="p-0 min-h-96">
 						{clusterIsLoading
 							? <TextLoadingSkeleton />
@@ -166,7 +167,7 @@ export function Instances() {
 							: <EmptyCluster />}
 					</CardContent>
 				</Card>
-			</div>
+			</ClusterPageLayout>
 		</>
 	);
 }

--- a/src/features/cluster/Instances.tsx
+++ b/src/features/cluster/Instances.tsx
@@ -60,7 +60,9 @@ export function Instances() {
 					size: 90,
 					header: 'Name',
 				},
-				{
+				// Self-hosted instances aren't monitored from here — no status column, and no per-instance
+				// status requests (InstanceStatusCell polls each instance's operations API).
+				!isSelfManaged && {
 					accessorKey: 'status',
 					header: 'Status',
 					size: 1,

--- a/src/features/cluster/Scaling.tsx
+++ b/src/features/cluster/Scaling.tsx
@@ -1,6 +1,6 @@
-import { NestedContentWithSubNavMenu } from '@/components/NestedContentWithSubNavMenu';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { activeClusterStatuses } from '@/config/clusterStatuses';
+import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
 import { ClusterCardAction } from '@/features/clusters/components/ClusterCardAction';
 import { ClusterProgress } from '@/features/clusters/components/ClusterProgress';
 import { useQuery } from '@tanstack/react-query';
@@ -20,15 +20,15 @@ export function Scaling() {
 
 	if (clusterIsLoading || !cluster) {
 		return (
-			<NestedContentWithSubNavMenu className="flex justify-center">
+			<ClusterContentWithSubNavMenu className="flex justify-center">
 				<TextLoadingSkeleton />
-			</NestedContentWithSubNavMenu>
+			</ClusterContentWithSubNavMenu>
 		);
 	}
 
 	if (clusterIsActive) {
 		return (
-			<NestedContentWithSubNavMenu className="flex justify-center">
+			<ClusterContentWithSubNavMenu className="flex justify-center">
 				<div className="center w-2xl flex flex-col gap-4">
 					<h1 className="text-xl text-center">All done!</h1>
 					<ClusterProgress cluster={cluster} forceProgressBarVisible={true} />
@@ -37,12 +37,12 @@ export function Scaling() {
 						<ClusterCardAction cluster={cluster} />
 					</div>
 				</div>
-			</NestedContentWithSubNavMenu>
+			</ClusterContentWithSubNavMenu>
 		);
 	}
 
 	return (
-		<NestedContentWithSubNavMenu className="flex justify-center">
+		<ClusterContentWithSubNavMenu className="flex justify-center">
 			<div className="center w-2xl flex flex-col gap-4">
 				<h1 className="text-xl text-center">Here we go!</h1>
 				<ClusterProgress cluster={cluster} forceProgressBarVisible={true} />
@@ -63,6 +63,6 @@ export function Scaling() {
 					</span>
 				</p>
 			</div>
-		</NestedContentWithSubNavMenu>
+		</ClusterContentWithSubNavMenu>
 	);
 }

--- a/src/features/cluster/components/ClusterContentWithSubNavMenu.tsx
+++ b/src/features/cluster/components/ClusterContentWithSubNavMenu.tsx
@@ -1,0 +1,20 @@
+import { SubNavMenu } from '@/components/SubNavMenu';
+import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
+import { ReactNode } from 'react';
+
+/**
+ * Cluster equivalent of NestedContentWithSubNavMenu: breadcrumb bar + the cluster sub-nav rail
+ * (ClusterPageLayout) wrapping the page content. Used by the cluster-scoped pages that render inside
+ * the rail (scaling, domains). StartingUp intentionally keeps the plain NestedContentWithSubNavMenu —
+ * it's a pre-provisioning wait screen with nothing to manage yet.
+ */
+export function ClusterContentWithSubNavMenu({ children, className }: { children: ReactNode; className?: string }) {
+	return (
+		<>
+			<SubNavMenu />
+			<ClusterPageLayout>
+				<div className={className}>{children}</div>
+			</ClusterPageLayout>
+		</>
+	);
+}

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -25,13 +25,13 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 
 	const items = [
 		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
-		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },
 		// Scaling and Version open the cluster editor (matching the card's "Edit Scaling" / "Edit
 		// Version"), not the /scaling update-progress screen. Both are exact so /edit/version doesn't
 		// also light up Scaling (/edit).
 		update && { to: `${base}/edit`, label: 'Scaling', icon: GaugeIcon, exact: true },
 		update && !selfManaged && { to: `${base}/edit/version`, label: 'Version', icon: TagIcon, exact: true },
 		update && !selfManaged && { to: `${base}/domains`, label: 'Domains', icon: GlobeIcon },
+		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },
 	].filter(Boolean) as SubNavItem[];
 
 	return (

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -26,7 +26,9 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 	const items = [
 		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
 		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },
-		update && { to: `${base}/scaling`, label: 'Scaling', icon: GaugeIcon },
+		// Scaling opens the cluster editor (matches the card's "Edit Scaling"), not the /scaling
+		// update-progress screen.
+		update && { to: `${base}/edit`, label: 'Scaling', icon: GaugeIcon },
 		update && !selfManaged && { to: `${base}/domains`, label: 'Domains', icon: GlobeIcon },
 	].filter(Boolean) as SubNavItem[];
 

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -4,7 +4,7 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { GaugeIcon, GlobeIcon, LayoutDashboardIcon, ServerIcon } from 'lucide-react';
+import { GaugeIcon, GlobeIcon, LayoutDashboardIcon, ServerIcon, TagIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 
 /**
@@ -26,9 +26,11 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 	const items = [
 		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
 		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },
-		// Scaling opens the cluster editor (matches the card's "Edit Scaling"), not the /scaling
-		// update-progress screen.
-		update && { to: `${base}/edit`, label: 'Scaling', icon: GaugeIcon },
+		// Scaling and Version open the cluster editor (matching the card's "Edit Scaling" / "Edit
+		// Version"), not the /scaling update-progress screen. Both are exact so /edit/version doesn't
+		// also light up Scaling (/edit).
+		update && { to: `${base}/edit`, label: 'Scaling', icon: GaugeIcon, exact: true },
+		update && !selfManaged && { to: `${base}/edit/version`, label: 'Version', icon: TagIcon, exact: true },
 		update && !selfManaged && { to: `${base}/domains`, label: 'Domains', icon: GlobeIcon },
 	].filter(Boolean) as SubNavItem[];
 

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -27,8 +27,9 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
 		// Scaling and Version open the cluster editor (matching the card's "Edit Scaling" / "Edit
 		// Version"), not the /scaling update-progress screen. Both are exact so /edit/version doesn't
-		// also light up Scaling (/edit).
-		update && { to: `${base}/edit`, label: 'Scaling', icon: GaugeIcon, exact: true },
+		// also light up Scaling (/edit). Self-hosted clusters don't scale from here — their editor
+		// only holds registration details, so the item reads "Configuration" instead.
+		update && { to: `${base}/edit`, label: selfManaged ? 'Configuration' : 'Scaling', icon: GaugeIcon, exact: true },
 		update && !selfManaged && { to: `${base}/edit/version`, label: 'Version', icon: TagIcon, exact: true },
 		update && !selfManaged && { to: `${base}/domains`, label: 'Domains', icon: GlobeIcon },
 		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -1,0 +1,43 @@
+import { SubNavItem, SubNavRail } from '@/components/SubNavRail';
+import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
+import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from '@tanstack/react-router';
+import { GaugeIcon, GlobeIcon, LayoutDashboardIcon, ServerIcon } from 'lucide-react';
+import { ReactNode } from 'react';
+
+/**
+ * Shared shell for the cluster-scoped pages (overview/home, instances, scaling, domains). Renders the
+ * same responsive sub-nav rail as the org page so those sections persist across them. The in-cluster
+ * studio (apps, databases, …) keeps its own top nav — this rail is the cluster-settings level. Items
+ * are gated by cluster permissions (scaling/domains require manage; domains also hides for self-managed).
+ */
+export function ClusterPageLayout({ children }: { children: ReactNode }) {
+	const { organizationId, clusterId } = useParams({ strict: false }) as {
+		organizationId?: string;
+		clusterId?: string;
+	};
+	const { view, update } = useOrganizationClusterPermissions(organizationId, clusterId);
+	const { data: cluster } = useQuery(getClusterInfoQueryOptions(clusterId, false));
+	const selfManaged = cluster ? clusterIsSelfManaged(cluster) : false;
+	const base = `/${organizationId}/${clusterId}`;
+
+	const items = [
+		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
+		view && { to: `${base}/instances`, label: 'Instances', icon: ServerIcon },
+		update && { to: `${base}/scaling`, label: 'Scaling', icon: GaugeIcon },
+		update && !selfManaged && { to: `${base}/domains`, label: 'Domains', icon: GlobeIcon },
+	].filter(Boolean) as SubNavItem[];
+
+	return (
+		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
+			<div className="md:grid gap-6 md:grid-cols-12">
+				<aside className="md:col-span-3 lg:col-span-2 mb-4 md:mb-0">
+					<SubNavRail items={items} ariaLabel="Cluster sections" />
+				</aside>
+				<section className="md:col-span-9 lg:col-span-10 min-w-0">{children}</section>
+			</div>
+		</div>
+	);
+}

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -36,7 +36,9 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 	].filter(Boolean) as SubNavItem[];
 
 	return (
-		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
+		// `relative` so absolutely-positioned page furniture (the cluster editor's price display) anchors
+		// to the content area, matching SubNavSimpleLayout — not the viewport, where the fixed header hides it.
+		<div className="relative mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
 			<div className="md:grid gap-6 md:grid-cols-12">
 				<aside className="md:col-span-3 lg:col-span-2 mb-4 md:mb-0">
 					<SubNavRail items={items} ariaLabel="Cluster sections" />

--- a/src/features/cluster/domains/Page.tsx
+++ b/src/features/cluster/domains/Page.tsx
@@ -1,10 +1,10 @@
-import { NestedContentWithSubNavMenu } from '@/components/NestedContentWithSubNavMenu';
+import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
 import { DomainsManagement } from './Management';
 
 export function DomainsPage() {
 	return (
-		<NestedContentWithSubNavMenu className="flex flex-col justify-start max-w-4xl">
+		<ClusterContentWithSubNavMenu className="flex flex-col justify-start max-w-4xl">
 			<DomainsManagement />
-		</NestedContentWithSubNavMenu>
+		</ClusterContentWithSubNavMenu>
 	);
 }

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -2,6 +2,7 @@ import { defaultInstanceRouteUpOne } from '@/config/constants';
 import { ClusterInstanceSignIn } from '@/features/auth/ClusterInstanceSignIn';
 import { authStore } from '@/features/auth/store/authStore';
 import { createRoute, redirect } from '@tanstack/react-router';
+import { ClusterHome } from './ClusterHome';
 import { clusterLayoutRoute } from './clusterLayoutRoute';
 import { DomainsPage } from './domains/Page';
 import { FinishSetup } from './FinishSetup';
@@ -97,6 +98,13 @@ const clusterFinishSetupRoute = createRoute({
 	component: FinishSetup,
 });
 
+const clusterHomeRoute = createRoute({
+	getParentRoute: () => clusterLayoutRoute,
+	path: 'home',
+	head: () => ({ meta: [{ title: 'Cluster — Harper Fabric' }] }),
+	component: ClusterHome,
+});
+
 export const clusterRoutes = [
 	clusterInstancesRoute,
 	clusterStartingUpRoute,
@@ -105,4 +113,5 @@ export const clusterRoutes = [
 	clusterFinishSetupRoute,
 	clusterSignInRoute,
 	instanceSignInRoute,
+	clusterHomeRoute,
 ];

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -98,9 +98,12 @@ const clusterFinishSetupRoute = createRoute({
 	component: FinishSetup,
 });
 
+// The cluster home is the cluster index (/{org}/{clusterId}). The within-cluster tabs (apps,
+// databases, …) live under the pathless instance layout, so they render with the instance nav; the
+// home is a sibling index and renders without it.
 const clusterHomeRoute = createRoute({
 	getParentRoute: () => clusterLayoutRoute,
-	path: 'home',
+	path: '/',
 	head: () => ({ meta: [{ title: 'Cluster — Harper Fabric' }] }),
 	component: ClusterHome,
 });

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -14,7 +14,7 @@ import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
 import { curryFilterByFuzzySearch } from '@/lib/string/filterByFuzzySearch';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link, Navigate, useParams } from '@tanstack/react-router';
-import { Plus } from 'lucide-react';
+import { Plus, SearchIcon } from 'lucide-react';
 import { FormEvent, useCallback, useMemo, useState } from 'react';
 
 export function ClustersList() {
@@ -52,34 +52,29 @@ export function ClustersList() {
 	return (
 		<>
 			<SubNavMenu>
-				{isSuccess
-					? (
-						<div className="flex w-full justify-end gap-2">
-							<Input
-								placeholder="Filter by name"
-								className="inline-block w-full text-xs"
-								value={filterByNameValue}
-								onChange={onFilterByNameChanged}
-							/>
-
-							{create && (
-								<Link to="new-cluster">
-									<Button
-										variant="positive"
-										accessKey="n"
-									>
-										<Plus />{' '}
-										<span className="hidden sm:inline-block">
-											<u>N</u>ew <span className="hidden md:inline-block">Cluster</span>
-										</span>
-									</Button>
-								</Link>
-							)}
-						</div>
-					)
-					: null}
+				{isSuccess && create && (
+					<div className="flex w-full justify-end">
+						<Link to="new-cluster">
+							<Button variant="positive" accessKey="n">
+								<Plus />{' '}
+								<span className="hidden sm:inline-block">
+									<u>N</u>ew <span className="hidden md:inline-block">Cluster</span>
+								</span>
+							</Button>
+						</Link>
+					</div>
+				)}
 			</SubNavMenu>
 			<OrgPageLayout>
+				<div className="relative mb-4 max-w-xs">
+					<SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						placeholder="Filter by name"
+						className="pl-8 text-xs bg-transparent border-border/60"
+						value={filterByNameValue}
+						onChange={onFilterByNameChanged}
+					/>
+				</div>
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-9 mb-4">
 					{filteredClusters.map((cluster) => (
 						<div key={cluster.id} className="col-span-1 md:col-span-3 xl:col-span-3 2xl:col-span-2">

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -66,11 +66,11 @@ export function ClustersList() {
 				)}
 			</SubNavMenu>
 			<OrgPageLayout>
-				<div className="relative mb-4 max-w-xs">
-					<SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+				<div className="relative mb-6 w-full">
+					<SearchIcon className="pointer-events-none absolute left-0 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
 					<Input
 						placeholder="Filter by name"
-						className="pl-8 text-xs bg-transparent border-border/60"
+						className="w-full rounded-none border-0 border-b border-border bg-transparent dark:bg-transparent pl-6 shadow-none focus-visible:border-primary focus-visible:ring-0"
 						value={filterByNameValue}
 						onChange={onFilterByNameChanged}
 					/>

--- a/src/features/clusters/ClustersList.tsx
+++ b/src/features/clusters/ClustersList.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { isTerminated } from '@/components/ui/utils/badgeStatus';
 import { ClusterCard } from '@/features/clusters/components/ClusterCard';
 import { UpsertCluster } from '@/features/clusters/upsert';
+import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
@@ -78,21 +79,21 @@ export function ClustersList() {
 					)
 					: null}
 			</SubNavMenu>
-			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
-				<div className="grid grid-cols-1 gap-4 md:grid-cols-12 mb-4">
+			<OrgPageLayout>
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-9 mb-4">
 					{filteredClusters.map((cluster) => (
-						<div key={cluster.id} className="col-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2">
+						<div key={cluster.id} className="col-span-1 md:col-span-3 xl:col-span-3 2xl:col-span-2">
 							<ClusterCard cluster={cluster} />
 						</div>
 					))}
 					{!filteredClusters.length && (
-						<div className="col-span-1 md:col-span-12 text-center">
+						<div className="col-span-1 md:col-span-9 text-center">
 							<h2 className="my-4 text-xl">No matches found.</h2>
 							<Button type="button" variant="outline" onClick={clearFilterByNameValue}>Clear Filters</Button>
 						</div>
 					)}
 				</div>
-			</section>
+			</OrgPageLayout>
 		</>
 	);
 }

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -136,7 +136,7 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 	// The whole card opens the cluster home for the normal "Open" case. Edge states (no FQDN → Instances,
 	// resetPassword → Finish Setup / Pending) keep their own explicit CTA in ClusterCardAction instead.
 	const cardHref = isActive && view && !isTerminated && !!cluster.fqdn && !cluster.resetPassword
-		? `/${cluster.organizationId}/${cluster.id}/home`
+		? `/${cluster.organizationId}/${cluster.id}`
 		: undefined;
 
 	const clusterFQDN = cluster.domains?.[0]?.domain || cluster.fqdn;
@@ -224,7 +224,11 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 
 	return (
 		<EntityContextMenu items={isTerminated ? [] : menuItems}>
-			<Card className="relative h-full justify-between hover:shadow-lg transition-shadow duration-200">
+			<Card
+				className={`relative h-full justify-between transition-[transform,box-shadow,border-color] duration-200 ${
+					cardHref ? 'hover:scale-[1.02] hover:shadow-lg hover:border-primary/50' : 'hover:shadow-lg'
+				}`}
+			>
 				{cardHref && (
 					<Link
 						to={cardHref}

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -133,9 +133,16 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 		});
 	}, [router, cluster.organizationId, cluster.id, cluster.name, terminateCluster, isSelfManaged, queryClient]);
 
-	// The whole card opens the cluster home for the normal "Open" case. Edge states (no FQDN → Instances,
-	// resetPassword → Finish Setup / Pending) keep their own explicit CTA in ClusterCardAction instead.
-	const cardHref = isActive && view && !isTerminated && !!cluster.fqdn && !cluster.resetPassword
+	// The whole card opens the cluster home (overview) for the normal "Open" case — including
+	// self-hosted clusters, which get their own overview. A managed cluster with no FQDN yet opens its
+	// instances; resetPassword (→ Finish Setup / Pending) keeps its explicit CTA in ClusterCardAction.
+	const cardHref = !isActive || !view || isTerminated
+		? undefined
+		: isSelfManaged
+		? `/${cluster.organizationId}/${cluster.id}`
+		: !cluster.fqdn
+		? `/${cluster.organizationId}/${cluster.id}/instances`
+		: !cluster.resetPassword
 		? `/${cluster.organizationId}/${cluster.id}`
 		: undefined;
 
@@ -234,7 +241,7 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 				{cardHref && (
 					<Link
 						to={cardHref}
-						aria-label={`Open ${cluster.name}`}
+						aria-label={`${isSelfManaged || cluster.fqdn ? 'Open' : 'View'} ${cluster.name}`}
 						className="absolute inset-0 rounded-[inherit] focus-visible:ring-2 focus-visible:ring-purple-200 focus-visible:outline-none"
 					/>
 				)}
@@ -280,7 +287,7 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 				</CardHeader>
 				<CardContent className="flex items-center justify-between gap-2">
 					<ClusterProgress cluster={cluster} />
-					{isActive && view && <ClusterCardAction cluster={cluster} />}
+					{isActive && view && <ClusterCardAction cluster={cluster} hasCardLink={!!cardHref} />}
 					{clusterHasFailed && cluster.status && (
 						<>
 							<Badge variant={renderBadgeStatusVariant(cluster.status)}>{capitalizeWords(cluster.status)}</Badge>

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -244,14 +244,17 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 							? (
 								<>
 									<span className="truncate max-w-48">{clusterFQDN}</span>
-									<CopyIcon
+									<button
+										type="button"
+										aria-label="Copy host name"
 										onClick={(e) => {
 											e.stopPropagation();
 											onCopyFQDNClick();
 										}}
-										size={16}
-										className="cursor-pointer relative z-10"
-									/>
+										className="relative z-10 -m-1.5 p-1.5 rounded-md text-muted-foreground cursor-pointer hover:bg-accent/60 hover:text-foreground"
+									>
+										<CopyIcon size={16} />
+									</button>
 									<span className="grow"></span>
 								</>
 							)

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -24,7 +24,7 @@ import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRouter } from '@tanstack/react-router';
+import { Link, useRouter } from '@tanstack/react-router';
 import {
 	ClipboardIcon,
 	CopyIcon,
@@ -133,6 +133,12 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 		});
 	}, [router, cluster.organizationId, cluster.id, cluster.name, terminateCluster, isSelfManaged, queryClient]);
 
+	// The whole card opens the cluster home for the normal "Open" case. Edge states (no FQDN → Instances,
+	// resetPassword → Finish Setup / Pending) keep their own explicit CTA in ClusterCardAction instead.
+	const cardHref = isActive && view && !isTerminated && !!cluster.fqdn && !cluster.resetPassword
+		? `/${cluster.organizationId}/${cluster.id}/home`
+		: undefined;
+
 	const clusterFQDN = cluster.domains?.[0]?.domain || cluster.fqdn;
 	const [onCopyFQDNClick, onCopyAPIClick] = useCopyToClipboard(
 		`${clusterFQDN}`,
@@ -219,21 +225,39 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 	return (
 		<EntityContextMenu items={isTerminated ? [] : menuItems}>
 			<Card className="relative h-full justify-between hover:shadow-lg transition-shadow duration-200">
+				{cardHref && (
+					<Link
+						to={cardHref}
+						aria-label={`Open ${cluster.name}`}
+						className="absolute inset-0 rounded-[inherit] focus-visible:ring-2 focus-visible:ring-purple-200 focus-visible:outline-none"
+					/>
+				)}
 				<CardHeader>
 					<CardDescription className="flex items-center justify-between">
 						{clusterFQDN
 							? (
 								<>
 									<span className="truncate max-w-48">{clusterFQDN}</span>
-									<CopyIcon onClick={onCopyFQDNClick} size={16} className="cursor-pointer" />
+									<CopyIcon
+										onClick={(e) => {
+											e.stopPropagation();
+											onCopyFQDNClick();
+										}}
+										size={16}
+										className="cursor-pointer relative z-10"
+									/>
 									<span className="grow"></span>
 								</>
 							)
 							: <span>Self-Hosted</span>}
 						{!isTerminated && (
 							<DropdownMenu>
-								<DropdownMenuTrigger>
-									<Ellipsis aria-label="Cluster options" />
+								<DropdownMenuTrigger
+									aria-label="Cluster options"
+									onClick={(e) => e.stopPropagation()}
+									className="relative z-10 -m-2 p-2 rounded-md hover:bg-accent/60"
+								>
+									<Ellipsis />
 								</DropdownMenuTrigger>
 								<DropdownMenuContent>
 									{renderEntityMenuItems(menuItems, 'dropdown')}

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -225,8 +225,10 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 	return (
 		<EntityContextMenu items={isTerminated ? [] : menuItems}>
 			<Card
-				className={`relative h-full justify-between transition-[transform,box-shadow,border-color] duration-200 ${
-					cardHref ? 'hover:scale-[1.02] hover:shadow-lg hover:border-primary/50' : 'hover:shadow-lg'
+				className={`relative h-full justify-between transition-[transform,box-shadow] duration-200 ${
+					cardHref
+						? 'hover:scale-[1.02] hover:shadow-lg hover:ring-2 hover:ring-primary/60 dark:hover:ring-violet-400/70'
+						: 'hover:shadow-lg'
 				}`}
 			>
 				{cardHref && (

--- a/src/features/clusters/components/ClusterCardAction.tsx
+++ b/src/features/clusters/components/ClusterCardAction.tsx
@@ -50,18 +50,11 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		);
 	}
 
-	// The cluster home owns the connect choice (Fabric Connect / Direct Sign In) and the connected
-	// state, so the card just opens it rather than guessing a connection mode here.
+	// The whole card is the click target for opening the cluster (see ClusterCard's stretched link),
+	// so this is just a visual affordance — not its own link.
 	return (
-		<Link
-			to={`${base}/home`}
-			className="text-sm text-nowrap"
-			aria-label={`Open ${cluster.name}`}
-			title={`Open ${cluster.name}`}
-		>
-			<span className="py-2 hover:border-b-2">
-				Open <ArrowRight className="inline-block" />
-			</span>
-		</Link>
+		<span className="text-sm text-nowrap py-2">
+			Open <ArrowRight className="inline-block" />
+		</span>
 	);
 }

--- a/src/features/clusters/components/ClusterCardAction.tsx
+++ b/src/features/clusters/components/ClusterCardAction.tsx
@@ -1,32 +1,22 @@
 import { Button } from '@/components/ui/button';
-import { defaultInstanceRoute } from '@/config/constants';
-import { authStore } from '@/features/auth/store/authStore';
-import { useInstanceAuth } from '@/hooks/useAuth';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/integrations/api/api.patch';
-import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight } from 'lucide-react';
-import { useCallback } from 'react';
 
 export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
-	const auth = useInstanceAuth(cluster.id);
 	const { view, update } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
-	const isFabricConnect = authStore.checkForFabricConnect(cluster.id);
-	const isDirectConnect = !isFabricConnect && !!auth.user;
-	const prepareForDirectSignIn = useCallback(() => {
-		authStore.setUserForEntity(cluster, null);
-		authStore.flagForFabricConnect(cluster.id, false);
-	}, [cluster]);
+	const base = `/${cluster.organizationId}/${cluster.id}`;
 
 	if (!view) {
 		return undefined;
 	}
 
+	// A cluster with no FQDN can't be connected to yet — send them to its instances.
 	if (!cluster.fqdn) {
 		return (
 			<Link
-				to={`/${cluster.organizationId}/${cluster.id}/instances`}
+				to={`${base}/instances`}
 				className="text-sm text-nowrap"
 				aria-label={`View ${cluster.name}`}
 				title={`View ${cluster.name}`}
@@ -42,7 +32,7 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		if (update) {
 			return (
 				<Link
-					to={`/${cluster.organizationId}/${cluster.id}/finish-setup`}
+					to={`${base}/finish-setup`}
 					className="text-sm text-nowrap"
 					aria-label={`Set Password on ${cluster.name}`}
 					title={`Set Password on ${cluster.name}`}
@@ -60,50 +50,17 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		);
 	}
 
-	if (auth.isLoading) {
-		return undefined;
-	}
-
-	if (isDirectConnect) {
-		return (
-			<Link
-				to={`/${cluster.organizationId}/${cluster.id}${defaultInstanceRoute}`}
-				className="text-sm text-nowrap"
-				aria-label={`View ${cluster.name}`}
-				title={`View ${cluster.name}`}
-			>
-				<span className="py-2 hover:border-b-2">
-					Direct Connect <ArrowRight className="inline-block" />
-				</span>
-			</Link>
-		);
-	}
-
-	if (update && !clusterIsSelfManaged(cluster)) {
-		return (
-			<Link
-				to={`/${cluster.organizationId}/${cluster.id}${defaultInstanceRoute}`}
-				className="text-sm text-nowrap"
-				aria-label={`Connect to ${cluster.name}`}
-				title={`Connect to ${cluster.name}`}
-			>
-				<span className="py-2 hover:border-b-2">
-					Fabric Connect <ArrowRight className="inline-block" />
-				</span>
-			</Link>
-		);
-	}
-
+	// The cluster home owns the connect choice (Fabric Connect / Direct Sign In) and the connected
+	// state, so the card just opens it rather than guessing a connection mode here.
 	return (
 		<Link
-			to={`/${cluster.organizationId}/${cluster.id}/sign-in`}
+			to={`${base}/home`}
 			className="text-sm text-nowrap"
-			aria-label={`Sign In to ${cluster.name}`}
-			title={`Sign In to ${cluster.name}`}
-			onClick={prepareForDirectSignIn}
+			aria-label={`Open ${cluster.name}`}
+			title={`Open ${cluster.name}`}
 		>
 			<span className="py-2 hover:border-b-2">
-				Direct Sign In <ArrowRight className="inline-block" />
+				Open <ArrowRight className="inline-block" />
 			</span>
 		</Link>
 	);

--- a/src/features/clusters/components/ClusterCardAction.tsx
+++ b/src/features/clusters/components/ClusterCardAction.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@/components/ui/button';
 import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { Cluster } from '@/integrations/api/api.patch';
+import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight } from 'lucide-react';
 
-export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
+export function ClusterCardAction({ cluster, hasCardLink = false }: { cluster: Cluster; hasCardLink?: boolean }) {
 	const { view, update } = useOrganizationClusterPermissions(cluster.organizationId, cluster.id);
 	const base = `/${cluster.organizationId}/${cluster.id}`;
 
@@ -12,8 +13,20 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		return undefined;
 	}
 
-	// A cluster with no FQDN can't be connected to yet — send them to its instances.
+	// Self-hosted clusters open their own overview (see SelfHostedClusterHome), like managed clusters.
+	if (clusterIsSelfManaged(cluster)) {
+		return <OpenAction cluster={cluster} hasCardLink={hasCardLink} />;
+	}
+
+	// A managed cluster with no FQDN can't be connected to yet — send them to its instances.
 	if (!cluster.fqdn) {
+		if (hasCardLink) {
+			return (
+				<span className="text-sm text-nowrap py-2 ml-auto">
+					Instances <ArrowRight className="inline-block" />
+				</span>
+			);
+		}
 		return (
 			<Link
 				to={`${base}/instances`}
@@ -50,11 +63,29 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 		);
 	}
 
-	// The whole card is the click target for opening the cluster (see ClusterCard's stretched link),
-	// so this is just a visual affordance — not its own link.
+	return <OpenAction cluster={cluster} hasCardLink={hasCardLink} />;
+}
+
+// Inside a card the whole card is the click target for opening the cluster (see ClusterCard's
+// stretched link), so this is just a visual affordance. Standalone (Scaling, StartingUp) it links.
+function OpenAction({ cluster, hasCardLink }: { cluster: Cluster; hasCardLink: boolean }) {
+	if (hasCardLink) {
+		return (
+			<span className="text-sm text-nowrap py-2 ml-auto">
+				Open <ArrowRight className="inline-block" />
+			</span>
+		);
+	}
 	return (
-		<span className="text-sm text-nowrap py-2 ml-auto">
-			Open <ArrowRight className="inline-block" />
-		</span>
+		<Link
+			to={`/${cluster.organizationId}/${cluster.id}`}
+			className="text-sm text-nowrap"
+			aria-label={`Open ${cluster.name}`}
+			title={`Open ${cluster.name}`}
+		>
+			<span className="py-2 hover:border-b-2">
+				Open <ArrowRight className="inline-block" />
+			</span>
+		</Link>
 	);
 }

--- a/src/features/clusters/components/ClusterCardAction.tsx
+++ b/src/features/clusters/components/ClusterCardAction.tsx
@@ -53,7 +53,7 @@ export function ClusterCardAction({ cluster }: { cluster: Cluster }) {
 	// The whole card is the click target for opening the cluster (see ClusterCard's stretched link),
 	// so this is just a visual affordance — not its own link.
 	return (
-		<span className="text-sm text-nowrap py-2">
+		<span className="text-sm text-nowrap py-2 ml-auto">
 			Open <ArrowRight className="inline-block" />
 		</span>
 	);

--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -1,9 +1,11 @@
 import { ContactUs } from '@/components/ContactUs';
 import { ErrorComponent } from '@/components/ErrorComponent';
 import { Loading } from '@/components/Loading';
+import { SubNavMenu } from '@/components/SubNavMenu';
 import { SubNavSimpleLayout } from '@/components/SubNavSimpleLayout';
 import { isFailed, isTerminated } from '@/components/ui/utils/badgeStatus';
 import { deletedClusterStatuses } from '@/config/clusterStatuses';
+import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
 import { getPlanTypesOptions } from '@/features/cluster/queries/getPlanTypesQuery';
 import { getHarperVersionsOptions, HarperVersionsResponse } from '@/features/clusters/queries/getHarperVersionsQuery';
 import { getRegionLocationsOptions } from '@/features/clusters/queries/getRegionLocationsQuery';
@@ -19,7 +21,7 @@ import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
 import { compareVersions, wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
 import { useQuery } from '@tanstack/react-query';
 import { useParams, useRouteContext } from '@tanstack/react-router';
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { z } from 'zod';
 import { ClusterForm } from './ClusterForm';
 import { isUpsertClusterSchema } from './isUpsertClusterSchema';
@@ -28,6 +30,26 @@ import {
 } from './lib/calculateDefaultDeploymentPerformanceAndRegionPlans';
 import { detectPartialUpgrade } from './lib/detectPartialUpgrade';
 import { UpsertClusterSchema, UpsertClusterSchemaType } from './upsertClusterSchema';
+
+// Editing an existing cluster gets the cluster sub-nav rail (so Scaling/Version editing keep it);
+// creating a new cluster has no cluster context yet, so it uses the plain breadcrumb layout.
+function UpsertClusterLayout({ isEdit, className, children }: {
+	isEdit: boolean;
+	className?: string;
+	children: ReactNode;
+}) {
+	if (isEdit) {
+		return (
+			<>
+				<SubNavMenu />
+				<ClusterPageLayout>
+					<div className={className}>{children}</div>
+				</ClusterPageLayout>
+			</>
+		);
+	}
+	return <SubNavSimpleLayout className={className}>{children}</SubNavSimpleLayout>;
+}
 
 export function UpsertCluster() {
 	const { organizationId, clusterId, mode }: { organizationId: string; clusterId?: string; mode?: 'version' } =
@@ -217,15 +239,15 @@ export function UpsertCluster() {
 		|| !regionLocationsDedicated;
 	if (isLoading) {
 		return (
-			<SubNavSimpleLayout>
+			<UpsertClusterLayout isEdit={!!clusterId}>
 				<Loading centered={true} text="Loading..." />
-			</SubNavSimpleLayout>
+			</UpsertClusterLayout>
 		);
 	}
 
 	if (cluster?.id ? !update : !create) {
 		return (
-			<SubNavSimpleLayout>
+			<UpsertClusterLayout isEdit={!!clusterId}>
 				<ErrorComponent
 					title={`Not Allowed`}
 					error={{
@@ -236,13 +258,13 @@ export function UpsertCluster() {
 						),
 					}}
 				/>
-			</SubNavSimpleLayout>
+			</UpsertClusterLayout>
 		);
 	}
 
 	if (planTypes.length === 0) {
 		return (
-			<SubNavSimpleLayout>
+			<UpsertClusterLayout isEdit={!!clusterId}>
 				<ErrorComponent
 					title={`Cluster ${clusterId ? 'Modification' : 'Creation'} Not Currently Allowed`}
 					error={{
@@ -253,12 +275,12 @@ export function UpsertCluster() {
 						),
 					}}
 				/>
-			</SubNavSimpleLayout>
+			</UpsertClusterLayout>
 		);
 	}
 
 	return (
-		<SubNavSimpleLayout className="max-w-4xl mx-auto">
+		<UpsertClusterLayout isEdit={!!clusterId} className="max-w-4xl mx-auto">
 			<ClusterForm
 				alreadyUsingFree={alreadyUsingFree}
 				clusterId={clusterId}
@@ -275,6 +297,6 @@ export function UpsertCluster() {
 				setSavedClusterState={setSavedClusterState}
 				startOffOnBilling={isUpsertClusterSchema(savedClusterState) && savedClusterState.skipToBilling === true}
 			/>
-		</SubNavSimpleLayout>
+		</UpsertClusterLayout>
 	);
 }

--- a/src/features/instance/InstanceNavBar.tsx
+++ b/src/features/instance/InstanceNavBar.tsx
@@ -47,7 +47,11 @@ export function InstanceNavBar() {
 	const links = useMemo(() =>
 		[
 			canManage && {
-				to: buildAbsoluteLinkToPage(params),
+				// In cluster context the bare index is the cluster home, so Applications lives at /apps.
+				// Instance and local modes keep Applications at their index.
+				to: params.clusterId && !params.instanceId
+					? buildAbsoluteLinkToPage(params, 'apps')
+					: buildAbsoluteLinkToPage(params),
 				activeOptions: { exact: true },
 				name: 'Applications',
 				shortName: 'Apps',

--- a/src/features/instance/applications/routes.ts
+++ b/src/features/instance/applications/routes.ts
@@ -1,10 +1,15 @@
 import { createInstanceLayoutRoute } from '@/features/instance/instanceLayoutRoute';
 import { createRoute, lazyRouteComponent } from '@tanstack/react-router';
 
-export function createApplicationsRoutes(instanceLayoutRoute: ReturnType<typeof createInstanceLayoutRoute>) {
+export function createApplicationsRoutes(
+	instanceLayoutRoute: ReturnType<typeof createInstanceLayoutRoute>,
+	mode: 'local' | 'cluster' | 'instance',
+) {
 	const instanceApplicationsIndexRoute = createRoute({
 		getParentRoute: () => instanceLayoutRoute,
-		path: '/',
+		// In cluster mode the bare cluster index is the cluster home (see ClusterHome); Applications
+		// moves to /apps. Local and instance modes keep Applications as their index.
+		path: mode === 'cluster' ? 'apps' : '/',
 		head: () => ({ meta: [{ title: 'Applications — Harper Fabric' }] }),
 		// Lazy: the applications editor pulls in Monaco, the AI SDK, motion and
 		// react-markdown. Loading it on demand keeps all of that off first paint.

--- a/src/features/instance/routes.ts
+++ b/src/features/instance/routes.ts
@@ -11,7 +11,7 @@ export function createInstanceRouteTree(mode: 'local' | 'cluster' | 'instance') 
 
 	const children = [
 		createLogRouteTree(instanceLayoutRoute),
-		...createApplicationsRoutes(instanceLayoutRoute),
+		...createApplicationsRoutes(instanceLayoutRoute, mode),
 		createAPIsRouteTree(instanceLayoutRoute),
 		createStatusRouteTree(instanceLayoutRoute),
 		createConfigRouteTree(instanceLayoutRoute),

--- a/src/features/organization/billing/index.tsx
+++ b/src/features/organization/billing/index.tsx
@@ -1,4 +1,5 @@
 import { SubNavMenu } from '@/components/SubNavMenu';
+import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { useOrganizationPermissions } from '@/hooks/usePermissions';
 import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
 import { Link, Outlet, useParams } from '@tanstack/react-router';
@@ -23,7 +24,7 @@ export function OrgBillingIndex() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<OrgPageLayout>
 				<div className="md:grid gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))] mb-12">
 					<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 md:border-r-1 border-b md:border-b-0 md:pr-4 border-gray-700">
 						<DesktopBillingNavBar />
@@ -33,7 +34,7 @@ export function OrgBillingIndex() {
 						<Outlet />
 					</section>
 				</div>
-			</div>
+			</OrgPageLayout>
 		</>
 	);
 }

--- a/src/features/organization/billing/index.tsx
+++ b/src/features/organization/billing/index.tsx
@@ -1,13 +1,7 @@
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { useOrganizationPermissions } from '@/hooks/usePermissions';
-import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
-import { Link, Outlet, useParams } from '@tanstack/react-router';
-import { CreditCardIcon, ReceiptIcon, ReceiptTextIcon } from 'lucide-react';
-
-const sharedClasses = 'flex items-center p-2 rounded-lg group';
-const inactiveProps = { className: 'text-foreground hover:bg-accent dark:text-white dark:hover:bg-gray-700' };
-const activeProps = { className: 'text-black bg-white pointer-events-none cursor-default' };
+import { Outlet, useParams } from '@tanstack/react-router';
 
 export function OrgBillingIndex() {
 	const { organizationId } = useParams({ strict: false });
@@ -21,86 +15,14 @@ export function OrgBillingIndex() {
 		);
 	}
 
+	// Payment Method and Invoices are surfaced as sub-items under Billing in the org sub-nav
+	// (OrgPageLayout), so this layout just hosts the active billing page.
 	return (
 		<>
 			<SubNavMenu />
 			<OrgPageLayout>
-				<div className="md:grid gap-4 md:grid-cols-12 min-h-[calc(100vh-theme(spacing.36))] mb-12">
-					<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 md:border-r-1 border-b md:border-b-0 md:pr-4 border-gray-700">
-						<DesktopBillingNavBar />
-						<MobileBillingNavBar />
-					</section>
-					<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9">
-						<Outlet />
-					</section>
-				</div>
+				<Outlet />
 			</OrgPageLayout>
 		</>
-	);
-}
-
-function DesktopBillingNavBar() {
-	const params = useParams({ strict: false });
-	return (
-		<div className="hidden md:block">
-			<span className={sharedClasses}>
-				<ReceiptIcon className="inline-block" />
-				<h3 className="ms-3 text-2xl font-extrabold text-foreground">Billing</h3>
-			</span>
-
-			<ul className="border-t border-gray-700 pt-4 mt-4 space-y-2">
-				<li>
-					<Link
-						to={buildAbsoluteLinkToPage(params, 'billing')}
-						className={sharedClasses}
-						activeOptions={{ exact: true }}
-						inactiveProps={inactiveProps}
-						activeProps={activeProps}
-					>
-						<CreditCardIcon className="inline-block" /> <span className="ms-3">Payment Method</span>
-					</Link>
-				</li>
-				<li>
-					<Link
-						to={buildAbsoluteLinkToPage(params, 'billing/invoices')}
-						className={sharedClasses}
-						inactiveProps={inactiveProps}
-						activeProps={activeProps}
-					>
-						<ReceiptTextIcon className="inline-block" />
-						<span className="ms-3">Invoices &amp; Payments</span>
-					</Link>
-				</li>
-			</ul>
-		</div>
-	);
-}
-
-function MobileBillingNavBar() {
-	const params = useParams({ strict: false });
-	return (
-		<ul className="flex space-x-4 md:hidden py-2">
-			<li>
-				<Link
-					to={buildAbsoluteLinkToPage(params, 'billing')}
-					className={sharedClasses}
-					activeOptions={{ exact: true }}
-					inactiveProps={inactiveProps}
-					activeProps={activeProps}
-				>
-					<CreditCardIcon className="inline-block" /> <span className="ms-3">Payment Method</span>
-				</Link>
-			</li>
-			<li>
-				<Link
-					to={buildAbsoluteLinkToPage(params, 'billing/invoices')}
-					className={sharedClasses}
-					inactiveProps={inactiveProps}
-					activeProps={activeProps}
-				>
-					<ReceiptTextIcon className="inline-block" /> <span className="ms-3">Invoices &amp; Payments</span>
-				</Link>
-			</li>
-		</ul>
 	);
 }

--- a/src/features/organization/components/OrgPageLayout.tsx
+++ b/src/features/organization/components/OrgPageLayout.tsx
@@ -5,18 +5,26 @@ import { Link, useLocation, useParams } from '@tanstack/react-router';
 import { ChevronDown, CreditCardIcon, ServerIcon, SettingsIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
 import { ComponentType, ReactNode } from 'react';
 
+interface OrgNavSubItem {
+	to: string;
+	label: string;
+	exact?: boolean;
+}
+
 interface OrgNavItem {
 	to: string;
 	label: string;
 	icon: ComponentType<{ className?: string }>;
 	exact?: boolean;
+	children?: OrgNavSubItem[];
 }
 
 /**
  * Shared shell for the org-level pages (clusters, users, roles, billing, settings). Renders a
  * responsive sub-nav — a left rail when there's room, a dropdown when small — so Users/Roles/Billing/
  * Settings are discoverable from the org page instead of only the global header. Items are gated by
- * the same permissions the org card menu uses.
+ * the same permissions the org card menu uses. A section with sub-items (Billing) expands them
+ * underneath when it's the active section.
  */
 export function OrgPageLayout({ children }: { children: ReactNode }) {
 	const { organizationId } = useParams({ strict: false }) as { organizationId?: string };
@@ -28,7 +36,15 @@ export function OrgPageLayout({ children }: { children: ReactNode }) {
 		{ to: base, label: 'Clusters', icon: ServerIcon, exact: true },
 		canViewUsersAndRoles && { to: `${base}/users`, label: 'Users', icon: UsersIcon },
 		canViewUsersAndRoles && { to: `${base}/roles`, label: 'Roles', icon: ShieldCheckIcon },
-		canManageOrg && { to: `${base}/billing`, label: 'Billing', icon: CreditCardIcon },
+		canManageOrg && {
+			to: `${base}/billing`,
+			label: 'Billing',
+			icon: CreditCardIcon,
+			children: [
+				{ to: `${base}/billing`, label: 'Payment Method', exact: true },
+				{ to: `${base}/billing/invoices`, label: 'Invoices and Payments' },
+			],
+		},
 		canManageOrg && { to: `${base}/settings`, label: 'Settings', icon: SettingsIcon },
 	].filter(Boolean) as OrgNavItem[];
 
@@ -45,14 +61,16 @@ export function OrgPageLayout({ children }: { children: ReactNode }) {
 }
 
 const linkClasses = 'flex items-center gap-3 p-2 rounded-lg text-sm transition-colors';
+const subLinkClasses = 'block p-2 rounded-lg text-sm transition-colors';
 const inactiveProps = { className: 'text-foreground hover:bg-accent dark:text-white dark:hover:bg-grey-700' };
 const activeProps = {
-	className: 'font-medium text-primary bg-primary/10 dark:text-white dark:bg-white/10 pointer-events-none',
+	className: 'font-medium text-primary bg-primary/10 dark:text-white dark:bg-white/10',
 };
 
 function OrgSubNav({ items }: { items: OrgNavItem[] }) {
 	const { pathname } = useLocation();
-	const active = items.find((item) => item.exact ? pathname === item.to : pathname.startsWith(item.to)) ?? items[0];
+	const isSectionActive = (item: OrgNavItem) => item.exact ? pathname === item.to : pathname.startsWith(item.to);
+	const active = items.find(isSectionActive) ?? items[0];
 	const ActiveIcon = active.icon;
 
 	return (
@@ -61,17 +79,34 @@ function OrgSubNav({ items }: { items: OrgNavItem[] }) {
 				{items.map((item) => {
 					const Icon = item.icon;
 					return (
-						<Link
-							key={item.to}
-							to={item.to}
-							className={linkClasses}
-							activeOptions={{ exact: !!item.exact }}
-							activeProps={activeProps}
-							inactiveProps={inactiveProps}
-						>
-							<Icon className="size-4 shrink-0" />
-							{item.label}
-						</Link>
+						<div key={item.to}>
+							<Link
+								to={item.to}
+								className={linkClasses}
+								activeOptions={{ exact: !!item.exact }}
+								activeProps={activeProps}
+								inactiveProps={inactiveProps}
+							>
+								<Icon className="size-4 shrink-0" />
+								{item.label}
+							</Link>
+							{item.children && isSectionActive(item) && (
+								<div className="mt-1 ml-4 flex flex-col gap-1 border-l border-border pl-3">
+									{item.children.map((child) => (
+										<Link
+											key={child.to}
+											to={child.to}
+											className={subLinkClasses}
+											activeOptions={{ exact: !!child.exact }}
+											activeProps={activeProps}
+											inactiveProps={inactiveProps}
+										>
+											{child.label}
+										</Link>
+									))}
+								</div>
+							)}
+						</div>
 					);
 				})}
 			</nav>
@@ -90,14 +125,23 @@ function OrgSubNav({ items }: { items: OrgNavItem[] }) {
 					<DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
 						{items.map((item) => {
 							const Icon = item.icon;
-							return (
+							return [
 								<DropdownMenuItem key={item.to} asChild>
 									<Link to={item.to} className="flex items-center gap-2">
 										<Icon className="size-4" />
 										{item.label}
 									</Link>
-								</DropdownMenuItem>
-							);
+								</DropdownMenuItem>,
+								...(item.children && isSectionActive(item)
+									? item.children.map((child) => (
+										<DropdownMenuItem key={child.to} asChild>
+											<Link to={child.to} className="flex items-center gap-2 pl-8">
+												{child.label}
+											</Link>
+										</DropdownMenuItem>
+									))
+									: []),
+							];
 						})}
 					</DropdownMenuContent>
 				</DropdownMenu>

--- a/src/features/organization/components/OrgPageLayout.tsx
+++ b/src/features/organization/components/OrgPageLayout.tsx
@@ -1,0 +1,107 @@
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
+import { useOrganizationPermissions, useOrganizationRolePermissions } from '@/hooks/usePermissions';
+import { Link, useLocation, useParams } from '@tanstack/react-router';
+import { ChevronDown, CreditCardIcon, ServerIcon, SettingsIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
+import { ComponentType, ReactNode } from 'react';
+
+interface OrgNavItem {
+	to: string;
+	label: string;
+	icon: ComponentType<{ className?: string }>;
+	exact?: boolean;
+}
+
+/**
+ * Shared shell for the org-level pages (clusters, users, roles, billing, settings). Renders a
+ * responsive sub-nav — a left rail when there's room, a dropdown when small — so Users/Roles/Billing/
+ * Settings are discoverable from the org page instead of only the global header. Items are gated by
+ * the same permissions the org card menu uses.
+ */
+export function OrgPageLayout({ children }: { children: ReactNode }) {
+	const { organizationId } = useParams({ strict: false }) as { organizationId?: string };
+	const { view: canViewUsersAndRoles } = useOrganizationRolePermissions(organizationId);
+	const { update: canManageOrg } = useOrganizationPermissions(organizationId);
+	const base = `/${organizationId}`;
+
+	const items = [
+		{ to: base, label: 'Clusters', icon: ServerIcon, exact: true },
+		canViewUsersAndRoles && { to: `${base}/users`, label: 'Users', icon: UsersIcon },
+		canViewUsersAndRoles && { to: `${base}/roles`, label: 'Roles', icon: ShieldCheckIcon },
+		canManageOrg && { to: `${base}/billing`, label: 'Billing', icon: CreditCardIcon },
+		canManageOrg && { to: `${base}/settings`, label: 'Settings', icon: SettingsIcon },
+	].filter(Boolean) as OrgNavItem[];
+
+	return (
+		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
+			<div className="md:grid gap-6 md:grid-cols-12">
+				<aside className="md:col-span-3 lg:col-span-2 mb-4 md:mb-0">
+					<OrgSubNav items={items} />
+				</aside>
+				<section className="md:col-span-9 lg:col-span-10 min-w-0">{children}</section>
+			</div>
+		</div>
+	);
+}
+
+const linkClasses = 'flex items-center gap-3 p-2 rounded-lg text-sm transition-colors';
+const inactiveProps = { className: 'text-foreground hover:bg-accent dark:text-white dark:hover:bg-grey-700' };
+const activeProps = {
+	className: 'font-medium text-primary bg-primary/10 dark:text-white dark:bg-white/10 pointer-events-none',
+};
+
+function OrgSubNav({ items }: { items: OrgNavItem[] }) {
+	const { pathname } = useLocation();
+	const active = items.find((item) => item.exact ? pathname === item.to : pathname.startsWith(item.to)) ?? items[0];
+	const ActiveIcon = active.icon;
+
+	return (
+		<>
+			<nav className="hidden md:flex flex-col gap-1" aria-label="Organization sections">
+				{items.map((item) => {
+					const Icon = item.icon;
+					return (
+						<Link
+							key={item.to}
+							to={item.to}
+							className={linkClasses}
+							activeOptions={{ exact: !!item.exact }}
+							activeProps={activeProps}
+							inactiveProps={inactiveProps}
+						>
+							<Icon className="size-4 shrink-0" />
+							{item.label}
+						</Link>
+					);
+				})}
+			</nav>
+
+			<div className="md:hidden">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button variant="outline" className="w-full justify-between">
+							<span className="flex items-center gap-2">
+								<ActiveIcon className="size-4" />
+								{active.label}
+							</span>
+							<ChevronDown className="size-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
+						{items.map((item) => {
+							const Icon = item.icon;
+							return (
+								<DropdownMenuItem key={item.to} asChild>
+									<Link to={item.to} className="flex items-center gap-2">
+										<Icon className="size-4" />
+										{item.label}
+									</Link>
+								</DropdownMenuItem>
+							);
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+		</>
+	);
+}

--- a/src/features/organization/components/OrgPageLayout.tsx
+++ b/src/features/organization/components/OrgPageLayout.tsx
@@ -42,7 +42,7 @@ export function OrgPageLayout({ children }: { children: ReactNode }) {
 			icon: CreditCardIcon,
 			children: [
 				{ to: `${base}/billing`, label: 'Payment Method', exact: true },
-				{ to: `${base}/billing/invoices`, label: 'Invoices and Payments' },
+				{ to: `${base}/billing/invoices`, label: 'Invoices' },
 			],
 		},
 		canManageOrg && { to: `${base}/settings`, label: 'Settings', icon: SettingsIcon },

--- a/src/features/organization/components/OrgPageLayout.tsx
+++ b/src/features/organization/components/OrgPageLayout.tsx
@@ -1,30 +1,14 @@
-import { Button } from '@/components/ui/button';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
+import { SubNavItem, SubNavRail } from '@/components/SubNavRail';
 import { useOrganizationPermissions, useOrganizationRolePermissions } from '@/hooks/usePermissions';
-import { Link, useLocation, useParams } from '@tanstack/react-router';
-import { ChevronDown, CreditCardIcon, ServerIcon, SettingsIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
-import { ComponentType, ReactNode } from 'react';
-
-interface OrgNavSubItem {
-	to: string;
-	label: string;
-	exact?: boolean;
-}
-
-interface OrgNavItem {
-	to: string;
-	label: string;
-	icon: ComponentType<{ className?: string }>;
-	exact?: boolean;
-	children?: OrgNavSubItem[];
-}
+import { useParams } from '@tanstack/react-router';
+import { CreditCardIcon, ServerIcon, SettingsIcon, ShieldCheckIcon, UsersIcon } from 'lucide-react';
+import { ReactNode } from 'react';
 
 /**
  * Shared shell for the org-level pages (clusters, users, roles, billing, settings). Renders a
  * responsive sub-nav — a left rail when there's room, a dropdown when small — so Users/Roles/Billing/
  * Settings are discoverable from the org page instead of only the global header. Items are gated by
- * the same permissions the org card menu uses. A section with sub-items (Billing) expands them
- * underneath when it's the active section.
+ * the same permissions the org card menu uses; Billing expands to its sub-pages when active.
  */
 export function OrgPageLayout({ children }: { children: ReactNode }) {
 	const { organizationId } = useParams({ strict: false }) as { organizationId?: string };
@@ -46,106 +30,16 @@ export function OrgPageLayout({ children }: { children: ReactNode }) {
 			],
 		},
 		canManageOrg && { to: `${base}/settings`, label: 'Settings', icon: SettingsIcon },
-	].filter(Boolean) as OrgNavItem[];
+	].filter(Boolean) as SubNavItem[];
 
 	return (
 		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
 			<div className="md:grid gap-6 md:grid-cols-12">
 				<aside className="md:col-span-3 lg:col-span-2 mb-4 md:mb-0">
-					<OrgSubNav items={items} />
+					<SubNavRail items={items} ariaLabel="Organization sections" />
 				</aside>
 				<section className="md:col-span-9 lg:col-span-10 min-w-0">{children}</section>
 			</div>
 		</div>
-	);
-}
-
-const linkClasses = 'flex items-center gap-3 p-2 rounded-lg text-sm transition-colors';
-const subLinkClasses = 'block p-2 rounded-lg text-sm transition-colors';
-const inactiveProps = { className: 'text-foreground hover:bg-accent dark:text-white dark:hover:bg-grey-700' };
-const activeProps = {
-	className: 'font-medium text-primary bg-primary/10 dark:text-white dark:bg-white/10',
-};
-
-function OrgSubNav({ items }: { items: OrgNavItem[] }) {
-	const { pathname } = useLocation();
-	const isSectionActive = (item: OrgNavItem) => item.exact ? pathname === item.to : pathname.startsWith(item.to);
-	const active = items.find(isSectionActive) ?? items[0];
-	const ActiveIcon = active.icon;
-
-	return (
-		<>
-			<nav className="hidden md:flex flex-col gap-1" aria-label="Organization sections">
-				{items.map((item) => {
-					const Icon = item.icon;
-					return (
-						<div key={item.to}>
-							<Link
-								to={item.to}
-								className={linkClasses}
-								activeOptions={{ exact: !!item.exact }}
-								activeProps={activeProps}
-								inactiveProps={inactiveProps}
-							>
-								<Icon className="size-4 shrink-0" />
-								{item.label}
-							</Link>
-							{item.children && isSectionActive(item) && (
-								<div className="mt-1 ml-4 flex flex-col gap-1 border-l border-border pl-3">
-									{item.children.map((child) => (
-										<Link
-											key={child.to}
-											to={child.to}
-											className={subLinkClasses}
-											activeOptions={{ exact: !!child.exact }}
-											activeProps={activeProps}
-											inactiveProps={inactiveProps}
-										>
-											{child.label}
-										</Link>
-									))}
-								</div>
-							)}
-						</div>
-					);
-				})}
-			</nav>
-
-			<div className="md:hidden">
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button variant="outline" className="w-full justify-between">
-							<span className="flex items-center gap-2">
-								<ActiveIcon className="size-4" />
-								{active.label}
-							</span>
-							<ChevronDown className="size-4" />
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="start" className="w-(--radix-dropdown-menu-trigger-width)">
-						{items.map((item) => {
-							const Icon = item.icon;
-							return [
-								<DropdownMenuItem key={item.to} asChild>
-									<Link to={item.to} className="flex items-center gap-2">
-										<Icon className="size-4" />
-										{item.label}
-									</Link>
-								</DropdownMenuItem>,
-								...(item.children && isSectionActive(item)
-									? item.children.map((child) => (
-										<DropdownMenuItem key={child.to} asChild>
-											<Link to={child.to} className="flex items-center gap-2 pl-8">
-												{child.label}
-											</Link>
-										</DropdownMenuItem>
-									))
-									: []),
-							];
-						})}
-					</DropdownMenuContent>
-				</DropdownMenu>
-			</div>
-		</>
 	);
 }

--- a/src/features/organization/roles/index.tsx
+++ b/src/features/organization/roles/index.tsx
@@ -2,6 +2,7 @@ import { Loading } from '@/components/Loading';
 import { SimpleBrowseDataTable } from '@/components/SimpleBrowseDataTable';
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { Button } from '@/components/ui/button';
+import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
@@ -72,7 +73,7 @@ export function OrgConfigRolesIndex() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
+			<OrgPageLayout>
 				<Suspense fallback={<Loading className="flex flex-col items-center justify-center h-full" text="Loading..." />}>
 					<SimpleBrowseDataTable data={orgRoles} columns={dataTableColumns} onRowClick={onRowClick}>
 						<Button
@@ -110,7 +111,7 @@ export function OrgConfigRolesIndex() {
 						/>
 					)}
 				</Suspense>
-			</div>
+			</OrgPageLayout>
 		</>
 	);
 }

--- a/src/features/organization/settings/index.tsx
+++ b/src/features/organization/settings/index.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { apiClient } from '@/config/apiClient';
+import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { getOrganizationQueryOptions } from '@/features/organization/queries/getOrganizationQuery';
 import { useCloudAuth } from '@/hooks/useAuth';
 import { writeToClipboard } from '@/hooks/useCopyToClipboard';
@@ -159,7 +160,7 @@ export function OrgSettingsIndex() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<OrgPageLayout>
 				<div className="max-w-2xl">
 					<h2 className="text-2xl text-foreground font-light mb-6">Authentication</h2>
 
@@ -483,7 +484,7 @@ export function OrgSettingsIndex() {
 						)}
 					</section>
 				</div>
-			</div>
+			</OrgPageLayout>
 		</>
 	);
 }

--- a/src/features/organization/users/index.tsx
+++ b/src/features/organization/users/index.tsx
@@ -2,6 +2,7 @@ import { Loading } from '@/components/Loading';
 import { SimpleBrowseDataTable } from '@/components/SimpleBrowseDataTable';
 import { SubNavMenu } from '@/components/SubNavMenu';
 import { Button } from '@/components/ui/button';
+import { OrgPageLayout } from '@/features/organization/components/OrgPageLayout';
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { dataTableColumns } from '@/features/organization/users/constants/tableDefinition';
 import { AddUserModal } from '@/features/organization/users/modals/AddUserModal';
@@ -96,7 +97,7 @@ export function OrgConfigUsersIndex() {
 	return (
 		<>
 			<SubNavMenu />
-			<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
+			<OrgPageLayout>
 				<Suspense fallback={<Loading className="flex flex-col items-center justify-center h-full" text="Loading..." />}>
 					<SimpleBrowseDataTable<SchemaUser, unknown>
 						data={cloudUsers}
@@ -141,7 +142,7 @@ export function OrgConfigUsersIndex() {
 						/>
 					)}
 				</Suspense>
-			</div>
+			</OrgPageLayout>
 		</>
 	);
 }

--- a/src/features/organizations/components/OrgCard.test.tsx
+++ b/src/features/organizations/components/OrgCard.test.tsx
@@ -32,7 +32,8 @@ describe('Org Card', () => {
 
 		// screen.debug();
 		expect(screen.getByText(/^Acme/).textContent).toBeTruthy();
-		const link = screen.getByTitle('View Acme');
+		// The whole card is a stretched link to the org; find it by its accessible name.
+		const link = screen.getByRole('link', { name: 'View Acme' });
 		expect(link).toBeTruthy();
 		const href = link.getAttribute('href');
 		expect(href).toBe('/#/123');

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -92,13 +92,22 @@ export function OrgCard({
 	return (
 		<EntityContextMenu items={remove ? menuItems : []}>
 			<Card className="relative h-full justify-between transition-[transform,box-shadow] duration-200 hover:scale-[1.02] hover:shadow-lg hover:ring-2 hover:ring-primary/60 dark:hover:ring-violet-400/70">
+				<Link
+					to={organizationId}
+					aria-label={`View ${organizationName ?? organizationId}`}
+					className="absolute inset-0 rounded-[inherit] focus-visible:ring-2 focus-visible:ring-purple-200 focus-visible:outline-none"
+				/>
 				<CardHeader>
 					<CardDescription className="flex items-center justify-between">
 						<span className="truncate">{organizationId}</span>
 						{remove && (
 							<DropdownMenu>
-								<DropdownMenuTrigger className="p-4 -m-4 -mr-6 hover:text-foreground">
-									<Ellipsis aria-label="Options" />
+								<DropdownMenuTrigger
+									aria-label="Options"
+									onClick={(e) => e.stopPropagation()}
+									className="relative z-10 p-4 -m-4 -mr-6 hover:text-foreground"
+								>
+									<Ellipsis />
 								</DropdownMenuTrigger>
 								<DropdownMenuContent>
 									{renderEntityMenuItems(menuItems, 'dropdown')}
@@ -114,16 +123,10 @@ export function OrgCard({
 					<Badge className="min-w-0 shrink" title={capitalizeWords(roleName)}>
 						<span className="truncate">{capitalizeWords(roleName)}</span>
 					</Badge>
-					<Link
-						to={organizationId}
-						className="text-sm shrink-0"
-						aria-label={`View ${organizationName ?? organizationId}`}
-						title={`View ${organizationName ?? organizationId}`}
-					>
-						<span className="py-2 transition-all duration-100 ease-in-out border-0 hover:border-b-2 whitespace-nowrap">
-							View <ArrowRight className="inline-block" />
-						</span>
-					</Link>
+					{/* The whole card opens the org (stretched link above); this is a visual affordance. */}
+					<span className="text-sm shrink-0 py-2 whitespace-nowrap ml-auto">
+						View <ArrowRight className="inline-block" />
+					</span>
 				</CardContent>
 				<AddCouponModal
 					organizationId={organizationId}

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -91,7 +91,7 @@ export function OrgCard({
 
 	return (
 		<EntityContextMenu items={remove ? menuItems : []}>
-			<Card className="relative h-full justify-between hover:shadow-lg transition-shadow duration-200">
+			<Card className="relative h-full justify-between transition-[transform,box-shadow] duration-200 hover:scale-[1.02] hover:shadow-lg hover:ring-2 hover:ring-primary/60 dark:hover:ring-violet-400/70">
 				<CardHeader>
 					<CardDescription className="flex items-center justify-between">
 						<span className="truncate">{organizationId}</span>

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -105,7 +105,7 @@ export function OrgCard({
 								<DropdownMenuTrigger
 									aria-label="Options"
 									onClick={(e) => e.stopPropagation()}
-									className="relative z-10 p-4 -m-4 -mr-6 hover:text-foreground"
+									className="relative z-10 -m-2 p-2 rounded-md hover:bg-accent/60 hover:text-foreground"
 								>
 									<Ellipsis />
 								</DropdownMenuTrigger>

--- a/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
+++ b/src/integrations/api/instance/auth/useInstanceLoginMutation.ts
@@ -43,6 +43,7 @@ export async function onInstanceLoginSubmit({
 		// Attempt to use the login with session storage only.
 		try {
 			const user = await getInstanceUserInfo({ instanceClient });
+			authStore.setLastConnectMode(entityId, 'direct');
 			return {
 				message,
 				user,
@@ -60,6 +61,7 @@ export async function onInstanceLoginSubmit({
 			auth,
 		});
 		authStore.flagForBasicAuth(entityId, auth);
+		authStore.setLastConnectMode(entityId, 'direct');
 		return {
 			message,
 			user,


### PR DESCRIPTION
> **Stacked on #1400** (JWT direct-connect + #1333). Review/merge that first; this targets its branch so the diff stays scoped to the cluster/org UX.

## What & why

Started as a fix for the connect-mode guessing behind #1333 and grew into a cohesive pass over the cluster and org navigation. Instead of the cluster card guessing a connection mode and the route guard auto-Fabric-Connecting, a dedicated **cluster home** owns the choice explicitly — and the surrounding cards/nav were brought in line with it.

### Cluster home (connect choice) — #1333, #1398
- **`ClusterHome`** is now the **cluster index** (`/{org}/{clusterId}/`); the in-cluster studio moved to `/{org}/{clusterId}/apps`. Hero with name/status/instance count, the host **linkified** (opens in a new tab) with a copy menu (**Copy host name** / **Copy API URL**).
- Unconnected: a **Fabric Connect / Direct sign-in** picker with a green **"Last used"** pill (remembered via `authStore.setLastConnectMode` — a preference, not a secret), purple **"Recommended"** for first-timers.
- Connected: a prominent **"Enter cluster"** card into the studio, with low-key switch/disconnect links.
- Guards read **live `authStore`** rather than the lagging router-context snapshot (the root cause of the direct-sign-in clobber).

### Full-card clickable cards — closes #1260
- **Org cards and cluster cards** are now clickable across the whole card (stretched-link overlay), except a generous hit area around the `⋯` menu; right-click still opens the context menu.
- Reactive hover (subtle grow + ring color shift), plus hover states on the cluster card's copy button and the org card's `⋯`. Cluster card's "Open →" is right-aligned.

### Self-hosted clusters get the same treatment
- **Self-hosted overview**: `ClusterHome` renders a self-hosted variant instead of redirecting to `/instances` — no status pill / FQDN / Fabric Connect (connections are per-instance), an instance count linking to Instances, and **Direct sign-in to the first instance**; when that instance is signed in, the same "Enter cluster" panel enters the studio through it.
- The **whole card opens the overview** for self-hosted too (managed clusters with no FQDN still go to Instances), and the standalone "Open →" on the Scaling/StartingUp pages is a real link again.
- The rail's **"Scaling" reads "Configuration"** for self-hosted (their editor only holds registration details), and the self-hosted **instances table drops the Status column** — which also stops the per-instance status polling.

### Fixes found along the way
- The **"Last used"/"Recommended" pill** gets a solid backdrop so the card border no longer shows through its translucent fill.
- The cluster editor's **price display** anchored to the viewport on the edit pages (hidden behind the fixed header) once editing moved under the rail — `ClusterPageLayout` now provides the `relative` container, matching `SubNavSimpleLayout`.

### Sub-nav rails (Config-page paradigm)
- **Org page** gets a responsive left rail (dropdown when narrow): Clusters / Users / Roles / Billing (→ Payment Method, Invoices) / Settings — pulling Users/Roles/Billing **out of the global header** into the org, permission-gated. Global header slimmed to Docs/Profile/theme/Sign out.
- **Cluster** gets a matching persistent rail: Overview / Scaling / Version / Domains / Instances, gated by cluster permissions. Scaling → `/edit`, Version → `/edit/version` (both exact so they don't cross-highlight); editing scaling/version keeps the rail.
- Cluster **"Filter by name"** moved into the list frame as a full-width underline input (no background pill).

## Design decisions (agreed while building)
- **Cluster home** is the index; **cluster-level** connect scope; **"Last used"** green pill over static "Recommended".
- Shared layout **components** (`SubNavRail`, `OrgPageLayout`, `ClusterPageLayout`) rendered per page, rather than restructuring the route tree — keeps `getParentRoute`/`addChildren` in lockstep per CLAUDE.md (router-matching regression test stays green).
- Single-cluster orgs intentionally **do not** auto-skip the org page — the enriched details are worth landing on.

## Verification
Typecheck, lint, format, full suite (**1036 passing**) incl. the router-matching regression test. Browser-verified on a live authenticated dev server across cluster / instance / local-studio modes: index promotion, card clickability, both rails and their active states, the connect picker, and the host copy menu. For the self-hosted pass: card click → overview → Direct sign-in lands on the first instance's sign-in page, the instances table makes no status requests after a fresh load (network log shows only org/user/cluster-info), and the editor price display renders top-right of the content area instead of behind the header.

Closes HarperFast/studio#1260
Refs HarperFast/studio#1398, HarperFast/studio#1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

