### PR TITLE
feat(chat): collapse back-to-back tool calls into an expandable single line

### DIFF
--- a/src/features/instance/applications/components/Chat/Chat.css
+++ b/src/features/instance/applications/components/Chat/Chat.css
@@ -162,6 +162,11 @@
 
 .tool-group {
     margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.tool-group:last-child {
+    margin-bottom: 0;
 }
 
 .tool-group-summary {
@@ -181,7 +186,7 @@
 }
 
 .tool-group-summary:hover {
-    background: var(--accent);
+    background: color-mix(in srgb, var(--card) 90%, var(--foreground));
     color: var(--foreground);
 }
 

--- a/src/features/instance/applications/components/Chat/Chat.css
+++ b/src/features/instance/applications/components/Chat/Chat.css
@@ -130,22 +130,44 @@
 }
 
 .content {
+    position: relative;
     padding: 0.75rem 1rem;
     border-radius: 12px;
     font-size: 0.9375rem;
     line-height: 1.5;
 }
 
+/* Tail pointing at the speaker's avatar (avatars are pinned to the top of the bubble). */
+.content::before {
+    content: '';
+    position: absolute;
+    top: 10px;
+    width: 0;
+    height: 0;
+    border-top: 6px solid transparent;
+    border-bottom: 6px solid transparent;
+}
+
 .user .content {
     background: var(--primary);
     color: var(--primary-foreground);
-    border-bottom-right-radius: 2px;
+    border-top-right-radius: 2px;
+}
+
+.user .content::before {
+    right: -6px;
+    border-left: 6px solid var(--primary);
 }
 
 .assistant .content {
     background: var(--muted);
     color: var(--foreground);
-    border-bottom-left-radius: 2px;
+    border-top-left-radius: 2px;
+}
+
+.assistant .content::before {
+    left: -6px;
+    border-right: 6px solid var(--muted);
 }
 
 .text-block {

--- a/src/features/instance/applications/components/Chat/Chat.css
+++ b/src/features/instance/applications/components/Chat/Chat.css
@@ -132,42 +132,43 @@
 .content {
     position: relative;
     padding: 0.75rem 1rem;
-    border-radius: 12px;
+    border-radius: 6px;
     font-size: 0.9375rem;
     line-height: 1.5;
 }
 
-/* Tail pointing at the speaker's avatar (avatars are pinned to the top of the bubble). */
+/* Tail pointing at the speaker's avatar: a right triangle whose flat side continues the
+   bubble's top edge, so the top corner nearest the avatar stays sharp. */
 .content::before {
     content: '';
     position: absolute;
-    top: 10px;
+    top: 0;
     width: 0;
     height: 0;
-    border-top: 6px solid transparent;
-    border-bottom: 6px solid transparent;
 }
 
 .user .content {
     background: var(--primary);
     color: var(--primary-foreground);
-    border-top-right-radius: 2px;
+    border-top-right-radius: 0;
 }
 
 .user .content::before {
-    right: -6px;
-    border-left: 6px solid var(--primary);
+    right: -10px;
+    border-top: 10px solid var(--primary);
+    border-right: 10px solid transparent;
 }
 
 .assistant .content {
     background: var(--muted);
     color: var(--foreground);
-    border-top-left-radius: 2px;
+    border-top-left-radius: 0;
 }
 
 .assistant .content::before {
-    left: -6px;
-    border-right: 6px solid var(--muted);
+    left: -10px;
+    border-top: 10px solid var(--muted);
+    border-left: 10px solid transparent;
 }
 
 .text-block {
@@ -185,6 +186,12 @@
 .tool-group {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
+}
+
+/* The bubble's own padding provides the spacing when a tool call leads or ends the message. */
+.tool-group:first-child,
+.tool-invocation:first-child {
+    margin-top: 0;
 }
 
 .tool-group:last-child {
@@ -208,6 +215,13 @@
 }
 
 .tool-group-summary:hover {
+    background: color-mix(in srgb, var(--card) 90%, var(--foreground));
+    color: var(--foreground);
+}
+
+/* The outline Button variant hovers to the card color in dark mode, so it disappears
+   against the tool card; give the approval actions the same tinted hover as the summary. */
+.tool-io .approval-outline:hover:not(:disabled) {
     background: color-mix(in srgb, var(--card) 90%, var(--foreground));
     color: var(--foreground);
 }
@@ -237,7 +251,9 @@
 }
 
 .tool-status {
-    color: var(--primary);
+    /* Straight var(--primary) is unreadable on the dark theme; tint it toward the
+       foreground so it keeps contrast in both themes. */
+    color: color-mix(in srgb, var(--primary) 55%, var(--foreground));
 }
 
 .tool-io {

--- a/src/features/instance/applications/components/Chat/Chat.css
+++ b/src/features/instance/applications/components/Chat/Chat.css
@@ -233,6 +233,39 @@
     flex-direction: column;
 }
 
+.thinking-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.thinking-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--muted-foreground);
+    animation: thinking-bounce 1.2s ease-in-out infinite;
+}
+
+.thinking-dot:nth-child(2) {
+    animation-delay: 0.15s;
+}
+
+.thinking-dot:nth-child(3) {
+    animation-delay: 0.3s;
+}
+
+@keyframes thinking-bounce {
+    0%, 60%, 100% {
+        opacity: 0.35;
+        transform: translateY(0);
+    }
+    30% {
+        opacity: 1;
+        transform: translateY(-3px);
+    }
+}
+
 .input-area {
     padding: 0.5rem;
     background: var(--card);

--- a/src/features/instance/applications/components/Chat/Chat.css
+++ b/src/features/instance/applications/components/Chat/Chat.css
@@ -160,6 +160,37 @@
     overflow: hidden;
 }
 
