### PR TITLE
feat(databases): tree nav, database overview, and shared table actions

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/FileTreeContextMenu.tsx
@@ -62,6 +62,9 @@ export function FileTreeContextMenu({
 }) {
 	const { setOpenedEntry, setFocusedItem, setSelectedItems, selectedItems } = useEditorView();
 	const [target, setTarget] = useState<ContextTarget | undefined>(undefined);
+	// Bumped to the cursor position on every right-click so the content remounts and re-anchors there
+	// (see onContextMenu) -- without it Radix leaves an already-open menu at its first position.
+	const [anchorKey, setAnchorKey] = useState('');
 	const { canRename, canAddEntries, canDeleteEntry, canDownload, canRedeploy } = useEntryActions(target?.entry);
 
 	const focusTarget = useCallback((next: ContextTarget) => {
@@ -105,6 +108,10 @@ export function FileTreeContextMenu({
 		// multi-delete still spans every selected row); otherwise target just this one.
 		const next: ContextTarget = { entry, id, selection: selectedItems.includes(id) ? selectedItems : [id] };
 		setTarget(next);
+		// Radix keeps an already-open context menu anchored to its first position (its exit animation
+		// prevents a re-measure on reopen), so remount the content -- keyed by the cursor point -- to
+		// force it to re-anchor where you actually right-clicked.
+		setAnchorKey(`${event.clientX},${event.clientY}`);
 	}, [items, selectedItems]);
 
 	// Re-assert the target as the action fires. This runs in the same React batch
@@ -139,7 +146,11 @@ export function FileTreeContextMenu({
 				</div>
 			</ContextMenuTrigger>
 			{target && (
-				<ContextMenuContent className="min-w-44" onCloseAutoFocus={event => event.preventDefault()}>
+				<ContextMenuContent
+					key={anchorKey}
+					className="min-w-44"
+					onCloseAutoFocus={event => event.preventDefault()}
+				>
 					<ContextMenuItem onSelect={() => copy(target.entry.name)}>
 						<CopyIcon />
 						Copy Name

--- a/src/features/instance/applications/components/ApplicationsSidebar/ItemArrow.tsx
+++ b/src/features/instance/applications/components/ApplicationsSidebar/ItemArrow.tsx
@@ -1,5 +1,3 @@
-import type { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
-import type { FileEntry } from '@/features/instance/applications/context/fileEntry';
 import { cn } from '@/lib/cn';
 import type { TreeItem } from 'react-complex-tree';
 import type { TreeItemRenderContext } from 'react-complex-tree/src/types';
@@ -22,7 +20,9 @@ import type { TreeItemRenderContext } from 'react-complex-tree/src/types';
  * class) so the visuals are unchanged. The enlarged hit area lives in CSS.
  */
 export function ItemArrow({ item, context }: {
-	item: TreeItem<DirectoryEntry | FileEntry | undefined>;
+	// Data-agnostic on purpose: reads only `item.isFolder`, so both the applications and databases
+	// trees reuse it. (Typed as the library default `TreeItem` = `TreeItem<any>`.)
+	item: TreeItem;
 	context: TreeItemRenderContext;
 }) {
 	if (!item.isFolder) {

--- a/src/features/instance/databases/components/DatabaseActionModals.tsx
+++ b/src/features/instance/databases/components/DatabaseActionModals.tsx
@@ -1,0 +1,104 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { AddTableRowModal } from '@/features/instance/databases/modals/AddTableRowModal';
+import { CreateNewTableModal } from '@/features/instance/databases/modals/CreateNewTableModal';
+import { DeleteDatabaseModal } from '@/features/instance/databases/modals/DeleteDatabaseModal';
+import { DeleteTableModal } from '@/features/instance/databases/modals/DeleteTableModal';
+import { ImportDataModal } from '@/features/instance/databases/modals/ImportDataModal';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
+import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams, useRouter } from '@tanstack/react-router';
+import { useCallback } from 'react';
+
+/**
+ * Single, always-mounted home for every database/table action modal. The tree context menu and the
+ * right-pane toolbar both fire the same target-carrying watched values (see `watchedValueKeys.ts`), so
+ * an action can target ANY database/table -- not just the currently-open one -- and there is exactly
+ * one instance of each modal. Mounted unconditionally by the Databases page (once the map loads) so
+ * Drop Database / Create Table work even when no table is open or a database is empty.
+ */
+export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabaseMap?: InstanceDatabaseMap }) {
+	const params: {
+		clusterId?: string;
+		instanceId?: string;
+		organizationId?: string;
+		databaseName?: string;
+		tableName?: string;
+	} = useParams({ strict: false });
+	const navigate = useNavigate();
+	const router = useRouter();
+	const queryClient = useQueryClient();
+	const instanceParams = useInstanceClientIdParams();
+
+	const goToTable = useCallback((databaseName?: string, tableName?: string) => {
+		void navigate({ to: buildAbsoluteLinkToDatabasePage({ ...params, databaseName, tableName }) });
+	}, [navigate, params]);
+
+	const { value: createTarget } = useWatchedValue('ShowCreateTable', false);
+	const { value: addTarget } = useWatchedValue('ShowAddTableRecords', false);
+	const { value: importTarget } = useWatchedValue('ShowImportData', false);
+
+	const addInstanceTable = addTarget
+		? instanceDatabaseMap?.[addTarget.databaseName]?.[addTarget.tableName]
+		: undefined;
+
+	const onImported = useCallback(async (databaseName: string, tableName: string) => {
+		// The import may have created a new table (or even database), so refresh the tree too.
+		await queryClient.invalidateQueries({
+			queryKey: [instanceParams.entityId, 'describe_all'],
+			refetchType: 'all',
+		});
+		goToTable(databaseName, tableName);
+		await router.invalidate();
+	}, [queryClient, instanceParams.entityId, goToTable, router]);
+
+	// After a drop, only navigate when the dropped entity is the one currently open -- dropping some
+	// other tree item just needs the `describe_all` invalidation (done by the modal) to rebuild the tree.
+	const onTableDropped = useCallback(({ databaseName, tableName }: { databaseName: string; tableName: string }) => {
+		if (params.databaseName === databaseName && params.tableName === tableName) {
+			goToTable(databaseName, undefined); // fall back to the database overview
+		}
+	}, [params.databaseName, params.tableName, goToTable]);
+	const onDatabaseDropped = useCallback(({ databaseName }: { databaseName: string }) => {
+		if (params.databaseName === databaseName) {
+			goToTable(undefined, undefined); // the page re-picks the first remaining database
+		}
+	}, [params.databaseName, goToTable]);
+
+	return (
+		<>
+			<CreateNewTableModal
+				isModalOpen={!!createTarget}
+				setIsModalOpen={open => setWatchedValue('ShowCreateTable', open ? (createTarget || {}) : false)}
+				databaseName={createTarget ? createTarget.databaseName : undefined}
+				onCreated={goToTable}
+			/>
+			{addTarget && addInstanceTable && (
+				<AddTableRowModal
+					instanceTable={addInstanceTable}
+					isModalOpen
+					setIsModalOpen={open => {
+						if (!open) {
+							setWatchedValue('ShowAddTableRecords', false);
+						}
+					}}
+					refreshTable={() =>
+						void queryClient.invalidateQueries({
+							queryKey: [instanceParams.entityId, addTarget.databaseName, addTarget.tableName],
+						})}
+				/>
+			)}
+			<ImportDataModal
+				isModalOpen={!!importTarget}
+				setIsModalOpen={open => setWatchedValue('ShowImportData', open ? (importTarget || {}) : false)}
+				instanceDatabaseMap={instanceDatabaseMap}
+				databaseName={importTarget ? importTarget.databaseName : undefined}
+				tableName={importTarget ? importTarget.tableName : undefined}
+				onImported={onImported}
+			/>
+			<DeleteTableModal onDeleted={onTableDropped} />
+			<DeleteDatabaseModal onDeleted={onDatabaseDropped} />
+		</>
+	);
+}

--- a/src/features/instance/databases/components/DatabaseActionModals.tsx
+++ b/src/features/instance/databases/components/DatabaseActionModals.tsx
@@ -9,7 +9,8 @@ import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
+import { toast } from 'sonner';
 
 /**
  * Single, always-mounted home for every database/table action modal. The tree context menu and the
@@ -42,6 +43,15 @@ export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabase
 	const addInstanceTable = addTarget
 		? instanceDatabaseMap?.[addTarget.databaseName]?.[addTarget.tableName]
 		: undefined;
+	// The Add Records modal needs the table's schema from the fast map. If the target isn't there
+	// (e.g. a stale map after the table was dropped elsewhere), tell the user instead of silently
+	// doing nothing, and clear the trigger.
+	useEffect(() => {
+		if (addTarget && !addInstanceTable) {
+			toast.error(`Couldn't open "${addTarget.tableName}" — it may have just been removed. Try refreshing.`);
+			setWatchedValue('ShowAddTableRecords', false);
+		}
+	}, [addTarget, addInstanceTable]);
 
 	const onImported = useCallback(async (databaseName: string, tableName: string) => {
 		// The import may have created a new table (or even database), so refresh the tree too.

--- a/src/features/instance/databases/components/DatabaseActionModals.tsx
+++ b/src/features/instance/databases/components/DatabaseActionModals.tsx
@@ -69,6 +69,7 @@ export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabase
 	return (
 		<>
 			<CreateNewTableModal
+				key={createTarget ? `create-${createTarget.databaseName ?? ''}` : 'create-closed'}
 				isModalOpen={!!createTarget}
 				setIsModalOpen={open => setWatchedValue('ShowCreateTable', open ? (createTarget || {}) : false)}
 				databaseName={createTarget ? createTarget.databaseName : undefined}
@@ -76,6 +77,7 @@ export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabase
 			/>
 			{addTarget && addInstanceTable && (
 				<AddTableRowModal
+					key={`add-${addTarget.databaseName}/${addTarget.tableName}`}
 					instanceTable={addInstanceTable}
 					isModalOpen
 					setIsModalOpen={open => {
@@ -90,6 +92,9 @@ export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabase
 				/>
 			)}
 			<ImportDataModal
+				key={importTarget
+					? `import-${importTarget.databaseName ?? ''}/${importTarget.tableName ?? ''}`
+					: 'import-closed'}
 				isModalOpen={!!importTarget}
 				setIsModalOpen={open => setWatchedValue('ShowImportData', open ? (importTarget || {}) : false)}
 				instanceDatabaseMap={instanceDatabaseMap}

--- a/src/features/instance/databases/components/DatabaseActionModals.tsx
+++ b/src/features/instance/databases/components/DatabaseActionModals.tsx
@@ -89,6 +89,7 @@ export function DatabaseActionModals({ instanceDatabaseMap }: { instanceDatabase
 				<AddTableRowModal
 					key={`add-${addTarget.databaseName}/${addTarget.tableName}`}
 					instanceTable={addInstanceTable}
+					databaseTables={instanceDatabaseMap?.[addTarget.databaseName]}
 					isModalOpen
 					setIsModalOpen={open => {
 						if (!open) {

--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -54,14 +54,18 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 			countByTable[tableName] = { recordCount: data.record_count, estimated: !!data.estimated_record_range };
 		}
 	});
-	const allCountsLoaded = countQueries.every((query) => !!query.data);
+	// Settled, not "has data": describe_table uses retry:false, so a single failed/never-resolving count
+	// would otherwise hang the total on "…" forever even though every other table counted fine. Sum the
+	// ones that resolved, and flag the total as an estimate if any contributing count was estimated.
+	const allCountsSettled = countQueries.every((query) => !query.isPending);
+	const anyEstimated = tableNames.some((tableName) => countByTable[tableName]?.estimated);
 
 	// Every table in a database shares the same underlying store, so db_size/db_audit_size are the same
 	// on each -- read them off any table.
 	const anyTable = tableNames.length ? tables[tableNames[0]] : undefined;
 	const dbSize = anyTable?.db_size ?? 0;
 	const auditSize = anyTable?.db_audit_size ?? 0;
-	const totalRecords = allCountsLoaded
+	const totalRecords = allCountsSettled
 		? tableNames.reduce((sum, tableName) => sum + (countByTable[tableName]?.recordCount ?? 0), 0)
 		: undefined;
 
@@ -113,7 +117,10 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 
 			<div className="grid grid-cols-2 lg:grid-cols-4 gap-3 pb-6">
 				<Stat label="Tables" value={tableNames.length.toLocaleString()} />
-				<Stat label="Records" value={totalRecords === undefined ? '…' : totalRecords.toLocaleString()} />
+				<Stat
+					label="Records"
+					value={totalRecords === undefined ? '…' : `${anyEstimated ? '~' : ''}${totalRecords.toLocaleString()}`}
+				/>
 				<Stat label="Size" value={formatBytes(dbSize)} />
 				<Stat label="Audit Size" value={formatBytes(auditSize)} />
 			</div>

--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -5,10 +5,10 @@ import { TableRowContextMenu } from '@/features/instance/databases/components/Ta
 import { formatBytes } from '@/features/instance/status/analytics/lib/time';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
-import { getDescribeAllQueryOptions } from '@/integrations/api/instance/database/getDescribeAll';
+import { getDescribeTableQueryOptions } from '@/integrations/api/instance/database/getDescribeTable';
 import { setWatchedValue } from '@/lib/events/watcher';
 import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { CloudUploadIcon, EllipsisIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { useCallback } from 'react';
@@ -38,18 +38,31 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 	const tables = instanceDatabaseMap?.[databaseName] ?? {};
 	const tableNames = Object.keys(tables).sort();
 
-	// Sizes are already in the fast (count-skipping) map. Record counts are not, so fetch describe_all
-	// WITH counts separately (distinct cache key) and backfill them as they arrive.
-	const { data: countedMap } = useQuery(getDescribeAllQueryOptions({ ...instanceParams }));
-	const countedTables = countedMap?.[databaseName];
+	// Sizes/schema are already in the fast (count-skipping) map, so they render instantly. Row counts
+	// aren't, so fetch them per-table via describe_table's cheap estimate path -- but only for the
+	// tables in THIS database, not the whole instance. These share React Query's cache with the table
+	// view, so counts stay consistent and opening a table is instant.
+	const countQueries = useQueries({
+		queries: tableNames.map((tableName) =>
+			getDescribeTableQueryOptions({ ...instanceParams, databaseName, tableName })
+		),
+	});
+	const countByTable: Record<string, { recordCount?: number; estimated: boolean }> = {};
+	tableNames.forEach((tableName, index) => {
+		const data = countQueries[index]?.data;
+		if (data) {
+			countByTable[tableName] = { recordCount: data.record_count, estimated: !!data.estimated_record_range };
+		}
+	});
+	const allCountsLoaded = countQueries.every((query) => !!query.data);
 
 	// Every table in a database shares the same underlying store, so db_size/db_audit_size are the same
 	// on each -- read them off any table.
 	const anyTable = tableNames.length ? tables[tableNames[0]] : undefined;
 	const dbSize = anyTable?.db_size ?? 0;
 	const auditSize = anyTable?.db_audit_size ?? 0;
-	const totalRecords = countedTables
-		? Object.values(countedTables).reduce((sum, table) => sum + (table.record_count ?? 0), 0)
+	const totalRecords = allCountsLoaded
+		? tableNames.reduce((sum, tableName) => sum + (countByTable[tableName]?.recordCount ?? 0), 0)
 		: undefined;
 
 	const goToTable = useCallback((tableName: string) => {
@@ -129,12 +142,11 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 								<tbody>
 									{tableNames.map((tableName) => {
 										const table = tables[tableName];
-										const counted = countedTables?.[tableName];
+										const counted = countByTable[tableName];
 										const primaryKey = table.primary_key ?? table.hash_attribute ?? '—';
-										const recordCount = counted?.record_count;
-										const recordLabel = recordCount === undefined
+										const recordLabel = counted?.recordCount === undefined
 											? '…'
-											: `${counted?.estimated_record_range ? '~' : ''}${recordCount.toLocaleString()}`;
+											: `${counted.estimated ? '~' : ''}${counted.recordCount.toLocaleString()}`;
 										return (
 											<tr
 												key={tableName}

--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -1,0 +1,165 @@
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { TableRowContextMenu } from '@/features/instance/databases/components/TableRowContextMenu';
+import { formatBytes } from '@/features/instance/status/analytics/lib/time';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { getDescribeAllQueryOptions } from '@/integrations/api/instance/database/getDescribeAll';
+import { setWatchedValue } from '@/lib/events/watcher';
+import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { CloudUploadIcon, EllipsisIcon, PlusIcon, Trash2Icon } from 'lucide-react';
+import { useCallback } from 'react';
+
+function Stat({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="rounded-md border border-border dark:border-grey-700 p-4">
+			<div className="text-sm text-muted-foreground">{label}</div>
+			<div className="text-2xl font-medium">{value}</div>
+		</div>
+	);
+}
+
+export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
+	instanceDatabaseMap?: InstanceDatabaseMap;
+	databaseName: string;
+}) {
+	const params: {
+		clusterId?: string;
+		instanceId?: string;
+		organizationId?: string;
+	} = useParams({ strict: false });
+	const navigate = useNavigate();
+	const instanceParams = useInstanceClientIdParams();
+	const canManage = useInstanceBrowseManagePermission();
+
+	const tables = instanceDatabaseMap?.[databaseName] ?? {};
+	const tableNames = Object.keys(tables).sort();
+
+	// Sizes are already in the fast (count-skipping) map. Record counts are not, so fetch describe_all
+	// WITH counts separately (distinct cache key) and backfill them as they arrive.
+	const { data: countedMap } = useQuery(getDescribeAllQueryOptions({ ...instanceParams }));
+	const countedTables = countedMap?.[databaseName];
+
+	// Every table in a database shares the same underlying store, so db_size/db_audit_size are the same
+	// on each -- read them off any table.
+	const anyTable = tableNames.length ? tables[tableNames[0]] : undefined;
+	const dbSize = anyTable?.db_size ?? 0;
+	const auditSize = anyTable?.db_audit_size ?? 0;
+	const totalRecords = countedTables
+		? Object.values(countedTables).reduce((sum, table) => sum + (table.record_count ?? 0), 0)
+		: undefined;
+
+	const goToTable = useCallback((tableName: string) => {
+		void navigate({ to: buildAbsoluteLinkToDatabasePage({ ...params, databaseName, tableName }) });
+	}, [navigate, params, databaseName]);
+
+	return (
+		<div className="pt-15 pb-4 pr-4">
+			<div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3 pb-6">
+				<div className="flex items-center gap-2 min-w-0">
+					<h1 className="text-3xl truncate">{databaseName}</h1>
+				</div>
+				{canManage && (
+					<div className="flex space-x-2 shrink-0">
+						<Button
+							variant="positiveOutline"
+							onClick={() => setWatchedValue('ShowCreateTable', { databaseName })}
+						>
+							<PlusIcon />
+							<span>Create a Table</span>
+						</Button>
+						<Button
+							variant="positiveOutline"
+							onClick={() => setWatchedValue('ShowImportData', { databaseName })}
+						>
+							<CloudUploadIcon />
+							<span>Import Data</span>
+						</Button>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button variant="ghost" size="icon">
+									<EllipsisIcon aria-label="Database options" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent side="bottom" align="end">
+								<DropdownMenuItem
+									className="focus:bg-red/70 focus:text-white"
+									onClick={() => setWatchedValue('ShowDeleteDatabase', { databaseName })}
+								>
+									<Trash2Icon />
+									Drop Database
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				)}
+			</div>
+
+			<div className="grid grid-cols-2 lg:grid-cols-4 gap-3 pb-6">
+				<Stat label="Tables" value={tableNames.length.toLocaleString()} />
+				<Stat label="Records" value={totalRecords === undefined ? '…' : totalRecords.toLocaleString()} />
+				<Stat label="Size" value={formatBytes(dbSize)} />
+				<Stat label="Audit Size" value={formatBytes(auditSize)} />
+			</div>
+
+			{tableNames.length === 0
+				? (
+					<div className="rounded-md border border-border dark:border-grey-700 p-8 text-center text-muted-foreground">
+						<p className="pb-2">This database has no tables yet.</p>
+						{canManage && <p>Use “Create a Table” above, or right-click the database in the sidebar.</p>}
+					</div>
+				)
+				: (
+					<TableRowContextMenu databaseName={databaseName} instanceDatabaseMap={instanceDatabaseMap}>
+						<div className="rounded-md border border-border dark:border-grey-700 overflow-x-auto">
+							<table className="w-full text-sm">
+								<thead>
+									<tr className="text-left text-muted-foreground border-b border-border dark:border-grey-700">
+										<th className="p-3 font-medium">Table</th>
+										<th className="p-3 font-medium text-right">Records</th>
+										<th className="p-3 font-medium text-right">Size</th>
+										<th className="p-3 font-medium text-right">Columns</th>
+										<th className="p-3 font-medium">Primary Key</th>
+										<th className="p-3 font-medium">Last Updated</th>
+									</tr>
+								</thead>
+								<tbody>
+									{tableNames.map((tableName) => {
+										const table = tables[tableName];
+										const counted = countedTables?.[tableName];
+										const primaryKey = table.primary_key ?? table.hash_attribute ?? '—';
+										const recordCount = counted?.record_count;
+										const recordLabel = recordCount === undefined
+											? '…'
+											: `${counted?.estimated_record_range ? '~' : ''}${recordCount.toLocaleString()}`;
+										return (
+											<tr
+												key={tableName}
+												data-table-name={tableName}
+												onClick={() => goToTable(tableName)}
+												className="border-b border-border dark:border-grey-700 last:border-0 cursor-pointer hover:bg-accent dark:hover:bg-grey-700/80"
+											>
+												<td className="p-3 font-medium">{tableName}</td>
+												<td className="p-3 text-right tabular-nums">{recordLabel}</td>
+												<td className="p-3 text-right tabular-nums">{formatBytes(table.table_size ?? 0)}</td>
+												<td className="p-3 text-right tabular-nums">{table.attributes.length.toLocaleString()}</td>
+												<td className="p-3">{primaryKey}</td>
+												<td className="p-3 text-muted-foreground">
+													{table.last_updated_record
+														? new Date(table.last_updated_record).toLocaleString()
+														: '—'}
+												</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</table>
+						</div>
+					</TableRowContextMenu>
+				)}
+		</div>
+	);
+}

--- a/src/features/instance/databases/components/DatabaseTableView.tsx
+++ b/src/features/instance/databases/components/DatabaseTableView.tsx
@@ -9,11 +9,8 @@ import {
 	syntheticAttributeNames,
 } from '@/features/instance/databases/functions/relationshipAttributes';
 import { getSchemaRelationshipsQueryOptions } from '@/features/instance/databases/functions/schemaRelationships';
-import { AddTableRowModal } from '@/features/instance/databases/modals/AddTableRowModal';
-import { DeleteDatabaseModal } from '@/features/instance/databases/modals/DeleteDatabaseModal';
-import { DeleteTableModal } from '@/features/instance/databases/modals/DeleteTableModal';
+import { useExportTableCsv } from '@/features/instance/databases/hooks/useExportTableCsv';
 import { EditTableRowModal } from '@/features/instance/databases/modals/EditTableRowModal';
-import { ImportDataModal } from '@/features/instance/databases/modals/ImportDataModal';
 import { useAdminMode } from '@/hooks/useAuth';
 import { useEffectedState } from '@/hooks/useEffectedState';
 import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
@@ -25,22 +22,20 @@ import { useCleanupOrphanBlobsMutation } from '@/integrations/api/instance/datab
 import { useDeleteTableRecords } from '@/integrations/api/instance/database/deleteTableRecords';
 import { getDescribeTableQueryOptions } from '@/integrations/api/instance/database/getDescribeTable';
 import {
-	getSearchByConditions,
 	getSearchByConditionsOptions,
 	SearchCondition,
 	translateColumnFilterToSearchConditions,
 } from '@/integrations/api/instance/database/getSearchByConditions';
 import { getSearchByIdOptions } from '@/integrations/api/instance/database/getSearchById';
-import { getSearchByValue, getSearchByValueOptions } from '@/integrations/api/instance/database/getSearchByValue';
+import { getSearchByValueOptions } from '@/integrations/api/instance/database/getSearchByValue';
 import { getTableRecordCountQueryOptions } from '@/integrations/api/instance/database/getTableRecordCount';
 import { useUpdateTableRecords } from '@/integrations/api/instance/database/updateTableRecords';
-import { useSetWatchedValue } from '@/lib/events/watcher';
+import { setWatchedValue } from '@/lib/events/watcher';
 import { keyBy } from '@/lib/keyBy';
 import { onClickStopPropagation } from '@/lib/onClickStopPropagation';
-import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import { Link, useParams, useSearch } from '@tanstack/react-router';
 import { Row, VisibilityState } from '@tanstack/react-table';
 import {
 	BrushCleaningIcon,
@@ -75,7 +70,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		instanceId?: string;
 	} = useParams({ strict: false });
 
-	const navigate = useNavigate();
 	const instanceParams = useInstanceClientIdParams();
 	const { clusterId, instanceId } = allParams;
 
@@ -214,8 +208,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 	]);
 
 	const { dataTableColumns, primaryKey } = formatBrowseDataTableHeader(instanceTable, relationshipInfoMap);
-	const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-	const [isImportDataModalOpen, setIsImportDataModalOpen] = useState(false);
 	const [sort, setSort] = useEffectedState(
 		{
 			attribute: primaryKey,
@@ -333,38 +325,19 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		});
 	}, [cleanupOrphanBlobs, databaseName, instanceParams, refreshTable]);
 
-	const [isExportingCSV, setisExportingCSV] = useState(false);
-	const onExportCSVClicked = useCallback(async () => {
-		if (!primaryKey) {
-			return;
-		}
-		const id = toast.loading('Loading CSV...');
-		setisExportingCSV(true);
-		const allResultsAsCSV = {
-			pageIndex: 0,
-			pageSize: 1_000_000,
-			// Raw records only: resolved relationship objects don't serialize usefully into CSV cells.
-			getAttributes: undefined,
-			headers: {
-				Accept: 'text/csv',
-			},
-		};
-		const response = await (
-			useFilteredList
-				? getSearchByConditions({ ...searchByConditionsParams, ...allResultsAsCSV })
-				: getSearchByValue({ ...searchByValueParams, ...allResultsAsCSV })
-		);
-		toast.loading('Preparing CSV...', { id });
-		const content = response.data as unknown as string;
-		const blob = new Blob([content], { type: 'text/csv' });
-		const url = URL.createObjectURL(blob);
-		const downloadLink = document.createElement('a');
-		downloadLink.href = url;
-		downloadLink.setAttribute('download', `${databaseName}.${tableName}.${new Date().toISOString()}.csv`);
-		downloadLink.click();
-		toast.success('CSV Exported!', { id });
-		setisExportingCSV(false);
-	}, [databaseName, tableName, searchByValueOptions, searchByConditionsOptions]);
+	// The toolbar exports what's on screen (active filters + sort); the tree/overview export the whole
+	// table. Both go through the shared hook, which fetches raw records (no relationship get_attributes)
+	// -- resolved relationship objects don't serialize usefully into CSV cells.
+	const { exportCsv, isExporting: isExportingCSV } = useExportTableCsv();
+	const onExportCSVClicked = useCallback(() => {
+		void exportCsv({
+			databaseName,
+			tableName,
+			primaryKey,
+			sort,
+			conditions: useFilteredList ? appliedSearchConditions : null,
+		});
+	}, [exportCsv, databaseName, tableName, primaryKey, sort, useFilteredList, appliedSearchConditions]);
 
 	const onRecordUpdate = useCallback((data: Record<string, unknown>[]) => {
 		updateTableRecords(
@@ -402,25 +375,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		);
 	}, [deleteTableRecords, instanceParams, databaseName, tableName, refreshTable]);
 
-	const onImported = useCallback(async (importedDatabase: string, importedTable: string) => {
-		// The import may have created a new table (or even database), so refresh the tree too.
-		await queryClient.invalidateQueries({
-			queryKey: [instanceParams.entityId, 'describe_all'],
-			refetchType: 'all',
-		});
-		if (importedDatabase === databaseName && importedTable === tableName) {
-			void refreshTable();
-		} else {
-			void navigate({
-				to: buildAbsoluteLinkToDatabasePage({
-					...allParams,
-					databaseName: importedDatabase,
-					tableName: importedTable,
-				}),
-			});
-		}
-	}, [queryClient, instanceParams.entityId, databaseName, tableName, refreshTable, navigate, allParams]);
-
 	const onRowClick = (rowData: Row<Record<string, unknown>>) => {
 		setSelectedIds([rowData.original[primaryKey]]);
 		setIsEditModalOpen(!isEditModalOpen);
@@ -434,17 +388,12 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 	const onRefreshClick = useRefreshClick(refreshTable);
 
 	const onAddClicked = useCallback(() => {
-		setIsAddModalOpen(true);
-	}, [setIsAddModalOpen]);
+		setWatchedValue('ShowAddTableRecords', { databaseName, tableName });
+	}, [databaseName, tableName]);
 
 	const onImportDataClicked = useCallback(() => {
-		setIsImportDataModalOpen(true);
-	}, [setIsImportDataModalOpen]);
-
-	const onDeleted = useCallback(
-		(deleted: 'table' | 'database') => void navigate({ to: deleted === 'table' ? '../' : '../../' }),
-		[navigate],
-	);
+		setWatchedValue('ShowImportData', { databaseName, tableName });
+	}, [databaseName, tableName]);
 
 	const [storedColumnVisibility, setColumnVisibility] = useSessionStorage(
 		`ColumnDisplayed/${databaseName}/${tableName}` as 'ColumnDisplayed/{database}/{table}',
@@ -458,9 +407,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		...storedColumnVisibility,
 	}), [relationshipInfoMap, storedColumnVisibility]);
 
-	const openDeleteTable = useSetWatchedValue('ShowDeleteTable', true);
-	const openDeleteDatabase = useSetWatchedValue('ShowDeleteDatabase', true);
-
 	return (
 		<>
 			<div className="flex flex-col md:flex-row items-center justify-between space-y-3 md:space-y-0 md:space-x-3 pt-15 pb-4 pr-4">
@@ -469,7 +415,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 						<Button
 							variant="positiveOutline"
 							onClick={onAddClicked}
-							disabled={isAddModalOpen}
 							accessKey="n"
 						>
 							<PlusIcon />
@@ -482,7 +427,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 						<Button
 							variant="positiveOutline"
 							onClick={onImportDataClicked}
-							disabled={isImportDataModalOpen}
 							accessKey="i"
 						>
 							<CloudUploadIcon />
@@ -583,14 +527,20 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 								</DropdownMenuItem>
 							)}
 							{canManageBrowseInstance && !isLastTableInDatabase && (
-								<DropdownMenuItem className="focus:bg-red/70 focus:text-white" onClick={openDeleteTable}>
+								<DropdownMenuItem
+									className="focus:bg-red/70 focus:text-white"
+									onClick={() => setWatchedValue('ShowDeleteTable', { databaseName, tableName })}
+								>
 									<TrashIcon className="inline-block " />
 									Drop Table
 								</DropdownMenuItem>
 							)}
 							{canManageBrowseInstance
 								&& (
-									<DropdownMenuItem className="focus:bg-red/70 focus:text-white" onClick={openDeleteDatabase}>
+									<DropdownMenuItem
+										className="focus:bg-red/70 focus:text-white"
+										onClick={() => setWatchedValue('ShowDeleteDatabase', { databaseName })}
+									>
 										<Trash2Icon />
 										Drop Database
 									</DropdownMenuItem>
@@ -623,15 +573,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 				setPageIndex={setPageIndex}
 				setPageSize={setPageSize}
 			/>
-			{canAddRecords && instanceTable && isAddModalOpen && (
-				<AddTableRowModal
-					instanceTable={instanceTable}
-					databaseTables={databaseTables}
-					isModalOpen={isAddModalOpen}
-					refreshTable={refreshTable}
-					setIsModalOpen={setIsAddModalOpen}
-				/>
-			)}
 			<EditTableRowModal
 				canEditRecords={canEditRecords}
 				canDeleteRecords={canDeleteRecords}
@@ -644,18 +585,6 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 				onDeleteRecord={onDeleteRecord}
 				isUpdateTableRecordsPending={isUpdateTableRecordsPending}
 				isDeleteTableRecordsPending={isDeleteTableRecordsPending}
-			/>
-
-			<DeleteDatabaseModal databaseName={databaseName} onDeleted={onDeleted} />
-			<DeleteTableModal databaseName={databaseName} tableName={tableName} onDeleted={onDeleted} />
-
-			<ImportDataModal
-				isModalOpen={isImportDataModalOpen}
-				setIsModalOpen={setIsImportDataModalOpen}
-				instanceDatabaseMap={instanceDatabaseMap}
-				databaseName={databaseName}
-				tableName={tableName}
-				onImported={onImported}
 			/>
 		</>
 	);

--- a/src/features/instance/databases/components/DatabasesSidebar.tsx
+++ b/src/features/instance/databases/components/DatabasesSidebar.tsx
@@ -1,179 +1,20 @@
 import { TextLoadingSkeleton } from '@/components/TextLoadingSkeleton';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scrollArea';
-import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { useInstanceClientIdParams } from '@/config/useInstanceClient';
-import { CreateNewTableModal } from '@/features/instance/databases/modals/CreateNewTableModal';
-import { ImportDataModal } from '@/features/instance/databases/modals/ImportDataModal';
-import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
-import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
-import { useQueryClient } from '@tanstack/react-query';
-import { useNavigate, useParams, useRouter } from '@tanstack/react-router';
-import { ArrowRight, CloudUploadIcon } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { DatabasesTree } from './DatabasesTree';
 
 export function DatabasesSidebar({ instanceDatabaseMap }: { instanceDatabaseMap?: InstanceDatabaseMap }) {
-	const router = useRouter();
-
 	const loading = !instanceDatabaseMap;
-
-	const params: { databaseName?: string; tableName?: string } = useParams({ strict: false });
-	const navigate = useNavigate();
-	const canManageBrowseInstance = useInstanceBrowseManagePermission();
-	const queryClient = useQueryClient();
-	const instanceParams = useInstanceClientIdParams();
-	const [isImportDataModalOpen, setIsImportDataModalOpen] = useState(false);
-
-	const { databaseNames, tableNames } = useMemo(() => {
-		const databaseNames = Object.keys(instanceDatabaseMap || {}).sort();
-		const tableNames = params.databaseName ? Object.keys(instanceDatabaseMap?.[params.databaseName] || []).sort() : [];
-		return {
-			databaseNames,
-			tableNames,
-		};
-	}, [instanceDatabaseMap, params.databaseName]);
-
-	const onSelectDatabase = useCallback((newDatabaseName: string | undefined) => {
-		const tableNames = newDatabaseName ? Object.keys(instanceDatabaseMap?.[newDatabaseName] || []).sort() : [];
-		if (!params.databaseName) {
-			void router.invalidate();
-		} else {
-			void navigate({
-				to: buildAbsoluteLinkToDatabasePage({
-					...params,
-					databaseName: newDatabaseName,
-					tableName: tableNames[0],
-				}),
-			});
-		}
-	}, [instanceDatabaseMap, params, router, navigate]);
-
-	const onSelectTable = useCallback((newDatabaseName: string | undefined, newTableName: string | undefined) => {
-		void navigate({
-			to: buildAbsoluteLinkToDatabasePage({
-				...params,
-				databaseName: newDatabaseName,
-				tableName: newTableName,
-			}),
-		});
-	}, [navigate, params]);
-
-	const onImported = useCallback(async (newDatabaseName: string, newTableName: string) => {
-		await queryClient.invalidateQueries({
-			queryKey: [instanceParams.entityId, 'describe_all'],
-			refetchType: 'all',
-		});
-		onSelectTable(newDatabaseName, newTableName);
-		await router.invalidate();
-	}, [queryClient, instanceParams.entityId, onSelectTable, router]);
 
 	return (
 		<div className="pl-3 flex flex-col h-full min-h-0">
 			<h1 className="pt-3 pb-3 text-3xl shrink-0">Databases</h1>
 			{loading
-				? <TextLoadingSkeleton className="w-full h-9 m-0 rounded-md shrink-0" />
+				? <TextLoadingSkeleton className="w-full flex-1 min-h-0 rounded-md" />
 				: (
-					<div className="flex space-x-2 shrink-0">
-						<Select
-							name="databaseSelect"
-							value={params.databaseName || ''}
-							disabled={databaseNames.length === 0}
-							onValueChange={onSelectDatabase}
-						>
-							<SelectTrigger className="w-full">
-								<SelectValue placeholder="Select a Database" />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectGroup>
-									{databaseNames.map((databaseName) => (
-										<SelectItem key={databaseName} value={databaseName}>
-											{databaseName}
-										</SelectItem>
-									))}
-								</SelectGroup>
-							</SelectContent>
-						</Select>
+					<div className="flex-1 min-h-0">
+						<DatabasesTree instanceDatabaseMap={instanceDatabaseMap} />
 					</div>
 				)}
-			{loading
-				? <TextLoadingSkeleton className="w-full flex-1 min-h-0 rounded-md mb-0 mt-4" />
-				: (
-					<ScrollArea type="auto" className="flex-1 min-h-0 border rounded-md border-grey-700 mt-4">
-						{tableNames.length === 0 && params.databaseName?.length
-							? (
-								<div className="w-full h-full text-center">
-									<p className="py-6">No tables found in this database.</p>
-									{canManageBrowseInstance && (
-										<p>
-											Tap "Create a Table" below!
-										</p>
-									)}
-								</div>
-							)
-							: tableNames.length === 0 && !params.databaseName?.length
-							? canManageBrowseInstance
-								? (
-									<p className="pt-2 text-sm text-center">
-										Please {databaseNames.length === 0 ? 'create' : 'select'} a table.
-									</p>
-								)
-								: (
-									<p className="pt-2 text-sm text-center">
-										Please {databaseNames.length === 0 ? 'ask your admin to create' : 'select'} a table.
-									</p>
-								)
-							: (
-								''
-							)}
-						<ul>
-							{tableNames.map((tableName) => (
-								<li
-									key={tableName}
-									className="flex items-center p-2 border-b hover:bg-accent border-border dark:hover:bg-grey-700/80 dark:border-grey-700"
-								>
-									<Button
-										onClick={() => onSelectTable(params.databaseName, tableName)}
-										size="lg"
-										className="items-center justify-between w-full bg-transparent border-none shadow-none hover:bg-transparent text-foreground"
-									>
-										{tableName}
-										<span>
-											{params.tableName === tableName && <ArrowRight />}
-										</span>
-									</Button>
-								</li>
-							))}
-						</ul>
-					</ScrollArea>
-				)}
-			{canManageBrowseInstance && (
-				<div className="shrink-0">
-					<CreateNewTableModal
-						databaseName={params.databaseName}
-						onSelectTable={onSelectTable}
-					/>
-					<div className="shrink-0 pb-4">
-						<Button
-							variant="defaultOutline"
-							className="w-full"
-							size="lg"
-							onClick={() => setIsImportDataModalOpen(true)}
-							disabled={isImportDataModalOpen || loading}
-						>
-							<CloudUploadIcon />
-							<span>Import Data</span>
-						</Button>
-					</div>
-					<ImportDataModal
-						isModalOpen={isImportDataModalOpen}
-						setIsModalOpen={setIsImportDataModalOpen}
-						instanceDatabaseMap={instanceDatabaseMap}
-						databaseName={params.databaseName}
-						onImported={onImported}
-					/>
-				</div>
-			)}
 		</div>
 	);
 }

--- a/src/features/instance/databases/components/DatabasesTree/DatabaseTreeContextMenu.tsx
+++ b/src/features/instance/databases/components/DatabasesTree/DatabaseTreeContextMenu.tsx
@@ -1,0 +1,92 @@
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from '@/components/ui/contextMenu';
+import { TableContextMenuItems } from '@/features/instance/databases/components/TableContextMenuItems';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { setWatchedValue } from '@/lib/events/watcher';
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { ReactNode, useCallback, useState } from 'react';
+import type { TreeItem } from 'react-complex-tree';
+import type { DbTreeData } from './buildItems';
+
+/**
+ * Right-click menu for the databases tree. Resolves the clicked row from `data-rct-item-id`, remembers
+ * it as the target, and fires the shared target-carrying watched values (reusing the same modals the
+ * toolbar uses). Table rows share their action list with the overview via `TableContextMenuItems`.
+ * `modal={false}` is load-bearing -- every action opens a Dialog, and a modal menu would leave
+ * `pointer-events: none` stuck on <body>, freezing the page.
+ */
+export function DatabaseTreeContextMenu({ items, instanceDatabaseMap, children }: {
+	items: Record<string, TreeItem<DbTreeData>>;
+	instanceDatabaseMap?: InstanceDatabaseMap;
+	children: ReactNode;
+}) {
+	const canManage = useInstanceBrowseManagePermission();
+	const [target, setTarget] = useState<DbTreeData | undefined>(undefined);
+	// Bumped to the cursor position on every right-click so the content remounts and re-anchors there
+	// -- without it Radix leaves an already-open menu at its first position.
+	const [anchorKey, setAnchorKey] = useState('');
+
+	const onContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+		const id = (event.target as HTMLElement).closest('[data-rct-item-id]')?.getAttribute('data-rct-item-id');
+		const data = id ? items[id]?.data : undefined;
+		// Suppress on empty space / the synthetic root + create-table rows. Clearing the target keeps a
+		// stale menu from flashing if the open-on-right-click still fires with nothing to show.
+		if (!data || data.kind === 'root' || data.kind === 'createTable') {
+			setTarget(undefined);
+			event.preventDefault();
+			return;
+		}
+		setTarget(data);
+		setAnchorKey(`${event.clientX},${event.clientY}`);
+	}, [items]);
+
+	return (
+		<ContextMenu modal={false}>
+			<ContextMenuTrigger asChild>
+				<div onContextMenu={onContextMenu} className="min-h-full">
+					{children}
+				</div>
+			</ContextMenuTrigger>
+			{target && (
+				<ContextMenuContent
+					key={anchorKey}
+					className="min-w-44"
+					onCloseAutoFocus={event => event.preventDefault()}
+				>
+					{target.kind === 'database' && canManage && (
+						<>
+							<ContextMenuItem
+								onSelect={() => setWatchedValue('ShowCreateTable', { databaseName: target.databaseName })}
+							>
+								<PlusIcon />
+								Create a Table
+							</ContextMenuItem>
+							<ContextMenuSeparator />
+							<ContextMenuItem
+								variant="destructive"
+								onSelect={() => setWatchedValue('ShowDeleteDatabase', { databaseName: target.databaseName })}
+							>
+								<Trash2Icon />
+								Drop Database
+							</ContextMenuItem>
+						</>
+					)}
+
+					{target.kind === 'table' && (
+						<TableContextMenuItems
+							databaseName={target.databaseName}
+							tableName={target.tableName}
+							instanceDatabaseMap={instanceDatabaseMap}
+						/>
+					)}
+				</ContextMenuContent>
+			)}
+		</ContextMenu>
+	);
+}

--- a/src/features/instance/databases/components/DatabasesTree/ItemTitle.tsx
+++ b/src/features/instance/databases/components/DatabasesTree/ItemTitle.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/cn';
+import { DatabaseIcon, PlusIcon, Table2Icon } from 'lucide-react';
+import type { TreeItem } from 'react-complex-tree';
+import type { DbTreeData } from './buildItems';
+
+const iconClassName = 'mr-1.5 h-4 w-4 shrink-0 pointer-events-none';
+
+export function ItemTitle({ title, item }: {
+	title: string;
+	item: TreeItem<DbTreeData>;
+}) {
+	const kind = item.data.kind;
+	return (
+		<>
+			{
+				/* Palette matches the applications sidebar: green "+" (New Application), orange containers
+			    (folders/databases), and a neutral leaf icon that inherits the row's text color -- so the
+			    two trees read as one system and stay high-contrast in both light and dark mode. */
+			}
+			{kind === 'createTable'
+				? <PlusIcon className={cn(iconClassName, 'text-green-500')} />
+				: kind === 'database'
+				? <DatabaseIcon className={cn(iconClassName, 'text-orange-400')} />
+				: <Table2Icon className={iconClassName} />}
+			<span className="text-nowrap pointer-events-none">{title}</span>
+		</>
+	);
+}

--- a/src/features/instance/databases/components/DatabasesTree/buildItems.test.ts
+++ b/src/features/instance/databases/components/DatabasesTree/buildItems.test.ts
@@ -1,0 +1,67 @@
+import { InstanceDatabaseMap, InstanceTable } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+import { buildItems, tableItemId } from './buildItems';
+import { getItemTitle } from './getItemTitle';
+import { createTableId, rootId } from './specialItems';
+
+function table(schema: string, name: string): InstanceTable {
+	return {
+		schema,
+		name,
+		audit: false,
+		schema_defined: true,
+		db_size: 0,
+		sources: [],
+		table_size: 0,
+		db_audit_size: 0,
+		attributes: [],
+	};
+}
+
+// One database with two tables (deliberately unsorted), a second database that shares a table NAME
+// (`shared`) with the first, and an empty database.
+const map: InstanceDatabaseMap = {
+	beta: { shared: table('beta', 'shared') },
+	alpha: { widgets: table('alpha', 'widgets'), shared: table('alpha', 'shared') },
+	empty: {},
+};
+
+describe('buildItems', () => {
+	it('sorts databases and tables, and mounts them under the synthetic root', () => {
+		const { items, rootId: root } = buildItems(map, { canManage: true });
+		expect(root).toBe(rootId);
+		// createTable row first, then databases alphabetically.
+		expect(items[rootId].children).toEqual([createTableId, 'alpha', 'beta', 'empty']);
+		expect(items['alpha'].isFolder).toBe(true);
+		expect(items['alpha'].children).toEqual([tableItemId('alpha', 'shared'), tableItemId('alpha', 'widgets')]);
+		expect(items['empty'].children).toEqual([]);
+	});
+
+	it('gives tables composite ids so duplicate names across databases do not collide', () => {
+		const { items } = buildItems(map, { canManage: true });
+		expect(items['alpha/shared'].data).toEqual({ kind: 'table', databaseName: 'alpha', tableName: 'shared' });
+		expect(items['beta/shared'].data).toEqual({ kind: 'table', databaseName: 'beta', tableName: 'shared' });
+		expect(items['alpha/shared'].isFolder).toBe(false);
+	});
+
+	it('omits the create-table row when the user cannot manage the instance', () => {
+		const { items } = buildItems(map, { canManage: false });
+		expect(items[rootId].children).toEqual(['alpha', 'beta', 'empty']);
+		// The item itself still exists (harmless), but it is not reachable from the root.
+		expect(items[rootId].children).not.toContain(createTableId);
+	});
+
+	it('handles an undefined map as an empty tree', () => {
+		const { items } = buildItems(undefined, { canManage: true });
+		expect(items[rootId].children).toEqual([createTableId]);
+	});
+});
+
+describe('getItemTitle', () => {
+	it('titles each kind of row', () => {
+		const { items } = buildItems(map, { canManage: true });
+		expect(getItemTitle(items[createTableId])).toBe('Create a Table');
+		expect(getItemTitle(items['alpha'])).toBe('alpha');
+		expect(getItemTitle(items['alpha/widgets'])).toBe('widgets');
+	});
+});

--- a/src/features/instance/databases/components/DatabasesTree/buildItems.ts
+++ b/src/features/instance/databases/components/DatabasesTree/buildItems.ts
@@ -1,0 +1,73 @@
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import type { TreeItem } from 'react-complex-tree';
+import { createTableId, rootId } from './specialItems';
+
+/** Discriminated union carried as each tree item's `data`. */
+export type DbTreeData =
+	| { kind: 'root' }
+	| { kind: 'createTable' }
+	| { kind: 'database'; databaseName: string }
+	| { kind: 'table'; databaseName: string; tableName: string };
+
+/**
+ * Composite id for a table row. A table name can repeat across databases, so the tree index must be
+ * unique per (database, table). `/` is safe: `schemaRegex` forbids it in database/table names, and the
+ * URL already joins `db/table` with `/`.
+ */
+export function tableItemId(databaseName: string, tableName: string): string {
+	return `${databaseName}/${tableName}`;
+}
+
+/**
+ * Convert the `describe_all` map into the flat `Record<id, TreeItem>` react-complex-tree consumes:
+ * a synthetic root whose children are an optional "Create a Table" row (management only) followed by
+ * each database (a folder of its tables).
+ */
+export function buildItems(
+	instanceDatabaseMap: InstanceDatabaseMap | undefined,
+	{ canManage }: { canManage: boolean },
+): { items: Record<string, TreeItem<DbTreeData>>; rootId: string } {
+	const items: Record<string, TreeItem<DbTreeData>> = {};
+	const databaseNames = Object.keys(instanceDatabaseMap || {}).sort();
+
+	for (const databaseName of databaseNames) {
+		const tableNames = Object.keys(instanceDatabaseMap?.[databaseName] || {}).sort();
+		items[databaseName] = {
+			index: databaseName,
+			isFolder: true,
+			children: tableNames.map(tableName => tableItemId(databaseName, tableName)),
+			data: { kind: 'database', databaseName },
+			canMove: false,
+			canRename: false,
+		};
+		for (const tableName of tableNames) {
+			const id = tableItemId(databaseName, tableName);
+			items[id] = {
+				index: id,
+				isFolder: false,
+				data: { kind: 'table', databaseName, tableName },
+				canMove: false,
+				canRename: false,
+			};
+		}
+	}
+
+	items[createTableId] = {
+		index: createTableId,
+		isFolder: false,
+		data: { kind: 'createTable' },
+		canMove: false,
+		canRename: false,
+	};
+
+	items[rootId] = {
+		index: rootId,
+		isFolder: true,
+		children: [...(canManage ? [createTableId] : []), ...databaseNames],
+		data: { kind: 'root' },
+		canMove: false,
+		canRename: false,
+	};
+
+	return { items, rootId };
+}

--- a/src/features/instance/databases/components/DatabasesTree/getItemTitle.ts
+++ b/src/features/instance/databases/components/DatabasesTree/getItemTitle.ts
@@ -1,0 +1,15 @@
+import type { TreeItem } from 'react-complex-tree';
+import type { DbTreeData } from './buildItems';
+
+export function getItemTitle(item: TreeItem<DbTreeData>): string {
+	switch (item.data.kind) {
+		case 'createTable':
+			return 'Create a Table';
+		case 'database':
+			return item.data.databaseName;
+		case 'table':
+			return item.data.tableName;
+		default:
+			return '';
+	}
+}

--- a/src/features/instance/databases/components/DatabasesTree/index.tsx
+++ b/src/features/instance/databases/components/DatabasesTree/index.tsx
@@ -1,0 +1,95 @@
+import { ItemArrow } from '@/features/instance/applications/components/ApplicationsSidebar/ItemArrow';
+import '@/features/instance/applications/components/ApplicationsSidebar/file-explorer-modern.css';
+import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { setWatchedValue } from '@/lib/events/watcher';
+import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { CSSProperties, useCallback, useMemo } from 'react';
+import { ControlledTreeEnvironment, InteractionMode, Tree, TreeItemIndex } from 'react-complex-tree';
+import { buildItems, DbTreeData } from './buildItems';
+import { DatabaseTreeContextMenu } from './DatabaseTreeContextMenu';
+import { getItemTitle } from './getItemTitle';
+import { ItemTitle } from './ItemTitle';
+import { useDatabaseTreeViewState } from './useDatabaseTreeViewState';
+
+// The shared `.app-tree-scroll` styling insets the scrollbar for the applications drop target; the
+// databases tree has none, so zero it out.
+const scrollStyle = { '--rct-drop-target-height': '0px' } as CSSProperties;
+
+export function DatabasesTree({ instanceDatabaseMap }: { instanceDatabaseMap?: InstanceDatabaseMap }) {
+	const params: {
+		clusterId?: string;
+		instanceId?: string;
+		organizationId?: string;
+		databaseName?: string;
+		tableName?: string;
+	} = useParams({ strict: false });
+	const navigate = useNavigate();
+	const canManage = useInstanceBrowseManagePermission();
+
+	const { items, rootId } = useMemo(
+		() => buildItems(instanceDatabaseMap, { canManage }),
+		[instanceDatabaseMap, canManage],
+	);
+	const { focusedItem, setFocusedItem, expandedItems, setExpandedItems, selectedItems } = useDatabaseTreeViewState(
+		params,
+	);
+
+	const goTo = useCallback((databaseName?: string, tableName?: string) => {
+		void navigate({ to: buildAbsoluteLinkToDatabasePage({ ...params, databaseName, tableName }) });
+	}, [navigate, params]);
+
+	// Single-click "selects" a row (see DoubleClickItemToExpandInteractionManager): a database navigates
+	// to its overview, a table to its data grid, and the synthetic row opens the create-table modal.
+	const onActivateItem = useCallback((data: DbTreeData) => {
+		switch (data.kind) {
+			case 'createTable':
+				setWatchedValue('ShowCreateTable', { databaseName: params.databaseName });
+				break;
+			case 'database':
+				if (params.databaseName !== data.databaseName || params.tableName) {
+					goTo(data.databaseName, undefined);
+				}
+				break;
+			case 'table':
+				if (params.databaseName !== data.databaseName || params.tableName !== data.tableName) {
+					goTo(data.databaseName, data.tableName);
+				}
+				break;
+		}
+	}, [params.databaseName, params.tableName, goTo]);
+
+	const onSelectItems = useCallback((selected: TreeItemIndex[]) => {
+		const id = selected[selected.length - 1];
+		const data = id !== undefined ? items[id]?.data : undefined;
+		if (data) {
+			onActivateItem(data);
+		}
+	}, [items, onActivateItem]);
+
+	return (
+		<div className="app-tree-scroll h-full overflow-auto pr-1.5" style={scrollStyle}>
+			<DatabaseTreeContextMenu items={items} instanceDatabaseMap={instanceDatabaseMap}>
+				<ControlledTreeEnvironment
+					canDragAndDrop={false}
+					canReorderItems={false}
+					canSearch={true}
+					canRename={false}
+					defaultInteractionMode={InteractionMode.DoubleClickItemToExpand}
+					getItemTitle={getItemTitle}
+					items={items}
+					renderItemArrow={ItemArrow}
+					renderItemTitle={ItemTitle}
+					viewState={{ databasesTree: { focusedItem, expandedItems, selectedItems } }}
+					onFocusItem={item => setFocusedItem(item.index)}
+					onExpandItem={item => setExpandedItems(prev => (prev.includes(item.index) ? prev : [...prev, item.index]))}
+					onCollapseItem={item => setExpandedItems(prev => prev.filter(index => index !== item.index))}
+					onSelectItems={onSelectItems}
+				>
+					<Tree treeId="databasesTree" rootItem={rootId} treeLabel="Databases tree" />
+				</ControlledTreeEnvironment>
+			</DatabaseTreeContextMenu>
+		</div>
+	);
+}

--- a/src/features/instance/databases/components/DatabasesTree/specialItems.ts
+++ b/src/features/instance/databases/components/DatabasesTree/specialItems.ts
@@ -1,0 +1,2 @@
+export const rootId = '__db_root__';
+export const createTableId = '__create_table__';

--- a/src/features/instance/databases/components/DatabasesTree/useDatabaseTreeViewState.ts
+++ b/src/features/instance/databases/components/DatabasesTree/useDatabaseTreeViewState.ts
@@ -1,0 +1,48 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { useSessionStorage } from '@/hooks/useSessionStorage';
+import { useEffect, useMemo, useState } from 'react';
+import type { TreeItemIndex } from 'react-complex-tree';
+import { tableItemId } from './buildItems';
+
+/**
+ * Owns the controlled tree view state (focus / expansion / selection). Selection is derived from the
+ * route (the open database/table is the selected row); expansion is persisted per instance in session
+ * storage. Navigation itself lives in the tree component -- this hook only tracks state.
+ */
+export function useDatabaseTreeViewState({ databaseName, tableName }: {
+	databaseName?: string;
+	tableName?: string;
+}) {
+	const { entityId } = useInstanceClientIdParams();
+
+	const selectedItems = useMemo<TreeItemIndex[]>(() => {
+		if (databaseName && tableName) {
+			return [tableItemId(databaseName, tableName)];
+		}
+		if (databaseName) {
+			return [databaseName];
+		}
+		return [];
+	}, [databaseName, tableName]);
+
+	const [focusedItem, setFocusedItem] = useState<TreeItemIndex | undefined>(selectedItems[0]);
+	// Re-sync keyboard focus to the open row whenever the route changes (deep link, nav from elsewhere).
+	useEffect(() => {
+		if (selectedItems[0] !== undefined) {
+			setFocusedItem(selectedItems[0]);
+		}
+	}, [selectedItems]);
+
+	const [expandedItems, setExpandedItems] = useSessionStorage(
+		`DatabaseTreeExpanded/${entityId}` as 'DatabaseTreeExpanded/{entityId}',
+		(databaseName ? [databaseName] : []) as TreeItemIndex[],
+	);
+	// The active database must always be expanded (e.g. deep-linking into a collapsed one).
+	useEffect(() => {
+		if (databaseName) {
+			setExpandedItems(prev => (prev.includes(databaseName) ? prev : [...prev, databaseName]));
+		}
+	}, [databaseName, setExpandedItems]);
+
+	return { focusedItem, setFocusedItem, expandedItems, setExpandedItems, selectedItems };
+}

--- a/src/features/instance/databases/components/TableContextMenuItems.tsx
+++ b/src/features/instance/databases/components/TableContextMenuItems.tsx
@@ -1,0 +1,65 @@
+import { ContextMenuItem, ContextMenuSeparator } from '@/components/ui/contextMenu';
+import { formatBrowseDataTableHeader } from '@/features/instance/databases/functions/formatBrowseDataTableHeader';
+import { useExportTableCsv } from '@/features/instance/databases/hooks/useExportTableCsv';
+import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { setWatchedValue } from '@/lib/events/watcher';
+import { useParams } from '@tanstack/react-router';
+import { CloudDownloadIcon, CloudUploadIcon, PlusIcon, TrashIcon } from 'lucide-react';
+
+/**
+ * The per-table right-click actions (Add Records / Import / Export CSV / Drop Table), shared by the
+ * sidebar tree and the database overview's table list so both menus stay identical. Fires the same
+ * target-carrying watched values the toolbar uses; Export runs the shared CSV hook directly.
+ * Renders only `ContextMenuItem`s, so it must live inside a `ContextMenuContent`.
+ */
+export function TableContextMenuItems({ databaseName, tableName, instanceDatabaseMap }: {
+	databaseName: string;
+	tableName: string;
+	instanceDatabaseMap?: InstanceDatabaseMap;
+}) {
+	const { clusterId, instanceId }: { clusterId?: string; instanceId?: string } = useParams({ strict: false });
+	const canManage = useInstanceBrowseManagePermission();
+	const canInsert = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'insert');
+	const { exportCsv } = useExportTableCsv();
+
+	const isLastTable = Object.keys(instanceDatabaseMap?.[databaseName] || {}).length <= 1;
+
+	const onExport = () => {
+		const { primaryKey } = formatBrowseDataTableHeader(instanceDatabaseMap?.[databaseName]?.[tableName]);
+		void exportCsv({ databaseName, tableName, primaryKey, conditions: null });
+	};
+
+	return (
+		<>
+			{canInsert && (
+				<ContextMenuItem onSelect={() => setWatchedValue('ShowAddTableRecords', { databaseName, tableName })}>
+					<PlusIcon />
+					Add New Record(s)
+				</ContextMenuItem>
+			)}
+			{canInsert && (
+				<ContextMenuItem onSelect={() => setWatchedValue('ShowImportData', { databaseName, tableName })}>
+					<CloudUploadIcon />
+					Import Data
+				</ContextMenuItem>
+			)}
+			<ContextMenuItem onSelect={onExport}>
+				<CloudDownloadIcon />
+				Export CSV
+			</ContextMenuItem>
+			{canManage && !isLastTable && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem
+						variant="destructive"
+						onSelect={() => setWatchedValue('ShowDeleteTable', { databaseName, tableName })}
+					>
+						<TrashIcon />
+						Drop Table
+					</ContextMenuItem>
+				</>
+			)}
+		</>
+	);
+}

--- a/src/features/instance/databases/components/TableRowContextMenu.tsx
+++ b/src/features/instance/databases/components/TableRowContextMenu.tsx
@@ -1,0 +1,55 @@
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@/components/ui/contextMenu';
+import { TableContextMenuItems } from '@/features/instance/databases/components/TableContextMenuItems';
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { ReactNode, useCallback, useState } from 'react';
+
+/**
+ * Wraps the database overview's table list so right-clicking a table row opens the same actions menu
+ * as right-clicking that table in the sidebar tree. Resolves the clicked row from a `data-table-name`
+ * attribute the caller puts on each row. `modal={false}` (as in the tree menu) keeps a menu-opened
+ * Dialog from leaving `pointer-events: none` stuck on <body>.
+ */
+export function TableRowContextMenu({ databaseName, instanceDatabaseMap, children }: {
+	databaseName: string;
+	instanceDatabaseMap?: InstanceDatabaseMap;
+	children: ReactNode;
+}) {
+	const [tableName, setTableName] = useState<string | undefined>(undefined);
+	// Bumped to the cursor position on every right-click so the content remounts and re-anchors there
+	// -- without it Radix leaves an already-open menu at its first position.
+	const [anchorKey, setAnchorKey] = useState('');
+
+	const onContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+		const name = (event.target as HTMLElement).closest('[data-table-name]')?.getAttribute('data-table-name');
+		if (!name) {
+			setTableName(undefined);
+			event.preventDefault();
+			return;
+		}
+		setTableName(name);
+		setAnchorKey(`${event.clientX},${event.clientY}`);
+	}, []);
+
+	return (
+		<ContextMenu modal={false}>
+			<ContextMenuTrigger asChild>
+				<div onContextMenu={onContextMenu}>
+					{children}
+				</div>
+			</ContextMenuTrigger>
+			{tableName && (
+				<ContextMenuContent
+					key={anchorKey}
+					className="min-w-44"
+					onCloseAutoFocus={event => event.preventDefault()}
+				>
+					<TableContextMenuItems
+						databaseName={databaseName}
+						tableName={tableName}
+						instanceDatabaseMap={instanceDatabaseMap}
+					/>
+				</ContextMenuContent>
+			)}
+		</ContextMenu>
+	);
+}

