### PR TITLE
feat(organizations): search orgs and clusters by id

### DIFF
--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useAdminMode } from '@/hooks/useAuth';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
+import { detectEntityId } from '@/lib/string/entityId';
 import { curryFilterByFuzzySearch } from '@/lib/string/filterByFuzzySearch';
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { Link, Navigate, useSearch } from '@tanstack/react-router';
@@ -52,9 +53,25 @@ export function OrganizationsIndex() {
 	// In the admin view, filtering happens server-side; debounce so we don't
 	// issue a request per keystroke.
 	const debouncedFilterValue = useDebounce(filterByNameValue, 300);
+
+	// A pasted organization/cluster id is resolved by id server-side rather than
+	// matched as a title (see getAllOrganizationsQueryOptions). This works for
+	// any fabric admin regardless of the "All Orgs" toggle, so support can jump
+	// straight to an org from an id copied out of a log or ticket.
+	const searchEntityId = useMemo(() => {
+		if (!isAdminMode) {
+			return null;
+		}
+		const entity = detectEntityId(debouncedFilterValue);
+		return entity?.kind === 'organization' || entity?.kind === 'cluster' ? entity : null;
+	}, [isAdminMode, debouncedFilterValue]);
+
+	// Both the "All Orgs" listing and an id lookup render from the server query.
+	const isServerSearch = showAll || !!searchEntityId;
+
 	const { data: allOrgsPage, isPending: isAllOrgsPending } = useQuery({
 		...getAllOrganizationsQueryOptions(pageIndex, debouncedFilterValue),
-		enabled: showAll,
+		enabled: isServerSearch,
 	});
 
 	const { organizationRoles, oauthLockedOrgs } = useMemo(() => {
@@ -92,7 +109,7 @@ export function OrganizationsIndex() {
 		}));
 	}, [allOrgsPage?.organizations, user?.roles]);
 
