### PR TITLE
fix(status): keep Overview usable when the analytics capability probe fails

### DIFF
--- a/src/features/instance/status/analytics/StatusTabs.tsx
+++ b/src/features/instance/status/analytics/StatusTabs.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
@@ -5,13 +6,13 @@ import { useSystemTheme } from '@/hooks/useSystemTheme';
 import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics.ts';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type StatusTabId, validateStatusSearch } from '../statusSearch.ts';
 import { AnalyticsOnboardingHint } from './components/AnalyticsOnboardingHint.tsx';
 import { TimeRangePicker } from './components/TimeRangePicker.tsx';
 import { type AnalyticsContextValue, AnalyticsProvider } from './context/AnalyticsContext.tsx';
 import { getPreset, type TimePresetId } from './context/timePresets.ts';
-import { useAnalyticsCapability } from './hooks/useAnalyticsCapability.ts';
+import { type AnalyticsCapability, useAnalyticsCapability } from './hooks/useAnalyticsCapability.ts';
 import { DatabaseTab } from './tabs/DatabaseTab.tsx';
 import { HealthTab } from './tabs/HealthTab.tsx';
 import { OverviewTab } from './tabs/OverviewTab.tsx';
@@ -40,37 +41,67 @@ const TAB_DEFS = [
 type TabId = StatusTabId;
 
 export function StatusTabs({ instanceParams, isLocalStudio }: Props) {
+	// The capability probe only gates the analytics-backed chart tabs —
+	// Overview reads get_status / get_system_information and must stay
+	// usable even when get_analytics is failing (#1442). The tab strip
+	// always renders; chart tab bodies swap to a probe / error notice.
 	const capability = useAnalyticsCapability(instanceParams);
-
-	if (capability.isLoading) {
-		return (
-			<div role="status" aria-live="polite" className="px-4 py-8 text-sm text-muted-foreground">
-				Checking analytics availability…
-			</div>
-		);
-	}
-
-	if (capability.error) {
-		return (
-			<div role="alert" className="px-4 py-8 text-sm text-muted-foreground">
-				<p className="mb-1 font-medium text-foreground">Analytics unavailable on this instance.</p>
-				<p>
-					The Harper instance returned an error from{' '}
-					<code>get_analytics</code>. Check that the instance is reachable and that analytics is enabled, then reload.
-				</p>
-			</div>
-		);
-	}
 
 	return (
 		<StatusTabsInner
 			instanceParams={instanceParams}
 			isLocalStudio={isLocalStudio}
+			capability={capability}
 		/>
 	);
 }
 
-function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
+/** Explains a failed capability probe inside a chart tab's body and offers
+ *  the Retry the hook promises. 401/403 get an auth-flavored message —
+ *  "analytics unavailable" would misdirect the user toward the instance
+ *  when their credentials are the problem. */
+function AnalyticsUnavailableNotice({ capability }: { capability: AnalyticsCapability }) {
+	return (
+		<div role="alert" className="px-4 py-8 text-sm text-muted-foreground">
+			{capability.isAuthError
+				? (
+					<>
+						<p className="mb-1 font-medium text-foreground">Analytics request was not authorized.</p>
+						<p>
+							The Harper instance rejected <code>get_analytics</code>{' '}
+							as unauthorized. Your credentials for this instance may have expired — re-enter them, then retry.
+						</p>
+					</>
+				)
+				: (
+					<>
+						<p className="mb-1 font-medium text-foreground">Analytics unavailable on this instance.</p>
+						<p>
+							The Harper instance returned an error from{' '}
+							<code>get_analytics</code>. Check that the instance is reachable and that analytics is enabled, then
+							retry.
+						</p>
+					</>
+				)}
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				className="mt-3"
+				onClick={capability.retry}
+				disabled={capability.isFetching}
+			>
+				{capability.isFetching ? 'Retrying…' : 'Retry'}
+			</Button>
+		</div>
+	);
+}
+
+interface InnerProps extends Props {
+	capability: AnalyticsCapability;
+}
+
+function StatusTabsInner({ instanceParams, isLocalStudio, capability }: InnerProps) {
 	const navigate = useNavigate();
 	// The route's validateSearch already normalized these; re-validating here
 	// only narrows the `strict: false` typing to the same single source of
@@ -136,6 +167,24 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 		void navigate({ to: '.', search: { tab, range: presetId, refresh: ms } });
 	}, [navigate, tab, presetId]);
 