--- a/src/features/instance/databases/functions/resolveDatabasesRedirect.test.ts
+++ b/src/features/instance/databases/functions/resolveDatabasesRedirect.test.ts
@@ -1,0 +1,50 @@
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+import { resolveDatabasesRedirect } from './resolveDatabasesRedirect';
+
+// Only key presence matters to the redirect logic, so minimal stand-ins suffice.
+const map = {
+	beta: { orders: {} },
+	alpha: { widgets: {}, shared: {} },
+	empty: {},
+} as unknown as InstanceDatabaseMap;
+
+describe('resolveDatabasesRedirect', () => {
+	it('does not redirect before the map has loaded', () => {
+		expect(resolveDatabasesRedirect(undefined, {})).toBeNull();
+	});
+
+	it('does not redirect when the instance has no databases', () => {
+		expect(resolveDatabasesRedirect({} as InstanceDatabaseMap, {})).toBeNull();
+	});
+
+	it('lands on the first database (sorted) when nothing is selected', () => {
+		expect(resolveDatabasesRedirect(map, {})).toEqual({ databaseName: 'alpha', tableName: undefined });
+	});
+
+	it('falls back to the first database when the selected one no longer exists', () => {
+		expect(resolveDatabasesRedirect(map, { databaseName: 'ghost' })).toEqual({
+			databaseName: 'alpha',
+			tableName: undefined,
+		});
+	});
+
+	it('drops a table that no longer exists, keeping the database', () => {
+		expect(resolveDatabasesRedirect(map, { databaseName: 'alpha', tableName: 'ghost' })).toEqual({
+			databaseName: 'alpha',
+			tableName: undefined,
+		});
+	});
+
+	it('stays put on a valid database with no table (its overview)', () => {
+		expect(resolveDatabasesRedirect(map, { databaseName: 'alpha' })).toBeNull();
+	});
+
+	it('stays put on a valid database and table', () => {
+		expect(resolveDatabasesRedirect(map, { databaseName: 'alpha', tableName: 'widgets' })).toBeNull();
+	});
+
+	it('stays put on an empty database (shows its overview, no redirect loop)', () => {
+		expect(resolveDatabasesRedirect(map, { databaseName: 'empty' })).toBeNull();
+	});
+});

