### PR TITLE
fix(layout): give <body> a BFC so header-clearance margin doesn't offset extension overlays

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -256,6 +256,17 @@
 
 	body {
 		@apply h-full bg-background font-ubuntu text-foreground;
+		/*
+		 * Establish a block formatting context on <body>. Every page layout uses an `mt-32`
+		 * (128px) top margin to clear the fixed header + nav; with no BFC in between, that
+		 * margin collapses up through <body> and shifts its box down ~128px. Absolutely
+		 * positioned overlays that browser extensions append to <body> and anchor from its
+		 * origin (e.g. LastPass's autofill menu, which becomes position:relative-anchored once
+		 * a modal opens) then inherit that offset and render ~1.5 fields below the focused
+		 * input. flow-root pins <body> at the viewport origin; the visible layout is unchanged
+		 * (the margin still spaces content below the header, just inside <body> now).
+		 */
+		display: flow-root;
 	}
 }
 


### PR DESCRIPTION
## Problem

LastPass's autofill dropdown renders **~1.5 fields too low** inside modals (e.g. the instance **Add New User** form), drifting further down per field and swallowing clicks meant for the controls beneath (like the Role picker). 1Password and other managers are unaffected.

## Root cause (it's not the modal)

Traced live in-browser with real LastPass:

- A standalone repro of the same centered modal **did not drift** — ruling out the dialog layout itself.
- Every page layout uses `mt-32` (`margin-top: 8rem` = **128px**) to clear the fixed header + nav. With no block formatting context between it and `<body>`, that top margin **collapses up through `<body>`**, shifting `<body>`'s box down 128px (`body.getBoundingClientRect().top === 128`, despite `body { margin: 0 }`).
- LastPass appends its autofill menu as an absolutely-positioned child of `<body>` and anchors it from `<body>`'s origin (once a Radix modal opens, `<body>` becomes `position: relative` via scroll-lock). It inherits the 128px offset → the drift. `128px ≈ 1.5 field heights`, matching the symptom exactly.
- 1Password renders in the browser top layer using viewport coordinates, so it never sees the offset.

Confirmed on prod: pasting `document.body.style.display = 'flow-root'` in the console pinned `<body>` back to `0` and the dropdowns aligned.

## Fix

Give `<body>` a block formatting context so the `mt-32` margin can't collapse through it:

```css
body {
  @apply h-full bg-background font-ubuntu text-foreground;
  display: flow-root;
}
```

`<body>` pins to the viewport origin; the `mt-32` still spaces content below the fixed header (verified content top stays at `128px`), so **the visible layout is unchanged**.

## Why this over the alternatives

- **Not** `data-lpignore` on the fields — that would disable LastPass autofill on the form. This keeps every password manager fully enabled.
- **Not** a modal/dialog change — the modal was proven innocent.
- One rule at the single common ancestor fixes overlay alignment for **every** form in the app (all ~11 `mt-32` layouts), no component code touched.

## Verification

- On the running app: `body.getBoundingClientRect().top` `128 → 0`; content still clears the header (`128px`); page renders identically (no layout shift).
- Full test suite passes (1141 tests), lint + format clean.
- Mechanism confirmed live with real LastPass on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)