### PR TITLE
refactor(status): share the panel card/state shell between MetricPanel and ConnectionsPanel

### DIFF
--- a/src/features/instance/status/analytics/lib/specRequiredFields.test.ts
+++ b/src/features/instance/status/analytics/lib/specRequiredFields.test.ts
@@ -24,6 +24,11 @@ describe('getSpecRequiredFields', () => {
 		expect(fields).toContain('period');
 	});
 
+	it('returns a stable array identity per metric (cached — panels call this every render)', () => {
+		expect(getSpecRequiredFields('db-read')).toBe(getSpecRequiredFields('db-read'));
+		expect(getSpecRequiredFields('not-a-metric')).toBe(getSpecRequiredFields('not-a-metric'));
+	});
+
 	it('uses derived-metric overrides for metrics not in the spec registry', () => {
 		const reqRate = getSpecRequiredFields('request-rate');
 		expect(reqRate).toContain('count');

--- a/src/features/instance/status/analytics/lib/specRequiredFields.ts
+++ b/src/features/instance/status/analytics/lib/specRequiredFields.ts
@@ -29,6 +29,20 @@ const DERIVED_REQUIRED_FIELDS: Record<string, readonly string[]> = {
  *  blank an otherwise-fine chart (we hit this with cpu-usage, which has a
  *  quantile picker but ships zero quantile fields by default). */
 export function getSpecRequiredFields(metric: string): readonly string[] {
+	let fields = requiredFieldsCache.get(metric);
+	if (!fields) {
+		fields = computeRequiredFields(metric);
+		requiredFieldsCache.set(metric, fields);
+	}
+	return fields;
+}
+
+/** Results are deterministic per metric (the registries are static module
+ *  state), so cache them — panels call this every render and a fresh array
+ *  identity would churn downstream memos. */
+const requiredFieldsCache = new Map<string, readonly string[]>();
+
+function computeRequiredFields(metric: string): readonly string[] {
 	const override = DERIVED_REQUIRED_FIELDS[metric];
 	if (override) { return override; }
 	const derived = derivedRegistry[metric];

--- a/src/features/instance/status/analytics/lib/specRequiredFields.ts
+++ b/src/features/instance/status/analytics/lib/specRequiredFields.ts
@@ -28,6 +28,8 @@ const DERIVED_REQUIRED_FIELDS: Record<string, readonly string[]> = {
  *  excluded — surfacing them as "missing" produces false positives that
  *  blank an otherwise-fine chart (we hit this with cpu-usage, which has a
  *  quantile picker but ships zero quantile fields by default). */
+const requiredFieldsCache = new Map<string, readonly string[]>();
+
 export function getSpecRequiredFields(metric: string): readonly string[] {
 	let fields = requiredFieldsCache.get(metric);
 	if (!fields) {
@@ -40,7 +42,6 @@ export function getSpecRequiredFields(metric: string): readonly string[] {
 /** Results are deterministic per metric (the registries are static module
  *  state), so cache them — panels call this every render and a fresh array
  *  identity would churn downstream memos. */
-const requiredFieldsCache = new Map<string, readonly string[]>();
 
 function computeRequiredFields(metric: string): readonly string[] {
 	const override = DERIVED_REQUIRED_FIELDS[metric];

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -1,13 +1,10 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useMemo, useRef } from 'react';
-import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
-import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
-import { ChartExportButton } from '../components/ChartExportButton.tsx';
+import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords.ts';
 import { ConnectionsRenderer } from '../pipeline/connections.tsx';
 import type { AnalyticsDataPoint } from '../types/analytics.ts';
 import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
+import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell.tsx';
 
 /** Some Harper builds split active-session telemetry across two metrics:
  *  `mqtt-connections` (active MQTT sessions) and `ws-connections` (active
@@ -31,9 +28,6 @@ export function ConnectionsPanel() {
 
 function ConnectionsPanelInner() {
 	const { timeRange, bucketMs, theme, instanceParams } = useAnalyticsContext();
-	// Chart-only ref; capturing the whole Card would include the action buttons
-	// in the exported PNG.
-	const chartRef = useRef<HTMLDivElement>(null);
 
 	const mqtt = useAnalyticsRecords({
 		metric: 'mqtt-connections',
@@ -62,13 +56,7 @@ function ConnectionsPanelInner() {
 	}, [mqtt.data, ws.data]);
 
 	const isEmpty = merged.length === 0;
-	const nodes = useMemo(() => {
-		const set = new Set<string>();
-		for (const r of merged) {
-			if (typeof r.node === 'string') { set.add(r.node); }
-		}
-		return [...set].sort();
-	}, [merged]);
+	const nodes = useMemo(() => collectNodes(merged), [merged]);
 
 	const canExport = !isLoading && !isError && !isEmpty;
 	const renderChart = (opts: { fillParent: boolean } = { fillParent: false }) => (
@@ -81,45 +69,30 @@ function ConnectionsPanelInner() {
 		/>
 	);
 
+	const retryBoth = () => {
+		mqtt.refetch();
+		ws.refetch();
+	};
+
 	return (
-		<Card>
-			<CardHeader className="flex flex-row items-start justify-between gap-2">
-				<div className="flex-1 min-w-0">
-					<CardTitle>Connections</CardTitle>
-					<CardDescription>Active MQTT + WebSocket sessions — chips solo / Ctrl-toggle.</CardDescription>
-				</div>
-				{canExport && (
-					<div className="flex items-center gap-1 shrink-0">
-						<ChartExpandButton
-							exportSlug="connections"
-							title="Connections"
-							description="Active MQTT + WebSocket sessions."
-							renderChart={renderChart}
-						/>
-						<ChartCopyButton captureRef={chartRef} exportSlug="connections" />
-						<ChartExportButton captureRef={chartRef} exportSlug="connections" />
-					</div>
-				)}
-			</CardHeader>
-			<CardContent>
-				<div ref={chartRef}>
-					{isLoading
-						? <div className="h-64 rounded-md bg-muted/30 animate-pulse" aria-label="Loading" />
-						: isError
-						? (
-							<div className="h-64 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
-								{`Failed to load: ${error?.message ?? 'unknown error'}`}
-							</div>
-						)
-						: isEmpty
-						? (
-							<div className="h-64 rounded-md border border-border bg-muted/20 p-4 text-sm text-muted-foreground flex items-center justify-center">
-								No active sessions in the selected time range.
-							</div>
-						)
-						: renderChart()}
-				</div>
-			</CardContent>
-		</Card>
+		<PanelCard
+			title="Connections"
+			description="Active MQTT + WebSocket sessions — chips solo / Ctrl-toggle."
+			expandDescription="Active MQTT + WebSocket sessions."
+			exportSlug="connections"
+			canExport={canExport}
+			renderChart={renderChart}
+		>
+			<PanelStateOrChart
+				isLoading={isLoading}
+				isError={isError}
+				error={error}
+				isEmpty={isEmpty}
+				emptyMessage="No active sessions in the selected time range."
+				onRetry={retryBoth}
+			>
+				{renderChart()}
+			</PanelStateOrChart>
+		</PanelCard>
 	);
 }

--- a/src/features/instance/status/analytics/tabs/MetricPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/MetricPanel.tsx
@@ -1,9 +1,4 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { type ReactNode, useRef } from 'react';
-import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
-import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
-import { ChartExportButton } from '../components/ChartExportButton.tsx';
+import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords.ts';
 import { getSpecRequiredFields } from '../lib/specRequiredFields.ts';
@@ -11,6 +6,7 @@ import { derivedRegistry } from '../pipeline/derived/index.ts';
 import { specRegistry } from '../pipeline/index.ts';
 import { MetricRenderer } from '../primitives/MetricRenderer.tsx';
 import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
+import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell.tsx';
 
 interface Props {
 	metric: string;
@@ -46,10 +42,7 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 	const derivedEntry = derivedRegistry[metric];
 	const title = titleOverride ?? specEntry?.spec?.title ?? derivedEntry?.title ?? metric;
 	const description = specEntry?.spec?.description ?? derivedEntry?.subtitle;
-	const nodes = collectNodes(data);
-	// Capture only the chart body, not the whole Card. Otherwise the exported
-	// PNG includes the title bar's Expand/Copy/Download icons.
-	const chartRef = useRef<HTMLDivElement>(null);
+	const nodes = useMemo(() => collectNodes(data), [data]);
 	const canExport = !isLoading && !isError && !isEmpty;
 
 	const renderChart = (opts: { fillParent: boolean } = { fillParent: false }) => (
@@ -64,94 +57,23 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 	);
 
 	return (
-		<Card>
-			<CardHeader className="flex flex-row items-start justify-between gap-2">
-				<div className="flex-1 min-w-0">
-					<CardTitle>{title}</CardTitle>
-					{description && <CardDescription>{description}</CardDescription>}
-				</div>
-				{canExport && (
-					<div className="flex items-center gap-1 shrink-0">
-						<ChartExpandButton
-							exportSlug={metric}
-							title={title}
-							description={description}
-							renderChart={renderChart}
-						/>
-						<ChartCopyButton captureRef={chartRef} exportSlug={metric} />
-						<ChartExportButton captureRef={chartRef} exportSlug={metric} />
-					</div>
-				)}
-			</CardHeader>
-			<CardContent>
-				<div ref={chartRef}>
-					<PanelStateOrChart
-						isLoading={isLoading}
-						isError={isError}
-						error={error}
-						isEmpty={isEmpty}
-						missingFields={missingFields}
-						onRetry={refetch}
-					>
-						{renderChart()}
-					</PanelStateOrChart>
-				</div>
-			</CardContent>
-		</Card>
+		<PanelCard
+			title={title}
+			description={description}
+			exportSlug={metric}
+			canExport={canExport}
+			renderChart={renderChart}
+		>
+			<PanelStateOrChart
+				isLoading={isLoading}
+				isError={isError}
+				error={error}
+				isEmpty={isEmpty}
+				missingFields={missingFields}
+				onRetry={refetch}
+			>
+				{renderChart()}
+			</PanelStateOrChart>
+		</PanelCard>
 	);
-}
-
-function PanelStateOrChart({
-	isLoading,
-	isError,
-	error,
-	isEmpty,
-	missingFields,
-	onRetry,
-	children,
-}: {
-	isLoading: boolean;
-	isError: boolean;
-	error: Error | null;
-	isEmpty: boolean;
-	missingFields: string[];
-	onRetry: () => void;
-	children: ReactNode;
-}) {
-	if (isLoading) {
-		return (
-			<div
-				role="status"
-				aria-live="polite"
-				className="h-64 rounded-md bg-muted/30 animate-pulse"
-				aria-label="Loading"
-			/>
-		);
-	}
-	if (isError) {
-		return (
-			<div className="h-64 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive flex flex-col items-start justify-center gap-3">
-				<div>{`Failed to load: ${error?.message ?? 'unknown error'}`}</div>
-				<Button variant="outline" size="sm" onClick={onRetry}>Retry</Button>
-			</div>
-		);
-	}
-	if (isEmpty) {
-		return (
-			<div className="h-64 rounded-md border border-border bg-muted/20 p-4 text-sm text-muted-foreground flex items-center justify-center">
-				{missingFields.length > 0
-					? `No data — server response is missing required field(s): ${missingFields.join(', ')}.`
-					: 'No data in the selected time range.'}
-			</div>
-		);
-	}
-	return <>{children}</>;
-}
-
-function collectNodes(rows: { node?: unknown }[]): string[] {
-	const set = new Set<string>();
-	for (const r of rows) {
-		if (typeof r.node === 'string') { set.add(r.node); }
-	}
-	return [...set].sort();
 }

--- a/src/features/instance/status/analytics/tabs/PanelShell.tsx
+++ b/src/features/instance/status/analytics/tabs/PanelShell.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { errorText } from '@/lib/errorText';
 import { type ReactNode, useRef } from 'react';
 import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
 import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
@@ -105,7 +106,7 @@ export function PanelStateOrChart({
 	if (isError) {
 		return (
 			<div className="h-64 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive flex flex-col items-start justify-center gap-3">
-				<div>{`Failed to load: ${error?.message ?? 'unknown error'}`}</div>
+				<div>{`Failed to load: ${errorText(error) ?? 'unknown error'}`}</div>
 				<Button variant="outline" size="sm" onClick={onRetry}>Retry</Button>
 			</div>
 		);

--- a/src/features/instance/status/analytics/tabs/PanelShell.tsx
+++ b/src/features/instance/status/analytics/tabs/PanelShell.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { type ReactNode, useRef } from 'react';
+import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
+import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
+import { ChartExportButton } from '../components/ChartExportButton.tsx';
+
+interface PanelCardProps {
+	title: string;
+	/** Shown under the title in the card header. */
+	description?: ReactNode;
+	/** Description for the expanded dialog when it should differ from the
+	 *  card header's (e.g. to drop hints that only apply inline). Defaults
+	 *  to `description`. */
+	expandDescription?: ReactNode;
+	/** Slug used for export filenames and the action buttons' aria-labels. */
+	exportSlug: string;
+	/** Hide the expand/copy/download actions while there is nothing to capture. */
+	canExport: boolean;
+	/** Chart render function, forwarded to ChartExpandButton so the dialog
+	 *  re-renders the chart at full size. */
+	renderChart: (opts: { fillParent: boolean }) => ReactNode;
+	children: ReactNode;
+}
+
+/** Shared analytics-panel chrome: a Card with title/description header, the
+ *  expand/copy/download action row, and a capture ref wrapping the body so
+ *  exports grab only the chart — not the header's action icons. Used by
+ *  MetricPanel and ConnectionsPanel so the two can't drift. */
+export function PanelCard({
+	title,
+	description,
+	expandDescription = description,
+	exportSlug,
+	canExport,
+	renderChart,
+	children,
+}: PanelCardProps) {
+	// Capture only the chart body, not the whole Card. Otherwise the exported
+	// PNG includes the title bar's Expand/Copy/Download icons.
+	const chartRef = useRef<HTMLDivElement>(null);
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-start justify-between gap-2">
+				<div className="flex-1 min-w-0">
+					<CardTitle>{title}</CardTitle>
+					{description && <CardDescription>{description}</CardDescription>}
+				</div>
+				{canExport && (
+					<div className="flex items-center gap-1 shrink-0">
+						<ChartExpandButton
+							exportSlug={exportSlug}
+							title={title}
+							description={expandDescription}
+							renderChart={renderChart}
+						/>
+						<ChartCopyButton captureRef={chartRef} exportSlug={exportSlug} />
+						<ChartExportButton captureRef={chartRef} exportSlug={exportSlug} />
+					</div>
+				)}
+			</CardHeader>
+			<CardContent>
+				<div ref={chartRef}>{children}</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+interface PanelStateOrChartProps {
+	isLoading: boolean;
+	isError: boolean;
+	error: Error | null;
+	isEmpty: boolean;
+	/** Required Harper fields absent from the response — switches the empty
+	 *  state to explicit schema-drift copy. */
+	missingFields?: string[];
+	/** Copy for the plain empty state (no missing fields). */
+	emptyMessage?: string;
+	onRetry: () => void;
+	children: ReactNode;
+}
+
+/** The loading / error / empty ladder every analytics panel shares. Falls
+ *  through to `children` (the chart) once data is ready. */
+export function PanelStateOrChart({
+	isLoading,
+	isError,
+	error,
+	isEmpty,
+	missingFields = [],
+	emptyMessage = 'No data in the selected time range.',
+	onRetry,
+	children,
+}: PanelStateOrChartProps) {
+	if (isLoading) {
+		return (
+			<div
+				role="status"
+				aria-live="polite"
+				className="h-64 rounded-md bg-muted/30 animate-pulse"
+				aria-label="Loading"
+			/>
+		);
+	}
+	if (isError) {
+		return (
+			<div className="h-64 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive flex flex-col items-start justify-center gap-3">
+				<div>{`Failed to load: ${error?.message ?? 'unknown error'}`}</div>
+				<Button variant="outline" size="sm" onClick={onRetry}>Retry</Button>
+			</div>
+		);
+	}
+	if (isEmpty) {
+		return (
+			<div className="h-64 rounded-md border border-border bg-muted/20 p-4 text-sm text-muted-foreground flex items-center justify-center">
+				{missingFields.length > 0
+					? `No data — server response is missing required field(s): ${missingFields.join(', ')}.`
+					: emptyMessage}
+			</div>
+		);
+	}
+	return <>{children}</>;
+}
+
+/** Distinct, sorted node names present in a record stream — feeds the
+ *  renderers' node chips. */
+export function collectNodes(rows: { node?: unknown }[]): string[] {
+	const set = new Set<string>();
+	for (const r of rows) {
+		if (typeof r.node === 'string') { set.add(r.node); }
+	}
+	return [...set].sort();
+}

--- a/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
+	useAnalyticsRecords: vi.fn(),
+}));
+
+import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords.ts';
+import { ConnectionsPanel } from '../ConnectionsPanel.tsx';
+import { AnalyticsTestWrapper, makeRows } from './testHelpers.tsx';
+
+const mockHook = vi.mocked(useAnalyticsRecords);
+
+afterEach(cleanup);
+// Braces matter: `mockReset()` returns the mock, and a function returned from
+// beforeEach is treated as a cleanup hook — vitest would then invoke the mock
+// itself (with no args) after each test.
+beforeEach(() => {
+	mockHook.mockReset();
+});
+
+type HookResult = ReturnType<typeof useAnalyticsRecords>;
+
+function makeResult(overrides: Partial<HookResult> = {}): HookResult {
+	return {
+		data: [],
+		isLoading: false,
+		isError: false,
+		error: null,
+		isEmpty: true,
+		fieldKeys: new Set(),
+		missingFields: [],
+		refetch: vi.fn(),
+		...overrides,
+	};
+}
+
+/** ConnectionsPanel calls useAnalyticsRecords twice (mqtt + ws); route each
+ *  call to its per-metric result. */
+function setHookResults(byMetric: Record<string, HookResult>) {
+	mockHook.mockImplementation(({ metric }) => {
+		const result = byMetric[metric];
+		if (!result) { throw new Error(`unexpected metric: ${metric}`); }
+		return result;
+	});
+	return byMetric;
+}
+
+describe('ConnectionsPanel', () => {
+	it('renders a loading skeleton while either source is loading', () => {
+		setHookResults({
+			'mqtt-connections': makeResult({ isLoading: true }),
+			'ws-connections': makeResult(),
+		});
+		render(
+			<AnalyticsTestWrapper>
+				<ConnectionsPanel />
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByLabelText('Loading')).toBeTruthy();
+	});
+
+	it('renders an error with a Retry button that refetches both sources', () => {
+		const results = setHookResults({
+			'mqtt-connections': makeResult({ isError: true, error: new Error('mqtt down') }),
+			'ws-connections': makeResult(),
+		});
+		render(
+			<AnalyticsTestWrapper>
+				<ConnectionsPanel />
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText(/Failed to load: mqtt down/)).toBeTruthy();
+		fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+		expect(results['mqtt-connections'].refetch).toHaveBeenCalledTimes(1);
+		expect(results['ws-connections'].refetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders the sessions-specific empty copy when both sources are empty', () => {
+		setHookResults({
+			'mqtt-connections': makeResult(),
+			'ws-connections': makeResult(),
+		});
+		render(
+			<AnalyticsTestWrapper>
+				<ConnectionsPanel />
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText(/No active sessions in the selected time range/)).toBeTruthy();
+	});
+
+	it('renders the merged chart when either source has data', () => {
+		setHookResults({
+			'mqtt-connections': makeResult({ data: makeRows(), isEmpty: false }),
+			'ws-connections': makeResult(),
+		});
+		const { container } = render(
+			<AnalyticsTestWrapper>
+				<ConnectionsPanel />
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText('Connections')).toBeTruthy();
+		// Export actions appear only when there is a chart to capture.
+		expect(screen.getByLabelText('Expand connections')).toBeTruthy();
+		expect(container.querySelector('[aria-label="Loading"]')).toBeNull();
+	});
+});

--- a/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
@@ -40,14 +40,17 @@ describe('MetricPanel', () => {
 		expect(screen.getByLabelText('Loading')).toBeTruthy();
 	});
 
-	it('renders an error message when isError', () => {
-		setHookResult({ isError: true, error: new Error('boom') });
+	it('renders an error message with a Retry button when isError', () => {
+		const refetch = vi.fn();
+		setHookResult({ isError: true, error: new Error('boom'), refetch });
 		render(
 			<AnalyticsTestWrapper>
 				<MetricPanel metric="cpu-usage" />
 			</AnalyticsTestWrapper>,
 		);
 		expect(screen.getByText(/Failed to load: boom/)).toBeTruthy();
+		fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+		expect(refetch).toHaveBeenCalledTimes(1);
 	});
 
 	it('renders generic empty copy when no data and no missing fields', () => {


### PR DESCRIPTION
Fixes [#1448 — Extract a shared panel shell so ConnectionsPanel stops drifting from MetricPanel](https://github.com/HarperFast/studio/issues/1448).

## What changed

- **New `tabs/PanelShell.tsx`** exporting the shell both panels now share:
  - `PanelCard` — the Card chrome: title/description header, the Expand/Copy/Download action row (hidden while there's nothing to capture), and the capture ref wrapping the body so exported PNGs exclude the header icons. An optional `expandDescription` lets ConnectionsPanel keep its shorter expanded-dialog copy.
  - `PanelStateOrChart` — the loading / error / empty ladder, moved out of `MetricPanel.tsx` unchanged, with an optional `emptyMessage` so ConnectionsPanel keeps its "No active sessions…" copy.
  - `collectNodes` — the distinct-sorted-nodes helper both panels previously implemented separately.
- **`MetricPanel.tsx`** consumes the shell; its `collectNodes(data)` call is now memoized with `useMemo` (ConnectionsPanel already memoized the same computation).
- **`ConnectionsPanel.tsx`** keeps its two-source merge (`mqtt-connections` + `ws-connections` → rows tagged with a synthesized `type`) and swaps its hand-rolled copy of the chrome for the shared shell.
- **`lib/specRequiredFields.ts`**: `getSpecRequiredFields` now caches results in a module-level `Map` keyed by metric (results are deterministic — the registries are static module state), so panels stop allocating a fresh array every render and churning downstream memos.

## Behavior change (the one intentional one)

ConnectionsPanel's error state regains the **Retry** button it had drifted away from — clicking it refetches both source metrics. Its loading skeleton also picks up the shell's `role="status"`/`aria-live` attributes. Everything else renders identical markup.

## Tests

- `tabs/__tests__/ConnectionsPanel.test.tsx` (new): loading skeleton, error state with a Retry that refetches **both** sources (mock level), sessions-specific empty copy, and merged-chart render with the export actions visible.
- `MetricPanel.test.tsx`: the error-state test now asserts the Retry button renders and clicking it calls `refetch`.
- `specRequiredFields.test.ts`: asserts stable per-metric array identity (the new cache).
- Test-infra gotcha found along the way: `beforeEach(() => mock.mockReset())` returns the mock, and vitest treats a function returned from `beforeEach` as a cleanup hook — so vitest itself invokes the mock with no args after each test. The new test file uses a braced body and documents why.

Coordination note: `pipeline/**` and `primitives/**` are untouched per the parallel-PR split; `ConnectionsRenderer` is imported exactly as before.

## Verification

`tsc -b` clean · full vitest suite 201 files / 1335 passed · dprint + oxlint clean · reviewed by Codex and Gemini 3.1 Pro (no findings).

> Reviewer note (post-approval clarification): the error path now renders via the shared `errorText(error)` helper rather than `error?.message` — identical for `Error` instances, and a strict improvement for string/structured Harper error shapes.

Generated by kAIle (Claude Fable 5).