--- a/src/features/instance/databases/functions/resolveDatabasesRedirect.ts
+++ b/src/features/instance/databases/functions/resolveDatabasesRedirect.ts
@@ -1,0 +1,34 @@
+import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
+
+/**
+ * Decides where the Databases tab should redirect, given the loaded database map and the current
+ * route params. Returns the `{ databaseName, tableName }` overrides to navigate to, or `null` to stay.
+ *
+ * - Nothing selected, or a database that no longer exists (stale link / just dropped) -> first database.
+ * - A valid database but a table that no longer exists -> that database's overview (drop the table).
+ * - Otherwise (valid db, valid-or-absent table, or no databases at all) -> stay put.
+ *
+ * Every redirect strictly narrows toward a valid target, so it can never loop.
+ */
+export function resolveDatabasesRedirect(
+	instanceDatabaseMap: InstanceDatabaseMap | undefined,
+	params: { databaseName?: string; tableName?: string },
+): { databaseName: string; tableName: undefined } | null {
+	if (!instanceDatabaseMap) {
+		return null;
+	}
+	const databaseExists = !!(params.databaseName && instanceDatabaseMap[params.databaseName]);
+	if (!databaseExists) {
+		const firstDatabaseName = Object.keys(instanceDatabaseMap).sort()[0];
+		// No redirect when there are no databases at all, or the fallback would land on the same
+		// (nonexistent) name we're already on -- both would otherwise loop.
+		if (firstDatabaseName && firstDatabaseName !== params.databaseName) {
+			return { databaseName: firstDatabaseName, tableName: undefined };
+		}
+		return null;
+	}
+	if (params.tableName && !instanceDatabaseMap[params.databaseName!][params.tableName]) {
+		return { databaseName: params.databaseName!, tableName: undefined };
+	}
+	return null;
+}