+.tool-group {
+    margin-top: 0.75rem;
+}
+
+.tool-group-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--muted-foreground);
+    cursor: pointer;
+    transition: background 0.2s, color 0.2s;
+}
+
+.tool-group-summary:hover {
+    background: var(--accent);
+    color: var(--foreground);
+}
+
+.tool-group-status {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
 .tool-info {
     padding: 0.5rem 0.75rem;
     background: var(--accent);

--- a/src/features/instance/applications/components/Chat/components/MessageBubble.test.tsx
+++ b/src/features/instance/applications/components/Chat/components/MessageBubble.test.tsx
@@ -11,7 +11,7 @@ import { MessageBubble } from './MessageBubble';
 afterEach(() => cleanup());
 
 describe('MessageBubble', () => {
-	it('should render without crashing when parts is undefined', async () => {
+	it('should render nothing when parts is undefined', async () => {
 		const mockMessage = {
 			id: '1',
 			role: 'assistant',
@@ -27,9 +27,8 @@ describe('MessageBubble', () => {
 
 		await act(() => null);
 
-		const contentDiv = container.querySelector('.content');
-		expect(contentDiv).toBeTruthy();
-		expect(contentDiv?.childNodes.length).toBe(0);
+		// Empty bubbles are hidden so the thinking indicator can stand alone while streaming starts.
+		expect(container.querySelector('.message-bubble')).toBeNull();
 	});
 
 	it('should render message parts when they exist', async () => {

--- a/src/features/instance/applications/components/Chat/components/MessageBubble.tsx
+++ b/src/features/instance/applications/components/Chat/components/MessageBubble.tsx
@@ -16,6 +16,13 @@ interface MessageBubbleProps {
 export function MessageBubble(
 	{ message: m, onApprove, onDeny, onAlwaysApprove, approvingToolCallIds }: MessageBubbleProps,
 ) {
+	// An assistant message exists before any of its parts stream in; hide the empty bubble
+	// so the thinking indicator stands alone until there is real content.
+	const hasVisibleContent = m.parts?.some(part => (isTextUIPart(part) && part.text.length > 0) || isToolUIPart(part));
+	if (!hasVisibleContent) {
+		return null;
+	}
+
 	return (
 		<motion.div
 			key={m.id}

--- a/src/features/instance/applications/components/Chat/components/MessageBubble.tsx
+++ b/src/features/instance/applications/components/Chat/components/MessageBubble.tsx
@@ -1,6 +1,8 @@
 import { isTextUIPart, isToolUIPart, type UIMessage } from 'ai';
 import { Bot, User } from 'lucide-react';
 import { motion } from 'motion/react';
+import { groupMessageParts } from './groupMessageParts';
+import { ToolCallGroup } from './ToolCallGroup';
 import { ToolInvocation } from './ToolInvocation';
 
 interface MessageBubbleProps {
@@ -25,15 +27,29 @@ export function MessageBubble(
 				{m.role === 'user' ? <User size={18} /> : <Bot size={18} />}
 			</div>
 			<div className="content">
-				{m.parts?.map((part, i) => {
+				{groupMessageParts(m.parts).map(item => {
+					if (item.kind === 'tool-group') {
+						return (
+							<ToolCallGroup
+								key={item.parts[0].toolCallId}
+								parts={item.parts}
+								onApprove={onApprove}
+								onDeny={onDeny}
+								onAlwaysApprove={onAlwaysApprove}
+								approvingToolCallIds={approvingToolCallIds}
+							/>
+						);
+					}
+
+					const { part, index } = item;
 					if (isTextUIPart(part)) {
-						return <div key={i} className="text-block">{part.text}</div>;
+						return <div key={index} className="text-block">{part.text}</div>;
 					}
 
 					if (isToolUIPart(part)) {
 						return (
 							<ToolInvocation
-								key={i}
+								key={index}
 								part={part}
 								onApprove={onApprove}
 								onDeny={onDeny}

--- a/src/features/instance/applications/components/Chat/components/ThinkingIndicator.tsx
+++ b/src/features/instance/applications/components/Chat/components/ThinkingIndicator.tsx
@@ -1,0 +1,22 @@
+import { Bot } from 'lucide-react';
+import { motion } from 'motion/react';
+
+export function ThinkingIndicator() {
+	return (
+		<motion.div
+			initial={{ opacity: 0, y: 10 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ delay: 0.2 }}
+			className="message-bubble assistant"
+		>
+			<div className="avatar">
+				<Bot size={18} />
+			</div>
+			<div className="content thinking-indicator" role="status" aria-label="Harper Agent is thinking">
+				<span className="thinking-dot" />
+				<span className="thinking-dot" />
+				<span className="thinking-dot" />
+			</div>
+		</motion.div>
+	);
+}

--- a/src/features/instance/applications/components/Chat/components/ToolCallGroup.test.tsx
+++ b/src/features/instance/applications/components/Chat/components/ToolCallGroup.test.tsx
@@ -131,6 +131,24 @@ describe('ToolCallGroup', () => {
 		expect(getByRole('button', { name: 'Approve' })).toBeTruthy();
 	});
 
+	it('groups tool calls separated only by invisible parts (step markers, reasoning)', async () => {
+		const message = assistantMessage([
+			completedToolPart('getComponents', 'call-1'),
+			{ type: 'step-start' },
+			{ type: 'reasoning', text: 'thinking about the next step' },
+			completedToolPart('getComponentFile', 'call-2'),
+		]);
+
+		const { getByText } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		expect(getByText('Used 2 tools')).toBeTruthy();
+	});
+
 	it('does not group tool calls separated by a text part', async () => {
 		const message = assistantMessage([
 			completedToolPart('getComponents', 'call-1'),

--- a/src/features/instance/applications/components/Chat/components/ToolCallGroup.test.tsx
+++ b/src/features/instance/applications/components/Chat/components/ToolCallGroup.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { TestProvider } from '@/lib/test/TestProvider';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import { act } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MessageBubble } from './MessageBubble';
+
+afterEach(() => cleanup());
+
+const completedToolPart = (toolName: string, toolCallId: string) => ({
+	type: `tool-${toolName}`,
+	toolCallId,
+	state: 'output-available',
+	input: { some: 'input' },
+	output: { some: 'output' },
+});
+
+const assistantMessage = (parts: unknown[]) =>
+	({
+		id: 'a1',
+		role: 'assistant',
+		parts,
+	}) as unknown as UIMessage;
+
+describe('ToolCallGroup', () => {
+	it('collapses back-to-back tool calls into a single summary line', async () => {
+		const message = assistantMessage([
+			completedToolPart('getComponents', 'call-1'),
+			completedToolPart('getComponentFile', 'call-2'),
+		]);
+
+		const { getByText, queryByText, container } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		expect(getByText('Used 2 tools')).toBeTruthy();
+		expect(queryByText('getComponents')).toBeNull();
+		expect(queryByText('getComponentFile')).toBeNull();
+		expect(container.querySelectorAll('.tool-invocation').length).toBe(0);
+	});
+
+	it('shows a single collapsed line for one tool call', async () => {
+		const message = assistantMessage([completedToolPart('getComponents', 'call-1')]);
+
+		const { getByText } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		expect(getByText('Used getComponents')).toBeTruthy();
+	});
+
+	it('shows an in-progress label while a grouped tool call is executing', async () => {
+		const message = assistantMessage([
+			{
+				type: 'tool-getComponents',
+				toolCallId: 'call-1',
+				state: 'input-available',
+				input: {},
+			},
+		]);
+
+		const { getByText } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		expect(getByText('Using getComponents...')).toBeTruthy();
+	});
+
+	it('expands on click and collapses on a second click', async () => {
+		const message = assistantMessage([
+			completedToolPart('getComponents', 'call-1'),
+			completedToolPart('getComponentFile', 'call-2'),
+		]);
+
+		const { getByRole, getByText, queryByText, container } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		const summary = getByRole('button', { name: /Used 2 tools/ });
+		fireEvent.click(summary);
+
+		expect(getByText('getComponents')).toBeTruthy();
+		expect(getByText('getComponentFile')).toBeTruthy();
+		expect(container.querySelectorAll('.tool-invocation').length).toBe(2);
+
+		fireEvent.click(summary);
+
+		expect(queryByText('getComponents')).toBeNull();
+		expect(container.querySelectorAll('.tool-invocation').length).toBe(0);
+	});
+
+	it('keeps tool calls awaiting approval expanded and out of groups', async () => {
+		const message = assistantMessage([
+			completedToolPart('getComponents', 'call-1'),
+			{
+				// createApp has requiresApproval: true and no output yet, so it is awaiting approval.
+				type: 'tool-createApp',
+				toolCallId: 'call-2',
+				state: 'input-available',
+				input: { name: 'my-app' },
+			},
+		]);
+
+		const { getByText, getByRole } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		// The non-approval tool is still collapsed...
+		expect(getByText('Used getComponents')).toBeTruthy();
+		// ...while the approval prompt renders fully expanded.
+		expect(getByText('createApp')).toBeTruthy();
+		expect(getByText('Awaiting Approval...')).toBeTruthy();
+		expect(getByRole('button', { name: 'Approve' })).toBeTruthy();
+	});
+
+	it('does not group tool calls separated by a text part', async () => {
+		const message = assistantMessage([
+			completedToolPart('getComponents', 'call-1'),
+			{ type: 'text', text: 'Here is what I found.' },
+			completedToolPart('getComponentFile', 'call-2'),
+		]);
+
+		const { getByText } = render(
+			<TestProvider>
+				<MessageBubble message={message} />
+			</TestProvider>,
+		);
+		await act(() => null);
+
+		expect(getByText('Used getComponents')).toBeTruthy();
+		expect(getByText('Here is what I found.')).toBeTruthy();
+		expect(getByText('Used getComponentFile')).toBeTruthy();
+	});
+});

--- a/src/features/instance/applications/components/Chat/components/ToolCallGroup.tsx
+++ b/src/features/instance/applications/components/Chat/components/ToolCallGroup.tsx
@@ -1,0 +1,58 @@
+import type { ToolNames } from '@harperfast/agent-tools/types/toolNames';
+import { getToolName } from 'ai';
+import { Check, ChevronDown, ChevronRight, Loader2, Wrench, XCircle } from 'lucide-react';
+import { useState } from 'react';
+import { getTool } from '../tools/clientTools';
+import type { ChatToolPart } from './groupMessageParts';
+import { ToolInvocation } from './ToolInvocation';
+
+interface ToolCallGroupProps {
+	parts: ChatToolPart[];
+	onApprove?: (toolCallId: string) => void;
+	onDeny?: (toolCallId: string) => void;
+	onAlwaysApprove?: (toolCallId: string) => void;
+	approvingToolCallIds?: Set<string>;
+}
+
+export function ToolCallGroup({ parts, onApprove, onDeny, onAlwaysApprove, approvingToolCallIds }: ToolCallGroupProps) {
+	const [isExpanded, setIsExpanded] = useState(false);
+	const isRunning = parts.some(part => part.state !== 'output-available' && part.state !== 'output-error');
+	const hasError = parts.some(part =>
+		part.state === 'output-error' || (part.state === 'output-available' && (part.output as any)?.error)
+	);
+	const singleToolName = parts.length === 1 ? getToolName(parts[0]) as ToolNames : undefined;
+	const Icon = (singleToolName && getTool(singleToolName)?.icon) || Wrench;
+	const subject = singleToolName ?? `${parts.length} tools`;
+
+	return (
+		<div className="tool-group">
+			<button
+				type="button"
+				className="tool-group-summary"
+				aria-expanded={isExpanded}
+				onClick={() => setIsExpanded(!isExpanded)}
+			>
+				{isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+				<Icon size={14} />
+				<span>{isRunning ? `Using ${subject}...` : `Used ${subject}`}</span>
+				<span className="tool-group-status">
+					{isRunning
+						? <Loader2 size={14} className="animate-spin" />
+						: hasError
+						? <XCircle size={14} className="text-destructive" />
+						: <Check size={14} />}
+				</span>
+			</button>
+			{isExpanded && parts.map(part => (
+				<ToolInvocation
+					key={part.toolCallId}
+					part={part}
+					onApprove={onApprove}
+					onDeny={onDeny}
+					onAlwaysApprove={onAlwaysApprove}
+					isApproving={approvingToolCallIds?.has(part.toolCallId)}
+				/>
+			))}
+		</div>
+	);
+}

--- a/src/features/instance/applications/components/Chat/components/ToolInvocation.tsx
+++ b/src/features/instance/applications/components/Chat/components/ToolInvocation.tsx
@@ -105,7 +105,7 @@ export function ToolInvocation({ part, onApprove, onDeny, onAlwaysApprove, isApp
 								type="button"
 								size="sm"
 								variant="outline"
-								className="h-8 text-xs"
+								className="h-8 text-xs approval-outline"
 								onClick={() => onAlwaysApprove?.(part.toolCallId)}
 								disabled={isApproving}
 							>
@@ -115,7 +115,7 @@ export function ToolInvocation({ part, onApprove, onDeny, onAlwaysApprove, isApp
 								type="button"
 								size="sm"
 								variant="outline"
-								className="h-8 text-xs"
+								className="h-8 text-xs approval-outline"
 								onClick={() => onDeny?.(part.toolCallId)}
 								disabled={isApproving}
 							>

--- a/src/features/instance/applications/components/Chat/components/groupMessageParts.ts
+++ b/src/features/instance/applications/components/Chat/components/groupMessageParts.ts
@@ -1,0 +1,34 @@
+import { type DynamicToolUIPart, getToolName, isToolUIPart, type ToolUIPart, type UIMessage } from 'ai';
+import { getTool } from '../tools/clientTools';
+
+export type ChatToolPart = ToolUIPart | DynamicToolUIPart;
+type MessagePart = UIMessage['parts'][number];
+
+export type MessagePartGroup =
+	| { kind: 'part'; part: MessagePart; index: number }
+	| { kind: 'tool-group'; parts: ChatToolPart[]; index: number };
+
+export function isAwaitingApproval(part: ChatToolPart): boolean {
+	return part.state === 'input-available' && Boolean(getTool(getToolName(part))?.requiresApproval);
+}
+
+/**
+ * Collapses runs of back-to-back tool calls into a single group. Tool calls that surface
+ * approval buttons stay out of groups so the Approve/Deny UI is always visible.
+ */
+export function groupMessageParts(parts: readonly MessagePart[] | undefined): MessagePartGroup[] {
+	const groups: MessagePartGroup[] = [];
+	for (const [index, part] of (parts ?? []).entries()) {
+		if (isToolUIPart(part) && !isAwaitingApproval(part)) {
+			const previous = groups.at(-1);
+			if (previous?.kind === 'tool-group') {
+				previous.parts.push(part);
+			} else {
+				groups.push({ kind: 'tool-group', parts: [part], index });
+			}
+		} else {
+			groups.push({ kind: 'part', part, index });
+		}
+	}
+	return groups;
+}

--- a/src/features/instance/applications/components/Chat/components/groupMessageParts.ts
+++ b/src/features/instance/applications/components/Chat/components/groupMessageParts.ts
@@ -1,4 +1,4 @@
-import { type DynamicToolUIPart, getToolName, isToolUIPart, type ToolUIPart, type UIMessage } from 'ai';
+import { type DynamicToolUIPart, getToolName, isTextUIPart, isToolUIPart, type ToolUIPart, type UIMessage } from 'ai';
 import { getTool } from '../tools/clientTools';
 
 export type ChatToolPart = ToolUIPart | DynamicToolUIPart;
@@ -14,19 +14,28 @@ export function isAwaitingApproval(part: ChatToolPart): boolean {
 
 /**
  * Collapses runs of back-to-back tool calls into a single group. Tool calls that surface
- * approval buttons stay out of groups so the Approve/Deny UI is always visible.
+ * approval buttons stay out of groups so the Approve/Deny UI is always visible, and only
+ * visible content (non-empty text, approval cards) breaks a run — invisible parts like
+ * step markers and reasoning render nothing, so they must not split the group.
  */
 export function groupMessageParts(parts: readonly MessagePart[] | undefined): MessagePartGroup[] {
 	const groups: MessagePartGroup[] = [];
 	for (const [index, part] of (parts ?? []).entries()) {
-		if (isToolUIPart(part) && !isAwaitingApproval(part)) {
+		if (isToolUIPart(part)) {
+			if (isAwaitingApproval(part)) {
+				groups.push({ kind: 'part', part, index });
+				continue;
+			}
 			const previous = groups.at(-1);
 			if (previous?.kind === 'tool-group') {
 				previous.parts.push(part);
 			} else {
 				groups.push({ kind: 'tool-group', parts: [part], index });
 			}
-		} else {
+			continue;
+		}
+
+		if (isTextUIPart(part) && part.text.length > 0) {
 			groups.push({ kind: 'part', part, index });
 		}
 	}

--- a/src/features/instance/applications/components/Chat/components/shouldShowThinkingIndicator.test.ts
+++ b/src/features/instance/applications/components/Chat/components/shouldShowThinkingIndicator.test.ts
@@ -1,0 +1,63 @@
+import type { UIMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { shouldShowThinkingIndicator } from './shouldShowThinkingIndicator';
+
+const assistant = (parts: unknown[] | undefined) => ({ id: '1', role: 'assistant', parts }) as unknown as UIMessage;
+const user = () => ({ id: '1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }) as unknown as UIMessage;
+
+describe('shouldShowThinkingIndicator', () => {
+	it('shows while a request is submitted', () => {
+		expect(shouldShowThinkingIndicator('submitted', user())).toBe(true);
+		expect(
+			shouldShowThinkingIndicator('submitted', assistant([{ type: 'tool-getComponents', state: 'output-available' }])),
+		)
+			.toBe(true);
+	});
+
+	it('shows while streaming before the assistant message has any parts', () => {
+		expect(shouldShowThinkingIndicator('streaming', user())).toBe(true);
+		expect(shouldShowThinkingIndicator('streaming', assistant([]))).toBe(true);
+		expect(shouldShowThinkingIndicator('streaming', undefined)).toBe(true);
+	});
+
+	it('hides while text is actively streaming in', () => {
+		expect(shouldShowThinkingIndicator('streaming', assistant([{ type: 'text', text: 'Sure', state: 'streaming' }])))
+			.toBe(false);
+	});
+
+	it('shows again after the last part finished but the stream is still open', () => {
+		expect(shouldShowThinkingIndicator('streaming', assistant([{ type: 'text', text: 'Sure', state: 'done' }])))
+			.toBe(true);
+		expect(
+			shouldShowThinkingIndicator(
+				'streaming',
+				assistant([{ type: 'tool-getComponents', state: 'output-available', toolCallId: 'c1' }]),
+			),
+		).toBe(true);
+	});
+
+	it('hides while a tool call is in flight (its group shows a spinner)', () => {
+		expect(
+			shouldShowThinkingIndicator(
+				'streaming',
+				assistant([{ type: 'tool-getComponents', state: 'input-streaming', toolCallId: 'c1' }]),
+			),
+		).toBe(false);
+		expect(
+			shouldShowThinkingIndicator(
+				'streaming',
+				assistant([{ type: 'tool-getComponents', state: 'input-available', toolCallId: 'c1' }]),
+			),
+		).toBe(false);
+	});
+
+	it('shows while invisible parts stream (reasoning, step markers)', () => {
+		expect(shouldShowThinkingIndicator('streaming', assistant([{ type: 'reasoning', text: 'hmm' }]))).toBe(true);
+		expect(shouldShowThinkingIndicator('streaming', assistant([{ type: 'step-start' }]))).toBe(true);
+	});
+
+	it('hides when idle or errored', () => {
+		expect(shouldShowThinkingIndicator('ready', assistant([{ type: 'text', text: 'Done' }]))).toBe(false);
+		expect(shouldShowThinkingIndicator('error', user())).toBe(false);
+	});
+});

--- a/src/features/instance/applications/components/Chat/components/shouldShowThinkingIndicator.ts
+++ b/src/features/instance/applications/components/Chat/components/shouldShowThinkingIndicator.ts
@@ -1,0 +1,27 @@
+import { type ChatStatus, isTextUIPart, isToolUIPart, type UIMessage } from 'ai';
+
+/**
+ * The indicator fills the dead air whenever a request is in flight but nothing visible is in
+ * progress — before the first token, between a finished tool call and the next part, and while
+ * invisible parts (reasoning, step markers) stream. Growing text and in-flight tool calls
+ * provide their own feedback, so the indicator stays hidden for those.
+ */
+export function shouldShowThinkingIndicator(status: ChatStatus, lastMessage: UIMessage | undefined): boolean {
+	if (status !== 'submitted' && status !== 'streaming') {
+		return false;
+	}
+	if (lastMessage?.role !== 'assistant') {
+		return true;
+	}
+	const lastPart = lastMessage.parts?.at(-1);
+	if (!lastPart) {
+		return true;
+	}
+	if (isTextUIPart(lastPart)) {
+		return lastPart.state === 'streaming' ? lastPart.text.length === 0 : true;
+	}
+	if (isToolUIPart(lastPart)) {
+		return lastPart.state === 'output-available' || lastPart.state === 'output-error';
+	}
+	return true;
+}

--- a/src/features/instance/applications/components/Chat/index.tsx
+++ b/src/features/instance/applications/components/Chat/index.tsx
@@ -16,6 +16,8 @@ import { SubmitEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { ChatInput } from './components/ChatInput';
 import { LoadingState } from './components/LoadingState';
 import { MessageBubble } from './components/MessageBubble';
+import { shouldShowThinkingIndicator } from './components/shouldShowThinkingIndicator';
+import { ThinkingIndicator } from './components/ThinkingIndicator';
 import { UsageBar } from './components/UsageBar';
 import { getTool } from './tools/clientTools';
 import './Chat.css';
@@ -217,6 +219,7 @@ export function Chat({ autoFocus, closeChat }: { autoFocus: boolean; closeChat: 
 								approvingToolCallIds={approvingToolCallIds}
 							/>
 						))}
+						{shouldShowThinkingIndicator(status, messages.at(-1)) && <ThinkingIndicator />}
 						<div ref={messagesEndRef} />
 					</div>
 


### PR DESCRIPTION
Closes #1427

## What

When the Harper Agent uses tools, back-to-back tool calls that don't require human approval now collapse into a single line — `Used 3 tools` (or `Used getComponents` for a lone call, `Using 2 tools...` with a spinner while running). Clicking the line expands the full tool cards; clicking it again collapses them back down.

- Tool calls **awaiting approval stay fully expanded** so the Approve / Always Approve / Deny buttons are always visible.
- Visible text breaks up groups, so tool calls interleaved with narration group naturally per run. Invisible parts (step markers, reasoning) do **not** split a run.
- The summary shows the tool's own icon for single calls (wrench for groups) and a check / error / spinner status on the right.
- A **thinking indicator** (animated dots bubble) fills the dead air whenever a request is in flight but nothing visible is in progress — before the first token, between a finished tool call and the next part, and while invisible parts stream. Growing text and in-flight tool spinners suppress it.
- Empty assistant bubbles (created before any parts stream in) are no longer rendered.

### Styling polish

- Message bubbles now read as speech from their avatars: a right-triangle caret whose flat side continues the bubble's top edge points out of the speaker's avatar; corners round at a slighter 6px. Avatars stay pinned to the top so nothing shifts while content streams.
- Consistent padding when a tool call is the first thing in a message, and breathing room between tool groups and following text.
- Dark-mode contrast fixes: the `Used N tools` hover, the `Awaiting Approval...` label, and the Always Approve / Deny hover all previously resolved to (or near) the card color in dark mode; they now tint toward the foreground so they read in both themes.

## How

- `groupMessageParts.ts` — pure helper that walks a message's parts and folds consecutive non-approval tool parts into `tool-group` runs; only visible content breaks a run.
- `ToolCallGroup.tsx` — collapsed-by-default summary row (`aria-expanded` toggle) that renders the existing `ToolInvocation` cards when expanded.
- `ThinkingIndicator.tsx` + `shouldShowThinkingIndicator.ts` — dots bubble plus the pure visibility predicate.
- `MessageBubble.tsx` — renders grouped parts instead of raw parts; approval-pending tool parts still render as standalone expanded `ToolInvocation`s; bubbles with no visible content render nothing.

## Testing

- 13 new jsdom/unit tests covering grouping, single-call labels, in-progress label, expand/collapse toggling, approval-stays-expanded, invisible-part grouping, text-part group breaking, and the thinking-indicator predicate. Full suite passes.
- Verified live in the studio preview against stage: collapsed groups on real chat history, expansion toggling, the approval card, thinking dots during real agent round-trips (including between tool rounds), no empty bubbles, and the caret/hover/contrast polish. Light + dark mode checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)