### PR TITLE
fix(router): create the TanStack router once, not on every AppRouted render

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,22 @@ tolerated the mismatch; the 1.133→1.170 bump exposed it.
 coverage lives in `src/router/__tests__/orgUndefinedRepro.test.ts`, which uses
 `router.matchRoutes()` (no loaders/network) to assert deep links parse params correctly.
 
+## Routing — the router must be created exactly once (never per render)
+
+`useNewRouter` memoizes `createRouter()`/`createHashHistory()` with a `useState` initializer
+— keep it that way. Every `createHashHistory()` call monkey-patches
+`window.history.pushState/replaceState` (wrappers chain and are never removed) and leaks
+`popstate`/scroll listeners. Worse, when the current history entry lacks `__TSR_key` (true
+after any raw `location.hash =` navigation), history creation synchronously calls
+`replaceState` — the patched chain then notifies the live router's subscriber mid-render,
+which React logs as **"Cannot update a component (`Transitioner`) while rendering a
+different component (`AppRouted`)"** (hit Jul 2026: `AppRouted` re-rendered on every
+authStore tick and rebuilt the router each time).
+
+Auth updates reach the memoized router via the `RouterProvider` `context` prop plus the
+`router.invalidate()` effect in `src/AppRouted.tsx` — that invalidate is what re-runs
+`beforeLoad` guards (e.g. the sign-out redirect in `dashboardRoute.ts`), so don't remove it.
+
 ## pnpm — dependency overrides go in `pnpm-workspace.yaml`, not `package.json`
 
 This repo uses pnpm 11. `overrides` (and other settings like `minimumReleaseAge`,

--- a/src/AppRouted.tsx
+++ b/src/AppRouted.tsx
@@ -2,10 +2,21 @@ import { useRootAuthenticationContext } from '@/hooks/useAuth';
 import { useNewRouter } from '@/router/useNewRouter';
 import { RouterProvider } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
+import { useEffect, useRef } from 'react';
 
 export function AppRouted() {
 	const authentication = useRootAuthenticationContext();
 	const router = useNewRouter({ authentication });
+	// The RouterProvider `context` prop keeps router context current, but already-loaded
+	// matches hold the context they were built with — invalidate so beforeLoad guards
+	// (e.g. the dashboardLayout sign-out redirect) re-run when authentication changes.
+	const lastAuthentication = useRef(authentication);
+	useEffect(() => {
+		if (lastAuthentication.current !== authentication) {
+			lastAuthentication.current = authentication;
+			void router.invalidate();
+		}
+	}, [router, authentication]);
 	return (
 		<>
 			<RouterProvider router={router} context={{ authentication }} />

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -12,11 +12,17 @@ import { useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
 export function useRootAuthenticationContext(): Record<EntityIds, AuthenticatedConnection> {
-	const [connections, setConnections] = useState(authStore.getAllConnections());
+	// Copy the store's record: getAllConnections() returns its live internal object, which
+	// mutates on every update and would make state comparisons lie.
+	const [connections, setConnections] = useState(() => ({ ...authStore.getAllConnections() }));
+	// Subscribe exactly once. Re-subscribing per change (the old `[connections]` dep) opened a
+	// gap between cleanup and re-subscribe in which updates were silently dropped — sign-out
+	// emits a burst (each instance entity, then OverallAppSignIn last), and losing that final
+	// event left AppRouted holding a signed-in context, so route guards never re-ran.
 	useEffect(() =>
 		authStore.listenToAllEntities((connection, id) => {
-			setConnections({ ...connections, [id]: connection });
-		}), [connections]);
+			setConnections((previous) => ({ ...previous, [id]: connection }));
+		}), []);
 	return connections;
 }
 

--- a/src/router/useNewRouter.ts
+++ b/src/router/useNewRouter.ts
@@ -5,26 +5,35 @@ import { browserIsTouchBased } from '@/lib/browserIsTouchBased';
 import { queryClient } from '@/react-query/queryClient';
 import { rootRouteTree } from '@/router/rootRouteTree';
 import { createHashHistory, createRouter } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export function useNewRouter({ routeTree = rootRouteTree, authentication }: {
 	routeTree?: typeof rootRouteTree;
 	authentication?: Record<EntityIds, AuthenticatedConnection>;
 }) {
-	const hashHistory = createHashHistory();
-	return createRouter({
-		routeTree,
-		history: hashHistory,
-		defaultNotFoundComponent: NotFoundComponent,
-		defaultErrorComponent: ErrorComponent,
-		defaultPreload: browserIsTouchBased() ? false : 'intent',
-		trailingSlash: 'never',
-		// Since we're using React Query, we don't want loader calls to ever be stale
-		// This will ensure that the loader is always called when the route is preloaded or visited
-		defaultPreloadStaleTime: 0,
-		scrollRestoration: true,
-		context: {
-			queryClient,
-			authentication: authentication || {},
-		},
-	});
+	// The router (and its hash history) must be created exactly once. Every
+	// `createHashHistory()` call monkey-patches window.history.pushState/replaceState and can
+	// synchronously notify the previous router's history subscriber mid-render, which React
+	// reports as "Cannot update a component (Transitioner) while rendering a different
+	// component (AppRouted)". `authentication` is only the INITIAL context here — updates flow
+	// through the RouterProvider `context` prop and `router.invalidate()` (see AppRouted).
+	const [router] = useState(() =>
+		createRouter({
+			routeTree,
+			history: createHashHistory(),
+			defaultNotFoundComponent: NotFoundComponent,
+			defaultErrorComponent: ErrorComponent,
+			defaultPreload: browserIsTouchBased() ? false : 'intent',
+			trailingSlash: 'never',
+			// Since we're using React Query, we don't want loader calls to ever be stale
+			// This will ensure that the loader is always called when the route is preloaded or visited
+			defaultPreloadStaleTime: 0,
+			scrollRestoration: true,
+			context: {
+				queryClient,
+				authentication: authentication || {},
+			},
+		})
+	);
+	return router;
 }


### PR DESCRIPTION
## Problem

Navigating around the app in dev logged repeated React errors:

> Cannot update a component (`Transitioner`) while rendering a different component (`AppRouted`).

`useNewRouter` called `createRouter()`/`createHashHistory()` unconditionally in the hook body, so **every render of `AppRouted` built a brand-new router and hash history** — and `AppRouted` re-renders on every authStore tick (which happens routinely while navigating into cluster/instance routes, e.g. the Fabric Connect proxy fallback).

Each `createHashHistory()` call:
- monkey-patches `window.history.pushState`/`replaceState` — the wrappers chain and are never removed — and leaks `popstate`/scroll listeners;
- when the current history entry lacks `__TSR_key` (true after any raw `location.hash =` navigation), synchronously calls `replaceState` **during render**. The patched wrapper chain then notifies the live router's history subscriber → `router.load()` → `router.startTransition` → `setIsTransitioning` inside `Transitioner` → the React warning.

Reproduced in the browser by opening that window (raw hash navigation, `history.state === null`) and firing an authStore update: the warning appeared verbatim and `history.state` gained `__TSR_key` in the same tick. This is app-side misuse (TanStack requires the router to be created once), not an upstream bug — no router patch bump fixes it.

## Fix

- `src/router/useNewRouter.ts`: create the router once via a `useState` initializer.
- `src/AppRouted.tsx`: call `router.invalidate()` when `authentication` changes. Sign-out doesn't navigate — it nulls the user and previously relied on the router being rebuilt to re-run the `dashboardLayout` `beforeLoad` redirect to `/sign-in`. The `RouterProvider` `context` prop keeps the router context current; the invalidate makes the guards re-evaluate it.
- `CLAUDE.md`: documented the gotcha.

## Verification

- Re-ran the exact repro after the fix: no warning, `window.history` no longer re-patched, `history.state` untouched, navigation works with no error toasts.
- Typecheck clean; full vitest suite passes (168 files, 1075 tests).
- Not covered live: the signed-in sign-out redirect end-to-end (stage session expired mid-testing); it rests on the `router.invalidate()` path described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)