### PR TITLE
fix(ui): remove button hover bounce and unify soft-edge radius

### DIFF
--- a/src/components/ApplyLicensesButton.tsx
+++ b/src/components/ApplyLicensesButton.tsx
@@ -22,7 +22,7 @@ export function ApplyLicensesButton({
 			<TooltipTrigger asChild>
 				<Button
 					variant="defaultOutline"
-					className="mx-0 md:mx-4 rounded-full"
+					className="mx-0 md:mx-4"
 					onClick={onApplyLicensesClick}
 					disabled={isApplyLicensesPending}
 				>

--- a/src/components/ConfirmDeletionModal.tsx
+++ b/src/components/ConfirmDeletionModal.tsx
@@ -62,12 +62,11 @@ export function ConfirmDeletionModal({
 				)}
 				<DialogFooter>
 					<div className="flex justify-center space-x-5">
-						<Button type="button" className="rounded-full" onClick={() => setIsModalOpen(false)}>
+						<Button type="button" onClick={() => setIsModalOpen(false)}>
 							<ArrowLeft /> Cancel
 						</Button>
 						<Button
 							variant="destructive"
-							className="rounded-full"
 							onClick={deletionConfirmed}
 							disabled={deletionPending}
 						>

--- a/src/components/RestartButton.tsx
+++ b/src/components/RestartButton.tsx
@@ -34,7 +34,7 @@ export function RestartButton({
 				<Button
 					type="button"
 					variant={variant || 'positiveOutline'}
-					className={cx('mx-0 md:mx-4 rounded-full', className)}
+					className={cx('mx-0 md:mx-4', className)}
 					onClick={targetNoun === 'Cluster' && operation === 'restart' ? onRestartClusterClick : onRestartClick}
 					disabled={disabled || isRestartPending || isRestartClusterPending}
 					title={`Restart ${targetNoun}`}

--- a/src/components/ui/buttonVariants.tsx
+++ b/src/components/ui/buttonVariants.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 const outlineCommon =
-	'border bg-transparent border-2 text-foreground shadow-xs transition-colors duration-200 hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40';
+	'bg-transparent text-foreground shadow-xs transition-colors duration-200 hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40';
 export const buttonVariants = cva(
 	`inline-flex
   items-center
@@ -37,11 +37,11 @@ export const buttonVariants = cva(
 				link: 'text-primary underline-offset-4 hover:underline',
 				positive: 'bg-green text-white shadow-xs hover:bg-green/90',
 				warning: 'bg-yellow text-white shadow-xs hover:bg-yellow/90',
-				outline: outlineCommon,
-				ghostOutline: `${outlineCommon} border-none`,
-				positiveOutline: `${outlineCommon} border-green`,
-				destructiveOutline: `${outlineCommon} border-destructive`,
-				defaultOutline: `${outlineCommon} border-primary`,
+				outline: `border-2 ${outlineCommon}`,
+				ghostOutline: outlineCommon,
+				positiveOutline: `border-2 border-green ${outlineCommon}`,
+				destructiveOutline: `border-2 border-destructive ${outlineCommon}`,
+				defaultOutline: `border-2 border-primary ${outlineCommon}`,
 			},
 			size: {
 				default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/src/components/ui/buttonVariants.tsx
+++ b/src/components/ui/buttonVariants.tsx
@@ -1,8 +1,7 @@
 import { cva } from 'class-variance-authority';
 
-const hoverBounce = 'hover:-translate-y-1 transition duration-200';
 const outlineCommon =
-	'border bg-transparent border-2 text-foreground shadow-xs hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40';
+	'border bg-transparent border-2 text-foreground shadow-xs transition-colors duration-200 hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40';
 export const buttonVariants = cva(
 	`inline-flex
   items-center
@@ -38,16 +37,16 @@ export const buttonVariants = cva(
 				link: 'text-primary underline-offset-4 hover:underline',
 				positive: 'bg-green text-white shadow-xs hover:bg-green/90',
 				warning: 'bg-yellow text-white shadow-xs hover:bg-yellow/90',
-				outline: `${outlineCommon} ${hoverBounce}`,
-				ghostOutline: `${outlineCommon} ${hoverBounce} border-none`,
-				positiveOutline: `${outlineCommon} ${hoverBounce} border-green`,
-				destructiveOutline: `${outlineCommon} ${hoverBounce} border-destructive`,
-				defaultOutline: `${outlineCommon} ${hoverBounce} border-primary`,
+				outline: outlineCommon,
+				ghostOutline: `${outlineCommon} border-none`,
+				positiveOutline: `${outlineCommon} border-green`,
+				destructiveOutline: `${outlineCommon} border-destructive`,
+				defaultOutline: `${outlineCommon} border-primary`,
 			},
 			size: {
 				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 rounded-md px-3 has-[>svg]:px-2.5',
-				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4 text-md',
+				sm: 'h-8 px-3 has-[>svg]:px-2.5',
+				lg: 'h-10 px-6 has-[>svg]:px-4 text-md',
 				icon: 'size-9',
 			},
 		},

--- a/src/components/ui/toggleVariants.tsx
+++ b/src/components/ui/toggleVariants.tsx
@@ -27,7 +27,7 @@ export const toggleVariants = cva(
 			variant: {
 				default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90',
 				outline:
-					'border bg-default border-primary border-2 text-foreground shadow-xs hover:-translate-y-1 transition duration-200 hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40',
+					'border bg-default border-primary border-2 text-foreground shadow-xs transition-colors duration-200 hover:bg-accent/60 dark:text-white dark:hover:bg-grey-700/40',
 			},
 			size: {
 				default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -172,7 +172,7 @@ export function ClusterInstanceSignIn() {
 									</FormItem>
 								)}
 							/>
-							<Button disabled={isPending} type="submit" variant="submit" className="w-full my-2 rounded-full">
+							<Button disabled={isPending} type="submit" variant="submit" className="w-full my-2">
 								Sign In
 							</Button>
 							{healthy === false && (

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -81,7 +81,7 @@ export function ForgotPassword() {
 							</FormItem>
 						)}
 					/>
-					<Button type="submit" variant="submit" disabled={isPending} className="w-full my-2 rounded-full">
+					<Button type="submit" variant="submit" disabled={isPending} className="w-full my-2">
 						Send Password Reset Email
 					</Button>
 				</form>

--- a/src/features/auth/ResetPassword.tsx
+++ b/src/features/auth/ResetPassword.tsx
@@ -118,7 +118,7 @@ export function ResetPassword() {
 							</FormItem>
 						)}
 					/>
-					<Button variant="submit" type="submit" disabled={isPending} className="w-full my-2 rounded-full">
+					<Button variant="submit" type="submit" disabled={isPending} className="w-full my-2">
 						Submit New Password
 					</Button>
 				</form>

--- a/src/features/auth/SignIn.tsx
+++ b/src/features/auth/SignIn.tsx
@@ -81,7 +81,7 @@ export function SignIn() {
 							</FormItem>
 						)}
 					/>
-					<Button type="submit" variant="submit" className="w-full my-2 rounded-full" disabled={isPending}>
+					<Button type="submit" variant="submit" className="w-full my-2" disabled={isPending}>
 						Sign In
 					</Button>
 					<div className="flex px-4 mt-4 underline place-content-between">

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -279,7 +279,7 @@ export function SignUp() {
 					/>
 					{termsCheckbox}
 
-					<Button type="submit" variant="submit" className="w-full rounded-full my-4">
+					<Button type="submit" variant="submit" className="w-full my-4">
 						Sign Up For Free
 					</Button>
 				</form>

--- a/src/features/auth/VerifyEmail.tsx
+++ b/src/features/auth/VerifyEmail.tsx
@@ -78,7 +78,7 @@ function SendEmailVerification() {
 						</FormItem>
 					)}
 				/>
-				<Button type="submit" variant="submit" disabled={isPending} className="w-full my-2 rounded-full">
+				<Button type="submit" variant="submit" disabled={isPending} className="w-full my-2">
 					Send Verification Email
 				</Button>
 			</form>

--- a/src/features/cluster/FinishSetup.tsx
+++ b/src/features/cluster/FinishSetup.tsx
@@ -167,7 +167,7 @@ export function FinishSetup() {
 								)}
 							/>
 
-							<Button disabled={isPending} type="submit" variant="submit" className="w-full my-2 rounded-full">
+							<Button disabled={isPending} type="submit" variant="submit" className="w-full my-2">
 								Create Admin User
 							</Button>
 						</form>

--- a/src/features/clusters/upsert/ClusterBilling.tsx
+++ b/src/features/clusters/upsert/ClusterBilling.tsx
@@ -46,7 +46,6 @@ export function ClusterBilling({
 				<Button
 					type="button"
 					variant="defaultOutline"
-					className="rounded-full"
 					disabled={isPending}
 					onClick={onGoBackToDetails}
 				>
@@ -56,7 +55,6 @@ export function ClusterBilling({
 					disabled={isPending || !hasValidPaymentMethod || replacingPaymentMethod}
 					type="submit"
 					variant="submit"
-					className="rounded-full"
 					onClick={onSubmit}
 				>
 					{clusterId ? 'Edit Cluster' : 'Create New Cluster'} <ArrowRightIcon />

--- a/src/features/clusters/upsert/ClusterDetails.tsx
+++ b/src/features/clusters/upsert/ClusterDetails.tsx
@@ -130,7 +130,6 @@ export function ClusterDetails({
 			<Button
 				type="submit"
 				variant="submit"
-				className="rounded-full"
 				disabled={isPending || (clusterId && !isDirty && !allowVersionResubmit) || !isValid}
 			>
 				{mode !== 'version' && totalPrice > 0

--- a/src/features/clusters/upsert/ClusterRegions.tsx
+++ b/src/features/clusters/upsert/ClusterRegions.tsx
@@ -104,7 +104,6 @@ export function ClusterRegions({
 					<Button
 						type="button"
 						variant="positiveOutline"
-						className="rounded-full"
 						onClick={onAddARegionClick}
 					>
 						<PlusIcon />

--- a/src/features/clusters/upsert/components/ClusterInstances.tsx
+++ b/src/features/clusters/upsert/components/ClusterInstances.tsx
@@ -42,7 +42,6 @@ export function ClusterInstances({
 				<Button
 					type="button"
 					variant="positiveOutline"
-					className="rounded-full"
 					onClick={onAddInstanceClick}
 				>
 					<PlusIcon />

--- a/src/features/instance/apis/APIDocs.tsx
+++ b/src/features/instance/apis/APIDocs.tsx
@@ -112,7 +112,6 @@ export function APIDocs() {
 						type="button"
 						disabled={isSettingConfiguration}
 						variant="warning"
-						className="rounded-full"
 						onClick={enableCORS}
 					>
 						<Plus />

--- a/src/features/instance/apis/swagger.css
+++ b/src/features/instance/apis/swagger.css
@@ -332,12 +332,11 @@
 	font-size: 0.875rem;
 	font-weight: 400;
 	box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-	transition: color 0.2s, box-shadow 0.2s, background-color 0.2s, transform 0.2s;
+	transition: color 0.2s, box-shadow 0.2s, background-color 0.2s;
 }
 .swagger-ui .dialog-ux .btn.authorize:hover,
 .swagger-ui .dialog-ux .btn.btn-done:hover {
 	background: color-mix(in srgb, var(--accent) 60%, transparent);
-	transform: translateY(-0.25rem);
 }
 .dark .swagger-ui .dialog-ux .btn.authorize,
 .dark .swagger-ui .dialog-ux .btn.btn-done {

--- a/src/features/instance/applications/components/SchemaEditorView/TableCard.tsx
+++ b/src/features/instance/applications/components/SchemaEditorView/TableCard.tsx
@@ -95,7 +95,6 @@ export function TableCard({
 						type="button"
 						variant="destructiveGhost"
 						size="sm"
-						className="rounded-full"
 						disabled={readOnly}
 						onClick={onRemove}
 					>

--- a/src/features/instance/applications/components/SchemaEditorView/index.tsx
+++ b/src/features/instance/applications/components/SchemaEditorView/index.tsx
@@ -189,7 +189,7 @@ export function SchemaEditorView() {
 						type="button"
 						variant="positive"
 						size="sm"
-						className="rounded-full shadow-md"
+						className="shadow-md"
 						onClick={() => dispatch({ type: 'addTable' })}
 					>
 						<PlusIcon /> Add table

--- a/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/AddDirectoryOrFileModal.tsx
@@ -181,13 +181,12 @@ export function AddDirectoryOrFileModal() {
 
 						<DialogFooter>
 							<div className="flex justify-between w-full">
-								<Button type="button" variant="ghostOutline" className="rounded-full" onClick={onCancelClick}>
+								<Button type="button" variant="ghostOutline" onClick={onCancelClick}>
 									Cancel
 								</Button>
 								<Button
 									variant="positiveOutline"
 									type="submit"
-									className="rounded-full"
 									disabled={isPending}
 								>
 									<Plus /> Add {type}

--- a/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
+++ b/src/features/instance/applications/modals/DeleteDirectoryOrFileModal.tsx
@@ -110,13 +110,13 @@ export function DeleteDirectoryOrFileModal() {
 				</DialogHeader>
 
 				<div className="flex w-full gap-4">
-					<Button type="button" variant="ghostOutline" className="w-full rounded-full" onClick={closeModal}>
+					<Button type="button" variant="ghostOutline" className="w-full" onClick={closeModal}>
 						Cancel
 					</Button>
 					<Button
 						variant="destructiveOutline"
 						type="button"
-						className="w-full rounded-full"
+						className="w-full"
 						autoFocus={true}
 						onClick={onClickYes}
 					>

--- a/src/features/instance/applications/modals/DownloadApplicationModal.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.tsx
@@ -83,13 +83,13 @@ export function DownloadApplicationModal() {
 				</Label>
 
 				<div className="flex w-full gap-4">
-					<Button type="button" variant="ghostOutline" className="w-full rounded-full" onClick={closeModal}>
+					<Button type="button" variant="ghostOutline" className="w-full" onClick={closeModal}>
 						Cancel
 					</Button>
 					<Button
 						variant="positive"
 						type="button"
-						className="w-full rounded-full"
+						className="w-full"
 						disabled={isPending}
 						autoFocus={true}
 						onClick={onClickYes}

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -173,7 +173,7 @@ export function RedeployApplicationModal() {
 							<Button
 								type="button"
 								variant="ghostOutline"
-								className="w-full rounded-full"
+								className="w-full"
 								onClick={closeModal}
 								disabled={isPending}
 							>
@@ -227,7 +227,7 @@ export function RedeployApplicationModal() {
 									<Button
 										variant="positiveOutline"
 										type="submit"
-										className="w-full rounded-full"
+										className="w-full"
 										disabled={isPending}
 									>
 										<RefreshCwIcon /> Redeploy Application
@@ -235,7 +235,7 @@ export function RedeployApplicationModal() {
 									<Button
 										type="button"
 										variant="ghostOutline"
-										className="w-full rounded-full"
+										className="w-full"
 										onClick={closeModal}
 										disabled={isPending}
 									>

--- a/src/features/instance/applications/modals/RenameFileModal.tsx
+++ b/src/features/instance/applications/modals/RenameFileModal.tsx
@@ -192,13 +192,12 @@ export function RenameFileModal() {
 
 						<DialogFooter>
 							<div className="flex justify-between w-full">
-								<Button type="button" variant="ghostOutline" className="rounded-full" onClick={onCancelClick}>
+								<Button type="button" variant="ghostOutline" onClick={onCancelClick}>
 									Cancel
 								</Button>
 								<Button
 									variant="positiveOutline"
 									type="submit"
-									className="rounded-full"
 									disabled={isPending || !form.formState.isDirty || !form.formState.isValid}
 								>
 									<PencilIcon /> Rename

--- a/src/features/instance/config/certificates/modals/AddCertificateModal.tsx
+++ b/src/features/instance/config/certificates/modals/AddCertificateModal.tsx
@@ -241,7 +241,6 @@ export function AddCertificateModal({
 								<Button
 									variant="destructiveOutline"
 									type="button"
-									className="rounded-full"
 									onClick={onClickCancel}
 									disabled={isPending}
 								>
@@ -250,7 +249,6 @@ export function AddCertificateModal({
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full"
 									disabled={isPending || !form.formState.isDirty || !form.formState.isValid}
 								>
 									<Save /> Add Certificate

--- a/src/features/instance/config/certificates/modals/ViewCertificateModal.tsx
+++ b/src/features/instance/config/certificates/modals/ViewCertificateModal.tsx
@@ -145,7 +145,6 @@ export function ViewCertificateModal({
 								<Button
 									type="button"
 									variant="destructiveOutline"
-									className="rounded-full"
 									onClick={onCertificateRemoveClicked}
 									disabled={isRemovePending}
 								>
@@ -155,7 +154,6 @@ export function ViewCertificateModal({
 								<Button
 									type="button"
 									variant="defaultOutline"
-									className="rounded-full"
 									onClick={() => closeModal()}
 								>
 									Close

--- a/src/features/instance/config/roles/modals/AddRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/AddRoleModal.tsx
@@ -144,13 +144,12 @@ export function AddRoleModal({
 								<Button
 									variant="destructiveOutline"
 									type="button"
-									className="rounded-full"
 									onClick={onClickCancel}
 									disabled={isAddPending}
 								>
 									Cancel
 								</Button>
-								<Button type="submit" variant="submit" className="rounded-full" disabled={isAddPending}>
+								<Button type="submit" variant="submit" disabled={isAddPending}>
 									<Save /> Add Role
 								</Button>
 							</div>

--- a/src/features/instance/config/roles/modals/EditRoleModal.tsx
+++ b/src/features/instance/config/roles/modals/EditRoleModal.tsx
@@ -1,3 +1,4 @@
+import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from '@/components/ui/dialog';
@@ -58,7 +59,8 @@ export function EditRoleModal({
 	const [showAttributes, onShowAttributesChanged] = useCheckboxCallback(updatedPermissions?.includes('attribute_name'));
 
 	const { mutate: alterRole, isPending } = useAlterRole();
-	const { mutate: dropRole } = useDeleteRoleMutation();
+	const { mutate: dropRole, isPending: isDeletePending } = useDeleteRoleMutation();
+	const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
 
 	const onValidate = useCallback(
 		(markers: unknown[]) => {
@@ -148,72 +150,81 @@ export function EditRoleModal({
 	}, [updatedPermissions, onRoleUpdated, isValidJSON]);
 
 	const onRoleDeleteClick = useCallback(() => {
-		onRoleDeleted();
-	}, [onRoleDeleted]);
+		setIsConfirmDeleteModalOpen(true);
+	}, []);
 
 	return (
-		<Dialog onOpenChange={closeModal} open={isModalOpen}>
-			<DialogContent resizable>
-				<DialogTitle>{isSelf ? 'View' : 'Edit'} Role "{role}"</DialogTitle>
-				<DialogDescription>
-					{isSelf
-						? 'You can view your own role, but you cannot edit it. Please assign yourself a different'
-							+ ' role to edit this role.'
-						: "Edit the role's permissions in JSON format or remove the role entirely."}
-				</DialogDescription>
-				<div className="flex-1 min-h-0">
-					{defaultValue
-						? (
-							<Editor
-								className="w-full h-full"
-								theme={monacoTheme}
-								defaultLanguage="json"
-								value={updatedPermissions}
-								options={{ readOnly: isSelf, automaticLayout: true }}
-								onValidate={onValidate}
-								onChange={setUpdatedPermissions}
-								defaultValue={defaultValue}
-							/>
-						)
-						: <TextLoadingSkeleton />}
-				</div>
-				<DialogFooter>
-					{!isSelf && (
-						<div className="flex justify-between w-full">
-							<Button
-								type="button"
-								variant="destructiveOutline"
-								className="rounded-full"
-								onClick={onRoleDeleteClick}
-								disabled={isPending}
-							>
-								Delete Role
-							</Button>
-
-							<div className="grow" />
-
-							<Label className="flex">
-								<Input
-									type="checkbox"
-									className="w-6"
-									checked={showAttributes}
-									onChange={onShowAttributesChanged}
+		<>
+			<Dialog onOpenChange={closeModal} open={isModalOpen}>
+				<DialogContent resizable>
+					<DialogTitle>{isSelf ? 'View' : 'Edit'} Role "{role}"</DialogTitle>
+					<DialogDescription>
+						{isSelf
+							? 'You can view your own role, but you cannot edit it. Please assign yourself a different'
+								+ ' role to edit this role.'
+							: "Edit the role's permissions in JSON format or remove the role entirely."}
+					</DialogDescription>
+					<div className="flex-1 min-h-0">
+						{defaultValue
+							? (
+								<Editor
+									className="w-full h-full"
+									theme={monacoTheme}
+									defaultLanguage="json"
+									value={updatedPermissions}
+									options={{ readOnly: isSelf, automaticLayout: true }}
+									onValidate={onValidate}
+									onChange={setUpdatedPermissions}
+									defaultValue={defaultValue}
 								/>
-								<span className="pl-4 pr-8 flex-1 py-2.5">Pick Attributes</span>
-							</Label>
+							)
+							: <TextLoadingSkeleton />}
+					</div>
+					<DialogFooter>
+						{!isSelf && (
+							<div className="flex justify-between w-full">
+								<Button
+									type="button"
+									variant="destructiveOutline"
+									onClick={onRoleDeleteClick}
+									disabled={isPending}
+								>
+									Delete Role
+								</Button>
 
-							<Button
-								variant="submit"
-								className="rounded-full"
-								onClick={onSubmitClick}
-								disabled={isPending || !isValidJSON}
-							>
-								Save Changes
-							</Button>
-						</div>
-					)}
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
+								<div className="grow" />
+
+								<Label className="flex">
+									<Input
+										type="checkbox"
+										className="w-6"
+										checked={showAttributes}
+										onChange={onShowAttributesChanged}
+									/>
+									<span className="pl-4 pr-8 flex-1 py-2.5">Pick Attributes</span>
+								</Label>
+
+								<Button
+									variant="submit"
+									onClick={onSubmitClick}
+									disabled={isPending || !isValidJSON}
+								>
+									Save Changes
+								</Button>
+							</div>
+						)}
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<ConfirmDeletionModal
+				isModalOpen={isConfirmDeleteModalOpen}
+				setIsModalOpen={setIsConfirmDeleteModalOpen}
+				deletionConfirmed={onRoleDeleted}
+				deletionPending={isDeletePending}
+				typeOfThingBeingDeleted="role"
+				nameOfThingBeingDeleted={role}
+				hideDataLossWarning={true}
+			/>
+		</>
 	);
 }

--- a/src/features/instance/config/sshKeys/KnownHosts.tsx
+++ b/src/features/instance/config/sshKeys/KnownHosts.tsx
@@ -85,7 +85,7 @@ export function KnownHosts() {
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full mt-2"
+									className="mt-2"
 									disabled={isPending || !form.formState.isDirty || !form.formState.isValid}
 								>
 									<Save /> {isPending ? 'Saving' : 'Save'} Known Hosts{isPending ? '...' : ''}

--- a/src/features/instance/config/sshKeys/modals/AddSSHKeyModal.tsx
+++ b/src/features/instance/config/sshKeys/modals/AddSSHKeyModal.tsx
@@ -213,7 +213,6 @@ export function AddSSHKeyModal({
 								<Button
 									variant="destructiveOutline"
 									type="button"
-									className="rounded-full"
 									onClick={onClickCancel}
 									disabled={isPending}
 								>
@@ -222,7 +221,6 @@ export function AddSSHKeyModal({
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full"
 									disabled={isPending || !form.formState.isDirty || !form.formState.isValid}
 								>
 									<Save /> Add SSH Key

--- a/src/features/instance/config/sshKeys/modals/EditSSHKeyModal.tsx
+++ b/src/features/instance/config/sshKeys/modals/EditSSHKeyModal.tsx
@@ -1,3 +1,4 @@
+import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form/Form';
@@ -17,7 +18,7 @@ import { UpdateSSHKeySchema, useUpdateSSHKey } from '@/integrations/api/instance
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { Row } from '@tanstack/react-table';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -53,7 +54,8 @@ export function EditSSHKeyModal({
 	}));
 
 	const { mutate: updateSSHKey, isPending } = useUpdateSSHKey();
-	const { mutate: deleteSSHKey } = useDeleteSSHKey();
+	const { mutate: deleteSSHKey, isPending: isDeletePending } = useDeleteSSHKey();
+	const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
 
 	const onSubmitClick = useCallback(
 		async ({ key }: z.infer<typeof UpdateSSHKeySchema>) => {
@@ -78,6 +80,10 @@ export function EditSSHKeyModal({
 	);
 
 	const onSSHKeyDeleteClicked = useCallback(() => {
+		setIsConfirmDeleteModalOpen(true);
+	}, []);
+
+	const onDeletionConfirmed = useCallback(() => {
 		deleteSSHKey(
 			{
 				name,
@@ -94,123 +100,132 @@ export function EditSSHKeyModal({
 	}, [name, deleteSSHKey, instanceParams, onChangesSaved, onSelectSSHKey]);
 
 	return (
-		<Dialog onOpenChange={closeModal} open={isModalOpen}>
-			<DialogContent className="sm:max-w-[750px]" aria-describedby={undefined}>
-				<Form {...form}>
-					<form
-						id="instance-edit-ssh-key-form"
-						name="instance-edit-ssh-key-form"
-						onSubmit={form.handleSubmit(onSubmitClick)}
-						className="grid gap-4 my-4 md:grid-cols-2"
-					>
-						<DialogTitle>Edit SSH Key</DialogTitle>
+		<>
+			<Dialog onOpenChange={closeModal} open={isModalOpen}>
+				<DialogContent className="sm:max-w-[750px]" aria-describedby={undefined}>
+					<Form {...form}>
+						<form
+							id="instance-edit-ssh-key-form"
+							name="instance-edit-ssh-key-form"
+							onSubmit={form.handleSubmit(onSubmitClick)}
+							className="grid gap-4 my-4 md:grid-cols-2"
+						>
+							<DialogTitle>Edit SSH Key</DialogTitle>
 
-						<FormField
-							control={form.control}
-							name="name"
-							render={({ field }) => (
-								<FormItem className="md:col-span-2">
-									<FormLabel className="pb-1">Name</FormLabel>
-									<FormControl>
-										<Input
-											type="text"
-											autoComplete="off"
-											autoCapitalize="off"
-											readOnly={true}
-											disabled={true}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+							<FormField
+								control={form.control}
+								name="name"
+								render={({ field }) => (
+									<FormItem className="md:col-span-2">
+										<FormLabel className="pb-1">Name</FormLabel>
+										<FormControl>
+											<Input
+												type="text"
+												autoComplete="off"
+												autoCapitalize="off"
+												readOnly={true}
+												disabled={true}
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-						<FormField
-							control={form.control}
-							name="key"
-							render={({ field }) => (
-								<FormItem className="md:col-span-2">
-									<FormLabel className="pb-1">Key</FormLabel>
-									<FormDescription>
-										Replace your existing private key. Lost it? Try out "ssh-keygen"! You'll want to add your public key
-										to your registry, i.e. GitHub.
-									</FormDescription>
-									<FormControl>
-										<Textarea
-											autoComplete="off"
-											autoCapitalize="off"
-											autoFocus={true}
-											rows={3}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+							<FormField
+								control={form.control}
+								name="key"
+								render={({ field }) => (
+									<FormItem className="md:col-span-2">
+										<FormLabel className="pb-1">Key</FormLabel>
+										<FormDescription>
+											Replace your existing private key. Lost it? Try out "ssh-keygen"! You'll want to add your public
+											key to your registry, i.e. GitHub.
+										</FormDescription>
+										<FormControl>
+											<Textarea
+												autoComplete="off"
+												autoCapitalize="off"
+												autoFocus={true}
+												rows={3}
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-						<FormItem className="md:col-span-2">
-							<FormLabel className="pb-1">Host</FormLabel>
-							<FormDescription>
-								A unique identifying name for the combination of this key and your hostname, i.e.
-								"your-repo.github.com". You will use this instead of the direct hostname to pick your key when importing
-								applications.
-							</FormDescription>
-							<FormControl>
-								<Input
-									type="text"
-									autoComplete="off"
-									autoCapitalize="off"
-									value={fullData?.host || ''}
-									disabled={true}
-									readOnly={true}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
+							<FormItem className="md:col-span-2">
+								<FormLabel className="pb-1">Host</FormLabel>
+								<FormDescription>
+									A unique identifying name for the combination of this key and your hostname, i.e.
+									"your-repo.github.com". You will use this instead of the direct hostname to pick your key when
+									importing applications.
+								</FormDescription>
+								<FormControl>
+									<Input
+										type="text"
+										autoComplete="off"
+										autoCapitalize="off"
+										value={fullData?.host || ''}
+										disabled={true}
+										readOnly={true}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
 
-						<FormItem className="md:col-span-2">
-							<FormLabel className="pb-1">Hostname</FormLabel>
-							<FormDescription>
-								When making the request, the actual hostname to use, i.e. "github.com".
-							</FormDescription>
-							<FormControl>
-								<Input
-									type="text"
-									autoComplete="off"
-									autoCapitalize="off"
-									value={fullData?.hostname || ''}
-									disabled={true}
-									readOnly={true}
-								/>
-							</FormControl>
-							<FormMessage />
-						</FormItem>
+							<FormItem className="md:col-span-2">
+								<FormLabel className="pb-1">Hostname</FormLabel>
+								<FormDescription>
+									When making the request, the actual hostname to use, i.e. "github.com".
+								</FormDescription>
+								<FormControl>
+									<Input
+										type="text"
+										autoComplete="off"
+										autoCapitalize="off"
+										value={fullData?.hostname || ''}
+										disabled={true}
+										readOnly={true}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
 
-						<DialogFooter className="md:col-span-2">
-							<Button
-								type="button"
-								variant="destructiveOutline"
-								className="rounded-full"
-								onClick={onSSHKeyDeleteClicked}
-								disabled={isPending}
-							>
-								Delete SSH Key
-							</Button>
+							<DialogFooter className="md:col-span-2">
+								<Button
+									type="button"
+									variant="destructiveOutline"
+									onClick={onSSHKeyDeleteClicked}
+									disabled={isPending}
+								>
+									Delete SSH Key
+								</Button>
 
-							<Button
-								type="submit"
-								variant="submit"
-								className="rounded-full"
-								disabled={isPending || !form.formState.isValid}
-							>
-								Update SSH Key
-							</Button>
-						</DialogFooter>
-					</form>
-				</Form>
-			</DialogContent>
-		</Dialog>
+								<Button
+									type="submit"
+									variant="submit"
+									disabled={isPending || !form.formState.isValid}
+								>
+									Update SSH Key
+								</Button>
+							</DialogFooter>
+						</form>
+					</Form>
+				</DialogContent>
+			</Dialog>
+			<ConfirmDeletionModal
+				isModalOpen={isConfirmDeleteModalOpen}
+				setIsModalOpen={setIsConfirmDeleteModalOpen}
+				deletionConfirmed={onDeletionConfirmed}
+				deletionPending={isDeletePending}
+				typeOfThingBeingDeleted="SSH key"
+				nameOfThingBeingDeleted={name}
+				hideDataLossWarning={true}
+			/>
+		</>
 	);
 }

--- a/src/features/instance/config/users/components/AlterUserForm.tsx
+++ b/src/features/instance/config/users/components/AlterUserForm.tsx
@@ -184,7 +184,6 @@ export function AlterUserForm({
 					<div className="flex justify-between w-full">
 						<Button
 							variant="submit"
-							className="rounded-full"
 							disabled={isUpdateUserPending}
 						>
 							<Save /> Save Changes

--- a/src/features/instance/config/users/components/DeleteUserForm.tsx
+++ b/src/features/instance/config/users/components/DeleteUserForm.tsx
@@ -81,7 +81,6 @@ export function DeleteUserForm({
 					<div className="flex justify-between w-full">
 						<Button
 							variant="destructive"
-							className="rounded-full"
 							disabled={isDeleteUserPending || !deleteForm.formState.isValid}
 						>
 							<Trash /> Delete User

--- a/src/features/instance/config/users/modals/AddUserModal.tsx
+++ b/src/features/instance/config/users/modals/AddUserModal.tsx
@@ -185,7 +185,7 @@ export function AddUserModal({
 
 						<DialogFooter>
 							<div className="flex justify-between w-full">
-								<Button type="submit" variant="submit" className="rounded-full" disabled={isAddPending}>
+								<Button type="submit" variant="submit" disabled={isAddPending}>
 									<Save /> Add User
 								</Button>
 							</div>

--- a/src/features/instance/databases/components/DatabasesSidebar.tsx
+++ b/src/features/instance/databases/components/DatabasesSidebar.tsx
@@ -156,7 +156,7 @@ export function DatabasesSidebar({ instanceDatabaseMap }: { instanceDatabaseMap?
 					<div className="shrink-0 pb-4">
 						<Button
 							variant="defaultOutline"
-							className="w-full rounded-full"
+							className="w-full"
 							size="lg"
 							onClick={() => setIsImportDataModalOpen(true)}
 							disabled={isImportDataModalOpen || loading}

--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -165,7 +165,6 @@ export function AddTableRowModal({
 					<div className="flex justify-between w-full">
 						<Button
 							variant="submit"
-							className="rounded-full"
 							onClick={onSubmitClick}
 							accessKey="s"
 							disabled={!addTableRecordData || !isValidJSON || isAddTableRecordsPending}

--- a/src/features/instance/databases/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/databases/modals/CreateNewTableModal.tsx
@@ -89,7 +89,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
 			<DialogTrigger asChild>
 				<div className="shrink-0 py-4">
-					<Button variant="positiveOutline" className="w-full rounded-full" size="lg" accessKey="t">
+					<Button variant="positiveOutline" className="w-full" size="lg" accessKey="t">
 						<Plus />
 						<span>
 							Create a <u>T</u>able
@@ -175,7 +175,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 							)}
 						/>
 						<DialogFooter>
-							<Button type="submit" variant="submit" className="rounded-full">
+							<Button type="submit" variant="submit">
 								<Table />
 								Create New Table
 							</Button>

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -86,7 +86,6 @@ export function EditTableRowModal({
 						{canDeleteRecords && (
 							<Button
 								variant="destructive"
-								className="rounded-full"
 								type="button"
 								autoFocus={false}
 								onClick={() => {
@@ -103,7 +102,6 @@ export function EditTableRowModal({
 						{canEditRecords && (
 							<Button
 								variant="submit"
-								className="rounded-full"
 								autoFocus={true}
 								accessKey="s"
 								onClick={() => {

--- a/src/features/instance/databases/modals/ImportDataModal.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.tsx
@@ -523,10 +523,10 @@ export function ImportDataModal({
 						)}
 
 						<DialogFooter>
-							<Button type="button" variant="ghost" className="rounded-full" onClick={closeModal} disabled={isPending}>
+							<Button type="button" variant="ghost" onClick={closeModal} disabled={isPending}>
 								Cancel
 							</Button>
-							<Button type="submit" variant="submit" className="rounded-full" disabled={isPending}>
+							<Button type="submit" variant="submit" disabled={isPending}>
 								{isPending ? <LoaderCircleIcon className="animate-spin" /> : <CloudUploadIcon />}
 								{isPending ? 'Importing...' : 'Import Data'}
 							</Button>

--- a/src/features/instance/modals/BrowseSettingsModal.tsx
+++ b/src/features/instance/modals/BrowseSettingsModal.tsx
@@ -9,7 +9,7 @@ export function BrowseSettingsModal() {
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
 			<DialogTrigger asChild>
 				<Button
-					className="mt-4 bg-linear-(--purple-dark-to-light-gradient) hover:bg-linear-(--purple-gradient) rounded-full w-full"
+					className="mt-4 bg-linear-(--purple-dark-to-light-gradient) hover:bg-linear-(--purple-gradient) w-full"
 					size="lg"
 				>
 					<Settings /> Settings
@@ -23,10 +23,10 @@ export function BrowseSettingsModal() {
 
 				<DialogFooter>
 					<div className="flex justify-between w-full">
-						<Button type="button" variant="destructive" className="rounded-full">
+						<Button type="button" variant="destructive">
 							<Trash /> Delete Row
 						</Button>
-						<Button variant="submit" className="rounded-full">
+						<Button variant="submit">
 							<Save /> Save Changes
 						</Button>
 					</div>

--- a/src/features/instance/modals/UploadCSVModal.tsx
+++ b/src/features/instance/modals/UploadCSVModal.tsx
@@ -20,7 +20,7 @@ export function UploadCSVModal() {
 				</DialogHeader>
 				<Input type="file" accept=".csv" />
 				<DialogFooter>
-					<Button variant="submit" className="rounded-full">
+					<Button variant="submit">
 						<UploadCloud /> Upload CSV
 					</Button>
 				</DialogFooter>

--- a/src/features/instance/secrets/SecretModals.tsx
+++ b/src/features/instance/secrets/SecretModals.tsx
@@ -139,7 +139,6 @@ export function AddSecretModal({
 								<Button
 									variant="destructiveOutline"
 									type="button"
-									className="rounded-full"
 									onClick={onClickCancel}
 									disabled={isPending}
 								>
@@ -148,7 +147,6 @@ export function AddSecretModal({
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full"
 									disabled={isPending || !isDirty || !isValid}
 								>
 									<Save /> Add Secret
@@ -286,7 +284,6 @@ export function EditSecretModal({
 										<Button
 											variant="destructiveOutline"
 											type="button"
-											className="rounded-full"
 											onClick={onDeleteClick}
 											disabled={busy}
 										>
@@ -297,7 +294,6 @@ export function EditSecretModal({
 										<Button
 											variant="destructiveOutline"
 											type="button"
-											className="rounded-full"
 											onClick={closeModal}
 											disabled={busy}
 										>
@@ -307,7 +303,6 @@ export function EditSecretModal({
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full"
 									disabled={busy || !isDirty || !isValid}
 								>
 									<Save /> Save

--- a/src/features/organization/billing/paymentMethod/AddNewPaymentMethodForm.tsx
+++ b/src/features/organization/billing/paymentMethod/AddNewPaymentMethodForm.tsx
@@ -83,7 +83,7 @@ export function AddNewPaymentMethodForm({
 			<AddressElement options={{ mode: 'billing' }} />
 
 			<div className="mt-4 flex gap-8 items-center">
-				<Button disabled={!stripe || !elements || loading} variant="submit" className="rounded-full">
+				<Button disabled={!stripe || !elements || loading} variant="submit">
 					<Save /> Add Payment Method
 				</Button>
 				{hasExistingBilling && (

--- a/src/features/organization/roles/modals/AddOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/AddOrganizationRoleModal.tsx
@@ -184,7 +184,6 @@ export function AddOrganizationRoleModal({
 							<div className="flex justify-between w-full">
 								<Button
 									variant="destructiveOutline"
-									className="rounded-full"
 									type="button"
 									onClick={() => setIsModalOpen(false)}
 									disabled={isPending}
@@ -193,7 +192,6 @@ export function AddOrganizationRoleModal({
 								</Button>
 								<Button
 									variant="submit"
-									className="rounded-full"
 									disabled={isPending || !isValidJSON || !form.formState.isValid}
 								>
 									Save Changes

--- a/src/features/organization/roles/modals/ConfirmDeletionContent.tsx
+++ b/src/features/organization/roles/modals/ConfirmDeletionContent.tsx
@@ -18,14 +18,12 @@ export function ConfirmDeletionContent({
 				<Button
 					type="button"
 					variant="defaultOutline"
-					className="rounded-full"
 					onClick={() => setIsConfirmingRoleDeletion(false)}
 				>
 					Cancel
 				</Button>
 				<Button
 					variant="destructiveOutline"
-					className="rounded-full"
 					onClick={onRoleDeleteClick}
 					disabled={isRoleDeletionPending}
 				>

--- a/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
+++ b/src/features/organization/roles/modals/EditOrganizationRoleModal.tsx
@@ -299,7 +299,6 @@ function EditOrganizationRoleModalContent({
 										<Button
 											type="button"
 											variant="destructiveOutline"
-											className="rounded-full"
 											onClick={() => setIsConfirmingRoleDeletion(true)}
 											disabled={isRoleUpdatePending}
 										>
@@ -309,7 +308,6 @@ function EditOrganizationRoleModalContent({
 									{update && (
 										<Button
 											variant="submit"
-											className="rounded-full"
 											disabled={!isValidJSON || isRoleUpdatePending || !form.formState.isValid
 												|| (!form.formState.isDirty && !isPermissionsDirty)}
 										>

--- a/src/features/organization/users/modals/AddUserModal.tsx
+++ b/src/features/organization/users/modals/AddUserModal.tsx
@@ -170,7 +170,6 @@ export function AddUserModal({
 								<Button
 									type="submit"
 									variant="submit"
-									className="rounded-full"
 									disabled={isAddPending || isInvitePending}
 								>
 									<Save /> {shouldInvite ? 'Invite User' : 'Add User'}

--- a/src/features/organizations/components/NewOrgForm.tsx
+++ b/src/features/organizations/components/NewOrgForm.tsx
@@ -127,7 +127,7 @@ export function NewOrgForm() {
 					</FormItem>
 
 					<DialogFooter>
-						<Button type="submit" variant="submit" className="rounded-full" disabled={isPending}>
+						<Button type="submit" variant="submit" disabled={isPending}>
 							Create New Organization <ArrowRight />
 						</Button>
 					</DialogFooter>

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -174,7 +174,6 @@ export function ProfileIndex() {
 						<Button
 							type="submit"
 							variant="submit"
-							className="rounded-full"
 							disabled={isUpdatePending || !isDirty || !isValid}
 						>
 							<Save /> Update Profile


### PR DESCRIPTION
Closes #1404.

## What & why
The issue asked to (1) remove the button "bounce-up-on-hover" everywhere, (2) make button corner radius consistent — soft edges, **not** full pills, and (3) audit "big action" buttons so consequential actions warn the user first.

## Changes

### 1. Removed the hover bounce
- `buttonVariants` / `toggleVariants`: dropped `hover:-translate-y-1 transition duration-200` from the outline variants. Outline hovers now just fade their background (`transition-colors`).
- `swagger.css`: removed `transform: translateY(-0.25rem)` from the API-docs dialog buttons (and the now-unused `transform` transition).

Verified in-browser: no `-translate-y-1` class remains on any element.

### 2. Consistent soft-edge radius (no pills)
- `buttonVariants` sizes: `sm`/`lg` no longer override to `rounded-md` — every size now uses the base `rounded-lg`, so all buttons share one radius.
- Stripped the `rounded-full` "pill" override from **every `<Button>`** across the app (~40 buttons in auth, clusters, databases, config, applications, secrets, organization, and shared modals). Buttons now render consistent soft edges (9.6px) instead of pills.
- Left non-button pills alone on purpose: badges, status dots, progress bars, chips, the `switch`, `tabs`, the floating-chat FAB, and step-number circles.

### 3. Big-action audit
Audited state-mutating buttons (restart, delete/drop/purge, redeploy, remove, terminate, revoke, apply…). Most already have a tooltip or confirmation (e.g. `RestartButton` tooltip, `ConfirmDeletionModal` on drop DB/table, terminate cluster, remove certificate). Two destructive actions fired immediately with **neither** — now fixed:
- **Instance "Delete Role"** (`EditRoleModal`) → opens a `ConfirmDeletionModal` confirmation.
- **"Delete SSH Key"** (`EditSSHKeyModal`) → opens a `ConfirmDeletionModal` confirmation.

Both reuse the existing confirmation pattern (mirrors `ViewCertificateModal`).

## Verification
- `tsc -b`, `oxlint`, `dprint check`, and `vitest` (1141 passing) all green (also enforced by the pre-commit hook).
- Browser-checked on a live org: buttons render at a uniform `rounded-lg`, no hover bounce, and modal footer buttons are soft-edged rather than pills.