--- a/src/features/instance/databases/hooks/useExportTableCsv.ts
+++ b/src/features/instance/databases/hooks/useExportTableCsv.ts
@@ -53,7 +53,9 @@ export function useExportTableCsv() {
 				downloadLink.href = url;
 				downloadLink.setAttribute('download', `${databaseName}.${tableName}.${new Date().toISOString()}.csv`);
 				downloadLink.click();
-				URL.revokeObjectURL(url);
+				// Defer revocation: revoking synchronously can cancel the download before some browsers
+				// (Firefox, iOS Safari) have started fetching the blob.
+				setTimeout(() => URL.revokeObjectURL(url), 1000);
 				toast.success('CSV Exported!', { id });
 			} catch (err) {
 				toast.error(err instanceof Error ? err.message : 'Failed to export CSV', { id });

--- a/src/features/instance/databases/hooks/useExportTableCsv.ts
+++ b/src/features/instance/databases/hooks/useExportTableCsv.ts
@@ -1,0 +1,68 @@
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { getSearchByConditions, SearchCondition } from '@/integrations/api/instance/database/getSearchByConditions';
+import { getSearchByValue } from '@/integrations/api/instance/database/getSearchByValue';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+interface ExportTableCsvParams {
+	databaseName: string;
+	tableName: string;
+	primaryKey: string;
+	/** Defaults to primary-key order (natural order) when omitted. */
+	sort?: { attribute: string; descending: boolean };
+	/** When provided, exports the filtered result set; otherwise the whole table. */
+	conditions?: SearchCondition[] | null;
+}
+
+/**
+ * Shared "download this table as CSV" plumbing, lifted out of the table view so both the right-pane
+ * toolbar (which passes the active filters/sort) and the tree context menu (which exports the whole
+ * table) can trigger it. Fetches every row with an `Accept: text/csv` header and downloads the blob.
+ */
+export function useExportTableCsv() {
+	const instanceParams = useInstanceClientIdParams();
+	const [isExporting, setIsExporting] = useState(false);
+
+	const exportCsv = useCallback(
+		async ({ databaseName, tableName, primaryKey, sort, conditions }: ExportTableCsvParams) => {
+			if (!primaryKey) {
+				toast.error(`Cannot export "${tableName}": no primary key found.`);
+				return;
+			}
+			const id = toast.loading('Loading CSV...');
+			setIsExporting(true);
+			try {
+				const base = {
+					...instanceParams,
+					databaseName,
+					tableName,
+					sort: sort ?? { attribute: primaryKey, descending: false },
+					pageIndex: 0,
+					pageSize: 1_000_000,
+					onlyIfCached: false,
+					headers: { Accept: 'text/csv' },
+				};
+				const response = await (conditions?.length
+					? getSearchByConditions({ ...base, conditions })
+					: getSearchByValue({ ...base, searchAttribute: primaryKey }));
+				toast.loading('Preparing CSV...', { id });
+				const content = response.data as unknown as string;
+				const blob = new Blob([content], { type: 'text/csv' });
+				const url = URL.createObjectURL(blob);
+				const downloadLink = document.createElement('a');
+				downloadLink.href = url;
+				downloadLink.setAttribute('download', `${databaseName}.${tableName}.${new Date().toISOString()}.csv`);
+				downloadLink.click();
+				URL.revokeObjectURL(url);
+				toast.success('CSV Exported!', { id });
+			} catch (err) {
+				toast.error(err instanceof Error ? err.message : 'Failed to export CSV', { id });
+			} finally {
+				setIsExporting(false);
+			}
+		},
+		[instanceParams],
+	);
+
+	return { exportCsv, isExporting };
+}

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -3,6 +3,8 @@ import { getDescribeAllQueryOptions } from '@/integrations/api/instance/database
 import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
 import { useQuery } from '@tanstack/react-query';
 import { Navigate, useParams } from '@tanstack/react-router';
+import { DatabaseActionModals } from './components/DatabaseActionModals';
+import { DatabaseOverview } from './components/DatabaseOverview';
 import { DatabasesSidebar } from './components/DatabasesSidebar';
 import { DatabaseTableView } from './components/DatabaseTableView';
 
@@ -16,50 +18,63 @@ export function Databases() {
 
 	const instanceParams = useInstanceClientIdParams();
 	// Skip the per-table record-count scan here: the sidebar and table view only need schema to render,
-	// and the selected table's count is fetched separately (see DatabaseTableView) so a slow count never
-	// blocks the database tree or the first page of records from appearing.
+	// and the selected table's count is fetched separately (see DatabaseTableView / DatabaseOverview) so
+	// a slow count never blocks the database tree or the first page of records from appearing.
 	const { data: instanceDatabaseMap } = useQuery(
 		getDescribeAllQueryOptions({ ...instanceParams, skipRecordCount: true }),
 	);
 
-	let newDatabaseName: string | undefined;
-	let newTableName: string | undefined;
 	if (instanceDatabaseMap) {
-		if (!params.databaseName) {
-			newDatabaseName = Object.keys(instanceDatabaseMap).sort()[0];
+		// Land on the first database's overview when nothing is selected, and recover from a stale link to
+		// a database that no longer exists (e.g. just dropped) by falling back to the first one.
+		const databaseExists = params.databaseName && instanceDatabaseMap[params.databaseName];
+		if (!databaseExists) {
+			const firstDatabaseName = Object.keys(instanceDatabaseMap).sort()[0];
+			if (firstDatabaseName && firstDatabaseName !== params.databaseName) {
+				return (
+					<Navigate
+						to={buildAbsoluteLinkToDatabasePage({ ...params, databaseName: firstDatabaseName, tableName: undefined })}
+						replace={true}
+					/>
+				);
+			}
+		} else if (params.tableName && !instanceDatabaseMap[params.databaseName!][params.tableName]) {
+			// Database exists but the table doesn't (stale link / dropped table): show the DB overview.
+			return (
+				<Navigate
+					to={buildAbsoluteLinkToDatabasePage({ ...params, tableName: undefined })}
+					replace={true}
+				/>
+			);
 		}
-		const databaseName = params.databaseName ?? newDatabaseName;
-		if (!params.tableName && databaseName && instanceDatabaseMap[databaseName]) {
-			newTableName = Object.keys(instanceDatabaseMap[databaseName]).sort()[0];
-		}
-	}
-	if (newDatabaseName || newTableName) {
-		return (
-			<Navigate
-				to={buildAbsoluteLinkToDatabasePage({
-					...params,
-					databaseName: newDatabaseName ?? params.databaseName,
-					tableName: newTableName,
-				})}
-				replace={true}
-			/>
-		);
 	}
 
 	return (
-		<main className="grid grid-cols-1 gap-4 md:grid-cols-12 md:items-start">
-			<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden">
-				<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
-			</section>
-			<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9 flex flex-col min-h-0">
-				{params.databaseName && params.tableName && (
-					<DatabaseTableView
-						instanceDatabaseMap={instanceDatabaseMap}
-						databaseName={params.databaseName}
-						tableName={params.tableName}
-					/>
-				)}
-			</section>
-		</main>
+		<>
+			<main className="grid grid-cols-1 gap-4 md:grid-cols-12 md:items-start">
+				<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden">
+					<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
+				</section>
+				<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9 flex flex-col min-h-0">
+					{params.databaseName && params.tableName
+						? (
+							<DatabaseTableView
+								instanceDatabaseMap={instanceDatabaseMap}
+								databaseName={params.databaseName}
+								tableName={params.tableName}
+							/>
+						)
+						: params.databaseName
+						? (
+							<DatabaseOverview
+								instanceDatabaseMap={instanceDatabaseMap}
+								databaseName={params.databaseName}
+							/>
+						)
+						: null}
+				</section>
+			</main>
+			{instanceDatabaseMap && <DatabaseActionModals instanceDatabaseMap={instanceDatabaseMap} />}
+		</>
 	);
 }

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -7,6 +7,7 @@ import { DatabaseActionModals } from './components/DatabaseActionModals';
 import { DatabaseOverview } from './components/DatabaseOverview';
 import { DatabasesSidebar } from './components/DatabasesSidebar';
 import { DatabaseTableView } from './components/DatabaseTableView';
+import { resolveDatabasesRedirect } from './functions/resolveDatabasesRedirect';
 
 export function Databases() {
 	const params: {
@@ -24,29 +25,16 @@ export function Databases() {
 		getDescribeAllQueryOptions({ ...instanceParams, skipRecordCount: true }),
 	);
 
-	if (instanceDatabaseMap) {
-		// Land on the first database's overview when nothing is selected, and recover from a stale link to
-		// a database that no longer exists (e.g. just dropped) by falling back to the first one.
-		const databaseExists = params.databaseName && instanceDatabaseMap[params.databaseName];
-		if (!databaseExists) {
-			const firstDatabaseName = Object.keys(instanceDatabaseMap).sort()[0];
-			if (firstDatabaseName && firstDatabaseName !== params.databaseName) {
-				return (
-					<Navigate
-						to={buildAbsoluteLinkToDatabasePage({ ...params, databaseName: firstDatabaseName, tableName: undefined })}
-						replace={true}
-					/>
-				);
-			}
-		} else if (params.tableName && !instanceDatabaseMap[params.databaseName!][params.tableName]) {
-			// Database exists but the table doesn't (stale link / dropped table): show the DB overview.
-			return (
-				<Navigate
-					to={buildAbsoluteLinkToDatabasePage({ ...params, tableName: undefined })}
-					replace={true}
-				/>
-			);
-		}
+	// Land on the first database's overview when nothing is selected, and recover from stale links to a
+	// dropped database/table (see resolveDatabasesRedirect for the exact rules + loop-freedom).
+	const redirect = resolveDatabasesRedirect(instanceDatabaseMap, params);
+	if (redirect) {
+		return (
+			<Navigate
+				to={buildAbsoluteLinkToDatabasePage({ ...params, ...redirect })}
+				replace={true}
+			/>
+		);
 	}
 
 	return (

--- a/src/features/instance/databases/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/databases/modals/CreateNewTableModal.tsx
@@ -23,7 +23,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Table } from 'lucide-react';
-import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -50,6 +49,8 @@ export function CreateNewTableModal({ isModalOpen, setIsModalOpen, databaseName,
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();
 	const router = useRouter();
+	// The action-modal hub remounts this per target (via a `key`), so the form's defaultValues seed the
+	// prefilled database correctly on each open -- no manual reset effect needed.
 	const form = useForm({
 		resolver: zodResolver(CreateTableSchema),
 		defaultValues: {
@@ -58,16 +59,6 @@ export function CreateNewTableModal({ isModalOpen, setIsModalOpen, databaseName,
 			primaryKey: '',
 		},
 	});
-
-	// This modal is mounted persistently (not remounted per trigger), so re-seed the form with the
-	// target database each time it opens -- otherwise a right-click on a different database would keep
-	// the previously-prefilled name.
-	const { reset } = form;
-	useEffect(() => {
-		if (isModalOpen) {
-			reset({ databaseName: databaseName || '', tableName: '', primaryKey: '' });
-		}
-	}, [isModalOpen, databaseName, reset]);
 
 	const { mutate: submitNewTableData } = useCreateTableMutation();
 

--- a/src/features/instance/databases/modals/CreateNewTableModal.tsx
+++ b/src/features/instance/databases/modals/CreateNewTableModal.tsx
@@ -6,7 +6,6 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
-	DialogTrigger,
 } from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form/Form';
 import { FormControl } from '@/components/ui/form/FormControl';
@@ -23,8 +22,8 @@ import { tableNameSchema } from '@/integrations/api/instance/database/tableNameS
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { Plus, Table } from 'lucide-react';
-import { useState } from 'react';
+import { Table } from 'lucide-react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -42,14 +41,15 @@ const CreateTableSchema = z.object({
 		}),
 });
 
-export function CreateNewTableModal({ databaseName, onSelectTable }: {
+export function CreateNewTableModal({ isModalOpen, setIsModalOpen, databaseName, onCreated }: {
+	readonly isModalOpen: boolean;
+	readonly setIsModalOpen: (open: boolean) => void;
 	readonly databaseName: string | undefined;
-	readonly onSelectTable: (databaseName: string | undefined, tableName: string | undefined) => void;
+	readonly onCreated: (databaseName: string, tableName: string) => void;
 }) {
 	const queryClient = useQueryClient();
 	const instanceParams = useInstanceClientIdParams();
 	const router = useRouter();
-	const [isModalOpen, setIsModalOpen] = useState(false);
 	const form = useForm({
 		resolver: zodResolver(CreateTableSchema),
 		defaultValues: {
@@ -58,6 +58,16 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 			primaryKey: '',
 		},
 	});
+
+	// This modal is mounted persistently (not remounted per trigger), so re-seed the form with the
+	// target database each time it opens -- otherwise a right-click on a different database would keep
+	// the previously-prefilled name.
+	const { reset } = form;
+	useEffect(() => {
+		if (isModalOpen) {
+			reset({ databaseName: databaseName || '', tableName: '', primaryKey: '' });
+		}
+	}, [isModalOpen, databaseName, reset]);
 
 	const { mutate: submitNewTableData } = useCreateTableMutation();
 
@@ -79,7 +89,7 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 				toast.success(`Table ${tableName} created successfully`);
 				setIsModalOpen(false);
 				form.reset();
-				onSelectTable(databaseName, tableName);
+				onCreated(databaseName, tableName);
 				await router.invalidate();
 			},
 		});
@@ -87,16 +97,6 @@ export function CreateNewTableModal({ databaseName, onSelectTable }: {
 
 	return (
 		<Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-			<DialogTrigger asChild>
-				<div className="shrink-0 py-4">
-					<Button variant="positiveOutline" className="w-full" size="lg" accessKey="t">
-						<Plus />
-						<span>
-							Create a <u>T</u>able
-						</span>
-					</Button>
-				</div>
-			</DialogTrigger>
 			<DialogContent className="sm:max-w-[425px]">
 				<DialogHeader>
 					<DialogTitle>Create a New Table</DialogTitle>

--- a/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
+++ b/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
@@ -2,7 +2,6 @@ import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { useDeleteDatabaseMutation } from '@/integrations/api/instance/database/deleteDatabase';
-import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -12,13 +11,14 @@ import { toast } from 'sonner';
 export function DeleteDatabaseModal({ onDeleted }: {
 	readonly onDeleted: (dropped: { databaseName: string }) => void;
 }) {
-	const { value: target, trigger } = useWatchedValue('ShowDeleteDatabase', false);
+	const { value: target } = useWatchedValue('ShowDeleteDatabase', false);
 	const isModalOpen = !!target;
 	const databaseName = target ? target.databaseName : '';
+	// The confirmation dialog (Radix) restores focus to the invoking control on close on its own; no
+	// manual trigger plumbing needed now that callers fire this via a target payload.
 	const closeModal = useCallback(() => {
 		setWatchedValue('ShowDeleteDatabase', false);
-		attemptToRestoreFocus(trigger);
-	}, [trigger]);
+	}, []);
 
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	const queryClient = useQueryClient();

--- a/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
+++ b/src/features/instance/databases/modals/DeleteDatabaseModal.tsx
@@ -9,11 +9,12 @@ import { useRouter } from '@tanstack/react-router';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-export function DeleteDatabaseModal({ databaseName, onDeleted }: {
-	readonly databaseName: string;
-	readonly onDeleted: (deleted: 'table' | 'database') => void;
+export function DeleteDatabaseModal({ onDeleted }: {
+	readonly onDeleted: (dropped: { databaseName: string }) => void;
 }) {
-	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteDatabase', false);
+	const { value: target, trigger } = useWatchedValue('ShowDeleteDatabase', false);
+	const isModalOpen = !!target;
+	const databaseName = target ? target.databaseName : '';
 	const closeModal = useCallback(() => {
 		setWatchedValue('ShowDeleteDatabase', false);
 		attemptToRestoreFocus(trigger);
@@ -39,7 +40,7 @@ export function DeleteDatabaseModal({ databaseName, onDeleted }: {
 				});
 				await router.invalidate();
 				toast.success(`Database ${databaseName} dropped successfully`);
-				onDeleted('database');
+				onDeleted({ databaseName });
 			},
 		});
 	}, [closeModal, databaseName, deleteDatabase, instanceParams, onDeleted, queryClient, router]);

--- a/src/features/instance/databases/modals/DeleteTableModal.tsx
+++ b/src/features/instance/databases/modals/DeleteTableModal.tsx
@@ -2,7 +2,6 @@ import { ConfirmDeletionModal } from '@/components/ConfirmDeletionModal';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { useDeleteTableMutation } from '@/integrations/api/instance/database/deleteTable';
-import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
@@ -12,14 +11,15 @@ import { toast } from 'sonner';
 export function DeleteTableModal({ onDeleted }: {
 	readonly onDeleted: (dropped: { databaseName: string; tableName: string }) => void;
 }) {
-	const { value: target, trigger } = useWatchedValue('ShowDeleteTable', false);
+	const { value: target } = useWatchedValue('ShowDeleteTable', false);
 	const isModalOpen = !!target;
 	const databaseName = target ? target.databaseName : '';
 	const tableName = target ? target.tableName : '';
+	// The confirmation dialog (Radix) restores focus to the invoking control on close on its own; no
+	// manual trigger plumbing needed now that callers fire this via a target payload.
 	const closeModal = useCallback(() => {
 		setWatchedValue('ShowDeleteTable', false);
-		attemptToRestoreFocus(trigger);
-	}, [trigger]);
+	}, []);
 
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	const queryClient = useQueryClient();

--- a/src/features/instance/databases/modals/DeleteTableModal.tsx
+++ b/src/features/instance/databases/modals/DeleteTableModal.tsx
@@ -9,12 +9,13 @@ import { useRouter } from '@tanstack/react-router';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 
-export function DeleteTableModal({ databaseName, tableName, onDeleted }: {
-	readonly databaseName: string;
-	readonly tableName: string;
-	readonly onDeleted: (deleted: 'table' | 'database') => void;
+export function DeleteTableModal({ onDeleted }: {
+	readonly onDeleted: (dropped: { databaseName: string; tableName: string }) => void;
 }) {
-	const { value: isModalOpen, trigger } = useWatchedValue('ShowDeleteTable', false);
+	const { value: target, trigger } = useWatchedValue('ShowDeleteTable', false);
+	const isModalOpen = !!target;
+	const databaseName = target ? target.databaseName : '';
+	const tableName = target ? target.tableName : '';
 	const closeModal = useCallback(() => {
 		setWatchedValue('ShowDeleteTable', false);
 		attemptToRestoreFocus(trigger);
@@ -43,7 +44,7 @@ export function DeleteTableModal({ databaseName, tableName, onDeleted }: {
 					});
 					await router.invalidate();
 					toast.success(`Table ${tableName} dropped successfully`);
-					onDeleted('table');
+					onDeleted({ databaseName, tableName });
 				},
 			},
 		);

--- a/src/hooks/checkSchemaTablePermission.test.ts
+++ b/src/hooks/checkSchemaTablePermission.test.ts
@@ -1,0 +1,41 @@
+import { LocalRolePermission } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+import { checkSchemaTablePermission } from './checkSchemaTablePermission';
+
+// The index-signature/boolean-flag shape of LocalRolePermission is awkward to build as a literal, so
+// cast minimal stand-ins.
+function perm(value: Record<string, unknown>): LocalRolePermission {
+	return value as unknown as LocalRolePermission;
+}
+
+describe('checkSchemaTablePermission', () => {
+	it('denies while the permission is still loading', () => {
+		expect(checkSchemaTablePermission(undefined, 'data', 'dog', 'insert')).toBe(false);
+	});
+
+	it('allows super_user and structure_user regardless of the specific table', () => {
+		expect(checkSchemaTablePermission(perm({ super_user: true }), 'data', 'dog', 'insert')).toBe(true);
+		expect(checkSchemaTablePermission(perm({ structure_user: true }), 'data', 'dog', 'insert')).toBe(true);
+	});
+
+	// Regression: a restricted (non-structure_user) user whose database grant doesn't list the table
+	// used to crash on `tables[tableName][action]` (missing optional chain) -- e.g. opening a table
+	// context menu. It must simply deny.
+	it('denies (without crashing) when the database has no entry for the table', () => {
+		expect(checkSchemaTablePermission(perm({ data: { tables: {} } }), 'data', 'dog', 'insert')).toBe(false);
+	});
+
+	it('denies when the database itself is absent from the permission map', () => {
+		expect(checkSchemaTablePermission(perm({ data: { tables: {} } }), 'other', 'dog', 'insert')).toBe(false);
+	});
+
+	it('reflects the per-action flag on a granted table', () => {
+		const permission = perm({
+			data: {
+				tables: { dog: { read: true, insert: true, update: false, delete: false, attribute_permissions: null } },
+			},
+		});
+		expect(checkSchemaTablePermission(permission, 'data', 'dog', 'insert')).toBe(true);
+		expect(checkSchemaTablePermission(permission, 'data', 'dog', 'update')).toBe(false);
+	});
+});

--- a/src/hooks/checkSchemaTablePermission.ts
+++ b/src/hooks/checkSchemaTablePermission.ts
@@ -1,0 +1,24 @@
+import { LocalRolePermission, LocalRolePermissionAction } from '@/integrations/api/api.patch';
+
+/**
+ * Pure table-permission check, kept out of `usePermissions` (and its auth-store imports) so the
+ * restricted-user path is unit-testable in isolation. A database whose `tables` map lacks the table
+ * (common for a non-`structure_user`) must return `false`, not crash -- the optional chain on
+ * `[tableName]` is load-bearing (it previously threw for any restricted user opening a table menu).
+ */
+export function checkSchemaTablePermission(
+	permission: LocalRolePermission | undefined,
+	databaseName: string,
+	tableName: string,
+	action: LocalRolePermissionAction,
+): boolean {
+	if (!permission) {
+		// If we don't yet have record of their permission, deny access.
+		// (We're probably still loading the user.)
+		return false;
+	}
+	if (permission.super_user === true || permission.structure_user === true) {
+		return true;
+	}
+	return permission[databaseName]?.tables?.[tableName]?.[action] === true;
+}

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -186,7 +186,7 @@ export function useInstanceSchemaTablePermission(
 		return true;
 	}
 	const specificPermission = permission[databaseName];
-	return specificPermission?.tables?.[tableName][action] === true;
+	return specificPermission?.tables?.[tableName]?.[action] === true;
 }
 
 export function useInstanceSchemaTableAttributePermission(
@@ -208,7 +208,7 @@ export function useInstanceSchemaTableAttributePermission(
 		return true;
 	}
 	const specificPermission = permission[databaseName];
-	if (specificPermission?.tables?.[tableName][action] === true) {
+	if (specificPermission?.tables?.[tableName]?.[action] === true) {
 		return true;
 	}
 	const table = specificPermission?.tables?.[tableName];

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,4 +1,5 @@
 import { EntityIds } from '@/features/auth/store/authStore';
+import { checkSchemaTablePermission } from '@/hooks/checkSchemaTablePermission';
 import { isAdminMode, useCloudAuth, useInstanceAuth } from '@/hooks/useAuth';
 import {
 	LocalLegacyRolePermissionTable,
@@ -176,17 +177,7 @@ export function useInstanceSchemaTablePermission(
 ): boolean {
 	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
 	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
-	const permission = user?.role?.permission;
-	if (!permission) {
-		// If we don't yet have record of their permission, deny access.
-		// (We're probably still loading the user.)
-		return false;
-	}
-	if (permission.super_user === true || permission.structure_user === true) {
-		return true;
-	}
-	const specificPermission = permission[databaseName];
-	return specificPermission?.tables?.[tableName]?.[action] === true;
+	return checkSchemaTablePermission(user?.role?.permission, databaseName, tableName, action);
 }
 
 export function useInstanceSchemaTableAttributePermission(

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -212,6 +212,9 @@ export function useInstanceSchemaTableAttributePermission(
 		return true;
 	}
 	const table = specificPermission?.tables?.[tableName];
+	if (!table) {
+		return false;
+	}
 	const attributePermission = ((table as LocalRolePermissionTable).attribute_permissions
 		|| (table as LocalLegacyRolePermissionTable).attribute_restrictions).find(a => a.attribute_name === attributeName);
 	return attributePermission?.[action] === true;

--- a/src/lib/storage/sessionStorageKeys.ts
+++ b/src/lib/storage/sessionStorageKeys.ts
@@ -8,6 +8,7 @@ export interface SessionStorageKeys {
 	'EditorFileContent/{entityId}/{path}': true;
 	'FolderOpened/{entityId}': true;
 	'FileSelected/{entityId}': true;
+	'DatabaseTreeExpanded/{entityId}': true;
 	'ColumnDisplayed/{database}/{table}': true;
 	'ShowAllOrganizations': true;
 }

--- a/src/lib/storage/watchedValueKeys.ts
+++ b/src/lib/storage/watchedValueKeys.ts
@@ -14,8 +14,13 @@ export interface WatchedValuesTypeMap {
 	ShowDownloadApplicationModal: boolean;
 	ShowRedeployApplicationModal: boolean;
 	ShowRenameFileModal: boolean;
-	ShowDeleteDatabase: boolean;
-	ShowDeleteTable: boolean;
+	// Database/table action triggers carry their target in the payload so the (single, always-mounted)
+	// modal hub can act on any tree item -- not just the currently-open table. `false` means "closed".
+	ShowDeleteDatabase: { databaseName: string } | false;
+	ShowDeleteTable: { databaseName: string; tableName: string } | false;
+	ShowCreateTable: { databaseName?: string } | false;
+	ShowAddTableRecords: { databaseName: string; tableName: string } | false;
+	ShowImportData: { databaseName?: string; tableName?: string } | false;
 	'Session:{key}': unknown;
 	ReloadApplicationRootEntries: true;
 	FocusEditor: true;


### PR DESCRIPTION
## What & why

Rebuilds the **Databases** left nav on the same `react-complex-tree` tech the Applications tab uses, and adds a **database overview page**. The old dropdown + flat table list only showed one database at a time, had no filter, and kept per-item actions in the right-pane toolbar only.

Now:
- **+ Create a Table** row at the top → **databases** as top-level items → **tables** nested underneath.
- **Type-to-filter** (the library's built-in search).
- **Single-click selects** — a database opens its new overview page, a table opens its data grid; **double-click / chevron expands** a database (the Applications model).

## Highlights

- **Database overview page** — DB size, audit size, table count, and a per-table breakdown (size, columns, primary key, last updated) with record counts backfilled lazily. Sizes/schema are instant from the `describe_all` map already loaded; counts come from a separate counted `describe_all`. Opening the tab now lands on the first database's overview.
- **Right-click menus** — databases (Create a Table, Drop Database) and tables (Add Record(s), Import Data, Export CSV, Drop Table). The table actions live in one `TableContextMenuItems` component **shared by the tree and the overview's table list**, so right-clicking a row in either place opens the same menu and they can't drift.
- **Single modal hub** — the action modals were lifted into an always-mounted `DatabaseActionModals` driven by target-carrying watched values, so an action can target **any** db/table (even one that isn't open, or an empty database), not just the currently-open one. CSV download extracted into `useExportTableCsv` (toolbar keeps its filter-aware export; the tree/overview export the whole table).
- Removed the redundant sidebar **Import Data** button (it's in the header).

## Fixes folded in

- **Context menu didn't re-anchor** on a second right-click while already open (Radix keeps it mounted through its exit animation, so it never re-measured) — the menu appeared over the wrong row. Fixed by remounting the content keyed to the cursor position. **Also applied to the Applications file tree**, which had the same bug.
- **Latent crash** in `useInstanceSchemaTablePermission` (a missing optional chain) that the new right-click menus would trigger for restricted (non-`structure_user`) users.

## No new backend operations

Everything reuses existing operations/modals (`create_table`, `drop_table`, `drop_database`, `insert`, imports, CSV export). Rename was explicitly out of scope.

## Verification

- Browser-verified end-to-end against a real cluster: tree render, type-to-filter, single/double-click, both context menus (including targeting a not-currently-open table and re-anchoring between rows), the overview stats, and the overview-row menu opening the correctly-targeted modal.
- Light + dark mode checked; the tree icons now match the Applications palette (green `+`, orange containers, neutral high-contrast leaves).
- `tsc -b`, oxlint, and dprint pass. `vitest` green (28 tests, incl. new coverage for the tree-item builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
