### PR TITLE
feat(logs): stream read_log over SSE with a polling fallback

### DIFF
--- a/src/features/instance/log/components/LogsFiltersForm.tsx
+++ b/src/features/instance/log/components/LogsFiltersForm.tsx
@@ -14,6 +14,11 @@ import { SearchIcon, SlidersHorizontalIcon } from 'lucide-react';
 import { UseFormReturn } from 'react-hook-form';
 import z from 'zod';
 
+// In dark mode `--card`, `--input`, and `--border` all resolve to grey-700, so a default
+// field is invisible against the filters card. Give the fields a distinct fill + visible
+// border — matching the schema editor's treatment (SchemaEditorView `FIELD_SURFACE`).
+const FIELD_SURFACE = 'dark:bg-grey-600 dark:border-grey-500';
+
 export function LogsFiltersForm({
 	form,
 	resetFilters,
@@ -68,7 +73,7 @@ export function LogsFiltersForm({
 												<Input
 													type="search"
 													placeholder="Search logs…"
-													className="pl-9"
+													className={cn('pl-9', FIELD_SURFACE)}
 													value={field.value ?? ''}
 													onChange={field.onChange}
 												/>
@@ -87,7 +92,7 @@ export function LogsFiltersForm({
 									<FormItem>
 										<FormLabel>Log file</FormLabel>
 										<Select onValueChange={field.onChange} value={field.value ?? undefined}>
-											<SelectTrigger className="w-full bg-white dark:bg-grey-700">
+											<SelectTrigger className={cn('w-full bg-white', FIELD_SURFACE)}>
 												<SelectValue placeholder="Select log file" />
 											</SelectTrigger>
 											<SelectContent>
@@ -110,7 +115,7 @@ export function LogsFiltersForm({
 									<FormItem>
 										<FormLabel>Limit</FormLabel>
 										<Select onValueChange={field.onChange} value={field.value ?? undefined}>
-											<SelectTrigger className="w-full bg-white dark:bg-grey-700">
+											<SelectTrigger className={cn('w-full bg-white', FIELD_SURFACE)}>
 												<SelectValue placeholder="Limit" />
 											</SelectTrigger>
 											<SelectContent>
@@ -134,7 +139,7 @@ export function LogsFiltersForm({
 									<FormItem>
 										<FormLabel>Level</FormLabel>
 										<Select onValueChange={field.onChange} value={field.value ?? undefined}>
-											<SelectTrigger className="w-full bg-white dark:bg-grey-700">
+											<SelectTrigger className={cn('w-full bg-white', FIELD_SURFACE)}>
 												<SelectValue placeholder="Level" />
 											</SelectTrigger>
 											<SelectContent>
@@ -161,7 +166,12 @@ export function LogsFiltersForm({
 								<FormItem>
 									<FormLabel>Start date</FormLabel>
 									<FormControl>
-										<Input type="datetime-local" value={field.value ?? undefined} onChange={field.onChange} />
+										<Input
+											type="datetime-local"
+											className={FIELD_SURFACE}
+											value={field.value ?? undefined}
+											onChange={field.onChange}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -174,7 +184,12 @@ export function LogsFiltersForm({
 								<FormItem>
 									<FormLabel>End date</FormLabel>
 									<FormControl>
-										<Input type="datetime-local" value={field.value ?? undefined} onChange={field.onChange} />
+										<Input
+											type="datetime-local"
+											className={FIELD_SURFACE}
+											value={field.value ?? undefined}
+											onChange={field.onChange}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/src/features/instance/log/hooks/mergeReadLogs.test.ts
+++ b/src/features/instance/log/hooks/mergeReadLogs.test.ts
@@ -1,0 +1,57 @@
+import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+import { describe, expect, it } from 'vitest';
+import { mergeReadLogs } from './mergeReadLogs';
+
+function entry(message: string, timestamp: string, overrides: Partial<ReadLogItem> = {}): ReadLogItem {
+	return { level: 'info', timestamp, thread: 'main/0', tags: [], node: '', message, ...overrides };
+}
+
+describe('mergeReadLogs', () => {
+	it('places live entries ahead of the snapshot, newest-first', () => {
+		const snapshot = [entry('older', '2026-07-07T00:00:01.000Z')];
+		const live = [entry('newer', '2026-07-07T00:00:05.000Z')];
+
+		expect(mergeReadLogs(snapshot, live, 100).map((e) => e.message)).toEqual(['newer', 'older']);
+	});
+
+	it('de-duplicates lines present in both sources', () => {
+		const shared = entry('shared', '2026-07-07T00:00:02.000Z');
+		const merged = mergeReadLogs([shared, entry('old', '2026-07-07T00:00:01.000Z')], [shared], 100);
+
+		expect(merged.map((e) => e.message)).toEqual(['shared', 'old']);
+	});
+
+	it('sorts defensively by timestamp regardless of input order', () => {
+		const live = [
+			entry('b', '2026-07-07T00:00:02.000Z'),
+			entry('d', '2026-07-07T00:00:04.000Z'),
+		];
+		const snapshot = [
+			entry('a', '2026-07-07T00:00:01.000Z'),
+			entry('c', '2026-07-07T00:00:03.000Z'),
+		];
+
+		expect(mergeReadLogs(snapshot, live, 100).map((e) => e.message)).toEqual(['d', 'c', 'b', 'a']);
+	});
+
+	it('caps the merged list at the limit', () => {
+		const live = Array.from({ length: 5 }, (_, i) => entry(`e${i}`, `2026-07-07T00:00:1${i}.000Z`));
+		expect(mergeReadLogs([], live, 3)).toHaveLength(3);
+	});
+
+	it('treats entries with the same timestamp but different messages as distinct', () => {
+		const ts = '2026-07-07T00:00:02.000Z';
+		const merged = mergeReadLogs([], [entry('one', ts), entry('two', ts)], 100);
+		expect(merged).toHaveLength(2);
+	});
+
+	it('keeps lines distinct across nodes even when otherwise identical', () => {
+		const ts = '2026-07-07T00:00:02.000Z';
+		const merged = mergeReadLogs(
+			[],
+			[entry('same', ts, { node: 'node-a' }), entry('same', ts, { node: 'node-b' })],
+			100,
+		);
+		expect(merged).toHaveLength(2);
+	});
+});

--- a/src/features/instance/log/hooks/mergeReadLogs.ts
+++ b/src/features/instance/log/hooks/mergeReadLogs.ts
@@ -1,0 +1,39 @@
+import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+
+/**
+ * Identity of a log line, so the buffered snapshot and the live tail can overlap safely.
+ * Fields are joined with a delimiter unlikely to collide so no combination of field
+ * contents is mistaken for a different line.
+ */
+function logKey(entry: ReadLogItem): string {
+	return [entry.timestamp, entry.node ?? '', entry.thread ?? '', entry.level, entry.message].join('|');
+}
+
+/**
+ * Merge the buffered snapshot with entries received over the live tail into a single
+ * newest-first list, de-duplicated (the two sources overlap: the tail may replay recent
+ * lines that the snapshot already holds) and capped at `limit`.
+ *
+ * Both inputs are expected newest-first already; we still sort defensively by timestamp so
+ * an out-of-order arrival cannot wedge a line into the wrong place. Ties keep first-seen
+ * order, and since `live` is scanned before `snapshot`, a replayed line prefers the tail's
+ * copy (which is the one carrying any freshly-attached `node`, etc.).
+ */
+export function mergeReadLogs(
+	snapshot: ReadLogItem[],
+	live: ReadLogItem[],
+	limit: number,
+): ReadLogItem[] {
+	const seen = new Set<string>();
+	const merged: ReadLogItem[] = [];
+	for (const entry of [...live, ...snapshot]) {
+		const key = logKey(entry);
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		merged.push(entry);
+	}
+	merged.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+	return limit > 0 && merged.length > limit ? merged.slice(0, limit) : merged;
+}

--- a/src/features/instance/log/hooks/streamReducer.test.ts
+++ b/src/features/instance/log/hooks/streamReducer.test.ts
@@ -1,0 +1,44 @@
+import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+import { describe, expect, it } from 'vitest';
+import { INITIAL_STREAM_STATE, streamReducer } from './streamReducer';
+
+function entry(message: string, timestamp: string): ReadLogItem {
+	return { level: 'info', timestamp, thread: 'main/0', tags: [], node: '', message };
+}
+
+describe('streamReducer', () => {
+	it('append accumulates entries under the cap', () => {
+		const a = entry('a', '2026-07-08T00:00:01.000Z');
+		const b = entry('b', '2026-07-08T00:00:02.000Z');
+		const state = streamReducer(INITIAL_STREAM_STATE, { kind: 'append', entries: [a, b], cap: 10 });
+		expect(state.entries).toEqual([a, b]);
+	});
+
+	it('append evicts the oldest by timestamp when over the cap', () => {
+		const old = entry('old', '2026-07-08T00:00:01.000Z');
+		const mid = entry('mid', '2026-07-08T00:00:02.000Z');
+		const recent = entry('recent', '2026-07-08T00:00:03.000Z');
+		const state = streamReducer(INITIAL_STREAM_STATE, { kind: 'append', entries: [old, mid, recent], cap: 2 });
+		expect(state.entries.map((e) => e.message)).toEqual(['recent', 'mid']);
+	});
+
+	it('retry clears the fall-back flag but keeps the streamed entries (Live re-enable)', () => {
+		const a = entry('a', '2026-07-08T00:00:01.000Z');
+		const fellBack = { entries: [a], fellBack: true };
+		const state = streamReducer(fellBack, { kind: 'retry' });
+		expect(state.fellBack).toBe(false);
+		expect(state.entries).toEqual([a]); // not discarded
+	});
+
+	it('retry is a no-op when not fallen back', () => {
+		const a = entry('a', '2026-07-08T00:00:01.000Z');
+		const base = { entries: [a], fellBack: false };
+		expect(streamReducer(base, { kind: 'retry' })).toBe(base);
+	});
+
+	it('reset clears entries and the fall-back flag (new filter/entity context)', () => {
+		const a = entry('a', '2026-07-08T00:00:01.000Z');
+		const state = streamReducer({ entries: [a], fellBack: true }, { kind: 'reset' });
+		expect(state).toEqual({ entries: [], fellBack: false });
+	});
+});

--- a/src/features/instance/log/hooks/streamReducer.ts
+++ b/src/features/instance/log/hooks/streamReducer.ts
@@ -1,0 +1,43 @@
+import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+
+export interface StreamState {
+	entries: ReadLogItem[];
+	/** The tail ended or errored; the query takes over polling until inputs change. */
+	fellBack: boolean;
+}
+
+export type StreamAction =
+	| { kind: 'reset' }
+	| { kind: 'retry' }
+	| { kind: 'append'; entries: ReadLogItem[]; cap: number }
+	| { kind: 'fellBack' };
+
+export const INITIAL_STREAM_STATE: StreamState = { entries: [], fellBack: false };
+
+/**
+ * Accumulator for the live SSE tail, driven by the hook via `useReducer`. Kept as a pure
+ * module (no React/auth imports) so it unit-tests in the node env without a DOM.
+ */
+export function streamReducer(state: StreamState, action: StreamAction): StreamState {
+	switch (action.kind) {
+		case 'reset':
+			return INITIAL_STREAM_STATE;
+		case 'retry':
+			// Re-attempt SSE (e.g. Live toggled back on) without discarding entries already shown.
+			return state.fellBack ? { ...state, fellBack: false } : state;
+		case 'append': {
+			if (action.entries.length === 0) {
+				return state;
+			}
+			const next = state.entries.concat(action.entries);
+			if (next.length <= action.cap) {
+				return { ...state, entries: next };
+			}
+			// Keep the newest `cap` entries by timestamp.
+			next.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+			return { ...state, entries: next.slice(0, action.cap) };
+		}
+		case 'fellBack':
+			return { ...state, fellBack: true };
+	}
+}

--- a/src/features/instance/log/hooks/useInstanceLogs.ts
+++ b/src/features/instance/log/hooks/useInstanceLogs.ts
@@ -1,0 +1,191 @@
+import { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import { getReadLogQueryOptions, ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+import { LogFiltersFormSchema } from '@/integrations/api/instance/status/logFiltersFormSchema';
+import { streamReadLog } from '@/integrations/api/instance/status/streamReadLog';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { z } from 'zod';
+import { mergeReadLogs } from './mergeReadLogs';
+import { useSupportsLogSSE } from './useSupportsLogSSE';
+
+type LogFilters = z.infer<typeof LogFiltersFormSchema>;
+
+/** How the logs are currently sourced, for UI messaging. */
+export type LogTransport = 'idle' | 'streaming' | 'polling';
+
+export interface UseInstanceLogsParams {
+	params: InstanceClientIdConfig & InstanceTypeConfig;
+	logFilters: LogFilters;
+	replicated: boolean;
+	/** The "Live" toggle. Off → one fetch + manual refresh; on → SSE tail, else 5s polling. */
+	live: boolean;
+}
+
+export interface UseInstanceLogsResult {
+	logs: ReadLogItem[];
+	isLoading: boolean;
+	isFetching: boolean;
+	refetch: () => Promise<unknown>;
+	/** `'streaming'` over SSE, `'polling'` on the 5s fallback, `'idle'` when not live. */
+	transport: LogTransport;
+}
+
+/** Fall back to Harper's own `read_log` default when the user clears the limit field. */
+const DEFAULT_LIMIT = 1000;
+/** Ceiling on retained live entries so a long-running tail can't grow state unbounded. */
+const MAX_LIVE_ENTRIES = 2000;
+/** Batch streamed entries into at most one render per this interval (a chatty tail safety net). */
+const FLUSH_INTERVAL_MS = 250;
+
+interface StreamState {
+	entries: ReadLogItem[];
+	/** The tail ended or errored; the query takes over polling until inputs change. */
+	fellBack: boolean;
+}
+
+type StreamAction =
+	| { kind: 'reset' }
+	| { kind: 'append'; entries: ReadLogItem[] }
+	| { kind: 'fellBack' };
+
+const INITIAL_STREAM_STATE: StreamState = { entries: [], fellBack: false };
+
+function streamReducer(state: StreamState, action: StreamAction): StreamState {
+	switch (action.kind) {
+		case 'reset':
+			return INITIAL_STREAM_STATE;
+		case 'append': {
+			if (action.entries.length === 0) {
+				return state;
+			}
+			const next = state.entries.concat(action.entries);
+			if (next.length <= MAX_LIVE_ENTRIES) {
+				return { ...state, entries: next };
+			}
+			// Keep the newest MAX_LIVE_ENTRIES by timestamp.
+			next.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
+			return { ...state, entries: next.slice(0, MAX_LIVE_ENTRIES) };
+		}
+		case 'fellBack':
+			return { ...state, fellBack: true };
+	}
+}
+
+function parseLimit(limit: LogFilters['limit']): number {
+	const parsed = limit ? parseInt(limit, 10) : NaN;
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT;
+}
+
+/** Stable identity for the filter set, so effects restart only when the requested slice changes. */
+function filtersKey(logFilters: LogFilters, replicated: boolean): string {
+	return JSON.stringify([
+		logFilters.limit,
+		logFilters.level,
+		logFilters.from,
+		logFilters.until,
+		logFilters.log_name,
+		logFilters.filter,
+		replicated,
+	]);
+}
+
+/**
+ * Single source of truth for the logs view: subscribes to `read_log` over SSE when the
+ * connection supports it, and transparently falls back to the existing 5s polling otherwise
+ * (proxy connection, an instance that doesn't stream, or a stream that errors/ends).
+ *
+ * The buffered React Query snapshot is always present — it provides the initial backlog and
+ * becomes the polling source on fallback — and live entries are merged on top of it, so the
+ * table never flickers when the transport switches.
+ */
+export function useInstanceLogs(
+	{ params, logFilters, replicated, live }: UseInstanceLogsParams,
+): UseInstanceLogsResult {
+	const supportsSSE = useSupportsLogSSE();
+	const [stream, dispatch] = useReducer(streamReducer, INITIAL_STREAM_STATE);
+
+	const useSSE = live && supportsSSE && !stream.fellBack;
+	const key = filtersKey(logFilters, replicated);
+	const limit = parseLimit(logFilters.limit);
+
+	const query = useQuery(
+		getReadLogQueryOptions({
+			...params,
+			logFilters,
+			replicated,
+			// Poll only when live and NOT streaming: the SSE tail carries live updates itself.
+			isAutoRefreshEnabled: live && !useSSE,
+		}),
+	);
+
+	// A new entity, filter set, or a fresh flip of the Live toggle is a new subscription
+	// context — drop stale live entries and clear a prior fall-back so SSE is retried.
+	useEffect(() => {
+		dispatch({ kind: 'reset' });
+	}, [params.entityId, key, live]);
+
+	// Keep the latest filters/replicated in refs so the tail can send the current slice without
+	// tearing the stream down on every keystroke — it restarts only when `key` changes below.
+	const streamArgsRef = useRef({ logFilters, replicated });
+	streamArgsRef.current = { logFilters, replicated };
+
+	useEffect(() => {
+		if (!useSSE) {
+			return;
+		}
+		const controller = new AbortController();
+		let pending: ReadLogItem[] = [];
+		const flush = () => {
+			if (pending.length > 0 && !controller.signal.aborted) {
+				const batch = pending;
+				pending = [];
+				dispatch({ kind: 'append', entries: batch });
+			}
+		};
+		const flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
+
+		streamReadLog({
+			connection: { id: params.entityId },
+			logFilters: streamArgsRef.current.logFilters,
+			replicated: streamArgsRef.current.replicated,
+			signal: controller.signal,
+			onEntry: (entry) => pending.push(entry),
+		})
+			.catch(() => {
+				// SSEUnsupported / SSEOperation / transport errors all mean: stop trusting SSE for
+				// this slice and let the query poll. A caller-driven abort is filtered out below.
+			})
+			.finally(() => {
+				clearInterval(flushTimer);
+				if (controller.signal.aborted) {
+					return;
+				}
+				flush();
+				// The tail is over (clean end or error). Poll to keep catching new entries.
+				dispatch({ kind: 'fellBack' });
+			});
+
+		return () => {
+			clearInterval(flushTimer);
+			controller.abort();
+		};
+	}, [useSSE, params.entityId, key]);
+
+	const logs = useMemo(() => {
+		const snapshot = query.data ?? [];
+		if (!live || stream.entries.length === 0) {
+			return snapshot;
+		}
+		return mergeReadLogs(snapshot, stream.entries, limit);
+	}, [query.data, stream.entries, live, limit]);
+
+	const transport: LogTransport = useSSE ? 'streaming' : live ? 'polling' : 'idle';
+
+	return {
+		logs,
+		isLoading: query.isLoading,
+		isFetching: query.isFetching,
+		refetch: () => query.refetch(),
+		transport,
+	};
+}

--- a/src/features/instance/log/hooks/useInstanceLogs.ts
+++ b/src/features/instance/log/hooks/useInstanceLogs.ts
@@ -1,11 +1,12 @@
 import { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
-import { getReadLogQueryOptions, ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+import { clampReadLogLimit, getReadLogQueryOptions, ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
 import { LogFiltersFormSchema } from '@/integrations/api/instance/status/logFiltersFormSchema';
 import { streamReadLog } from '@/integrations/api/instance/status/streamReadLog';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { z } from 'zod';
 import { mergeReadLogs } from './mergeReadLogs';
+import { INITIAL_STREAM_STATE, streamReducer } from './streamReducer';
 import { useSupportsLogSSE } from './useSupportsLogSSE';
 
 type LogFilters = z.infer<typeof LogFiltersFormSchema>;
@@ -32,48 +33,17 @@ export interface UseInstanceLogsResult {
 
 /** Fall back to Harper's own `read_log` default when the user clears the limit field. */
 const DEFAULT_LIMIT = 1000;
-/** Ceiling on retained live entries so a long-running tail can't grow state unbounded. */
+/**
+ * Floor on retained live entries so a long-running tail can't grow state unbounded. The actual
+ * cap is `max(this, limit)` so a user asking for more than this still sees a contiguous tail
+ * (a smaller cap would silently drop the oldest live entries with no backfill while streaming).
+ */
 const MAX_LIVE_ENTRIES = 2000;
 /** Batch streamed entries into at most one render per this interval (a chatty tail safety net). */
 const FLUSH_INTERVAL_MS = 250;
 
-interface StreamState {
-	entries: ReadLogItem[];
-	/** The tail ended or errored; the query takes over polling until inputs change. */
-	fellBack: boolean;
-}
-
-type StreamAction =
-	| { kind: 'reset' }
-	| { kind: 'append'; entries: ReadLogItem[] }
-	| { kind: 'fellBack' };
-
-const INITIAL_STREAM_STATE: StreamState = { entries: [], fellBack: false };
-
-function streamReducer(state: StreamState, action: StreamAction): StreamState {
-	switch (action.kind) {
-		case 'reset':
-			return INITIAL_STREAM_STATE;
-		case 'append': {
-			if (action.entries.length === 0) {
-				return state;
-			}
-			const next = state.entries.concat(action.entries);
-			if (next.length <= MAX_LIVE_ENTRIES) {
-				return { ...state, entries: next };
-			}
-			// Keep the newest MAX_LIVE_ENTRIES by timestamp.
-			next.sort((a, b) => (a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0));
-			return { ...state, entries: next.slice(0, MAX_LIVE_ENTRIES) };
-		}
-		case 'fellBack':
-			return { ...state, fellBack: true };
-	}
-}
-
 function parseLimit(limit: LogFilters['limit']): number {
-	const parsed = limit ? parseInt(limit, 10) : NaN;
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LIMIT;
+	return clampReadLogLimit(limit) ?? DEFAULT_LIMIT;
 }
 
 /** Stable identity for the filter set, so effects restart only when the requested slice changes. */
@@ -107,6 +77,10 @@ export function useInstanceLogs(
 	const useSSE = live && supportsSSE && !stream.fellBack;
 	const key = filtersKey(logFilters, replicated);
 	const limit = parseLimit(logFilters.limit);
+	// Retain at least `limit` live entries so a user asking for a large slice still sees a
+	// contiguous tail rather than the oldest streamed lines silently dropping (polling is off
+	// while streaming, so there is no backfill to close such a gap).
+	const retainCap = Math.max(MAX_LIVE_ENTRIES, limit);
 
 	const query = useQuery(
 		getReadLogQueryOptions({
@@ -118,11 +92,20 @@ export function useInstanceLogs(
 		}),
 	);
 
-	// A new entity, filter set, or a fresh flip of the Live toggle is a new subscription
-	// context — drop stale live entries and clear a prior fall-back so SSE is retried.
+	// A new entity or filter set is a new subscription context — drop stale live entries and any
+	// fall-back. Deliberately NOT keyed on `live`: toggling Live off must keep the streamed tail
+	// on screen (otherwise the table jumps back to the pre-Live snapshot with no signal).
 	useEffect(() => {
 		dispatch({ kind: 'reset' });
-	}, [params.entityId, key, live]);
+	}, [params.entityId, key]);
+
+	// Turning Live back on after a fall-back should re-attempt SSE — but without discarding the
+	// entries already on screen, so only the fall-back flag is cleared.
+	useEffect(() => {
+		if (live) {
+			dispatch({ kind: 'retry' });
+		}
+	}, [live]);
 
 	// Keep the latest filters/replicated in refs so the tail can send the current slice without
 	// tearing the stream down on every keystroke — it restarts only when `key` changes below.
@@ -139,7 +122,7 @@ export function useInstanceLogs(
 			if (pending.length > 0 && !controller.signal.aborted) {
 				const batch = pending;
 				pending = [];
-				dispatch({ kind: 'append', entries: batch });
+				dispatch({ kind: 'append', entries: batch, cap: retainCap });
 			}
 		};
 		const flushTimer = setInterval(flush, FLUSH_INTERVAL_MS);
@@ -173,11 +156,10 @@ export function useInstanceLogs(
 
 	const logs = useMemo(() => {
 		const snapshot = query.data ?? [];
-		if (!live || stream.entries.length === 0) {
-			return snapshot;
-		}
-		return mergeReadLogs(snapshot, stream.entries, limit);
-	}, [query.data, stream.entries, live, limit]);
+		// Merge whenever there are streamed entries — including after Live is toggled off — so the
+		// tail the user was watching stays on screen instead of snapping back to the older snapshot.
+		return stream.entries.length === 0 ? snapshot : mergeReadLogs(snapshot, stream.entries, limit);
+	}, [query.data, stream.entries, limit]);
 
 	const transport: LogTransport = useSSE ? 'streaming' : live ? 'polling' : 'idle';
 

--- a/src/features/instance/log/hooks/useSupportsLogSSE.ts
+++ b/src/features/instance/log/hooks/useSupportsLogSSE.ts
@@ -1,0 +1,20 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { authStore } from '@/features/auth/store/authStore';
+
+/**
+ * True when we should attempt a LIVE SSE tail of `read_log` for this entity.
+ *
+ * Gated purely on a direct connection: the central-manager fabric-connect proxy buffers
+ * `text/event-stream` (it withholds the whole response until the operation completes), so a
+ * tail over it never streams — mirroring `useSupportsDeploymentSSE`.
+ *
+ * Deliberately NOT gated on a Harper version. Streaming `read_log` is negotiated per request
+ * via the `Accept` header, and `streamReadLog` detects a non-streaming instance cheaply (a
+ * non-`text/event-stream` response throws `SSEUnsupportedError` before any tail begins), so
+ * the caller falls back to polling with no wasted work. A version gate can be added here once
+ * the minimum streaming version is pinned down.
+ */
+export function useSupportsLogSSE(): boolean {
+	const params = useInstanceClientIdParams();
+	return authStore.isDirectConnection(params.entityId);
+}

--- a/src/features/instance/log/index.tsx
+++ b/src/features/instance/log/index.tsx
@@ -11,7 +11,7 @@ import { LogsDataTable } from '@/features/instance/log/LogsDataTable';
 import { ViewLogModal } from '@/features/instance/log/modals/ViewLogModal';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
-import { getReadLogQueryOptions, ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
+import { ReadLogItem } from '@/integrations/api/instance/status/getReadLog';
 import { getRegistrationInfoQueryOptions } from '@/integrations/api/instance/status/getRegistrationInfo';
 import { LogFiltersFormSchema } from '@/integrations/api/instance/status/logFiltersFormSchema';
 import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
@@ -36,6 +36,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { LogsFiltersForm } from './components/LogsFiltersForm';
+import { useInstanceLogs } from './hooks/useInstanceLogs';
 
 type RowData = {
 	original: ReadLogItem;
@@ -182,7 +183,7 @@ export function Logs() {
 
 	const [isViewLogModalOpen, setIsViewLogModalOpen] = useState(false);
 	const [selectedLogData, setSelectedLogData] = useState<ReadLogItem | undefined>();
-	const [isAutoRefreshEnabled, setIsAutoRefreshEnabled] = useState(false);
+	const [isLive, setIsLive] = useState(false);
 	// Persisted per browser/user across all clusters and instances; defaults to newest-first.
 	const [isReversed, setIsReversed] = useLocalStorage<boolean>(LocalStorageKeys.LogsOrderReversed, false);
 	const [isFiltersOpen, setIsFiltersOpen] = useState(false);
@@ -195,18 +196,17 @@ export function Logs() {
 	const showFilter = !!version && wasAReleasedBeforeB('4.7.16', version);
 
 	const {
-		data: instanceLogs,
+		logs: instanceLogs,
 		isLoading,
-		refetch: refetchReadLogQueryOptions,
 		isFetching: isFetchingInstanceLogs,
-	} = useQuery(
-		getReadLogQueryOptions({
-			logFilters,
-			...instanceParams,
-			replicated: instanceParams.entityType === 'cluster',
-			isAutoRefreshEnabled,
-		}),
-	);
+		refetch: refetchReadLogQueryOptions,
+		transport,
+	} = useInstanceLogs({
+		params: instanceParams,
+		logFilters,
+		replicated: instanceParams.entityType === 'cluster',
+		live: isLive,
+	});
 
 	// Logs arrive newest-first from the API; reversing flips the view to oldest-first without re-fetching.
 	const displayedLogs = useMemo(
@@ -224,12 +224,12 @@ export function Logs() {
 		el.scrollTo({ top: isReversed ? el.scrollHeight : 0 });
 	}, [isReversed, isLoading]);
 
-	// While auto-refreshing, follow new entries like `tail -f`, keeping the newest in view as they arrive.
+	// While live, follow new entries like `tail -f`, keeping the newest in view as they arrive.
 	useEffect(() => {
 		const el = tableScrollRef.current;
-		if (!isAutoRefreshEnabled || isLoading || !el) { return; }
+		if (!isLive || isLoading || !el) { return; }
 		el.scrollTo({ top: isReversed ? el.scrollHeight : 0 });
-	}, [displayedLogs, isAutoRefreshEnabled, isReversed, isLoading]);
+	}, [displayedLogs, isLive, isReversed, isLoading]);
 
 	const form = useForm({
 		resolver: zodResolver(LogFiltersFormSchema),
@@ -282,7 +282,7 @@ export function Logs() {
 					<Button
 						variant="defaultOutline"
 						onClick={onRefreshClick}
-						disabled={isFetchingInstanceLogs || isLoading || isAutoRefreshEnabled}
+						disabled={isFetchingInstanceLogs || isLoading || isLive}
 						aria-label="Refresh logs"
 						className="flex-1"
 					>
@@ -316,7 +316,7 @@ export function Logs() {
 					<Button
 						variant="defaultOutline"
 						onClick={onRefreshClick}
-						disabled={isFetchingInstanceLogs || isLoading || isAutoRefreshEnabled}
+						disabled={isFetchingInstanceLogs || isLoading || isLive}
 						className="w-full"
 					>
 						<RefreshCwIcon />
@@ -325,16 +325,20 @@ export function Logs() {
 					<div className="flex flex-col gap-2.5">
 						<div className="flex items-center gap-2 text-sm text-foreground">
 							<Switch
-								id="logs-auto-refresh-switch"
-								aria-label="Toggle auto refresh"
-								checked={isAutoRefreshEnabled}
-								onCheckedChange={setIsAutoRefreshEnabled}
+								id="logs-live-switch"
+								aria-label="Toggle live logs"
+								checked={isLive}
+								onCheckedChange={setIsLive}
 							/>
-							<label htmlFor="logs-auto-refresh-switch" className="flex items-center gap-2 cursor-pointer">
+							<label htmlFor="logs-live-switch" className="flex items-center gap-2 cursor-pointer">
 								<RefreshCwIcon
-									className={`size-4 ${isAutoRefreshEnabled ? 'animate-spin [animation-duration:3s]' : ''}`}
+									className={`size-4 ${isLive ? 'animate-spin [animation-duration:3s]' : ''}`}
 								/>
-								Auto refresh (every 5s)
+								{isLive
+									? transport === 'streaming'
+										? 'Live (streaming)'
+										: 'Live (polling every 5s)'
+									: 'Live'}
 							</label>
 						</div>
 						<div className="flex items-center gap-2 text-sm text-foreground">

--- a/src/integrations/api/instance/status/getReadLog.test.ts
+++ b/src/integrations/api/instance/status/getReadLog.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildReadLogBody, clampReadLogLimit, MAX_READ_LOG_LIMIT } from './getReadLog';
+
+describe('clampReadLogLimit', () => {
+	it('returns undefined for blank or invalid input', () => {
+		expect(clampReadLogLimit(undefined)).toBeUndefined();
+		expect(clampReadLogLimit(null)).toBeUndefined();
+		expect(clampReadLogLimit('')).toBeUndefined();
+		expect(clampReadLogLimit('abc')).toBeUndefined();
+		expect(clampReadLogLimit('0')).toBeUndefined();
+		expect(clampReadLogLimit('-5')).toBeUndefined();
+	});
+
+	it('passes values at or below the ceiling through unchanged', () => {
+		expect(clampReadLogLimit('100')).toBe(100);
+		expect(clampReadLogLimit(String(MAX_READ_LOG_LIMIT))).toBe(MAX_READ_LOG_LIMIT);
+	});
+
+	it('clamps values above the ceiling', () => {
+		expect(clampReadLogLimit('999999')).toBe(MAX_READ_LOG_LIMIT);
+	});
+});
+
+describe('buildReadLogBody', () => {
+	it('clamps an oversized limit before it reaches the wire', () => {
+		expect(buildReadLogBody({ limit: '5000000' }, false).limit).toBe(MAX_READ_LOG_LIMIT);
+	});
+
+	it('omits limit entirely when the field is blank', () => {
+		expect(buildReadLogBody({ limit: '' }, false).limit).toBeUndefined();
+	});
+});

--- a/src/integrations/api/instance/status/getReadLog.ts
+++ b/src/integrations/api/instance/status/getReadLog.ts
@@ -19,6 +19,25 @@ interface GetReadLogParams {
 }
 
 /**
+ * Client-side ceiling on the `limit` we put on the wire, regardless of what the user types.
+ * The backend's SSE tail has an O(n·limit) cost for large limits (see harper#1693), so this
+ * keeps an unbounded number off the wire independent of whatever the backend eventually clamps.
+ */
+export const MAX_READ_LOG_LIMIT = 10000;
+
+/** Parse the user-supplied `limit` string, clamped to {@link MAX_READ_LOG_LIMIT}; undefined if blank/invalid. */
+export function clampReadLogLimit(limit: string | null | undefined): number | undefined {
+	if (!limit) {
+		return undefined;
+	}
+	const parsed = parseInt(limit, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return undefined;
+	}
+	return Math.min(parsed, MAX_READ_LOG_LIMIT);
+}
+
+/**
  * Build the `read_log` operation body from the current filters. Shared by the buffered
  * (axios) fetch and the SSE tail so the two paths request the exact same slice — the only
  * difference between them is the `Accept` header (see `streamReadLog`).
@@ -31,7 +50,7 @@ export function buildReadLogBody(
 		operation: 'read_log',
 		start: 0,
 		replicated,
-		limit: logFilters.limit ? parseInt(logFilters.limit, 10) : undefined,
+		limit: clampReadLogLimit(logFilters.limit),
 		level: logFilters.level !== 'undefined' ? logFilters.level : undefined,
 		from: logFilters.from ? new Date(logFilters.from).toISOString() : undefined,
 		until: logFilters.until ? new Date(logFilters.until).toISOString() : undefined,

--- a/src/integrations/api/instance/status/getReadLog.ts
+++ b/src/integrations/api/instance/status/getReadLog.ts
@@ -18,10 +18,16 @@ interface GetReadLogParams {
 	isAutoRefreshEnabled: boolean;
 }
 
-export async function getReadLog(
-	{ instanceClient, logFilters, replicated }: Omit<GetReadLogParams, 'isAutoRefreshEnabled'> & InstanceClientIdConfig,
-): Promise<ReadLogItem[]> {
-	const { data } = await instanceClient.post<ReadLogItem[]>('/', {
+/**
+ * Build the `read_log` operation body from the current filters. Shared by the buffered
+ * (axios) fetch and the SSE tail so the two paths request the exact same slice — the only
+ * difference between them is the `Accept` header (see `streamReadLog`).
+ */
+export function buildReadLogBody(
+	logFilters: z.infer<typeof LogFiltersFormSchema>,
+	replicated: boolean,
+): Record<string, unknown> {
+	return {
 		operation: 'read_log',
 		start: 0,
 		replicated,
@@ -32,7 +38,13 @@ export async function getReadLog(
 		log_name: logFilters.log_name ?? undefined,
 		filter: logFilters.filter ? logFilters.filter : undefined,
 		order: 'desc',
-	});
+	};
+}
+
+export async function getReadLog(
+	{ instanceClient, logFilters, replicated }: Omit<GetReadLogParams, 'isAutoRefreshEnabled'> & InstanceClientIdConfig,
+): Promise<ReadLogItem[]> {
+	const { data } = await instanceClient.post<ReadLogItem[]>('/', buildReadLogBody(logFilters, replicated));
 	return data;
 }
 

--- a/src/integrations/api/instance/status/streamReadLog.test.ts
+++ b/src/integrations/api/instance/status/streamReadLog.test.ts
@@ -1,0 +1,166 @@
+import { SSEOperationError, SSEUnsupportedError } from '@/integrations/api/sse/errors';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/integrations/api/sse/resolveInstanceConnection', () => ({
+	resolveInstanceConnection: () => ({
+		url: 'https://host:9925/',
+		headers: { Accept: 'text/event-stream' },
+		credentials: 'include' as RequestCredentials,
+	}),
+}));
+
+import { ReadLogItem } from './getReadLog';
+import { streamReadLog } from './streamReadLog';
+
+function sseResponse(body: string, init?: { status?: number; contentType?: string }): Response {
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(body));
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: init?.status ?? 200,
+		headers: { 'content-type': init?.contentType ?? 'text/event-stream' },
+	});
+}
+
+const filters = { limit: '100', level: 'undefined' as const };
+
+function entry(message: string, timestamp = '2026-07-07T00:00:00.000Z'): ReadLogItem {
+	return { level: 'info', timestamp, thread: 'main/0', tags: [], node: '', message };
+}
+
+function collect() {
+	const entries: ReadLogItem[] = [];
+	return { entries, onEntry: (e: ReadLogItem) => entries.push(e) };
+}
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('streamReadLog', () => {
+	it('forwards each streamed log entry to onEntry and resolves when the stream ends', async () => {
+		const { entries, onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse(
+					': keep-alive\n\n'
+						+ `data: ${JSON.stringify(entry('first', '2026-07-07T00:00:01.000Z'))}\n\n`
+						+ `data: ${JSON.stringify(entry('second', '2026-07-07T00:00:02.000Z'))}\n\n`,
+				),
+			),
+		);
+
+		await expect(
+			streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry }),
+		).resolves.toBeUndefined();
+		expect(entries.map((e) => e.message)).toEqual(['first', 'second']);
+	});
+
+	it('unwraps a batch array delivered in a single event', async () => {
+		const { entries, onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse(`data: ${JSON.stringify([entry('a'), entry('b')])}\n\n`)),
+		);
+
+		await streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry });
+		expect(entries.map((e) => e.message)).toEqual(['a', 'b']);
+	});
+
+	it('drops records that are not log entries', async () => {
+		const { entries, onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse(
+					'data: {"hello":"world"}\n\n'
+						+ `data: ${JSON.stringify(entry('real'))}\n\n`,
+				),
+			),
+		);
+
+		await streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry });
+		expect(entries.map((e) => e.message)).toEqual(['real']);
+	});
+
+	it('stops at a terminal done event', async () => {
+		const { entries, onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				sseResponse(
+					`data: ${JSON.stringify(entry('before'))}\n\n`
+						+ 'event: done\ndata: {}\n\n'
+						+ `data: ${JSON.stringify(entry('after'))}\n\n`,
+				),
+			),
+		);
+
+		await streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry });
+		expect(entries.map((e) => e.message)).toEqual(['before']);
+	});
+
+	it('throws SSEOperationError on a terminal error event', async () => {
+		const { onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse('event: error\ndata: {"message":"boom","code":500}\n\n')),
+		);
+
+		await expect(
+			streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry }),
+		).rejects.toMatchObject({ name: 'SSEOperationError', message: 'boom', code: 500 });
+		expect(SSEOperationError).toBeDefined();
+	});
+
+	it('throws SSEUnsupportedError when the response is not an event stream', async () => {
+		const { onEntry } = collect();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(sseResponse('[{"message":"ok"}]', { contentType: 'application/json' })),
+		);
+
+		await expect(
+			streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry }),
+		).rejects.toBeInstanceOf(SSEUnsupportedError);
+	});
+
+	it('throws SSEUnsupportedError when fetch rejects before streaming', async () => {
+		const { onEntry } = collect();
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('network down')));
+
+		await expect(
+			streamReadLog({ connection: { id: 'ins-1' }, logFilters: filters, replicated: false, onEntry }),
+		).rejects.toBeInstanceOf(SSEUnsupportedError);
+	});
+
+	it('propagates a caller abort rather than masking it as unsupported', async () => {
+		const { onEntry } = collect();
+		const controller = new AbortController();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockImplementation((_url, init?: RequestInit) =>
+				Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError', signal: init?.signal }))
+			),
+		);
+		controller.abort();
+
+		await expect(
+			streamReadLog({
+				connection: { id: 'ins-1' },
+				logFilters: filters,
+				replicated: false,
+				signal: controller.signal,
+				onEntry,
+			}),
+		).rejects.not.toBeInstanceOf(SSEUnsupportedError);
+	});
+});

