### PR TITLE
fix(rum): drop browser-extension "Object Not Found Matching Id" errors

### DIFF
--- a/src/integrations/datadog/shouldKeepEvent.test.ts
+++ b/src/integrations/datadog/shouldKeepEvent.test.ts
@@ -23,6 +23,22 @@ describe('shouldKeepEvent', () => {
 		expect(shouldKeepEvent(errorEvent({ message: 'Fabric Connect not established' }))).toBe(false);
 	});
 
+	// Regression test for the browser-extension-injected "Object Not Found Matching Id"
+	// error: a bare string (no stack) that a couple of extension-carrying sessions emit
+	// hundreds of times, doubling total RUM error volume without indicating a Studio bug.
+	it('discards browser-extension "Object Not Found Matching Id" errors', () => {
+		expect(
+			shouldKeepEvent(
+				errorEvent({ message: 'Uncaught "Object Not Found Matching Id:1, MethodName:update, ParamCount:4"' }),
+			),
+		).toBe(false);
+		expect(
+			shouldKeepEvent(
+				errorEvent({ message: 'Uncaught "Object Not Found Matching Id:2, MethodName:update, ParamCount:4"' }),
+			),
+		).toBe(false);
+	});
+
 	// Regression test for issue #1371: handled AxiosError timeouts reach RUM via
 	// console.error with no resource URL, so they must be discarded on the message alone.
 	it('discards timeout errors even when no resource URL is present', () => {

--- a/src/integrations/datadog/shouldKeepEvent.ts
+++ b/src/integrations/datadog/shouldKeepEvent.ts
@@ -45,6 +45,17 @@ export function shouldKeepEvent(event: DatadogErrorEvent) {
 		return false;
 	}
 
+	// `Object Not Found Matching Id:N, MethodName:update, ParamCount:4` is injected by a
+	// browser extension, not thrown by Studio: it arrives as a bare string (so RUM records
+	// `type: null` and "No stack, consider using an instance of Error") and only ever from
+	// the handful of sessions whose user has the extension installed. In the wild a single
+	// such session emits hundreds of these — on 2026-07-09, 2 sessions produced ~1160 events
+	// in 24h, doubling total RUM error volume — so it drowns real signal in Error Tracking
+	// without pointing at any Studio bug. Match the stable signature and drop it globally.
+	if (/Object Not Found Matching Id:\d+, MethodName:/i.test(message)) {
+		return false;
+	}
+
 	// A request timeout is a connectivity-class failure, never a Studio bug: the
 	// instance, cluster, or backend was too slow to answer in time. Unlike the
 	// network failures below we drop these unconditionally, because the handled


### PR DESCRIPTION
## Summary

Adds a `beforeSend` filter rule in [`shouldKeepEvent`](src/integrations/datadog/shouldKeepEvent.ts) to discard the browser-extension-injected `Object Not Found Matching Id:N, MethodName:update, ParamCount:4` error from RUM.

## Datadog findings (last 24h, 2026-07-09)

Surfaced by the daily RUM review. This error became the **#1 error by volume**, and it was **entirely absent in the prior 24h window**:

| Window | `Object Not Found Matching Id` events | Total RUM errors |
|---|---|---|
| 48h→24h ago | 0 | 773 |
| last 24h | **~1,160** (Id:1 → 652, Id:2 → 507) | 1,783 |

Characterization of a sampled 390 events:
- **Only 2 distinct sessions** (one Mac OS X, one Windows), both **Chrome 142**, all on the `/` view, all app version `v2.133.0`.
- Thrown as a **bare string**, not an `Error`: RUM records `type: null`, `handling: unhandled`, and `stack: "No stack, consider using an instance of Error"`.

This is the well-known signature of an error **injected by a browser extension**, not thrown by Studio code. A single extension-carrying session emits hundreds of them, so a couple of users nearly **doubled total RUM error volume** and drowned real signal in Error Tracking — without pointing at any Studio bug.

## Fix

Drop events whose message matches `/Object Not Found Matching Id:\d+, MethodName:/i`, alongside the existing connectivity/noise drops (timeouts #1371, 401s #1386, etc.). Added a regression test; full suite green (1226 passed).

## Notes
- No customer-identifying information is included (session IDs are opaque UUIDs; browser/OS are generic).
- This is noise suppression only — it does not mask any Studio-originated error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)