### PR TITLE
refactor(config): alphabetize the instance Config nav items

### DIFF
--- a/src/features/instance/config/index.tsx
+++ b/src/features/instance/config/index.tsx
@@ -45,40 +45,9 @@ export function ConfigIndex() {
 	);
 	const isSelfManaged = cluster === undefined || clusterIsSelfManaged(cluster);
 
+	// Overview lives at the top (rendered by the nav bars below); the rest are kept alphabetical.
 	const children = canManage && (
 		<>
-			<li>
-				<Link
-					to={buildAbsoluteLinkToPage(params, 'config/users')}
-					className={sharedClasses}
-					inactiveProps={inactiveProps}
-					activeProps={activeProps}
-				>
-					<UsersIcon className="hidden md:inline-block" /> <span className="ms-3">Users</span>
-				</Link>
-			</li>
-			<li>
-				<Link
-					to={buildAbsoluteLinkToPage(params, 'config/roles')}
-					className={sharedClasses}
-					inactiveProps={inactiveProps}
-					activeProps={activeProps}
-				>
-					<HandshakeIcon className="hidden md:inline-block" /> <span className="ms-3">Roles</span>
-				</Link>
-			</li>
-			{deploymentsAvailable && (
-				<li>
-					<Link
-						to={buildAbsoluteLinkToPage(params, 'config/deployments')}
-						className={sharedClasses}
-						inactiveProps={inactiveProps}
-						activeProps={activeProps}
-					>
-						<RocketIcon className="hidden md:inline-block" /> <span className="ms-3">Deployments</span>
-					</Link>
-				</li>
-			)}
 			{certsAvailable && (
 				<li>
 					<Link
@@ -88,6 +57,18 @@ export function ConfigIndex() {
 						activeProps={activeProps}
 					>
 						<ShieldCheckIcon className="hidden md:inline-block" /> <span className="ms-3">Certificates</span>
+					</Link>
+				</li>
+			)}
+			{deploymentsAvailable && (
+				<li>
+					<Link
+						to={buildAbsoluteLinkToPage(params, 'config/deployments')}
+						className={sharedClasses}
+						inactiveProps={inactiveProps}
+						activeProps={activeProps}
+					>
+						<RocketIcon className="hidden md:inline-block" /> <span className="ms-3">Deployments</span>
 					</Link>
 				</li>
 			)}
@@ -103,18 +84,16 @@ export function ConfigIndex() {
 					</Link>
 				</li>
 			)}
-			{certsAvailable && (
-				<li>
-					<Link
-						to={buildAbsoluteLinkToPage(params, 'config/ssh-keys')}
-						className={sharedClasses}
-						inactiveProps={inactiveProps}
-						activeProps={activeProps}
-					>
-						<KeyIcon className="hidden md:inline-block" /> <span className="ms-3">SSH Keys</span>
-					</Link>
-				</li>
-			)}
+			<li>
+				<Link
+					to={buildAbsoluteLinkToPage(params, 'config/roles')}
+					className={sharedClasses}
+					inactiveProps={inactiveProps}
+					activeProps={activeProps}
+				>
+					<HandshakeIcon className="hidden md:inline-block" /> <span className="ms-3">Roles</span>
+				</Link>
+			</li>
 			{
 				/* Secrets (the replicated hdb_secret store): any instance or cluster on a supported
 			    version — key custody may be file-based (self-hosted) or injected (Fabric). Manage-gated
@@ -133,6 +112,28 @@ export function ConfigIndex() {
 					</Link>
 				</li>
 			)}
+			{certsAvailable && (
+				<li>
+					<Link
+						to={buildAbsoluteLinkToPage(params, 'config/ssh-keys')}
+						className={sharedClasses}
+						inactiveProps={inactiveProps}
+						activeProps={activeProps}
+					>
+						<KeyIcon className="hidden md:inline-block" /> <span className="ms-3">SSH Keys</span>
+					</Link>
+				</li>
+			)}
+			<li>
+				<Link
+					to={buildAbsoluteLinkToPage(params, 'config/users')}
+					className={sharedClasses}
+					inactiveProps={inactiveProps}
+					activeProps={activeProps}
+				>
+					<UsersIcon className="hidden md:inline-block" /> <span className="ms-3">Users</span>
+				</Link>
+			</li>
 		</>
 	);
 


### PR DESCRIPTION
> **Stacked on #1402** (the cluster Secrets page). Review the top commit only; everything below belongs to #1402. Retarget to `stage` once #1402 (and its own base #1409) land.

## What

Reorders the instance **Config** page nav so the items read alphabetically. **Overview** stays pinned at the top and keeps its divider (`border-t`) from the rest — only the items below the divider move.

Before → after:

| Before (order added) | After (alphabetical) |
| --- | --- |
| Users | Certificates |
| Roles | Deployments |
| Deployments | Domains |
| Certificates | Roles |
| Domains | Secrets |
| SSH Keys | SSH Keys |
| Secrets | Users |

(“Secrets” is the entry #1402 adds; it slots in alphabetically here so the two PRs don't fight over ordering.)

Only the JSX order in [`src/features/instance/config/index.tsx`](https://github.com/HarperFast/studio/blob/chore/alphabetize-config-menu/src/features/instance/config/index.tsx) changed. Every item keeps its icon and its existing version/permission gate (`certsAvailable`, `deploymentsAvailable`, `secretsSupported`, self-managed/local checks) — nothing was added or removed, just resequenced. Icon imports were already alphabetized on the base branch, so no import change.

## Verification

- Full suite green (1275 passed), `tsc`, `oxlint`, `dprint` all clean via the pre-commit hooks.
- Rendered menu order maps 1:1 to the static JSX order, verified at the source level. Not click-tested in a browser: port 5173 is held by a different checkout and a fresh-origin dev server hits the auth wall, so the live Config page wasn't reachable this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)