### PR TITLE
fix(status): fall back to the spec bucket size when rate records lack period

### DIFF
--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
@@ -40,12 +40,13 @@ describe('bytes-received spec — runPipeline', () => {
 		expect(mqtt.points[0].y, 'sum/sum across two nodes = 100 B/s').toBe(100);
 	});
 
-	it('drops records with period <= 0 (rate transform null guard)', () => {
+	it('falls back to bucket.fallbackMs for records with period <= 0 (#1444)', () => {
 		const records: AnalyticsDataPoint[] = [
 			{ time: 100_000, node: 'n1', type: 'mqtt', count: 60, mean: 50, period: 0 } as any,
 		];
 		const out = runPipeline(bytesReceivedSpec, records, window, ['n1']);
 		const mqtt = out.series.find((s) => s.key === 'mqtt')!;
-		expect(mqtt, 'no series when only record has period=0').toBe(undefined);
+		// 3000 bytes over the spec's 60 s fallback = 50 B/s — not dropped.
+		expect(mqtt.points[0].y, 'rate computed with fallbackMs when period=0').toBe(50);
 	});
 });

--- a/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
@@ -37,6 +37,17 @@ describe('rate transform period fallback (groupBy)', () => {
 		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
 	});
 
+	it('treats a non-positive fallbackMs as misconfigured and uses the 60s default', () => {
+		const spec: MetricSpec = { ...groupBySpec, bucket: { source: 'period-field', fallbackMs: 0 } };
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000 },
+		];
+		const out = runPipeline(spec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		// fallbackMs: 0 must not reintroduce the divide-by-zero drop — 60 s default applies.
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
+	});
+
 	it('treats period: 0 the same as a missing period', () => {
 		const records: AnalyticsDataPoint[] = [
 			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000, period: 0 },

--- a/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
@@ -1,0 +1,125 @@
+// Regression tests for issue #1444: records missing `period` (or carrying an
+// invalid one — 0, negative, NaN) must not be silently dropped by rate
+// transforms. The pipeline resolves the effective period via the same
+// `spec.bucket.fallbackMs ?? 60_000` convention snapToBucketTime uses.
+import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../../pipeline/pipeline.ts';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+
+const window: TimeRange = { startTime: 1_000_000, endTime: 1_060_000 };
+
+const groupBySpec: MetricSpec = {
+	title: 'Bytes (rate fallback test)',
+	description: 'groupBy spec with a rate transform',
+	tab: 'traffic',
+	primaryDimension: 'node',
+	subDimension: 'type',
+	series: {
+		kind: 'groupBy',
+		dimension: 'type',
+		field: { field: 'bytes', label: 'bytes/sec', transform: { kind: 'rate' } },
+	},
+	timestamp: 'time',
+	bucket: { source: 'period-field', fallbackMs: 60000 },
+	aggregator: { temporal: 'sum', crossNode: 'sum' },
+	primitive: 'stacked-area',
+	yAxis: { unit: 'B/s', formatter: 'bytes-si' },
+};
+
+describe('rate transform period fallback (groupBy)', () => {
+	it('computes the rate with bucket.fallbackMs when period is missing', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000 },
+		];
+		const out = runPipeline(groupBySpec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		// 120000 bytes over the 60 s fallback = 2000 B/s — not dropped.
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
+	});
+
+	it('treats period: 0 the same as a missing period', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000, period: 0 },
+		];
+		const out = runPipeline(groupBySpec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
+	});
+
+	it('treats negative and NaN periods the same as a missing period', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 60_000, period: -30_000 },
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 60_000, period: NaN },
+		];
+		const out = runPipeline(groupBySpec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		// Each record: 60000 bytes / 60 s fallback = 1000 B/s; temporal sum = 2000.
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 2 }]);
+	});
+
+	it('uses the record period unchanged when it is a positive finite number', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000, period: 30_000 },
+		];
+		const out = runPipeline(groupBySpec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		// 120000 bytes over the record's own 30 s = 4000 B/s.
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 4000, count: 1 }]);
+	});
+
+	it('honors a non-default spec fallbackMs', () => {
+		const spec: MetricSpec = { ...groupBySpec, bucket: { source: 'period-field', fallbackMs: 30_000 } };
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000 },
+		];
+		const out = runPipeline(spec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		// 120000 bytes over the spec's 30 s fallback = 4000 B/s.
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 4000, count: 1 }]);
+	});
+
+	it('defaults to 60_000 when the spec has no fallbackMs', () => {
+		const spec: MetricSpec = { ...groupBySpec, bucket: { source: 'period-field' } };
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', type: 'mqtt', bytes: 120_000 },
+		];
+		const out = runPipeline(spec, records, window, ['n1']);
+		const mqtt = out.series.find((s) => s.key === 'mqtt');
+		expect(mqtt?.points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
+	});
+});
+
+describe('rate transform period fallback (field)', () => {
+	const fieldSpec: MetricSpec = {
+		title: 'Transfer (rate fallback test)',
+		description: 'field spec with a rate transform',
+		tab: 'traffic',
+		primaryDimension: 'node',
+		series: {
+			kind: 'field',
+			fields: [{ field: 'bytes', label: 'bytes/sec', transform: { kind: 'rate' } }],
+		},
+		timestamp: 'time',
+		bucket: { source: 'period-field', fallbackMs: 60000 },
+		aggregator: { temporal: 'sum', crossNode: 'sum' },
+		primitive: 'line',
+		yAxis: { unit: 'B/s', formatter: 'bytes-si' },
+	};
+
+	it('computes the rate with bucket.fallbackMs when period is missing', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', bytes: 120_000 },
+		];
+		const out = runPipeline(fieldSpec, records, window, ['n1']);
+		expect(out.series[0].points).toEqual([{ x: 1_000_000, y: 2000, count: 1 }]);
+	});
+
+	it('mixes fallback and explicit periods within one bucket', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 1_000_000, node: 'n1', bytes: 120_000 }, // 60 s fallback → 2000 B/s
+			{ time: 1_000_000, node: 'n1', bytes: 120_000, period: 30_000 }, // → 4000 B/s
+		];
+		const out = runPipeline(fieldSpec, records, window, ['n1']);
+		expect(out.series[0].points).toEqual([{ x: 1_000_000, y: 6000, count: 2 }]);
+	});
+});

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -92,7 +92,10 @@ function snapToBucketTime(spec: MetricSpec, record: AnalyticsDataPoint, time: nu
 function resolvePeriod(spec: MetricSpec, record: AnalyticsDataPoint): number {
 	const p = record.period;
 	if (typeof p === 'number' && Number.isFinite(p) && p > 0) { return p; }
-	return spec.bucket?.fallbackMs ?? 60_000;
+	// A misconfigured non-positive fallbackMs gets the same treatment as a
+	// bad record period — rates must never divide by zero or flip sign.
+	const fallback = spec.bucket?.fallbackMs;
+	return typeof fallback === 'number' && Number.isFinite(fallback) && fallback > 0 ? fallback : 60_000;
 }
 
 /** Resolve the timestamp on a record per `spec.timestamp`. Defaults to 'time'.

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -79,11 +79,20 @@ export function runPipeline(
  *  aggregates because nodes reporting at e.g. 1:59:43, 2:00:03, 2:00:16
  *  would split across two buckets. */
 function snapToBucketTime(spec: MetricSpec, record: AnalyticsDataPoint, time: number): number {
-	let period = 0;
-	const p = record.period;
-	if (typeof p === 'number' && Number.isFinite(p) && p > 0) { period = p; }
-	if (period <= 0) { period = spec.bucket?.fallbackMs ?? 60_000; }
+	const period = resolvePeriod(spec, record);
 	return Math.round(time / period) * period;
+}
+
+/** Effective period (ms) for a record: `record.period` when it is a positive
+ *  finite number, else `spec.bucket.fallbackMs ?? 60_000`. Present-but-invalid
+ *  values (0, negative, NaN) get the same fallback as a missing field — a
+ *  Harper build omitting or zeroing `period` should degrade to the spec's
+ *  bucket size (rate transforms compute against it), not silently drop the
+ *  record. */
+function resolvePeriod(spec: MetricSpec, record: AnalyticsDataPoint): number {
+	const p = record.period;
+	if (typeof p === 'number' && Number.isFinite(p) && p > 0) { return p; }
+	return spec.bucket?.fallbackMs ?? 60_000;
 }
 
 /** Resolve the timestamp on a record per `spec.timestamp`. Defaults to 'time'.
@@ -107,14 +116,14 @@ function resolveTime(spec: MetricSpec, record: AnalyticsDataPoint): number | nul
 }
 
 function projectValue(
+	spec: MetricSpec,
 	fieldSpec: FieldSpec,
 	record: AnalyticsDataPoint,
 ): number | null {
 	const raw = typeof fieldSpec.field === 'string'
 		? (typeof record[fieldSpec.field] === 'number' ? (record[fieldSpec.field] as number) : null)
 		: evalFieldExpr(fieldSpec.field as FieldExpr, record);
-	const period = typeof record.period === 'number' ? record.period : 0;
-	return runTransform(fieldSpec.transform ?? { kind: 'raw' }, raw, period);
+	return runTransform(fieldSpec.transform ?? { kind: 'raw' }, raw, resolvePeriod(spec, record));
 }
 
 interface NodeBucket {
@@ -138,7 +147,7 @@ function runGroupBy(
 	for (const r of records) {
 		const dimVal = r[src.dimension];
 		if (typeof dimVal !== 'string' && typeof dimVal !== 'number') { continue; }
-		const v = projectValue(src.field, r);
+		const v = projectValue(spec, src.field, r);
 		if (v === null) { continue; }
 		const resolvedTime = resolveTime(spec, r);
 		if (resolvedTime === null) {
@@ -346,7 +355,7 @@ function runFieldSpecs(
 				}
 				continue;
 			}
-			const v = projectValue(f, r);
+			const v = projectValue(spec, f, r);
 			if (v === null) { continue; }
 			const recordCount = typeof r.count === 'number' && Number.isFinite(r.count) ? r.count : 1;
 			const node = typeof r.node === 'string' ? r.node : '_no_node';

--- a/src/features/instance/status/analytics/pipeline/runTransform.ts
+++ b/src/features/instance/status/analytics/pipeline/runTransform.ts
@@ -1,8 +1,11 @@
 import type { Transform } from '../types/analytics.ts';
 import { type NamedTransformKey, namedTransforms } from './transforms.ts';
 
-/** Apply a Transform to a scalar. `period` is the record's `period` field in
- *  ms; only `rate` consults it. Null input short-circuits to null. */
+/** Apply a Transform to a scalar. `period` is the record's period in ms; only
+ *  `rate` consults it. Null input short-circuits to null. The pipeline resolves
+ *  missing/invalid record periods to the spec's bucket fallback before calling
+ *  this (see `resolvePeriod` in pipeline.ts), so the non-positive guard on
+ *  `rate` is a backstop for direct callers, not a drop path in practice. */
 export function runTransform(
 	transform: Transform,
 	value: number | null,


### PR DESCRIPTION
Fixes [#1444 — Rate pipeline silently drops records missing period instead of using the spec fallback](https://github.com/HarperFast/studio/issues/1444).

## Problem

In `pipeline.ts`, `projectValue` defaulted a missing `period` to `0`, and `runTransform` returns `null` for the `rate` transform when `period <= 0` — so the record was silently skipped. This was inconsistent with `snapToBucketTime` in the same file, which falls back to `spec.bucket.fallbackMs ?? 60_000` for the same missing field, and with `derived/request-rate.tsx`, which defaults `period` to 60000. A Harper build omitting `period` would blank the bytes-sent/received, mqtt-traffic-*, and resource-usage panels with zero signal.

## Fix

- Extracted the fallback logic `snapToBucketTime` already used into a shared `resolvePeriod` helper: use `record.period` when it is a positive finite number, else `spec.bucket.fallbackMs ?? 60_000`.
- `projectValue` now takes the spec and resolves the period through that helper before calling `runTransform`, so rate transforms compute against the spec's bucket size instead of dropping the record.
- Documented the semantics for present-but-invalid periods (`0`, negative, `NaN`): they mirror the missing-field behavior and get the same fallback rather than being silently dropped.
- Updated the `runTransform` doc comment to note its non-positive-period guard is now a backstop for direct callers, not a drop path in pipeline practice.

## Tests

- New `analytics/__tests__/pipeline/rate-period-fallback.test.ts`: records without `period` produce rates computed with `fallbackMs`; `period: 0`, negative, and `NaN` behave the same; a valid `period` is used unchanged; a non-default `fallbackMs` is honored; a spec without `fallbackMs` defaults to 60 s — covering both the `groupBy` and `field` pipeline paths.
- Updated `bytes-received-pipeline.test.ts`, which previously asserted the old drop behavior, to assert the fallback instead.
- Full suite: 198 files / 1318 tests passed; `tsc -b`, `dprint`, and `oxlint` clean.

## Review

Cross-model review (Codex and Gemini 3.1 Pro) on the diff: no correctness issues identified by either.

Generated by kAIle (Claude Fable 5).