### PR TITLE
fix(status): scope the freshness indicator to the viewed instance; unify status query keys

### DIFF
--- a/src/features/clusters/upsert/ClusterForm.tsx
+++ b/src/features/clusters/upsert/ClusterForm.tsx
@@ -18,6 +18,7 @@ import { collapseKebabsToMaxLength } from '@/lib/string/collapseKebabsToMaxLengt
 import { stringsShareAPrefix } from '@/lib/string/stringsShareAPrefix';
 import { toKebabCase } from '@/lib/string/to-kebab-case';
 import { isPositive } from '@/lib/types/isPositive';
+import { invalidateEntityQueries } from '@/react-query/invalidateEntityQueries';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useRouter } from '@tanstack/react-router';
@@ -340,7 +341,7 @@ export function ClusterForm({
 
 		void queryClient.invalidateQueries({ queryKey: [organizationId], refetchType: 'active' });
 		if (!creating) {
-			void queryClient.invalidateQueries({ queryKey: [clusterId], refetchType: 'active' });
+			void invalidateEntityQueries(queryClient, clusterId, { refetchType: 'active' });
 		}
 
 		void router.invalidate();

--- a/src/features/instance/applications/components/NewApplication/useImportApplication.ts
+++ b/src/features/instance/applications/components/NewApplication/useImportApplication.ts
@@ -5,6 +5,7 @@ import { useSupportsDeploymentSSE } from '@/features/instance/applications/hooks
 import { reportDeployHealth } from '@/features/instance/applications/modals/reportDeployHealth';
 import { useDeployComponentMutation } from '@/integrations/api/instance/applications/deployComponent';
 import { SSEInconclusiveError } from '@/integrations/api/sse/errors';
+import { invalidateEntityQueries } from '@/react-query/invalidateEntityQueries';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
@@ -32,7 +33,7 @@ export function useImportApplication(
 
 	const onImported = useCallback((project: string) => {
 		setIsReloading(true);
-		void queryClient.invalidateQueries({ queryKey: [instanceParams.entityId] });
+		void invalidateEntityQueries(queryClient, instanceParams.entityId);
 		void reloadRootEntries();
 		setFocusedItem(project);
 		setSelectedItems([project]);

--- a/src/features/instance/status/analytics/StatusTabs.tsx
+++ b/src/features/instance/status/analytics/StatusTabs.tsx
@@ -106,9 +106,11 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 		//  - in-flight: when Harper is slower than the cadence, sliding the
 		//    window again would key a fresh POST batch on top of the running
 		//    one (new key = no dedupe); skip until the current batch settles.
+		//    Scoped to this instance so another instance's open Status page
+		//    can't starve our refresh cadence.
 		const canTick = () =>
 			!document.hidden
-			&& queryClient.isFetching({ queryKey: [ANALYTICS_QUERY_KEY_PREFIX] }) === 0;
+			&& queryClient.isFetching({ queryKey: [ANALYTICS_QUERY_KEY_PREFIX, instanceParams.entityId] }) === 0;
 		const intervalId = setInterval(() => {
 			if (canTick()) { refresh(); }
 		}, refreshMs);
@@ -120,7 +122,7 @@ function StatusTabsInner({ instanceParams, isLocalStudio }: Props) {
 			clearInterval(intervalId);
 			document.removeEventListener('visibilitychange', onVisibilityChange);
 		};
-	}, [refreshMs, refresh, queryClient, tick]);
+	}, [refreshMs, refresh, queryClient, tick, instanceParams.entityId]);
 
 	const theme = useSystemTheme();
 

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
+import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
 import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets.ts';
 import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness.ts';
 
@@ -20,7 +21,8 @@ export function TimeRangePicker({
 	onRefreshChange,
 	onManualRefresh,
 }: Props) {
-	const { isFetching, lastFetchedAt, now } = useAnalyticsFreshness();
+	const { instanceParams } = useAnalyticsContext();
+	const { isFetching, lastFetchedAt, now } = useAnalyticsFreshness(instanceParams.entityId);
 	const updatedLabel = formatRelativeUpdate(lastFetchedAt, now);
 
 	return (

--- a/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.test.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.test.ts
@@ -1,5 +1,61 @@
-import { describe, expect, it } from 'vitest';
-import { formatRelativeUpdate } from './useAnalyticsFreshness.ts';
+/** @vitest-environment jsdom */
+import type { EntityIds } from '@/features/auth/store/authStore';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { formatRelativeUpdate, useAnalyticsFreshness } from './useAnalyticsFreshness.ts';
+
+/** Panel-shaped key per getAnalytics.ts: [prefix, entityId, metric, start, end, bucket, conditions]. */
+const analyticsKey = (entityId: string) => ['get_analytics_raw', entityId, 'cpu-usage', 0, 60_000, null, null];
+
+function makeWrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useAnalyticsFreshness — instance scoping', () => {
+	afterEach(cleanup);
+
+	it("ignores another instance's fetch events and timestamps (two Status pages open)", async () => {
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+		// inst-B is mid-fetch when the inst-A hook mounts.
+		let resolveB!: (rows: unknown[]) => void;
+		void client.prefetchQuery({
+			queryKey: analyticsKey('inst-B'),
+			queryFn: () => new Promise<unknown[]>((resolve) => (resolveB = resolve)),
+		});
+		const { result } = renderHook(
+			() => useAnalyticsFreshness('inst-A' as EntityIds),
+			{ wrapper: makeWrapper(client) },
+		);
+
+		// B's in-flight fetch must not spin A's refresh icon.
+		expect(result.current.isFetching).toBe(false);
+
+		act(() => resolveB([]));
+		await waitFor(() => expect(client.getQueryState(analyticsKey('inst-B'))?.status).toBe('success'));
+		// B's success timestamp must not populate A's "Updated Xs ago" pill.
+		expect(result.current.lastFetchedAt).toBeNull();
+		expect(result.current.isFetching).toBe(false);
+
+		// A's own fetch IS reflected: busy while in flight, timestamped on success.
+		let resolveA!: (rows: unknown[]) => void;
+		let fetchA: Promise<unknown> | undefined;
+		act(() => {
+			fetchA = client.fetchQuery({
+				queryKey: analyticsKey('inst-A'),
+				queryFn: () => new Promise<unknown[]>((resolve) => (resolveA = resolve)),
+			});
+		});
+		await waitFor(() => expect(result.current.isFetching).toBe(true));
+		await act(async () => {
+			resolveA([]);
+			await fetchA;
+		});
+		await waitFor(() => expect(result.current.isFetching).toBe(false));
+		expect(result.current.lastFetchedAt).toBe(client.getQueryState(analyticsKey('inst-A'))!.dataUpdatedAt);
+	});
+});
 
 describe('formatRelativeUpdate', () => {
 	const now = 1_700_000_000_000;

--- a/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.ts
@@ -1,3 +1,4 @@
+import type { EntityIds } from '@/features/auth/store/authStore';
 import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics.ts';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
@@ -18,8 +19,10 @@ export interface AnalyticsFreshness {
 /** Watches the React Query cache for activity on the `get_analytics`
  *  prefix and exposes a busy flag + most-recent-success timestamp. The
  *  TimeRangePicker uses these to show an active/spinning refresh icon
- *  and a "last updated" relative-time label. */
-export function useAnalyticsFreshness(): AnalyticsFreshness {
+ *  and a "last updated" relative-time label. Scoped to `entityId` (key
+ *  position 1, per getAnalytics.ts) so two instance Status pages open
+ *  at once don't reflect each other's fetches. */
+export function useAnalyticsFreshness(entityId: EntityIds): AnalyticsFreshness {
 	const client = useQueryClient();
 	const [isFetching, setIsFetching] = useState(false);
 	const [lastFetchedAt, setLastFetchedAt] = useState<number | null>(null);
@@ -27,7 +30,8 @@ export function useAnalyticsFreshness(): AnalyticsFreshness {
 
 	useEffect(() => {
 		const cache = client.getQueryCache();
-		const isOurs = (q: { queryKey: unknown }) => Array.isArray(q.queryKey) && q.queryKey[0] === PREFIX;
+		const isOurs = (q: { queryKey: unknown }) =>
+			Array.isArray(q.queryKey) && q.queryKey[0] === PREFIX && q.queryKey[1] === entityId;
 		const sync = () => {
 			let fetching = false;
 			let mostRecent: number | null = null;
@@ -53,7 +57,7 @@ export function useAnalyticsFreshness(): AnalyticsFreshness {
 			sync();
 		});
 		return () => unsub();
-	}, [client]);
+	}, [client, entityId]);
 
 	useEffect(() => {
 		// Tick rate adapts to age so we don't burn a 1Hz timer per picker

--- a/src/hooks/useApplyLicensesClick.tsx
+++ b/src/hooks/useApplyLicensesClick.tsx
@@ -95,7 +95,7 @@ export function useApplyLicensesClick({ licenses }: ApplyLicensesClickParams): A
 		}
 
 		await queryClient.invalidateQueries({
-			queryKey: [instanceParams.entityId, 'get_usage_licenses'],
+			queryKey: ['get_usage_licenses', instanceParams.entityId],
 			refetchType: 'active',
 		});
 		setIsApplyLicensesPending(false);

--- a/src/hooks/useRestartClusterClick.tsx
+++ b/src/hooks/useRestartClusterClick.tsx
@@ -8,6 +8,7 @@ import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { pluralize } from '@/lib/pluralize';
 import { sleep } from '@/lib/sleep';
 import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
+import { invalidateEntityQueries } from '@/react-query/invalidateEntityQueries';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
@@ -112,7 +113,7 @@ export function useRestartClusterClick(
 		}
 
 		setIsRestartPending(false);
-		void queryClient.invalidateQueries({ queryKey: [clusterId] });
+		void invalidateEntityQueries(queryClient, clusterId);
 
 		if (canceled) {
 			toast.error('Cancelled', {

--- a/src/hooks/useRestartInstanceClick.ts
+++ b/src/hooks/useRestartInstanceClick.ts
@@ -1,6 +1,7 @@
 import { isLocalStudio } from '@/config/constants';
 import { InstanceClientConfig } from '@/config/instanceClientConfig';
 import { useRestartInstance } from '@/integrations/api/instance/status/restartInstance';
+import { invalidateEntityQueries } from '@/react-query/invalidateEntityQueries';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { useCallback } from 'react';
@@ -44,8 +45,8 @@ export function useRestartInstanceClick({
 				replicated: operation === 'restart_service' && targetNoun === 'Cluster',
 				instanceClient,
 			});
-			void queryClient.invalidateQueries({ queryKey: [clusterId] });
-			void queryClient.invalidateQueries({ queryKey: [instanceId] });
+			void invalidateEntityQueries(queryClient, clusterId);
+			void invalidateEntityQueries(queryClient, instanceId);
 			toast.dismiss(toastId);
 			toast.success('Success', {
 				description: `${targetNoun} restarted!`,

--- a/src/hooks/useRollingConfigUpdate.tsx
+++ b/src/hooks/useRollingConfigUpdate.tsx
@@ -122,7 +122,7 @@ export function useRollingConfigUpdate(
 		}
 
 		setIsPending(false);
-		void queryClient.invalidateQueries({ queryKey: [operationsParams.entityId, 'get_configuration'] });
+		void queryClient.invalidateQueries({ queryKey: ['get_configuration', operationsParams.entityId] });
 
 		if (canceled) {
 			toast.error('Cancelled', {

--- a/src/integrations/api/instance/auth/installUsageLicense.ts
+++ b/src/integrations/api/instance/auth/installUsageLicense.ts
@@ -18,6 +18,6 @@ export function useInstallUsageLicenseMutation(entityId: EntityIds) {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: installUsageLicense,
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: [entityId, 'get_usage_licenses'] }),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['get_usage_licenses', entityId] }),
 	});
 }

--- a/src/integrations/api/instance/status/getConfiguration.ts
+++ b/src/integrations/api/instance/status/getConfiguration.ts
@@ -16,7 +16,7 @@ interface ConfigurationInfoResponse {
 
 export function getConfigurationQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
-		queryKey: [entityId, 'get_configuration'] as const,
+		queryKey: ['get_configuration', entityId] as const,
 		queryFn: async () => {
 			const { data } = await instanceClient.post('/', {
 				operation: 'get_configuration',

--- a/src/integrations/api/instance/status/getInstanceHealth.ts
+++ b/src/integrations/api/instance/status/getInstanceHealth.ts
@@ -6,7 +6,7 @@ export function getInstanceHealthQueryOptions({
 	instanceClient,
 }: InstanceClientIdConfig) {
 	return queryOptions({
-		queryKey: [entityId, 'health'] as const,
+		queryKey: ['health', entityId] as const,
 		queryFn: async () => {
 			try {
 				await instanceClient.get('/health');

--- a/src/integrations/api/instance/status/getOpenAPI.ts
+++ b/src/integrations/api/instance/status/getOpenAPI.ts
@@ -3,7 +3,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 export function getOpenAPIQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
-		queryKey: [entityId, 'OpenAPI'] as const,
+		queryKey: ['OpenAPI', entityId] as const,
 		queryFn: async () => {
 			const { data } = await instanceClient.get('/api/openapi/rest');
 			return data;

--- a/src/integrations/api/instance/status/getReadLog.ts
+++ b/src/integrations/api/instance/status/getReadLog.ts
@@ -71,8 +71,8 @@ export function getReadLogQueryOptions(params: GetReadLogParams & InstanceClient
 	const logFilters = params.logFilters;
 	return queryOptions({
 		queryKey: [
-			params.entityId,
 			'read_log',
+			params.entityId,
 			logFilters.limit,
 			logFilters.level,
 			logFilters.from,

--- a/src/integrations/api/instance/status/getRegistrationInfo.ts
+++ b/src/integrations/api/instance/status/getRegistrationInfo.ts
@@ -7,7 +7,7 @@ export interface RegistrationInfoResponse {
 
 export function getRegistrationInfoQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
-		queryKey: [entityId, 'registration_info'] as const,
+		queryKey: ['registration_info', entityId] as const,
 		staleTime: 60_000,
 		gcTime: 5_000,
 		queryFn: async () => {

--- a/src/integrations/api/instance/status/getStatus.ts
+++ b/src/integrations/api/instance/status/getStatus.ts
@@ -39,7 +39,7 @@ interface StatusResponse {
 
 export function getStatusQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig, enabled?: boolean) {
 	return queryOptions({
-		queryKey: [entityId, 'get_status'] as const,
+		queryKey: ['get_status', entityId] as const,
 		staleTime: 9_000,
 		refetchInterval: 10_000,
 		retryDelay: 10_000,

--- a/src/integrations/api/instance/status/getSystemInformation.ts
+++ b/src/integrations/api/instance/status/getSystemInformation.ts
@@ -98,7 +98,7 @@ interface SystemInformationResponse {
 
 export function getSystemInformationQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
-		queryKey: [entityId, 'system_information'] as const,
+		queryKey: ['system_information', entityId] as const,
 		queryFn: async () => {
 			const { data } = await instanceClient.post<SystemInformationResponse>('/', {
 				operation: 'system_information',

--- a/src/integrations/api/instance/status/getUsageLicenses.ts
+++ b/src/integrations/api/instance/status/getUsageLicenses.ts
@@ -29,7 +29,7 @@ interface UsageLicense {
 
 export function getUsageLicensesQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig, enabled: boolean) {
 	return queryOptions({
-		queryKey: [entityId, 'get_usage_licenses'] as const,
+		queryKey: ['get_usage_licenses', entityId] as const,
 		enabled,
 		queryFn: async () => {
 			try {

--- a/src/integrations/api/instance/status/setStatus.ts
+++ b/src/integrations/api/instance/status/setStatus.ts
@@ -23,6 +23,6 @@ async function setStatus({
 export function useSetStatus() {
 	return useMutation({
 		mutationFn: setStatus,
-		onSuccess: (_data, variables) => queryClient.invalidateQueries({ queryKey: [variables.entityId, 'get_status'] }),
+		onSuccess: (_data, variables) => queryClient.invalidateQueries({ queryKey: ['get_status', variables.entityId] }),
 	});
 }

--- a/src/react-query/invalidateEntityQueries.ts
+++ b/src/react-query/invalidateEntityQueries.ts
@@ -1,0 +1,19 @@
+import type { InvalidateQueryFilters, QueryClient } from '@tanstack/react-query';
+
+/** Invalidate every cached query that belongs to an entity (instance or
+ *  cluster), regardless of key convention: entity-first keys
+ *  (`[entityId, ...]`, e.g. databases/applications) and operation-first
+ *  keys (`[operation, entityId, ...]`, e.g. `integrations/api/instance/status`)
+ *  both match. Prefer this over `invalidateQueries({ queryKey: [entityId] })`,
+ *  which silently misses the operation-first keys. */
+export function invalidateEntityQueries(
+	queryClient: QueryClient,
+	entityId: string | undefined,
+	options?: Pick<InvalidateQueryFilters, 'refetchType'>,
+): Promise<void> {
+	if (entityId === undefined) { return Promise.resolve(); }
+	return queryClient.invalidateQueries({
+		predicate: (query) => query.queryKey[0] === entityId || query.queryKey[1] === entityId,
+		...options,
+	});
+}


### PR DESCRIPTION
Fixes [#1445 — Analytics freshness indicator doesn't filter by instance; query-key shapes are inconsistent](https://github.com/HarperFast/studio/issues/1445).

## What changed

### 1. Freshness indicator is now scoped to the viewed instance

`useAnalyticsFreshness` matched cache entries by key prefix only (`get_analytics_raw` at position 0), so with two instance Status pages open, the "Updated Xs ago" pill and the refresh spinner reflected whichever instance fetched last. The hook now takes the instance `entityId` and matches it at key position 1 (where `getAnalytics.ts` puts it). `TimeRangePicker` threads it in from `AnalyticsContext`.

Same fix applied to the auto-refresh in-flight guard in `StatusTabs` — `queryClient.isFetching({ queryKey: [ANALYTICS_QUERY_KEY_PREFIX] })` was also unscoped, so another instance's in-flight analytics batch could starve this instance's refresh cadence.

### 2. Query-key convention unified on operation-first

`src/integrations/api/instance/status/` mixed two shapes: `getAnalytics.ts` used `['get_analytics_raw', entityId, ...]` while everything else used `[entityId, 'operation']`. Prefix matching (the freshness hook) and targeted invalidation depend on a single convention, so the whole directory is now operation-first:

| File | Key (before → after) |
| --- | --- |
| `getStatus.ts` | `[entityId, 'get_status']` → `['get_status', entityId]` |
| `getConfiguration.ts` | `[entityId, 'get_configuration']` → `['get_configuration', entityId]` |
| `getSystemInformation.ts` | `[entityId, 'system_information']` → `['system_information', entityId]` |
| `getInstanceHealth.ts` | `[entityId, 'health']` → `['health', entityId]` |
| `getOpenAPI.ts` | `[entityId, 'OpenAPI']` → `['OpenAPI', entityId]` |
| `getRegistrationInfo.ts` | `[entityId, 'registration_info']` → `['registration_info', entityId]` |
| `getUsageLicenses.ts` | `[entityId, 'get_usage_licenses']` → `['get_usage_licenses', entityId]` |
| `getReadLog.ts` | `[entityId, 'read_log', ...filters]` → `['read_log', entityId, ...filters]` |
| `getAnalytics.ts` | `['get_analytics_raw', entityId, ...]` (unchanged — already the target shape) |

Post-change symmetry audit: every query-key definition in the directory is `['operation', entityId, ...]`.

## Blast radius of the key flip

Every repo consumer of the flipped keys was located (grep for `invalidateQueries` / `setQueryData` / `getQueryData` / `removeQueries` / `isFetching` / key literals) and updated:

**Targeted invalidations** (key literal flipped in place):
- `setStatus.ts` — `get_status` invalidation after `set_status`
- `installUsageLicense.ts`, `useApplyLicensesClick.tsx` — `get_usage_licenses`
- `useRollingConfigUpdate.tsx` — `get_configuration`

**Broad entity-prefix invalidations** — the subtle part. Several flows invalidated *everything for an entity* via `invalidateQueries({ queryKey: [entityId] })`, which only works while keys are entity-first. Those would have silently stopped matching the status-directory queries (e.g. restart would no longer refetch `get_status`, so `restartRequired` would linger). They now use a new predicate-based helper, `invalidateEntityQueries` (`src/react-query/invalidateEntityQueries.ts`), which matches `entityId` at key position 0 *or* 1, covering both conventions:
- `useRestartInstanceClick.ts` (instance + cluster restart)
- `useRestartClusterClick.tsx` (rolling cluster restart)
- `ClusterForm.tsx` (post-create/update `[clusterId]` invalidation)
- `useImportApplication.ts` (post-import instance invalidation)

Org-scoped broad invalidations (`[organizationId]`) were left alone — no status-directory key is ever keyed by an organization id.

## Tests

- New regression in `useAnalyticsFreshness.test.ts`: cache entries for `inst-A` and `inst-B`; the hook keyed to `inst-A` ignores B's in-flight fetch and success timestamp, and still reports A's own fetch/timestamp. Fails against the old unscoped implementation.
- Full suite: 197 files / 1311 passed (11 skipped). `tsc -b`, `dprint`, and `oxlint` clean.

## Cross-model review

- **Gemini 3.1 Pro** (read-only, asked specifically to verify every consumer of the changed keys): clean — confirmed all consumers updated, the predicate helper preserves prior invalidation reach, the hook scoping/effect deps are correct, and the regression test fails against the old implementation. No findings at any severity.
- **Codex** (`codex exec review`): clean — "no discrete correctness issues in the reviewed changes. The query-key updates and scoped analytics freshness logic appear consistently applied with matching invalidation updates."

Cross-model reviews: both complete and clean (Codex finished after opening: "no discrete correctness issues... consistently applied with matching invalidation updates").

Generated by kAIle (Claude Fable 5).