--- a/src/integrations/api/instance/status/streamReadLog.ts
+++ b/src/integrations/api/instance/status/streamReadLog.ts
@@ -1,0 +1,120 @@
+import { SSEOperationError, SSEUnsupportedError } from '@/integrations/api/sse/errors';
+import { parseSSEData, parseSSEStream } from '@/integrations/api/sse/parseSSEStream';
+import {
+	resolveInstanceConnection,
+	ResolveInstanceConnectionParams,
+} from '@/integrations/api/sse/resolveInstanceConnection';
+import { z } from 'zod';
+import { buildReadLogBody, ReadLogItem } from './getReadLog';
+import { LogFiltersFormSchema } from './logFiltersFormSchema';
+
+export interface StreamReadLogParams {
+	/** Connection target — same shape `resolveInstanceConnection` accepts. */
+	connection: ResolveInstanceConnectionParams;
+	logFilters: z.infer<typeof LogFiltersFormSchema>;
+	replicated: boolean;
+	/** Caller-owned abort (auto-refresh toggled off, filters changed, component unmount). */
+	signal?: AbortSignal;
+	/** Called for each log entry as it arrives, to drive the live tail. */
+	onEntry: (entry: ReadLogItem) => void;
+}
+
+/**
+ * Subscribe to `read_log` over SSE — the streaming counterpart to {@link getReadLog}. It
+ * sends the same operation body (so the server sees the same filters/slice) but with
+ * `Accept: text/event-stream`, and forwards each streamed {@link ReadLogItem} to `onEntry`
+ * as it arrives.
+ *
+ * Unlike `streamOperation` (built for request/response operations that end with a terminal
+ * `done` event), a log tail is open-ended: an idle connection is normal — no new lines
+ * simply means no events — so there is no idle watchdog here. Teardown is entirely the
+ * caller's job via `signal`.
+ *
+ * Resolution and failure modes:
+ * - Resolves (returns) when the stream ends cleanly. That happens when the server sent a
+ *   bounded slice and closed (an instance that content-negotiates SSE but does not keep the
+ *   subscription open), or emitted a terminal `done`/`end` event. Either way the tail is
+ *   over; the caller should resume polling to keep catching new entries.
+ * - Throws {@link SSEUnsupportedError} when no stream could be established (bad response,
+ *   wrong content-type — e.g. an older Harper that ignores `Accept`, or the buffering proxy
+ *   — or a connection error before any bytes). The caller should fall back to polling.
+ * - Throws {@link SSEOperationError} when a terminal `error` event arrives.
+ * - Re-throws the caller's abort untouched so it is not mistaken for "unsupported".
+ */
+export async function streamReadLog({
+	connection,
+	logFilters,
+	replicated,
+	signal,
+	onEntry,
+}: StreamReadLogParams): Promise<void> {
+	const { url, headers, credentials } = resolveInstanceConnection(connection);
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: 'POST',
+			headers,
+			credentials,
+			body: JSON.stringify(buildReadLogBody(logFilters, replicated)),
+			signal,
+		});
+	} catch (error) {
+		// A deliberate caller abort must surface as-is, not be masked as "unsupported".
+		if (signal?.aborted) {
+			throw error;
+		}
+		throw new SSEUnsupportedError('Failed to open the read_log SSE stream.', { cause: error });
+	}
+
+	const contentType = response.headers.get('content-type') ?? '';
+	if (!response.ok || !contentType.includes('text/event-stream') || !response.body) {
+		// Drain the body so the connection can be reused, then fall back to polling.
+		await response.body?.cancel().catch(() => {});
+		throw new SSEUnsupportedError(
+			`read_log did not return an event stream (status ${response.status}, content-type "${contentType}").`,
+		);
+	}
+
+	for await (const message of parseSSEStream(response.body, signal)) {
+		if (message.event === 'error') {
+			const data = parseSSEData(message);
+			if (!data || typeof data !== 'object') {
+				throw new SSEOperationError(typeof data === 'string' && data ? data : 'The log stream failed.');
+			}
+			const err = data as { message?: string; code?: string | number };
+			throw new SSEOperationError(err.message ?? 'The log stream failed.', { code: err.code });
+		}
+		// A terminal marker (some servers close a bounded stream with one) ends the tail.
+		if (message.event === 'done' || message.event === 'end') {
+			return;
+		}
+		for (const entry of coerceReadLogEntries(parseSSEData(message))) {
+			onEntry(entry);
+		}
+	}
+}
+
+/**
+ * Coerce an SSE record's payload into log entries. Tolerant of the shapes the server may
+ * emit for an async-iterable of log lines: a single entry, a batch array, or a native
+ * message wrapper whose `value` is the entry (Harper's SSE serializer unwraps that into the
+ * `data:` field). Anything without the minimal log-entry shape is dropped.
+ */
+function coerceReadLogEntries(data: unknown): ReadLogItem[] {
+	if (Array.isArray(data)) {
+		return data.filter(isReadLogItem);
+	}
+	return isReadLogItem(data) ? [data] : [];
+}
+
+function isReadLogItem(value: unknown): value is ReadLogItem {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	const entry = value as Record<string, unknown>;
+	// `timestamp` is the one field every log line carries; `level`/`message` pin it as a log
+	// entry rather than some other streamed object.
+	return typeof entry.timestamp === 'string'
+		&& (typeof entry.level === 'string' || typeof entry.message === 'string');
+}


