### PR TITLE
fix(databases): reset to page 1 when the table filter changes

### DIFF
--- a/src/features/instance/databases/components/DatabaseTableView.tsx
+++ b/src/features/instance/databases/components/DatabaseTableView.tsx
@@ -155,7 +155,10 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		allParams,
 	);
 
-	const [pageIndex, setPageIndex] = useEffectedState(0, [databaseName, tableName]);
+	// Reset to the first page when the table changes OR the applied filter changes. Without the
+	// filter dependency a stale page (e.g. page 3 -> offset 40) would be sent with the new filter,
+	// and a filter that matches fewer rows than that offset comes back empty (#1463).
+	const [pageIndex, setPageIndex] = useEffectedState(0, [databaseName, tableName, appliedSearchConditions]);
 	const [pageSize, setPageSize] = useState(20);
 
 	// The count comes from whichever describe carries it: the map when the server still returns counts


### PR DESCRIPTION
## Problem

Fixes #1463.

In the database/table browser (`DatabaseTableView`), the current page (offset) is **not** reset when a column filter is applied or cleared. `pageIndex` is translated straight into `offset: pageIndex * pageSize` for the search request, so if you're on page 3+ (offset ≥ 40) and apply a filter whose matches all live earlier, the server gets `offset: 40` against a result set with fewer than 41 rows and returns an empty page — the list looks empty even though matches exist on page 1.

### Steps to reproduce
1. Open a table with enough rows to paginate and page forward to page 2+.
2. Apply a column filter whose matching rows fall on page 1.
3. The result list comes back empty.

## Fix

Add `appliedSearchConditions` to the `pageIndex` `useEffectedState` dependency list so the page resets to `0` whenever the **applied** filter changes:

```ts
const [pageIndex, setPageIndex] = useEffectedState(0, [databaseName, tableName, appliedSearchConditions]);
```

This is the same reset-on-dependency-change pattern the file already uses for `sort`, `selectedIds`, `wantExactCount`, and `pageIndex`-on-table-change. Because it keys off the applied-filter state that actually drives the query, it covers **both** the apply and clear paths (`applyFilters` / `clearFilters`) and any future code path that mutates the applied filter — the reset can't be forgotten. It mirrors the existing imperative precedents (`changePageSize` in `TablePagination`, and the org-list `onFilterByNameChanged`), which also reset the page to 0 on a window change.

`DatabaseTableView` is the only list view in the app with both server-side offset pagination and filtering that wasn't already resetting the page (the org list already handles it; logs/deployments/`SimpleBrowseDataTable`-based views don't use offset pagination).

## Testing

- `tsc -b` — clean
- `oxlint` — clean
- `vitest run` — 1267 passed / 11 skipped (full suite; the 6 databases-feature test files pass)

Browser verification of the exact flow deferred — will confirm together against real cluster data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)