### PR TITLE
fix(editor): keep the OK button inside the rejected-uploads toast

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/DropTarget.tsx
@@ -116,7 +116,10 @@ export function DropTarget() {
 
 				toast.loading(`Upload in progress...`, {
 					id,
-					descriptionClassName: 'whitespace-pre',
+					// pre-line (not pre): sonner toasts are fixed-width flex rows, so an
+					// unwrappable line wider than the toast pushes the action button
+					// outside the container (#1323).
+					descriptionClassName: 'whitespace-pre-line',
 					description: `${counter} of ${pluralize(filesToUpload.length, 'file', 'files')}
 ${file.name}
 ${humanFileSize(uploadedBytes)} of ${humanFileSize(totalBytes)}`,
@@ -184,7 +187,7 @@ ${humanFileSize(uploadedBytes)} of ${humanFileSize(totalBytes)}`,
 				toast.error(canceled ? 'Cancelled uploads' : 'Rejected uploads', {
 					id,
 					action: toastOKAction,
-					descriptionClassName: 'whitespace-pre overflow-y-auto',
+					descriptionClassName: 'whitespace-pre-line overflow-y-auto',
 					description: filesRejected
 						.slice(0, 5)
 						.map(r => r.errors.map(e => e.message).join('\n'))


### PR DESCRIPTION
## Summary

Fixes #1323 — the OK button on the "Rejected uploads" toast rendered outside the toast container when dotfiles were rejected during a drag-and-drop upload into the cluster editor.

## Root cause

Sonner toasts are fixed-width (356px) flex rows: `[icon] [content column] [action button]`, with the button set to `flex-shrink: 0`. The upload toasts in `DropTarget.tsx` set `descriptionClassName: 'whitespace-pre'`, and `white-space: pre` forbids all line wrapping. A rejection message longer than the toast (e.g. "Sensitive files and folders starting with . are skipped.") therefore widened the content column past the toast's fixed width and pushed the OK button out of the container.

## Fix

Use `whitespace-pre-line` instead of `whitespace-pre` on both upload toasts (the in-progress toast had the same latent bug — a long file name would push its Cancel button out the same way). `pre-line` keeps the intentional newlines between rejected files but lets long lines wrap; sonner already applies `overflow-wrap: anywhere` to toast content, so even unbroken long file paths wrap cleanly.

## Verification

Reproduced the exact sonner DOM + stylesheet in an isolated page and measured with both classes (the real flow needs an authenticated cluster editor):

- **Before** (`whitespace-pre`): OK button overflows the toast by **42px** — matches the screenshot in the issue.
- **After** (`whitespace-pre-line`): messages wrap; the OK button sits fully inside the toast (17px of padding to spare).

| Before | After |
| --- | --- |
| Button pushed outside the toast (clipped at viewport edge) | Text wraps, button inside |

Full test suite (1036 tests), oxlint, dprint, and `tsc -b` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)