### PR DESCRIPTION
Closes #1422.

## What

Adds a live **SSE tail** of instance/cluster logs so the Logs view subscribes to log changes instead of polling every 5s. The old "Auto refresh (every 5s)" toggle becomes a **Live** toggle:

- **Live on + connection supports streaming** → opens an SSE stream of `read_log` (`Accept: text/event-stream`) and appends entries as they arrive. Label: *"Live (streaming)"*.
- **Live on + streaming unsupported/failed** → transparently falls back to the existing 5s React Query polling. Label: *"Live (polling every 5s)"*.
- **Live off** → a single fetch + manual Refresh, exactly as before.

The buffered React Query snapshot is always present: it seeds the backlog instantly and becomes the polling source on fallback, and live entries are merged onto it (de-duplicated), so the table never flickers when the transport switches.

## How

This mirrors the existing **deploy** SSE plumbing (`resolveInstanceConnection` / `parseSSEStream` / `errors`), reusing it rather than adding a new transport.

- `integrations/api/instance/status/streamReadLog.ts` — an **open-ended** SSE consumer for `read_log`. Unlike `streamOperation` (built for request/response ops that end with a terminal `done` and has a 120s idle watchdog), a log tail may idle indefinitely with no new lines, so there's no idle timeout — teardown is the caller's job via `AbortSignal`. It sends the same operation body as the buffered `getReadLog` (factored into a shared `buildReadLogBody`) and is tolerant of the entry shapes Harper's SSE serializer can emit (single object, batch array, or native-message wrapper).
- `features/instance/log/hooks/useSupportsLogSSE.ts` — gates streaming on a **direct connection** (the fabric-connect proxy buffers `text/event-stream`). Deliberately *not* version-gated: `streamReadLog` detects a non-streaming instance cheaply via the response content-type and falls back, so no version constant to guess/maintain yet.
- `features/instance/log/hooks/useInstanceLogs.ts` — one data source that runs the tail or polls and merges the two. Streamed entries are **batched** (one render per 250ms) so a chatty tail can't thrash React, and retained entries are capped.
- `features/instance/log/hooks/mergeReadLogs.ts` — pure merge/de-dup/cap, newest-first.

