### PR TITLE
feat(ci): report test coverage on PRs

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [dev, stage, prod]
+permissions:
+  contents: read
+  # Lets the coverage step post/update its sticky PR comment.
+  pull-requests: write
 jobs:
   verifyPR:
     name: Verify PR
@@ -23,7 +27,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run unit tests
-        run: pnpm test
+        run: pnpm test:coverage
+      - name: Report coverage
+        # Runs on test failure too — coverage is still written thanks to
+        # reportOnFailure in vitest.config.ts.
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@3c054a2d2e2ca45446417ad5d6d5eb33092af8f1 # v2.12.1
       - name: Run lint
         run: pnpm lint
       - name: Build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,12 @@ export default defineConfig({
 		globals: true,
 		coverage: {
 			provider: 'v8',
-			reporter: ['text', 'lcov'],
+			// json-summary + json feed the PR coverage comment in CI
+			// (vitest-coverage-report-action); lcov stays for Sonar.
+			reporter: ['text', 'lcov', 'json-summary', 'json'],
+			// Still write coverage output when tests fail, so CI can post
+			// the coverage report alongside the failure.
+			reportOnFailure: true,
 		},
 	},
 	resolve: {


### PR DESCRIPTION
## Summary

Surfaces vitest coverage in CI, outside of Sonar (closes #1319):

- **Verify PR** now runs `pnpm test:coverage` instead of `pnpm test`.
- A new **Report coverage** step ([`davelosert/vitest-coverage-report-action`](https://github.com/davelosert/vitest-coverage-report-action), pinned to the v2.12.1 commit SHA like the other actions) posts a sticky PR comment with the coverage table — statements/branches/functions/lines plus per-file detail for files changed in the PR — and writes the same table to the workflow job summary.
- `vitest.config.ts` adds the `json-summary` and `json` coverage reporters the action reads (`lcov` stays for Sonar), plus `reportOnFailure: true` so coverage still posts when tests fail (the report step runs `if: always()`).
- Adds an explicit `permissions` block (`contents: read`, `pull-requests: write`) so the action can create/update its comment.

## Notes

- Verified locally: `pnpm test:coverage` produces `coverage/coverage-summary.json` and `coverage/coverage-final.json`, the action's default input paths; `/coverage` is already gitignored.
- The PR comment requires a same-repo PR (fork PRs would still get the job summary, just no comment).
- This very PR should demonstrate the comment once the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)