### PR TITLE
fix(clusters): exclude terminated instances from partial-upgrade banner

### DIFF
--- a/src/features/clusters/upsert/index.tsx
+++ b/src/features/clusters/upsert/index.tsx
@@ -108,7 +108,7 @@ export function UpsertCluster() {
 	// re-run the upgrade for the lagging instances. We surface this so the form can allow re-submitting
 	// the current target as a recovery path.
 	const partialUpgrade = useMemo(
-		() => detectPartialUpgrade(cluster?.instances?.map(i => i.version) ?? []),
+		() => detectPartialUpgrade(cluster?.instances ?? []),
 		[cluster],
 	);
 

--- a/src/features/clusters/upsert/lib/detectPartialUpgrade.test.ts
+++ b/src/features/clusters/upsert/lib/detectPartialUpgrade.test.ts
@@ -1,36 +1,61 @@
 import { describe, expect, it } from 'vitest';
-import { detectPartialUpgrade } from './detectPartialUpgrade';
+import { detectPartialUpgrade, UpgradeCandidateInstance } from './detectPartialUpgrade';
+
+/** Build an instance with the given version; defaults to a live (RUNNING) status. */
+const inst = (version?: string | null, status: string = 'RUNNING'): UpgradeCandidateInstance => ({ version, status });
 
 describe('detectPartialUpgrade', () => {
 	it('returns null when every instance is on the same version', () => {
-		expect(detectPartialUpgrade(['5.0.31', '5.0.31', '5.0.31'])).toBeNull();
+		expect(detectPartialUpgrade([inst('5.0.31'), inst('5.0.31'), inst('5.0.31')])).toBeNull();
 	});
 
 	it('returns null for fewer than two reported versions', () => {
 		expect(detectPartialUpgrade([])).toBeNull();
-		expect(detectPartialUpgrade(['5.0.31'])).toBeNull();
-		expect(detectPartialUpgrade([undefined, null, '5.0.31'])).toBeNull();
+		expect(detectPartialUpgrade([inst('5.0.31')])).toBeNull();
+		expect(detectPartialUpgrade([inst(undefined), inst(null), inst('5.0.31')])).toBeNull();
 	});
 
 	it('detects the reported partial-upgrade scenario (one instance stuck on the old version)', () => {
 		// First instance failed to upgrade and stayed on 5.0.31 while the rest reached 5.0.32.
-		const result = detectPartialUpgrade(['5.0.31', '5.0.32', '5.0.32']);
+		const result = detectPartialUpgrade([inst('5.0.31'), inst('5.0.32'), inst('5.0.32')]);
 		expect(result).toEqual({ latest: '5.0.32', behindCount: 1, total: 3 });
 	});
 
 	it('counts every instance behind the latest, including differing older versions', () => {
-		const result = detectPartialUpgrade(['5.0.30', '5.0.31', '5.0.32']);
+		const result = detectPartialUpgrade([inst('5.0.30'), inst('5.0.31'), inst('5.0.32')]);
 		expect(result).toEqual({ latest: '5.0.32', behindCount: 2, total: 3 });
 	});
 
 	it('ignores instances that are not yet reporting a version', () => {
-		const result = detectPartialUpgrade(['5.0.31', undefined, '5.0.32', null]);
+		const result = detectPartialUpgrade([inst('5.0.31'), inst(undefined), inst('5.0.32'), inst(null)]);
 		expect(result).toEqual({ latest: '5.0.32', behindCount: 1, total: 2 });
 	});
 
 	it('treats the latest as the semver-highest, not the lexicographically-highest', () => {
 		// "5.0.9" < "5.0.10" by semver, but "5.0.9" > "5.0.10" lexicographically.
-		const result = detectPartialUpgrade(['5.0.9', '5.0.10']);
+		const result = detectPartialUpgrade([inst('5.0.9'), inst('5.0.10')]);
 		expect(result).toEqual({ latest: '5.0.10', behindCount: 1, total: 2 });
+	});
+
+	it('excludes terminated/removed instances, so their stale version does not fake a partial upgrade', () => {
+		// The two live instances are both on 5.1.17; only terminated instances lag behind.
+		const result = detectPartialUpgrade([
+			inst('5.1.17'),
+			inst('5.1.17'),
+			inst('5.0.31', 'TERMINATED'),
+			inst('5.0.31', 'TERMINATING'),
+			inst('5.0.31', 'REMOVED'),
+		]);
+		expect(result).toBeNull();
+	});
+
+	it('only counts live instances when a genuine partial upgrade coexists with terminated ones', () => {
+		const result = detectPartialUpgrade([
+			inst('5.1.16'),
+			inst('5.1.17'),
+			inst('5.1.17'),
+			inst('5.0.31', 'TERMINATED'),
+		]);
+		expect(result).toEqual({ latest: '5.1.17', behindCount: 1, total: 3 });
 	});
 });

--- a/src/features/clusters/upsert/lib/detectPartialUpgrade.ts
+++ b/src/features/clusters/upsert/lib/detectPartialUpgrade.ts
@@ -1,3 +1,4 @@
+import { deletedClusterStatuses } from '@/config/clusterStatuses';
 import { compareVersions } from '@/lib/string/wasAReleasedBeforeB';
 
 export interface PartialUpgrade {
@@ -9,21 +10,37 @@ export interface PartialUpgrade {
 	total: number;
 }
 
+/** The minimal instance shape this detection needs — a reported version and a lifecycle status. */
+export interface UpgradeCandidateInstance {
+	version?: string | null;
+	status?: string | null;
+}
+
 /**
- * Given the versions reported by a cluster's instances, detect whether the cluster is in a
- * partially-upgraded state — i.e. at least one instance is on an older version than the rest.
+ * Given a cluster's instances, detect whether the cluster is in a partially-upgraded state — i.e.
+ * at least one instance is on an older version than the rest.
  *
  * This happens when an upgrade succeeds on some instances but fails on others: the failed instance
  * stays on the old version while the rest move to the target. The version picker treats the highest
  * version as "current" and offers nothing newer, so there is otherwise no way to re-run the upgrade
  * for the lagging instances.
  *
+ * Terminated/removed instances are excluded — they are no longer part of the cluster, so their
+ * (now-stale) reported version must not make an otherwise-uniform cluster look partially upgraded.
+ *
  * Returns the target version, how many instances are behind it, and the total reporting a version.
- * Returns null when the cluster is uniform (or fewer than two instances report a version), since
- * there is nothing to re-run.
+ * Returns null when the cluster is uniform (or fewer than two live instances report a version),
+ * since there is nothing to re-run.
  */
-export function detectPartialUpgrade(versions: Array<string | undefined | null>): PartialUpgrade | null {
-	const reported = versions.filter((v): v is string => !!v);
+export function detectPartialUpgrade(
+	instances: Array<UpgradeCandidateInstance | undefined | null>,
+): PartialUpgrade | null {
+	const reported = instances
+		.filter((i): i is UpgradeCandidateInstance =>
+			!!i && !(i.status != null && deletedClusterStatuses.includes(i.status))
+		)
+		.map(i => i.version)
+		.filter((v): v is string => !!v);
 	if (reported.length < 2) {
 		return null;
 	}


### PR DESCRIPTION
## Problem

The **"X of Y instances are still on an older version. Re-run the upgrade…"** banner on the cluster edit screen counts *every* instance's reported version — including `TERMINATED`, `TERMINATING`, and `REMOVED` instances.

A torn-down instance keeps its stale (old) version, so:
- a fully-upgraded *live* cluster still shows the partial-upgrade warning, and
- the `X`/`Y` counts are inflated by instances that no longer exist.

## Fix

Move the "which instances count toward the upgrade" decision into `detectPartialUpgrade` itself (where it's documented), and skip any instance whose status is in `deletedClusterStatuses` (`TERMINATING`/`TERMINATED`/`REMOVED`) — the same convention already used for the instance list elsewhere in this feature.

- `detectPartialUpgrade` now takes instances (`{ version, status }`) instead of bare version strings; the call site passes `cluster.instances` directly.
- Added regression tests: terminated instances no longer fake a partial upgrade, and a genuine partial upgrade correctly counts only live instances when terminated ones are also present.

**Scope note:** only `deletedClusterStatuses` are excluded. `FAILED`/`ERROR` instances are still counted — those are exactly the instances that failed to upgrade and legitimately are "behind."

## Testing

- `detectPartialUpgrade` unit tests: 8 pass (incl. 2 new regression cases)
- `tsc -b`, `oxlint`, `dprint` all clean
- Pre-existing unrelated failures in `src/router/__tests__/preloadEvictionRepro.test.ts` exist on `stage` and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)