## ⚠️ Backend contract (please confirm)

The current `read_log` returns a plain array — I did not find a shipped backend that keeps a `read_log` SSE subscription open. This PR is written to consume a live tail **when the backend provides one**, and to **degrade gracefully to polling** when it doesn't, so it's safe to merge regardless. The client is tolerant of the exact event/data shape; if the backend's streaming contract differs, the parsing in `streamReadLog` is the one spot to adjust. Let's confirm the intended backend behavior when we verify together.

## Verification

Verified in the preview against a real stage cluster (Acme / Anvils):

- Logs render correctly via the buffered path (unchanged). ✅
- Toggling **Live** attempts a direct SSE POST to the instance; the browser can't reach the instance origin from studio (CORS/`ERR_FAILED`), so it throws `SSEUnsupportedError` and **falls back to polling through the proxy** — logs keep updating, label shows *"Live (polling every 5s)"*, no console/React errors. ✅ (This is exactly the graceful-degradation path.)

Still needs **joint verification**: the live-streaming happy path against a streaming-capable instance whose origin is reachable/CORS-permitted from the studio origin (stage instances aren't, from a browser). That's the "verify together in the preview" piece.

- `tsc -b`, `oxlint`, `dprint` clean; full suite `1155 passed`. New unit tests: `streamReadLog.test.ts` (stream/parse/fallback/abort) and `mergeReadLogs.test.ts` (order/dedup/cap).