-	const displayedOrganizationRoles = showAll ? allOrganizationRoles : organizationRoles;
+	const displayedOrganizationRoles = isServerSearch ? allOrganizationRoles : organizationRoles;
 
 	const onFilterByNameChanged = useCallback((e: FormEvent<HTMLInputElement>) => {
 		// Keep the raw casing: the fuzzy filter lowercases internally, and the
@@ -171,8 +188,8 @@ export function OrganizationsIndex() {
 			</SubNavMenu>
 			<section className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-theme(spacing.32))]">
 				<div className="grid grid-cols-1 gap-4 md:grid-cols-12">
-					{/* OAuth-locked orgs only apply to the user's own orgs, not the admin show-all listing. */}
-					{!showAll && oauthLockedOrgs.map((lockedOrg) => (
+					{/* OAuth-locked orgs only apply to the user's own orgs, not a server-driven listing. */}
+					{!isServerSearch && oauthLockedOrgs.map((lockedOrg) => (
 						<div
 							key={lockedOrg.organizationId}
 							className="col-span-1 md:col-span-4 lg:col-span-3 2xl:col-span-2"
@@ -184,7 +201,7 @@ export function OrganizationsIndex() {
 							/>
 						</div>
 					))}
-					{showAll && isAllOrgsPending
+					{isServerSearch && isAllOrgsPending
 						? Array.from({ length: ALL_ORGANIZATIONS_PAGE_SIZE }, (_, index) => (
 							<Skeleton
 								key={index}
@@ -199,7 +216,8 @@ export function OrganizationsIndex() {
 								<OrgCard organizationRole={organizationRole} onDeleteOrgModal={onDeleteOrgModal} />
 							</div>
 						))}
-					{!displayedOrganizationRoles.length && !(showAll && isAllOrgsPending) && (showAll || !oauthLockedOrgs.length)
+					{!displayedOrganizationRoles.length && !(isServerSearch && isAllOrgsPending)
+						&& (isServerSearch || !oauthLockedOrgs.length)
 						&& (
 							<div className="col-span-1 md:col-span-12 text-center">
 								<h2 className="my-4 text-xl">No matches found.</h2>
@@ -207,7 +225,7 @@ export function OrganizationsIndex() {
 							</div>
 						)}
 				</div>
-				{showAll && (pageIndex > 0 || allOrgsPage?.hasNextPage) && (
+				{isServerSearch && (pageIndex > 0 || allOrgsPage?.hasNextPage) && (
 					<div className="flex items-center justify-center gap-4 py-6">
 						<Button
 							variant="defaultOutline"

--- a/src/features/organizations/queries/getAllOrganizations.test.ts
+++ b/src/features/organizations/queries/getAllOrganizations.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from 'vitest';
-import { ALL_ORGANIZATIONS_PAGE_SIZE, buildAllOrganizationsUrl } from './getAllOrganizations';
+import { apiClient } from '@/config/apiClient';
+import { AxiosError, type AxiosResponse } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	ALL_ORGANIZATIONS_PAGE_SIZE,
+	buildAllOrganizationsUrl,
+	getAllOrganizationsQueryOptions,
+	getOrganizationByIdPage,
+	getOrganizationForClusterPage,
+} from './getAllOrganizations';
+
+vi.mock('@/config/apiClient', () => ({
+	apiClient: {
+		get: vi.fn(),
+	},
+}));
+
+const mockedGet = vi.mocked(apiClient.get);
+
+function notFound() {
+	return new AxiosError('Not Found', 'ERR_BAD_REQUEST', undefined, undefined, {
+		status: 404,
+	} as AxiosResponse);
+}
+
+beforeEach(() => {
+	mockedGet.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe('buildAllOrganizationsUrl', () => {
 	it('requests the first page sorted by name, with one extra record to detect a next page', () => {
@@ -31,6 +61,92 @@ describe('buildAllOrganizationsUrl', () => {
 			`/Admin/Organization/?status=ne=DELETED&sort(name)&limit(${ALL_ORGANIZATIONS_PAGE_SIZE},${
 				ALL_ORGANIZATIONS_PAGE_SIZE * 2 + 1
 			})`,
+		);
+	});
+});
+
+describe('getOrganizationByIdPage', () => {
+	it('fetches the organization by its exact id and returns a one-item page', async () => {
+		mockedGet.mockResolvedValue({ data: { id: 'org-1', name: 'Acme' } });
+
+		const page = await getOrganizationByIdPage('org-1');
+
+		expect(mockedGet).toHaveBeenCalledWith('/Admin/Organization/org-1');
+		expect(page).toEqual({ organizations: [{ id: 'org-1', name: 'Acme' }], hasNextPage: false });
+	});
+
+	it('returns an empty page when the organization does not exist', async () => {
+		mockedGet.mockRejectedValue(notFound());
+
+		await expect(getOrganizationByIdPage('org-missing')).resolves.toEqual({ organizations: [], hasNextPage: false });
+	});
+
+	it('rethrows non-404 errors', async () => {
+		mockedGet.mockRejectedValue(new Error('boom'));
+
+		await expect(getOrganizationByIdPage('org-1')).rejects.toThrow('boom');
+	});
+});
+
+describe('getOrganizationForClusterPage', () => {
+	it('resolves the cluster to its owning organization', async () => {
+		mockedGet
+			.mockResolvedValueOnce({ data: { id: 'clu-1', organizationId: 'org-7' } })
+			.mockResolvedValueOnce({ data: { id: 'org-7', name: 'Owner Org' } });
+
+		const page = await getOrganizationForClusterPage('clu-1');
+
+		expect(mockedGet).toHaveBeenNthCalledWith(1, '/Cluster/clu-1');
+		expect(mockedGet).toHaveBeenNthCalledWith(2, '/Admin/Organization/org-7');
+		expect(page).toEqual({ organizations: [{ id: 'org-7', name: 'Owner Org' }], hasNextPage: false });
+	});
+
+	it('returns an empty page when the cluster does not exist', async () => {
+		mockedGet.mockRejectedValue(notFound());
+
+		await expect(getOrganizationForClusterPage('clu-missing')).resolves.toEqual({
+			organizations: [],
+			hasNextPage: false,
+		});
+	});
+
+	it('returns an empty page when the cluster has no owning organization', async () => {
+		mockedGet.mockResolvedValue({ data: { id: 'clu-1' } });
+
+		const page = await getOrganizationForClusterPage('clu-1');
+
+		expect(mockedGet).toHaveBeenCalledTimes(1);
+		expect(page).toEqual({ organizations: [], hasNextPage: false });
+	});
+});
+
+describe('getAllOrganizationsQueryOptions', () => {
+	it('looks an organization up by id when the search value is an org id', async () => {
+		mockedGet.mockResolvedValue({ data: { id: 'org-1', name: 'Acme' } });
+
+		await getAllOrganizationsQueryOptions(0, 'org-1').queryFn!({} as never);
+
+		expect(mockedGet).toHaveBeenCalledWith('/Admin/Organization/org-1');
+	});
+
+	it('resolves an org via its cluster when the search value is a cluster id', async () => {
+		mockedGet
+			.mockResolvedValueOnce({ data: { id: 'clu-1', organizationId: 'org-7' } })
+			.mockResolvedValueOnce({ data: { id: 'org-7', name: 'Owner Org' } });
+
+		await getAllOrganizationsQueryOptions(0, 'clu-1').queryFn!({} as never);
+
+		expect(mockedGet).toHaveBeenNthCalledWith(1, '/Cluster/clu-1');
+		expect(mockedGet).toHaveBeenNthCalledWith(2, '/Admin/Organization/org-7');
+	});
+
+	it('runs a name search when the value is not an id', async () => {
+		mockedGet.mockResolvedValue({ data: [] });
+
+		await getAllOrganizationsQueryOptions(0, 'Acme').queryFn!({} as never);
+
+		expect(mockedGet).toHaveBeenCalledWith(
+			'/Admin/Organization/?name=ct=Acme&status=ne=DELETED&sort(name)&limit(0,13)',
 		);
 	});
 });

--- a/src/features/organizations/queries/getAllOrganizations.ts
+++ b/src/features/organizations/queries/getAllOrganizations.ts
@@ -1,6 +1,8 @@
 import { apiClient } from '@/config/apiClient';
-import { Organization } from '@/integrations/api/api.patch';
+import { Cluster, Organization } from '@/integrations/api/api.patch';
+import { detectEntityId } from '@/lib/string/entityId';
 import { keepPreviousData, queryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
 // Server-side page size for the fabric admin "all organizations" view. Sized
 // to roughly one screen of cards: full rows at every breakpoint (3 per row at
@@ -39,10 +41,68 @@ export async function getAllOrganizations(pageIndex: number, nameFilter: string)
 	};
 }
 
-export function getAllOrganizationsQueryOptions(pageIndex: number, nameFilter: string) {
+const EMPTY_PAGE: AllOrganizationsPage = { organizations: [], hasNextPage: false };
+
+function isNotFoundError(error: unknown): boolean {
+	return error instanceof AxiosError && (error.response?.status === 404 || error.status === 404);
+}
+
+/**
+ * Fetches a single organization by its exact id, shaped as a one-item page so
+ * it can share the admin list's rendering. A missing id (typo, wrong prefix)
+ * resolves to an empty page ("No matches found") rather than an error.
+ */
+export async function getOrganizationByIdPage(organizationId: string): Promise<AllOrganizationsPage> {
+	try {
+		const { data } = await apiClient.get(
+			`/Admin/Organization/${organizationId}` as '/Admin/Organization/{id}',
+		);
+		return data ? { organizations: [data as Organization], hasNextPage: false } : EMPTY_PAGE;
+	} catch (error) {
+		if (isNotFoundError(error)) {
+			return EMPTY_PAGE;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Resolves a cluster id to the organization that owns it (a cluster response
+ * carries its `organizationId`), then returns that org as a one-item page. An
+ * unknown cluster resolves to an empty page.
+ */
+export async function getOrganizationForClusterPage(clusterId: string): Promise<AllOrganizationsPage> {
+	try {
+		const { data: cluster } = await apiClient.get(`/Cluster/${clusterId}` as '/Cluster/{id}');
+		const organizationId = (cluster as Cluster)?.organizationId;
+		return organizationId ? getOrganizationByIdPage(organizationId) : EMPTY_PAGE;
+	} catch (error) {
+		if (isNotFoundError(error)) {
+			return EMPTY_PAGE;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Query for the admin organization search. When the search value looks like an
+ * organization or cluster id (a lowercase `org-`/`clu-` prefix — see
+ * {@link detectEntityId}), it resolves that id server-side instead of running a
+ * title/name search, so pasting an id jumps straight to the matching org.
+ */
+export function getAllOrganizationsQueryOptions(pageIndex: number, searchValue: string) {
+	const entity = detectEntityId(searchValue);
 	return queryOptions({
-		queryKey: ['admin-all-organizations', nameFilter, pageIndex],
-		queryFn: () => getAllOrganizations(pageIndex, nameFilter),
+		queryKey: ['admin-all-organizations', searchValue, pageIndex],
+		queryFn: () => {
+			if (entity?.kind === 'organization') {
+				return getOrganizationByIdPage(entity.id);
+			}
+			if (entity?.kind === 'cluster') {
+				return getOrganizationForClusterPage(entity.id);
+			}
+			return getAllOrganizations(pageIndex, searchValue);
+		},
 		// Keep the previous page on screen while the next one loads.
 		placeholderData: keepPreviousData,
 		retry: false,

--- a/src/features/organizations/queries/getAllOrganizations.ts
+++ b/src/features/organizations/queries/getAllOrganizations.ts
@@ -75,7 +75,8 @@ export async function getOrganizationForClusterPage(clusterId: string): Promise<
 	try {
 		const { data: cluster } = await apiClient.get(`/Cluster/${clusterId}` as '/Cluster/{id}');
 		const organizationId = (cluster as Cluster)?.organizationId;
-		return organizationId ? getOrganizationByIdPage(organizationId) : EMPTY_PAGE;
+		// Await so a rejection from the org lookup is caught here, not orphaned.
+		return organizationId ? await getOrganizationByIdPage(organizationId) : EMPTY_PAGE;
 	} catch (error) {
 		if (isNotFoundError(error)) {
 			return EMPTY_PAGE;

--- a/src/lib/string/entityId.test.ts
+++ b/src/lib/string/entityId.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { detectEntityId } from './entityId';
+
+describe('detectEntityId', () => {
+	it('detects organization ids', () => {
+		expect(detectEntityId('org-qpz5akmyrp1d0opj')).toEqual({ kind: 'organization', id: 'org-qpz5akmyrp1d0opj' });
+		expect(detectEntityId('org-1')).toEqual({ kind: 'organization', id: 'org-1' });
+	});
+
+	it('detects cluster ids', () => {
+		expect(detectEntityId('clu-tc9pqw20vrks2zik')).toEqual({ kind: 'cluster', id: 'clu-tc9pqw20vrks2zik' });
+		expect(detectEntityId('clu-1333')).toEqual({ kind: 'cluster', id: 'clu-1333' });
+	});
+
+	it('detects instance ids', () => {
+		expect(detectEntityId('ins-abc123')).toEqual({ kind: 'instance', id: 'ins-abc123' });
+	});
+
+	it('trims surrounding whitespace before matching', () => {
+		expect(detectEntityId('  org-1  ')).toEqual({ kind: 'organization', id: 'org-1' });
+	});
+
+	it('returns null for titles that merely resemble an id', () => {
+		const cases = [
+			'',
+			'Acme',
+			'org', // no body
+			'org-', // empty body
+			'Org-1', // uppercase prefix is a title, not an id
+			'ORG-1',
+			'org 1', // space, not a hyphen
+			'org-my org', // space in body
+			'org-ABC', // uppercase body
+			'organization', // no hyphen boundary
+			'foo-1', // unknown prefix
+			'my-org-1', // prefix not at the start
+		];
+		for (const value of cases) {
+			expect(detectEntityId(value), value).toBeNull();
+		}
+	});
+
+	it('returns null for non-string input', () => {
+		expect(detectEntityId(undefined)).toBeNull();
+		expect(detectEntityId(null)).toBeNull();
+	});
+});

--- a/src/lib/string/entityId.ts
+++ b/src/lib/string/entityId.ts
@@ -1,0 +1,34 @@
+// Harper resources are addressed by IDs that carry a distinct, lowercase prefix
+// per resource type (e.g. `org-qpz5akmyrp1d0opj`, `clu-tc9pqw20vrks2zik`,
+// `ins-…`). The lowercase casing is what lets us tell a pasted ID apart from a
+// human-typed title — a title like "Org Chart" or "Cluster West" never matches.
+
+export type EntityIdKind = 'organization' | 'cluster' | 'instance';
+
+const PREFIX_TO_KIND: Record<string, EntityIdKind> = {
+	org: 'organization',
+	clu: 'cluster',
+	ins: 'instance',
+};
+
+// Lowercase prefix + lowercase alphanumeric body, anchored end-to-end so
+// partial/looser matches (mixed case, spaces, trailing junk) fall through to
+// the normal name search instead of being treated as an ID.
+const ENTITY_ID_PATTERN = /^(org|clu|ins)-[a-z0-9]+$/;
+
+/**
+ * Detects whether a string is a Harper resource ID and, if so, which kind of
+ * resource it identifies. Returns `null` for anything that only looks like a
+ * title (so callers can fall back to a name search).
+ */
+export function detectEntityId(value: string | undefined | null): { kind: EntityIdKind; id: string } | null {
+	if (typeof value !== 'string') {
+		return null;
+	}
+	const id = value.trim();
+	const match = ENTITY_ID_PATTERN.exec(id);
+	if (!match) {
+		return null;
+	}
+	return { kind: PREFIX_TO_KIND[match[1]], id };
+}


### PR DESCRIPTION
## What

Lets the admin **organization search** find an org/cluster by **ID** instead of only matching titles. Paste something that looks like a Harper id — distinguished by its distinct lowercase prefix — and it's resolved server-side:

- `org-<id>` → `GET /Admin/Organization/{id}` → shows that org's card
- `clu-<id>` → `GET /Cluster/{id}`, then resolves the cluster's `organizationId` → shows the **owning** org's card

Anything that only *looks* like a title (mixed case, spaces, unknown prefix) falls through to the existing name-`ct=` search unchanged. A missing/unknown id resolves to an empty page ("No matches found") rather than an error.

Closes #1420.

## Why

Support/admin often has just an `org-…` or `clu-…` id (from a log, ticket, or Datadog). The server search only matched `name`, so pasting an id returned nothing. The lowercase-prefix casing is exactly what lets us tell a real id apart from a human-typed title, as the issue notes.

## How

- **`src/lib/string/entityId.ts`** — new `detectEntityId()` helper. Matches `^(org|clu|ins)-[a-z0-9]+$` (anchored, lowercase-only) and returns the resource `kind`, or `null` for titles.
- **`getAllOrganizations.ts`** — `getAllOrganizationsQueryOptions` now branches: org-id → `getOrganizationByIdPage`, cluster-id → `getOrganizationForClusterPage` (cluster → owning org), otherwise the existing name search. 404s resolve to an empty page.
- **`organizations/index.tsx`** — a recognized id enables the server query for **any fabric admin regardless of the "All Orgs" toggle**, so an id lookup jumps straight to the result. Render gating switched from `showAll` to a `isServerSearch` flag (`showAll || id-lookup`).

Non-admins are unaffected — server lookups are admin-only, and their own orgs already match by id via the client-side fuzzy filter.

## Testing

- `src/lib/string/entityId.test.ts` — prefix/casing/whitespace detection + negatives (titles, uppercase, unknown prefixes).
- `getAllOrganizations.test.ts` — org-id lookup, cluster→org resolution, name-search fallthrough, and 404 → empty-page for both.
- Full suite green (1156 passed, 11 skipped), typecheck (`tsc -b`), `oxlint`, and `dprint` all clean.

> Note: not exercised in a live browser — port 5173 (the same-origin, backend-authed dev server) was held by another session, and this needs fabric-admin auth + real prod ids. Verified at the mechanism level via the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)