+	// When the probe fails while a chart tab is selected, land on Overview so
+	// the page opens on live data instead of an error. One-shot per failure —
+	// mark the error handled even when already on Overview, or the first
+	// click into a chart tab would bounce straight back; the user can always
+	// visit chart tabs to see the unavailable notice and its Retry button.
+	const landedOnOverviewRef = useRef(false);
+	useEffect(() => {
+		if (!capability.error) {
+			landedOnOverviewRef.current = false;
+			return;
+		}
+		if (landedOnOverviewRef.current) { return; }
+		landedOnOverviewRef.current = true;
+		if (tab !== 'overview') {
+			void navigate({ to: '.', search: { tab: 'overview', range: presetId, refresh: refreshMs }, replace: true });
+		}
+	}, [capability.error, tab, navigate, presetId, refreshMs]);
+
 	const ctxValue = useMemo<AnalyticsContextValue>(() => {
 		const preset = getPreset(presetId);
 		const endTime = Date.now();
@@ -164,6 +213,22 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 		)
 		: null;
 
+	// Chart tabs need get_analytics; substitute their bodies while the probe
+	// is pending / failed. Overview renders unconditionally below.
+	const chartBody = (content: ReactNode) => {
+		if (capability.isLoading) {
+			return (
+				<div role="status" aria-live="polite" className="px-4 py-8 text-sm text-muted-foreground">
+					Checking analytics availability…
+				</div>
+			);
+		}
+		if (capability.error) {
+			return <AnalyticsUnavailableNotice capability={capability} />;
+		}
+		return <TabBody picker={picker}>{content}</TabBody>;
+	};
+
 	return (
 		<AnalyticsProvider value={ctxValue}>
 			<Tabs value={tab} onValueChange={(v) => updateTab(v as TabId)} className="px-4 py-2">
@@ -171,7 +236,7 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 					/* Hint applies to chart interactions; hide it on Overview which
 				    has none of those affordances. */
 				}
-				{tab !== 'overview' && <AnalyticsOnboardingHint />}
+				{tab !== 'overview' && !capability.isLoading && !capability.error && <AnalyticsOnboardingHint />}
 				{
 					/*
 					 * Tab strip layout:
@@ -199,34 +264,22 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 				</TabsList>
 
 				<TabsContent value="health">
-					<TabBody picker={picker}>
-						<HealthTab />
-					</TabBody>
+					{chartBody(<HealthTab />)}
 				</TabsContent>
 				<TabsContent value="traffic">
-					<TabBody picker={picker}>
-						<TrafficTab />
-					</TabBody>
+					{chartBody(<TrafficTab />)}
 				</TabsContent>
 				<TabsContent value="requests">
-					<TabBody picker={picker}>
-						<RequestsTab />
-					</TabBody>
+					{chartBody(<RequestsTab />)}
 				</TabsContent>
 				<TabsContent value="database">
-					<TabBody picker={picker}>
-						<DatabaseTab />
-					</TabBody>
+					{chartBody(<DatabaseTab />)}
 				</TabsContent>
 				<TabsContent value="replication">
-					<TabBody picker={picker}>
-						<ReplicationTab />
-					</TabBody>
+					{chartBody(<ReplicationTab />)}
 				</TabsContent>
 				<TabsContent value="storage">
-					<TabBody picker={picker}>
-						<StorageTab />
-					</TabBody>
+					{chartBody(<StorageTab />)}
 				</TabsContent>
 				<TabsContent value="overview">
 					<OverviewTab instanceParams={instanceParams} isLocalStudio={isLocalStudio} />

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for #1442: a failed get_analytics capability probe used
+// to blank the WHOLE Status page — including Overview, which reads
+// get_status / get_system_information and doesn't need analytics. The probe
+// now gates only the chart tab bodies; the tab strip and Overview always
+// render, the error notice carries a Retry button, and 401/403 get an
+// auth-flavored message instead of "analytics unavailable".
+
+vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
+	useAnalyticsRecords: () => ({
+		data: [],
+		isLoading: false,
+		isError: false,
+		error: null,
+		isEmpty: true,
+		fieldKeys: new Set<string>(),
+		missingFields: [],
+		refetch: vi.fn(),
+	}),
+}));
+
+// Mutable capability so each test can drive loading / error / auth states.
+interface MockCapability {
+	supported: boolean;
+	error?: Error;
+	isAuthError: boolean;
+	isLoading: boolean;
+	isFetching: boolean;
+	retry: () => void;
+}
+let mockCapability: MockCapability;
+vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
+	useAnalyticsCapability: () => mockCapability,
+}));
+
+// Overview's real body suspends on get_status; stub it so these tests assert
+// "Overview renders" without plumbing status fixtures.
+vi.mock('../tabs/OverviewTab.tsx', () => ({
+	OverviewTab: () => <div data-testid="overview-content">overview content</div>,
+}));
+
+let currentSearch: Record<string, unknown> = {};
+const navigateMock = vi.fn(async (opts: { search?: unknown }) => {
+	if (typeof opts.search === 'object' && opts.search !== null) {
+		currentSearch = { ...(opts.search as Record<string, unknown>) };
+	} else {
+		currentSearch = {};
+	}
+});
+vi.mock('@tanstack/react-router', () => ({
+	useSearch: () => currentSearch,
+	useNavigate: () => navigateMock,
+}));
+
+beforeEach(() => {
+	currentSearch = {};
+	navigateMock.mockClear();
+	mockCapability = { supported: true, isLoading: false, isFetching: false, isAuthError: false, retry: vi.fn() };
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		configurable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+import { StatusTabs } from '../StatusTabs.tsx';
+
+const instanceParams = {
+	instanceClient: { post: vi.fn(async () => ({ data: [] })) } as never,
+	entityId: 'inst-A' as never,
+	entityType: 'instance' as const,
+};
+
+function ui(client: QueryClient) {
+	return (
+		<QueryClientProvider client={client}>
+			<StatusTabs instanceParams={instanceParams} isLocalStudio={false} />
+		</QueryClientProvider>
+	);
+}
+
+function mount() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	const view = render(ui(client));
+	// `rerenderSame` re-renders the identical tree (e.g. after mutating
+	// `currentSearch` to simulate a route change) without remounting.
+	return { ...view, rerenderSame: () => view.rerender(ui(client)) };
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('StatusTabs capability gating (#1442)', () => {
+	it('still renders the Overview tab content when the capability probe errors', () => {
+		mockCapability = {
+			supported: false,
+			error: new Error('analytics exploded'),
+			isAuthError: false,
+			isLoading: false,
+			isFetching: false,
+			retry: vi.fn(),
+		};
+		currentSearch = { tab: 'overview' };
+		mount();
+
+		expect(screen.getByTestId('overview-content')).toBeTruthy();
+		// The tab strip stays usable — all 7 tabs are present, not an error wall.
+		expect(screen.getAllByRole('tab')).toHaveLength(7);
+		// Already on Overview: no redirect needed.
+		expect(navigateMock).not.toHaveBeenCalled();
+	});
+
+	it('lands on Overview when the probe fails while a chart tab is selected', async () => {
+		mockCapability = {
+			supported: false,
+			error: new Error('analytics exploded'),
+			isAuthError: false,
+			isLoading: false,
+			isFetching: false,
+			retry: vi.fn(),
+		};
+		currentSearch = { tab: 'health' };
+		await act(async () => {
+			mount();
+		});
+
+		const lastCall = navigateMock.mock.calls.at(-1)?.[0] as
+			| { search?: Record<string, unknown>; replace?: boolean }
+			| undefined;
+		expect(lastCall?.search).toMatchObject({ tab: 'overview' });
+		expect(lastCall?.replace).toBe(true);
+	});
+
+	it('does not bounce the user back to Overview when the error occurred while already on Overview', async () => {
+		// Regression (cross-model review): the one-shot redirect must mark the
+		// failure handled even when it lands with Overview already selected —
+		// otherwise the user's FIRST click into a chart tab redirected them
+		// straight back to Overview.
+		mockCapability = {
+			supported: false,
+			error: new Error('analytics exploded'),
+			isAuthError: false,
+			isLoading: false,
+			isFetching: false,
+			retry: vi.fn(),
+		};
+		currentSearch = { tab: 'overview' };
+		const view = mount();
+		await act(async () => {});
+		expect(navigateMock).not.toHaveBeenCalled();
+
+		// User clicks into a chart tab: the route updates to ?tab=health.
+		currentSearch = { tab: 'health' };
+		await act(async () => {
+			view.rerenderSame();
+		});
+		// No redirect back to Overview — the chart tab shows the notice.
+		expect(navigateMock).not.toHaveBeenCalled();
+		expect(screen.getByText('Analytics unavailable on this instance.')).toBeTruthy();
+	});
+
+	it('disables the Retry button and shows progress while the probe refetch is in flight', () => {
+		mockCapability = {
+			supported: false,
+			error: new Error('analytics exploded'),
+			isAuthError: false,
+			isLoading: false,
+			isFetching: true,
+			retry: vi.fn(),
+		};
+		currentSearch = { tab: 'health' };
+		mount();
+
+		const button = screen.getByRole('button', { name: 'Retrying…' }) as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+	});
+
+	it('shows the unavailable notice in a chart tab and the Retry button invokes retry()', () => {
+		const retry = vi.fn();
+		mockCapability = {
+			supported: false,
+			error: new Error('analytics exploded'),
+			isAuthError: false,
+			isLoading: false,
+			isFetching: false,
+			retry,
+		};
+		currentSearch = { tab: 'health' };
+		mount();
+
+		expect(screen.getByText('Analytics unavailable on this instance.')).toBeTruthy();
+		fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+		expect(retry).toHaveBeenCalledTimes(1);
+	});
+
+	it('shows an auth-flavored message (not "unavailable") on a 401/403 probe failure', () => {
+		mockCapability = {
+			supported: false,
+			error: new Error('Request failed with status code 401'),
+			isAuthError: true,
+			isLoading: false,
+			isFetching: false,
+			retry: vi.fn(),
+		};
+		currentSearch = { tab: 'health' };
+		mount();
+
+		expect(screen.getByText('Analytics request was not authorized.')).toBeTruthy();
+		expect(screen.queryByText('Analytics unavailable on this instance.')).toBeNull();
+		// Retry is still offered — re-auth then retry is the recovery path.
+		expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+	});
+
+	it('renders Overview immediately while the probe is still loading', () => {
+		mockCapability = { supported: false, isAuthError: false, isLoading: true, isFetching: true, retry: vi.fn() };
+		currentSearch = { tab: 'overview' };
+		mount();
+
+		expect(screen.getByTestId('overview-content')).toBeTruthy();
+	});
+
+	it('shows a probe-pending placeholder in chart tabs while loading', () => {
+		mockCapability = { supported: false, isAuthError: false, isLoading: true, isFetching: true, retry: vi.fn() };
+		currentSearch = { tab: 'health' };
+		mount();
+
+		expect(screen.getByText('Checking analytics availability…')).toBeTruthy();
+		expect(navigateMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
@@ -27,7 +27,13 @@ vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
 }));
 
 vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
-	useAnalyticsCapability: () => ({ supported: true, isLoading: false, retry: vi.fn() }),
+	useAnalyticsCapability: () => ({
+		supported: true,
+		isLoading: false,
+		isFetching: false,
+		isAuthError: false,
+		retry: vi.fn(),
+	}),
 }));
 
 let currentSearch: Record<string, unknown> = {};

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
@@ -21,7 +21,13 @@ vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
 // Capability probe must succeed so the inner StatusTabs renders (vs. the
 // fallback path).
 vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
-	useAnalyticsCapability: () => ({ supported: true, isLoading: false, retry: vi.fn() }),
+	useAnalyticsCapability: () => ({
+		supported: true,
+		isLoading: false,
+		isFetching: false,
+		isAuthError: false,
+		retry: vi.fn(),
+	}),
 }));
 
 // Stub the TanStack Router hooks so we can drive search state in tests

--- a/src/features/instance/status/analytics/hooks/useAnalyticsCapability.test.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsCapability.test.ts
@@ -80,6 +80,26 @@ describe('useAnalyticsCapability', () => {
 		}
 	});
 
+	it.each([401, 403])(
+		'bails immediately on %i without walking the metric list or backing off, and flags isAuthError',
+		async (status) => {
+			// Expired credentials fail every metric identically — walking the
+			// list would just burn 3 more requests, and backoff retries can't
+			// fix auth. One call, immediate error, auth-flavored flag.
+			const post = vi.fn(async () => {
+				const err = new Error('unauthorized') as Error & { status?: number };
+				err.status = status;
+				throw err;
+			});
+			const { Wrapper } = wrap();
+			const { result } = renderHook(() => useAnalyticsCapability(makeParams(post)), { wrapper: Wrapper });
+			await waitFor(() => expect(result.current.error).toBeTruthy());
+			expect(post).toHaveBeenCalledTimes(1);
+			expect(result.current.isAuthError).toBe(true);
+			expect(result.current.supported).toBe(false);
+		},
+	);
+
 	it('reports an error when every probe metric throws', async () => {
 		vi.useFakeTimers();
 		try {
@@ -93,6 +113,7 @@ describe('useAnalyticsCapability', () => {
 			});
 			expect(result.current.error).toBeTruthy();
 			expect(result.current.supported).toBe(false);
+			expect(result.current.isAuthError).toBe(false);
 			expect(result.current.error?.message).toMatch(/analytics disabled/);
 		} finally {
 			vi.useRealTimers();

--- a/src/features/instance/status/analytics/hooks/useAnalyticsCapability.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsCapability.ts
@@ -4,7 +4,14 @@ import { useQuery } from '@tanstack/react-query';
 export interface AnalyticsCapability {
 	supported: boolean;
 	error?: Error;
+	/** True when the probe failed with 401/403 — credentials, not analytics
+	 *  support, are the problem, so the UI should say so. */
+	isAuthError: boolean;
 	isLoading: boolean;
+	/** True while any probe request is in flight, including a `retry()`
+	 *  refetch (during which `isLoading` stays false and `error` stays
+	 *  populated) — lets the Retry button show progress. */
+	isFetching: boolean;
 	retry: () => void;
 }
 
@@ -23,24 +30,39 @@ const PROBE_METRICS: readonly string[] = [
 
 const PROBE_STALE_TIME_MS = 30 * 60_000;
 
-/** True when the error is plausibly a "this metric isn't emitted on this
- *  build" signal (HTTP 4xx). False when the error is transport-level
- *  (5xx, timeout, network) — those mean the *instance* is unhealthy, so
- *  walking to the next metric just compounds load on an already
- *  struggling Harper. */
-function isMetricNotFoundError(err: unknown): boolean {
-	const status = (err as { response?: { status?: number }; status?: number })?.response?.status
+function errorStatus(err: unknown): number | undefined {
+	return (err as { response?: { status?: number }; status?: number })?.response?.status
 		?? (err as { status?: number })?.status;
+}
+
+/** 401/403 mean the *credentials* are bad, not that a metric is missing —
+ *  every other metric would fail identically, and React Query retries
+ *  can't fix expired auth. */
+function isAuthStatusError(err: unknown): boolean {
+	const status = errorStatus(err);
+	return status === 401 || status === 403;
+}
+
+/** True when the error is plausibly a "this metric isn't emitted on this
+ *  build" signal (HTTP 4xx, excluding 401/403 auth failures). False when
+ *  the error is transport-level (5xx, timeout, network) — those mean the
+ *  *instance* is unhealthy, so walking to the next metric just compounds
+ *  load on an already struggling Harper. */
+function isMetricNotFoundError(err: unknown): boolean {
+	const status = errorStatus(err);
 	if (typeof status !== 'number') { return false; }
-	return status >= 400 && status < 500;
+	return status >= 400 && status < 500 && !isAuthStatusError(err);
 }
 
 /** Probe `get_analytics` once per instance and cache the result for 30
  *  minutes. Falls through the metric list ONLY on per-metric 4xx errors
- *  (Harper version drift); bails immediately on transport-level errors so
- *  a slow / unhealthy Harper isn't hit 4× per attempt. Retries up to twice
- *  with exponential backoff for transient blips. The hook exposes a
- *  `retry()` function for a Retry button on the fallback view. */
+ *  (Harper version drift) — 401/403 bail immediately and set `isAuthError`
+ *  since bad credentials fail every metric identically; other
+ *  transport-level errors also bail so a slow / unhealthy Harper isn't hit
+ *  4× per attempt. Retries up to twice
+ *  with exponential backoff for transient blips (never for auth errors).
+ *  The hook exposes a `retry()` function for the Retry button on the
+ *  fallback view. */
 export function useAnalyticsCapability(
 	instanceParams: InstanceClientIdConfig & InstanceTypeConfig,
 ): AnalyticsCapability {
@@ -69,7 +91,8 @@ export function useAnalyticsCapability(
 			}
 			throw lastError instanceof Error ? lastError : new Error('Analytics probe failed for all metrics');
 		},
-		retry: 2,
+		// Backoff can't fix expired credentials — surface auth errors at once.
+		retry: (failureCount, error) => !isAuthStatusError(error) && failureCount < 2,
 		retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
 		staleTime: PROBE_STALE_TIME_MS,
 		gcTime: PROBE_STALE_TIME_MS,
@@ -78,7 +101,9 @@ export function useAnalyticsCapability(
 	return {
 		supported: query.isSuccess === true,
 		error: query.error as Error | undefined,
+		isAuthError: query.error != null && isAuthStatusError(query.error),
 		isLoading: query.isLoading,
+		isFetching: query.isFetching,
 		retry: () => {
 			void query.refetch();
 		},


### PR DESCRIPTION
Fixes [#1442 — get_analytics capability failure blanks the whole Status page, including Overview](https://github.com/HarperFast/studio/issues/1442).

## What / why

The `get_analytics` capability probe gated the **entire** Status page: while pending everything was a loading line, and on error everything became "Analytics unavailable" — including the Overview tab, which reads `get_status` / `get_system_information` and doesn't need analytics at all. The hook also promised a Retry button that was never wired, and treated 401/403 like "metric not found," so expired credentials probed all four fallback metrics and then blamed the instance.

- **Gate only the chart tab bodies** (`StatusTabs.tsx`). The tab strip and Overview always render — Overview now paints immediately instead of waiting out the probe — and chart tabs show a probe-pending placeholder or the unavailable notice in their content area.
- **Land on Overview on probe failure.** If the probe fails while a chart tab is selected, a one-shot `replace` navigation lands on Overview so the page opens on live data; chart tabs stay clickable and show the notice with Retry.
- **Wire the Retry button.** It calls `capability.retry()`, disables itself, and shows "Retrying…" while the refetch is in flight (`error`/`isLoading` don't change during a refetch, so the hook now exposes `isFetching`).
- **401/403 are auth failures, not metric drift** (`useAnalyticsCapability.ts`). The probe bails immediately (no metric-list walk, no backoff retries), sets `isAuthError`, and the UI shows an auth-flavored message pointing at credentials instead of the instance.

This also resolves the issue's optimistic-render note for the common case: tabs and Overview render during the probe, so the serial probe waterfall no longer blocks first paint (chart bodies still wait on the probe by design).

## Where to look

- `src/features/instance/status/analytics/StatusTabs.tsx` — capability now flows into `StatusTabsInner`; `chartBody()` swaps chart-tab content; `AnalyticsUnavailableNotice` carries the Retry button and auth variant; one-shot land-on-Overview effect. The sliding-refresh clock logic is untouched.
- `src/features/instance/status/analytics/hooks/useAnalyticsCapability.ts` — 401/403 excluded from the metric walk and from React Query retries; `isAuthError` / `isFetching` added.
- Tests: new `__tests__/StatusTabs.capability-gating.test.tsx` (Overview-under-error, redirect, bounce-back regression, Retry wiring + in-flight state, auth message, optimistic render while probing); `hooks/useAnalyticsCapability.test.ts` adds 401/403 bail-immediately coverage.

## Verification

`tsc -b`, full `vitest run` (198 files, 1320 passed / 11 skipped), `dprint fmt`, and `oxlint` all clean. Cross-model review (Codex + Gemini) was run; both significant findings — a redirect bounce-back when the error landed with Overview already selected, and a Retry button with no in-flight feedback — are fixed and regression-tested. No open review concerns remain.

Generated by kAIle (Claude Fable 5).