### PR TITLE
fix(cluster): exclude deleted instances from the overview instance count

### DIFF
--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -116,6 +116,9 @@ export function ClusterHome() {
 	const isFabricConnect = authStore.checkForFabricConnect(cluster.id);
 	const connected = !!user;
 	const lastMode = authStore.getLastConnectMode(cluster.id);
+	const instanceCount = (cluster.instances ?? [])
+		.filter((instance) => instance.status && !deletedClusterStatuses.includes(instance.status))
+		.length;
 
 	return (
 		<ClusterHomeShell>
@@ -129,7 +132,7 @@ export function ClusterHome() {
 						<StatusPill status={cluster.status} />
 					</div>
 					<div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-						<span>{cluster.instances?.length ?? 0} instances</span>
+						<span>{instanceCount} {instanceCount === 1 ? 'instance' : 'instances'}</span>
 						<span aria-hidden="true">·</span>
 						<a
 							href={`https://${clusterHost}`}


### PR DESCRIPTION
Closes #1432.

The managed-cluster overview header (`ClusterHome`) rendered `cluster.instances?.length`, counting every instance including ones in `TERMINATING`/`TERMINATED`/`REMOVED` states. The self-hosted overview in the same file and the Instances table both already filter those out via `deletedClusterStatuses`.

This applies the same filter to the managed header's count, and pluralizes ("1 instance" vs "n instances") to match the self-hosted branch.

**Verification:** ran the worktree dev server against stage and opened the Anvils cluster overview. Injected two fake instances (`TERMINATED`, `REMOVED`) into the react-query cache alongside the two real `RUNNING` ones (with a sentinel cluster name to prove the re-render happened from the mutated data): the header kept showing **2 instances** while the sentinel name rendered — the old code would have shown 4. Full test suite (1240 tests), oxlint, and dprint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)