### PR TITLE
refactor(status): one roving radiogroup primitive for all chip selectors

### DIFF
--- a/src/features/instance/status/analytics/__tests__/charts/table-size-chip-row.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/charts/table-size-chip-row.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TableSizeChipRow } from '../../charts/TableSizeChipRow.tsx';
+import { OTHER_KEY } from '../../lib/tableSize.ts';
+
+describe('TableSizeChipRow radiogroup (shared roving-tabindex primitive)', () => {
+	afterEach(() => cleanup());
+
+	const tables = ['db.dog', 'db.cat', 'db.bird'];
+
+	it('is a single tab stop: only the selected chip has tabIndex=0', () => {
+		render(
+			<TableSizeChipRow
+				tableSet={tables}
+				hasOther
+				selectedTable="db.cat"
+				onSelectTable={() => {}}
+			/>,
+		);
+		const chips = screen.getAllByTestId('table-size-chip');
+		expect(chips.length).toBe(4); // 3 tables + Other
+		const tabbable = chips.filter((c) => (c as HTMLButtonElement).tabIndex === 0);
+		expect(tabbable.length).toBe(1);
+		expect(tabbable[0].getAttribute('data-table')).toBe('db.cat');
+	});
+
+	it('arrow keys move selection with wrap, skipping the Other chip', () => {
+		const picks: string[] = [];
+		render(
+			<TableSizeChipRow
+				tableSet={tables}
+				hasOther
+				selectedTable="db.bird"
+				onSelectTable={(t) => picks.push(t)}
+			/>,
+		);
+		const chips = screen.getAllByTestId('table-size-chip');
+		// From the last selectable chip, Right wraps to the first (not Other).
+		fireEvent.keyDown(chips[2], { key: 'ArrowRight' });
+		expect(picks).toEqual(['db.dog']);
+	});
+
+	it('Other chip is a disabled radio: aria-disabled, never checked, tabIndex=-1', () => {
+		render(
+			<TableSizeChipRow
+				tableSet={tables}
+				hasOther
+				selectedTable="db.dog"
+				onSelectTable={() => {}}
+			/>,
+		);
+		const other = screen
+			.getAllByTestId('table-size-chip')
+			.find((c) => c.getAttribute('data-table') === OTHER_KEY);
+		expect(other, 'Other chip rendered').toBeTruthy();
+		expect(other!.getAttribute('role')).toBe('radio');
+		expect(other!.getAttribute('aria-disabled')).toBe('true');
+		expect(other!.getAttribute('aria-checked')).toBe('false');
+		expect((other as HTMLButtonElement).tabIndex).toBe(-1);
+	});
+
+	it('falls back to the first chip as tab stop when selection is null or Other', () => {
+		render(
+			<TableSizeChipRow
+				tableSet={tables}
+				hasOther
+				selectedTable={null}
+				onSelectTable={() => {}}
+			/>,
+		);
+		const chips = screen.getAllByTestId('table-size-chip');
+		expect((chips[0] as HTMLButtonElement).tabIndex).toBe(0);
+		expect(chips.filter((c) => (c as HTMLButtonElement).tabIndex === 0).length).toBe(1);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-chip-row.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-chip-row.test.tsx
@@ -73,24 +73,44 @@ describe('DimensionChipRow primitive', () => {
 		expect(picks).toEqual(['/api/orders', '/api/products']);
 	});
 
-	it('Other chip is non-interactive (aria-disabled, no role=radio, not in roving tab order)', () => {
+	it('Other chip is a disabled radio (aria-disabled, never checked, not in roving tab order)', () => {
+		const picks: string[] = [];
 		render(
 			<DimensionChipRow
 				dimensionValues={values}
 				selected={'/api/users'}
 				otherKey="Other"
-				onSelect={() => {}}
+				onSelect={(v) => picks.push(v)}
 			/>,
 		);
-		// Only the selectable values are role=radio.
+		// The Other chip participates in the group as a perceivable, disabled radio.
 		const radios = screen.getAllByRole('radio');
-		expect(radios.length).toBe(3);
-		// The Other chip exists with aria-disabled and tabIndex=-1.
+		expect(radios.length).toBe(4);
 		const chips = screen.getAllByTestId('dimension-chip');
 		const otherChip = chips.find((c) => c.getAttribute('data-value') === 'Other');
 		expect(otherChip, 'Other chip rendered').toBeTruthy();
+		expect(otherChip!.getAttribute('role')).toBe('radio');
 		expect(otherChip!.getAttribute('aria-disabled')).toBe('true');
-		expect(otherChip!.getAttribute('role')).toBe(null);
+		expect(otherChip!.getAttribute('aria-checked')).toBe('false');
 		expect((otherChip as HTMLButtonElement).tabIndex).toBe(-1);
+		// Arrow keys never land on it: from the last selectable chip, Right
+		// wraps to the first selectable chip.
+		fireEvent.keyDown(chips[2], { key: 'ArrowRight' });
+		expect(picks).toEqual(['/api/users']);
+	});
+
+	it('the group is a single tab stop (exactly one chip with tabIndex=0), even with Other', () => {
+		render(
+			<DimensionChipRow
+				dimensionValues={values}
+				selected={'/api/orders'}
+				otherKey="Other"
+				onSelect={() => {}}
+			/>,
+		);
+		const chips = screen.getAllByTestId('dimension-chip');
+		const tabbable = chips.filter((c) => (c as HTMLButtonElement).tabIndex === 0);
+		expect(tabbable.length).toBe(1);
+		expect(tabbable[0].getAttribute('data-value')).toBe('/api/orders');
 	});
 });

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-combobox.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-combobox.test.tsx
@@ -20,10 +20,11 @@ function Harness(props: { values: readonly string[]; initial: string; otherKey?:
 // WAI-ARIA APG button-pattern combobox: the popup-trigger is a <button> with
 // aria-haspopup='listbox' (NOT role='combobox'); when open, the searchbox
 // inside the popup is the actual role='combobox' with aria-activedescendant
-// driving option highlight. Tests target the trigger by its aria-label and
-// the searchbox by role='combobox' (only present while open).
+// driving option highlight. Tests target the trigger by its aria-label —
+// which composes the current selection into the accessible name — and the
+// searchbox by role='combobox' (only present while open).
 function getTrigger() {
-	return screen.getByRole('button', { name: 'Path' });
+	return screen.getByRole('button', { name: /^Path/ });
 }
 
 describe('DimensionCombobox primitive', () => {
@@ -36,6 +37,18 @@ describe('DimensionCombobox primitive', () => {
 		expect(trigger.textContent ?? '').toMatch(/\/b/);
 		expect(trigger.getAttribute('aria-expanded')).toBe('false');
 		expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
+	});
+
+	it('trigger accessible name contains the current selection (and tracks it)', () => {
+		const values = ['/users', '/orders', '/health'];
+		render(<Harness values={values} initial="/users" />);
+		// aria-label composes label + selection so SR users hear the value.
+		expect(screen.getByRole('button', { name: 'Path: /users' })).toBeTruthy();
+		fireEvent.click(getTrigger());
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		fireEvent.change(input, { target: { value: 'ord' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		expect(screen.getByRole('button', { name: 'Path: /orders' })).toBeTruthy();
 	});
 
 	it('opens the listbox on click; Escape closes', () => {

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer.tsx';
 import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
@@ -69,9 +69,68 @@ describe('DimensionSelectorRenderer chip↔combobox auto-switch', () => {
 		);
 		// DimensionCombobox uses APG button-pattern: trigger is a button with
 		// aria-haspopup='listbox', not role='combobox'. The role='combobox' is
-		// the searchbox INSIDE the popup, only present while open.
-		const trigger = await screen.findByRole('button', { name: 'Dimension' });
+		// the searchbox INSIDE the popup, only present while open. The trigger's
+		// accessible name composes the label with the current selection.
+		const trigger = await screen.findByRole('button', { name: /^Dimension: / });
 		expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
 		expect(screen.queryAllByRole('radio').length).toBe(0);
+	});
+});
+
+describe('DimensionSelectorRenderer quantile picker radiogroup', () => {
+	afterEach(() => cleanup());
+
+	function quantileSpec(): MetricSpec {
+		return {
+			...specForN(3),
+			quantileSelector: {
+				fields: [
+					{ field: 'p50', label: 'Median' },
+					{ field: 'p95', label: 'p95' },
+					{ field: 'p99', label: 'p99' },
+				],
+				default: 'p95',
+			},
+		};
+	}
+
+	function renderQuantile() {
+		render(
+			<DimensionSelectorRenderer
+				spec={quantileSpec()}
+				records={recordsForN(3)}
+				timeRange={range}
+				nodes={['n1']}
+				theme="light"
+			/>,
+		);
+		return screen.getAllByTestId('quantile-button');
+	}
+
+	it('is a single tab stop: only the selected quantile has tabIndex=0', () => {
+		const buttons = renderQuantile();
+		expect(buttons.length).toBe(3);
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([-1, 0, -1]);
+		expect(buttons.map((b) => b.getAttribute('aria-checked'))).toEqual(['false', 'true', 'false']);
+	});
+
+	it('ArrowRight moves selection (and the tab stop) to the next quantile, wrapping', () => {
+		const buttons = renderQuantile();
+		// p95 selected → ArrowRight selects p99.
+		fireEvent.keyDown(buttons[1], { key: 'ArrowRight' });
+		expect(buttons[2].getAttribute('aria-checked')).toBe('true');
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([-1, -1, 0]);
+		// ArrowRight from the last wraps to the first.
+		fireEvent.keyDown(buttons[2], { key: 'ArrowRight' });
+		expect(buttons[0].getAttribute('aria-checked')).toBe('true');
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([0, -1, -1]);
+	});
+
+	it('ArrowLeft wraps backwards from the first quantile', () => {
+		const buttons = renderQuantile();
+		fireEvent.keyDown(buttons[1], { key: 'ArrowLeft' });
+		expect(buttons[0].getAttribute('aria-checked')).toBe('true');
+		fireEvent.keyDown(buttons[0], { key: 'ArrowLeft' });
+		expect(buttons[2].getAttribute('aria-checked')).toBe('true');
 	});
 });

--- a/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TrafficByTypeRenderer } from '../../primitives/TrafficByTypeRenderer.tsx';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+
+const range = { startTime: 0, endTime: 10_000_000 };
+
+const spec: MetricSpec = {
+	title: 'stack-by test',
+	description: '',
+	tab: 'traffic',
+	primaryDimension: 'type',
+	series: {
+		kind: 'groupBy',
+		dimension: 'type',
+		field: { field: 'value', label: 'value' },
+	},
+	timestamp: 'time',
+	bucket: { source: 'period-field', fallbackMs: 60000 },
+	aggregator: { temporal: 'mean', crossNode: 'sum' },
+	primitive: 'stacked-area',
+	yAxis: { unit: '', formatter: 'count' },
+};
+
+const records: AnalyticsDataPoint[] = (['n1', 'n2'] as const).flatMap((node) =>
+	(['mqtt', 'http'] as const).map((type) => ({
+		time: 100_000,
+		node,
+		type,
+		value: 5,
+		count: 10,
+		period: 60_000,
+	} as any))
+);
+
+function renderToggle() {
+	render(
+		<TrafficByTypeRenderer
+			spec={spec}
+			typeField="type"
+			records={records}
+			timeRange={range}
+			nodes={['n1', 'n2']}
+			theme="light"
+		/>,
+	);
+	return screen.getAllByTestId('stack-by-button');
+}
+
+describe('StackByToggle radiogroup (shared roving-tabindex primitive)', () => {
+	afterEach(() => cleanup());
+
+	it('is a single tab stop: only the active option has tabIndex=0', () => {
+		const buttons = renderToggle();
+		expect(buttons.length).toBe(3);
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([0, -1, -1]);
+		expect(buttons.map((b) => b.getAttribute('aria-checked'))).toEqual(['true', 'false', 'false']);
+	});
+
+	it('arrow keys move selection and the tab stop, wrapping at the ends', () => {
+		const buttons = renderToggle();
+		fireEvent.keyDown(buttons[0], { key: 'ArrowRight' });
+		expect(buttons[1].getAttribute('aria-checked')).toBe('true');
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([-1, 0, -1]);
+		// Left from the first wraps to the last.
+		fireEvent.keyDown(buttons[1], { key: 'ArrowLeft' });
+		fireEvent.keyDown(buttons[0], { key: 'ArrowLeft' });
+		expect(buttons[2].getAttribute('aria-checked')).toBe('true');
+	});
+
+	it('click selects an option', () => {
+		const buttons = renderToggle();
+		fireEvent.click(buttons[2]);
+		expect(buttons[2].getAttribute('aria-checked')).toBe('true');
+		expect(buttons.map((b) => (b as HTMLButtonElement).tabIndex)).toEqual([-1, -1, 0]);
+	});
+});

--- a/src/features/instance/status/analytics/charts/TableSizeChipRow.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeChipRow.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useRef } from 'react';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
 import { getTableColor, OTHER_COLOR } from '../lib/tableColors.ts';
 import { OTHER_KEY } from '../lib/tableSize.ts';
 
@@ -25,43 +25,10 @@ export function TableSizeChipRow({
 	selectedTable,
 	onSelectTable,
 }: TableSizeChipRowProps) {
-	const chipRefs = useRef<Array<HTMLButtonElement | null>>([]);
-
-	useEffect(() => {
-		chipRefs.current = chipRefs.current.slice(0, tableSet.length);
-	}, [tableSet.length]);
-
-	// Figure out which chip gets tabIndex=0. Default to the selected chip; if
-	// selectedTable is not in tableSet (e.g. transient refetch gap, or selection
-	// is `Other`), fall back to the first chip so the radiogroup stays reachable.
-	const activeIdx = selectedTable === null ? -1 : tableSet.indexOf(selectedTable);
-	const tabbableIdx = activeIdx >= 0 ? activeIdx : 0;
-
-	function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			onSelectTable(tableSet[idx]);
-			return;
-		}
-
-		if (
-			e.key !== 'ArrowLeft'
-			&& e.key !== 'ArrowRight'
-			&& e.key !== 'ArrowDown'
-			&& e.key !== 'ArrowUp'
-		) {
-			return;
-		}
-
-		e.preventDefault();
-		const n = tableSet.length;
-		if (n === 0) { return; }
-		let next = idx;
-		if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { next = (idx + 1) % n; }
-		if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { next = (idx - 1 + n) % n; }
-		chipRefs.current[next]?.focus();
-		onSelectTable(tableSet[next]);
-	}
+	// Roving tabindex: the selected chip gets tabIndex=0; if selectedTable is
+	// not in tableSet (transient refetch gap, or selection is `Other`), the
+	// hook falls back to the first chip so the radiogroup stays reachable.
+	const { getRadioProps } = useRovingRadioGroup(tableSet, selectedTable, onSelectTable);
 
 	if (tableSet.length === 0 && !hasOther) { return null; }
 
@@ -78,16 +45,10 @@ export function TableSizeChipRow({
 				return (
 					<button
 						key={tableKey}
-						ref={(el) => {
-							chipRefs.current[idx] = el;
-						}}
-						role="radio"
-						aria-checked={selected}
-						tabIndex={idx === tabbableIdx ? 0 : -1}
+						type="button"
+						{...getRadioProps(idx)}
 						data-testid="table-size-chip"
 						data-table={tableKey}
-						onKeyDown={(e) => handleKeyDown(e, idx)}
-						onClick={() => onSelectTable(tableKey)}
 						className={`inline-flex min-h-8 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs ${
 							selected
 								? 'font-semibold text-(--color-text-primary)'
@@ -103,6 +64,8 @@ export function TableSizeChipRow({
 			{hasOther && (
 				<button
 					type="button"
+					role="radio"
+					aria-checked={false}
 					aria-disabled="true"
 					tabIndex={-1}
 					data-testid="table-size-chip"

--- a/src/features/instance/status/analytics/hooks/useNodeSelection.ts
+++ b/src/features/instance/status/analytics/hooks/useNodeSelection.ts
@@ -1,34 +1,10 @@
-import { useCallback, useState } from 'react';
+// Node-legend flavor of the shared solo/Ctrl-toggle hook. Kept as a named
+// wrapper because many chart/renderer call sites destructure
+// `handleLegendClick`.
+
+import { useSoloToggleSelection } from './useSoloToggleSelection.ts';
 
 export function useNodeSelection(nodeIds: string[]) {
-	const [activeNodes, setActiveNodes] = useState<Set<string> | null>(null);
-
-	const isActive = useCallback((nodeId: string) => {
-		return activeNodes === null || activeNodes.has(nodeId);
-	}, [activeNodes]);
-
-	const handleLegendClick = useCallback((nodeId: string, ctrlKey: boolean) => {
-		setActiveNodes((prev) => {
-			if (ctrlKey) {
-				if (prev === null) {
-					return new Set(nodeIds.filter((id) => id !== nodeId));
-				}
-				const next = new Set(prev);
-				if (next.has(nodeId)) {
-					next.delete(nodeId);
-					if (next.size === 0) { return null; }
-				} else {
-					next.add(nodeId);
-					if (next.size === nodeIds.length) { return null; }
-				}
-				return next;
-			}
-			if (prev !== null && prev.size === 1 && prev.has(nodeId)) {
-				return null;
-			}
-			return new Set([nodeId]);
-		});
-	}, [nodeIds]);
-
-	return { isActive, handleLegendClick, activeNodes };
+	const { isActive, handleClick, activeSet } = useSoloToggleSelection(nodeIds);
+	return { isActive, handleLegendClick: handleClick, activeNodes: activeSet };
 }

--- a/src/features/instance/status/analytics/hooks/useRovingRadioGroup.ts
+++ b/src/features/instance/status/analytics/hooks/useRovingRadioGroup.ts
@@ -1,0 +1,68 @@
+// Shared roving-tabindex radiogroup behavior (WAI-ARIA APG "Radio Group"
+// pattern): exactly one radio is in the tab order — the selected one, falling
+// back to the first — arrow keys move focus AND selection with wrap-around,
+// and Enter/Space select the focused radio. Used by every single-select
+// chip/segmented selector in the Status analytics dashboards
+// (DimensionChipRow, TableSizeChipRow, StackByToggle, quantile picker) so the
+// keyboard contract can't drift between them.
+
+import { type KeyboardEvent, useEffect, useRef } from 'react';
+
+export function useRovingRadioGroup<T extends string, E extends HTMLElement = HTMLButtonElement>(
+	values: readonly T[],
+	selected: T | null,
+	onSelect: (value: T) => void,
+) {
+	const radioRefs = useRef<Array<E | null>>([]);
+
+	useEffect(() => {
+		radioRefs.current = radioRefs.current.slice(0, values.length);
+	}, [values.length]);
+
+	const selectedIdx = selected === null ? -1 : values.indexOf(selected);
+	// Default the tab stop to the selected radio; if the selection isn't in
+	// `values` (transient refetch gap, or a non-selectable aggregate), fall
+	// back to the first radio so the group stays keyboard-reachable.
+	const tabbableIdx = selectedIdx >= 0 ? selectedIdx : 0;
+
+	function handleKeyDown(e: KeyboardEvent<E>, idx: number) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			onSelect(values[idx]);
+			return;
+		}
+		if (
+			e.key !== 'ArrowLeft'
+			&& e.key !== 'ArrowRight'
+			&& e.key !== 'ArrowDown'
+			&& e.key !== 'ArrowUp'
+		) {
+			return;
+		}
+		e.preventDefault();
+		const n = values.length;
+		if (n === 0) { return; }
+		const dir = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
+		const next = (idx + dir + n) % n;
+		radioRefs.current[next]?.focus();
+		onSelect(values[next]);
+	}
+
+	/** ARIA + interaction props to spread onto each radio element, in
+	 *  `values` order. The caller still owns rendering (element type,
+	 *  className, children). */
+	function getRadioProps(idx: number) {
+		return {
+			role: 'radio' as const,
+			'aria-checked': idx === selectedIdx,
+			tabIndex: idx === tabbableIdx ? 0 : -1,
+			ref: (el: E | null) => {
+				radioRefs.current[idx] = el;
+			},
+			onKeyDown: (e: KeyboardEvent<E>) => handleKeyDown(e, idx),
+			onClick: () => onSelect(values[idx]),
+		};
+	}
+
+	return { getRadioProps, selectedIdx };
+}

--- a/src/features/instance/status/analytics/hooks/useSoloToggleSelection.ts
+++ b/src/features/instance/status/analytics/hooks/useSoloToggleSelection.ts
@@ -4,10 +4,14 @@
 // it's already the solo), Ctrl/Cmd-click toggles individual values, and the
 // set collapses back to `null` when it would become empty or complete.
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 export function useSoloToggleSelection(values: readonly string[]) {
 	const [activeSet, setActiveSet] = useState<Set<string> | null>(null);
+	// Read `values` through a ref so handleClick stays reference-stable even
+	// when callers pass a freshly-derived array each render.
+	const valuesRef = useRef(values);
+	valuesRef.current = values;
 
 	const isActive = useCallback(
 		(value: string) => activeSet === null || activeSet.has(value),
@@ -15,6 +19,7 @@ export function useSoloToggleSelection(values: readonly string[]) {
 	);
 
 	const handleClick = useCallback((value: string, ctrlKey: boolean) => {
+		const values = valuesRef.current;
 		setActiveSet((prev) => {
 			if (ctrlKey) {
 				if (prev === null) { return new Set(values.filter((v) => v !== value)); }
@@ -32,7 +37,7 @@ export function useSoloToggleSelection(values: readonly string[]) {
 			if (prev !== null && prev.size === 1 && prev.has(value)) { return null; }
 			return new Set([value]);
 		});
-	}, [values]);
+	}, []);
 
 	return { isActive, handleClick, activeSet };
 }

--- a/src/features/instance/status/analytics/hooks/useSoloToggleSelection.ts
+++ b/src/features/instance/status/analytics/hooks/useSoloToggleSelection.ts
@@ -1,0 +1,38 @@
+// Solo / Ctrl-toggle selection over a categorical value set, shared by the
+// node legend (useNodeSelection) and the type-filter chip rows. `null` is the
+// default "everything active" state; plain click solos a value (or resets if
+// it's already the solo), Ctrl/Cmd-click toggles individual values, and the
+// set collapses back to `null` when it would become empty or complete.
+
+import { useCallback, useState } from 'react';
+
+export function useSoloToggleSelection(values: readonly string[]) {
+	const [activeSet, setActiveSet] = useState<Set<string> | null>(null);
+
+	const isActive = useCallback(
+		(value: string) => activeSet === null || activeSet.has(value),
+		[activeSet],
+	);
+
+	const handleClick = useCallback((value: string, ctrlKey: boolean) => {
+		setActiveSet((prev) => {
+			if (ctrlKey) {
+				if (prev === null) { return new Set(values.filter((v) => v !== value)); }
+				const next = new Set(prev);
+				if (next.has(value)) {
+					next.delete(value);
+					if (next.size === 0) { return null; }
+				} else {
+					next.add(value);
+					if (next.size === values.length) { return null; }
+				}
+				return next;
+			}
+			// Plain click: solo (or reset to all if already soloed)
+			if (prev !== null && prev.size === 1 && prev.has(value)) { return null; }
+			return new Set([value]);
+		});
+	}, [values]);
+
+	return { isActive, handleClick, activeSet };
+}

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -1,4 +1,5 @@
 import { type JSX, useMemo, useState } from 'react';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
 import { HeatmapMatrix } from '../primitives/HeatmapMatrix.tsx';
 import { LineChart } from '../primitives/LineChart.tsx';
 import type {
@@ -481,19 +482,22 @@ interface QuantileSelectorProps {
 }
 
 function QuantileSelector({ value, onChange }: QuantileSelectorProps) {
+	const { getRadioProps } = useRovingRadioGroup(
+		REPLICATION_QUANTILE_FIELDS.map((q) => q.field),
+		value,
+		onChange,
+	);
 	return (
 		<div role="radiogroup" aria-label="Quantile" className="flex flex-wrap gap-1 pb-2">
-			{REPLICATION_QUANTILE_FIELDS.map((q) => {
+			{REPLICATION_QUANTILE_FIELDS.map((q, idx) => {
 				const active = q.field === value;
 				return (
 					<button
 						key={q.field}
 						type="button"
-						role="radio"
-						aria-checked={active}
 						data-testid="quantile-button"
 						data-value={q.field}
-						onClick={() => onChange(q.field)}
+						{...getRadioProps(idx)}
 						className={`rounded px-2 py-0.5 text-[11px] ${
 							active
 								? 'bg-(--color-accent)/20 text-(--color-text-primary) font-semibold'

--- a/src/features/instance/status/analytics/primitives/DimensionChipRow.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionChipRow.tsx
@@ -3,9 +3,10 @@
 // matches TypeFilterChipRow used by the Traffic tab — minimal inline-flex
 // text + a tiny colored bar — so chip selectors look the same across
 // every analytics dashboard. Behaviorally still a radiogroup: one value
-// active at a time, arrow keys move focus and selection.
+// active at a time, arrow keys move focus and selection
+// (useRovingRadioGroup).
 
-import { type KeyboardEvent, useEffect, useRef } from 'react';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
 
 interface DimensionChipRowProps {
 	/** Selectable dimension values, in display order. */
@@ -33,38 +34,7 @@ export function DimensionChipRow({
 	colorFor,
 	ariaLabel = 'Dimension selector',
 }: DimensionChipRowProps) {
-	const chipRefs = useRef<Array<HTMLButtonElement | null>>([]);
-
-	useEffect(() => {
-		chipRefs.current = chipRefs.current.slice(0, dimensionValues.length);
-	}, [dimensionValues.length]);
-
-	const activeIdx = dimensionValues.indexOf(selected);
-	const tabbableIdx = activeIdx >= 0 ? activeIdx : 0;
-
-	function handleKeyDown(e: KeyboardEvent<HTMLButtonElement>, idx: number) {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			onSelect(dimensionValues[idx]);
-			return;
-		}
-		if (
-			e.key !== 'ArrowLeft'
-			&& e.key !== 'ArrowRight'
-			&& e.key !== 'ArrowDown'
-			&& e.key !== 'ArrowUp'
-		) {
-			return;
-		}
-		e.preventDefault();
-		const n = dimensionValues.length;
-		if (n === 0) { return; }
-		let next = idx;
-		if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { next = (idx + 1) % n; }
-		if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') { next = (idx - 1 + n) % n; }
-		chipRefs.current[next]?.focus();
-		onSelect(dimensionValues[next]);
-	}
+	const { getRadioProps } = useRovingRadioGroup(dimensionValues, selected, onSelect);
 
 	if (dimensionValues.length === 0 && !otherKey) { return null; }
 
@@ -81,18 +51,11 @@ export function DimensionChipRow({
 				return (
 					<button
 						key={value}
-						ref={(el) => {
-							chipRefs.current[idx] = el;
-						}}
 						type="button"
-						role="radio"
-						aria-checked={isSelected}
-						tabIndex={idx === tabbableIdx ? 0 : -1}
+						{...getRadioProps(idx)}
 						data-testid="dimension-chip"
 						data-value={value}
 						title="Click to select"
-						onKeyDown={(e) => handleKeyDown(e, idx)}
-						onClick={() => onSelect(value)}
 						className="inline-flex items-center gap-1.5 cursor-pointer border-none bg-transparent p-0"
 						style={{ color, opacity: isSelected ? 1 : 0.55 }}
 					>
@@ -105,12 +68,20 @@ export function DimensionChipRow({
 				);
 			})}
 			{otherKey && (
-				<span
+				<button
+					type="button"
+					// Disabled radio, not a role-less span: SR users perceive it as
+					// part of the group with an explicit disabled state. Kept out of
+					// the roving tab order (tabIndex=-1) so the group stays a single
+					// tab stop. Mirrors TableSizeChipRow's Other treatment.
+					role="radio"
+					aria-checked={false}
+					aria-disabled="true"
+					tabIndex={-1}
 					data-testid="dimension-chip"
 					data-value={otherKey}
-					aria-disabled="true"
 					title="Aggregate of smaller buckets; not selectable."
-					className="inline-flex items-center gap-1.5 cursor-not-allowed"
+					className="inline-flex items-center gap-1.5 cursor-not-allowed border-none bg-transparent p-0"
 					style={{ color: DEFAULT_COLOR, opacity: 0.4 }}
 				>
 					<span
@@ -118,7 +89,7 @@ export function DimensionChipRow({
 						style={{ backgroundColor: DEFAULT_COLOR }}
 					/>
 					<span>{otherKey}</span>
-				</span>
+				</button>
 			)}
 		</div>
 	);

--- a/src/features/instance/status/analytics/primitives/DimensionCombobox.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionCombobox.tsx
@@ -110,7 +110,10 @@ export function DimensionCombobox({
 				// aria-haspopup='listbox' but is NOT itself role='combobox'.
 				// The searchbox below is the actual combobox element with
 				// aria-activedescendant for option highlight tracking.
-				aria-label={ariaLabel}
+				// Compose the selection into the accessible name — a bare
+				// aria-label would mask the visible value, so SR users would
+				// never hear the current selection.
+				aria-label={selected ? `${ariaLabel}: ${selected}` : ariaLabel}
 				aria-expanded={open}
 				aria-controls={listboxId}
 				aria-haspopup="listbox"

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -14,6 +14,7 @@
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
 import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
 import { runPipeline } from '../pipeline/pipeline.ts';
 import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
 import { DimensionChipRow } from './DimensionChipRow.tsx';
@@ -58,6 +59,15 @@ export function DimensionSelectorRenderer({
 	const effectiveQuantile = quantileFields?.some((q) => q.field === quantile)
 		? quantile
 		: (spec.quantileSelector?.default ?? '');
+
+	// Roving-tabindex radiogroup behavior for the quantile picker (single tab
+	// stop, arrow keys move focus + selection).
+	const quantileValues = useMemo(() => quantileFields?.map((q) => q.field) ?? [], [quantileFields]);
+	const { getRadioProps: getQuantileRadioProps } = useRovingRadioGroup(
+		quantileValues,
+		effectiveQuantile,
+		setQuantile,
+	);
 
 	// Build the runtime spec — substitute the chosen percentile field if a
 	// quantile selector is active. groupBy specs only.
@@ -119,17 +129,15 @@ export function DimensionSelectorRenderer({
 					aria-label="Quantile"
 					className="flex flex-wrap justify-center gap-x-3 gap-y-1 pt-2 text-[11px]"
 				>
-					{quantileFields.map((q) => {
+					{quantileFields.map((q, idx) => {
 						const active = q.field === effectiveQuantile;
 						return (
 							<button
 								key={q.field}
 								type="button"
-								role="radio"
-								aria-checked={active}
+								{...getQuantileRadioProps(idx)}
 								data-testid="quantile-button"
 								data-value={q.field}
-								onClick={() => setQuantile(q.field)}
 								className="inline-flex items-center cursor-pointer border-none bg-transparent p-0 text-(--color-text-secondary)"
 								style={{ opacity: active ? 1 : 0.3 }}
 							>

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -17,13 +17,15 @@
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
 import { useNodeSelection } from '../hooks/useNodeSelection.ts';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
+import { useSoloToggleSelection } from '../hooks/useSoloToggleSelection.ts';
 import { getTypeColor } from '../lib/colorAllocators/typeColors.ts';
 import { getNodeColor } from '../lib/nodeColors.ts';
 import { runPipeline } from '../pipeline/pipeline.ts';
 import type { AnalyticsDataPoint, MetricSpec, Series, SeriesData, TimeRange } from '../types/analytics.ts';
 import { SmallMultiples } from './SmallMultiples.tsx';
 import { StackedAreaChart } from './StackedAreaChart.tsx';
-import { TypeFilterChipRow, useTypeFilter } from './TypeFilterChipRow.tsx';
+import { TypeFilterChipRow } from './TypeFilterChipRow.tsx';
 
 interface Props {
 	/** Underlying spec (groupBy on `typeField`, primitive `stacked-area`). */
@@ -67,7 +69,7 @@ export function TrafficByTypeRenderer({
 		return [...set].sort();
 	}, [records, typeField]);
 
-	const { isActive, handleClick } = useTypeFilter(types);
+	const { isActive, handleClick } = useSoloToggleSelection(types);
 	const { isActive: isNodeActive, handleLegendClick: handleNodeClick } = useNodeSelection(nodes);
 
 	// "All active" = default state where no chip / node has been soloed.
@@ -184,17 +186,12 @@ const STACK_BY_OPTIONS: ReadonlyArray<{ value: StackBy; label: string }> = [
 	{ value: 'grid', label: 'Per-node grid' },
 ];
 
+const STACK_BY_VALUES: readonly StackBy[] = STACK_BY_OPTIONS.map((o) => o.value);
+
 function StackByToggle({ stackBy, onChange }: StackByToggleProps) {
-	// Roving tabindex pattern: only the active radio is in the tab order; arrow
-	// keys move selection within the group. Matches DimensionChipRow.
-	const activeIdx = Math.max(0, STACK_BY_OPTIONS.findIndex((o) => o.value === stackBy));
-	const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-		if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft' && e.key !== 'ArrowDown' && e.key !== 'ArrowUp') { return; }
-		e.preventDefault();
-		const dir = e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1 : -1;
-		const next = (activeIdx + dir + STACK_BY_OPTIONS.length) % STACK_BY_OPTIONS.length;
-		onChange(STACK_BY_OPTIONS[next].value);
-	};
+	// Shared roving tabindex pattern: only the active radio is in the tab
+	// order; arrow keys move focus and selection within the group.
+	const { getRadioProps } = useRovingRadioGroup(STACK_BY_VALUES, stackBy, onChange);
 	return (
 		<div
 			role="radiogroup"
@@ -208,13 +205,9 @@ function StackByToggle({ stackBy, onChange }: StackByToggleProps) {
 					<button
 						key={opt.value}
 						type="button"
-						role="radio"
-						aria-checked={active}
-						tabIndex={idx === activeIdx ? 0 : -1}
-						onKeyDown={onKeyDown}
+						{...getRadioProps(idx)}
 						data-testid="stack-by-button"
 						data-value={opt.value}
-						onClick={() => onChange(opt.value)}
 						className="inline-flex items-center cursor-pointer border-none bg-transparent p-0 text-(--color-text-secondary)"
 						style={{ opacity: active ? 1 : 0.55 }}
 					>

--- a/src/features/instance/status/analytics/primitives/TypeFilterChipRow.tsx
+++ b/src/features/instance/status/analytics/primitives/TypeFilterChipRow.tsx
@@ -3,55 +3,13 @@
 // state = all chips active; click solos that chip; Ctrl-click toggles
 // individual chips. Mirrors NodeLegend's interaction model so the panel
 // has a consistent dual-legend pattern (TypeFilterChipRow above / below
-// the chart, NodeLegend at the bottom).
-
-import { useCallback, useMemo, useState } from 'react';
+// the chart, NodeLegend at the bottom). State lives in the shared
+// useSoloToggleSelection hook (same one that backs useNodeSelection).
 
 interface Props {
 	values: readonly string[];
 	colorFor?: (value: string) => string;
 	ariaLabel?: string;
-}
-
-export interface TypeFilterState {
-	isActive: (value: string) => boolean;
-	activeValues: readonly string[];
-}
-
-/** Hook holding active-set state + the click handler. Component below
- *  consumes both. Separating them lets the parent renderer use
- *  `isActive` to filter records in the same render pass. */
-export function useTypeFilter(values: readonly string[]) {
-	const [active, setActive] = useState<Set<string> | null>(null);
-
-	const isActive = useCallback((v: string) => active === null || active.has(v), [active]);
-
-	const handleClick = useCallback((v: string, ctrlKey: boolean) => {
-		setActive((prev) => {
-			if (ctrlKey) {
-				if (prev === null) { return new Set(values.filter((x) => x !== v)); }
-				const next = new Set(prev);
-				if (next.has(v)) {
-					next.delete(v);
-					if (next.size === 0) { return null; }
-				} else {
-					next.add(v);
-					if (next.size === values.length) { return null; }
-				}
-				return next;
-			}
-			// Plain click: solo (or reset if already soloed)
-			if (prev !== null && prev.size === 1 && prev.has(v)) { return null; }
-			return new Set([v]);
-		});
-	}, [values]);
-
-	const activeValues = useMemo(
-		() => (active === null ? values : values.filter((v) => active.has(v))),
-		[active, values],
-	);
-
-	return { isActive, handleClick, activeValues };
 }
 
 interface TypeFilterChipRowProps extends Props {


### PR DESCRIPTION
Fixes [#1449 — Consolidate chip/radiogroup selectors into one roving-tabindex primitive](https://github.com/HarperFast/studio/issues/1449).

## What changed

### One shared primitive, four call sites
The roving-radiogroup keyboard pattern was implemented four different ways under `src/features/instance/status/analytics/`. This PR extracts **`hooks/useRovingRadioGroup.ts`** — the WAI-ARIA APG Radio Group pattern in one place (single tab stop on the selected radio with first-radio fallback, arrow keys move focus *and* selection with wrap-around, Enter/Space select) — and uses it in:

- `primitives/DimensionChipRow.tsx` (was copy #1)
- `charts/TableSizeChipRow.tsx` (was copy #2 — also picks up a missing `type="button"` on its chips)
- `StackByToggle` in `primitives/TrafficByTypeRenderer.tsx` (was copy #3 — arrow keys now move DOM focus along with selection, not just selection)
- the quantile picker in `primitives/DimensionSelectorRenderer.tsx` — **behavior fix**: it previously rendered `role="radio"` with *no* roving tabindex and *no* arrow-key handling (every radio was a tab stop, violating the APG pattern). It gains both for free from the hook.

### Duplicate solo/Ctrl-toggle hook folded
`useTypeFilter` (in `TypeFilterChipRow.tsx`) was a rename-only copy of `hooks/useNodeSelection.ts`. Both now delegate to one generic **`hooks/useSoloToggleSelection.ts`**; `useNodeSelection` stays as a thin named wrapper so its many call sites (including the pipeline renderers) are untouched.

### Two a11y fixes from the issue
- **`DimensionCombobox.tsx`** — the trigger's bare `aria-label` ("Path"/"Dimension") masked the visible selected value, so screen-reader users never heard the current selection. The accessible name now composes both: `"Path: /orders"`.
- **"Other" chip** — in `DimensionChipRow` it was a role-less `<span aria-disabled>` (meaningless to AT). It is now a perceivable disabled radio in both chip rows: `role="radio" aria-checked="false" aria-disabled="true"`, kept out of the roving order (`tabIndex={-1}`) so each group remains a single tab stop.

## Tests
- Updated: `dimension-chip-row.test.tsx` (Other chip's improved semantics + single-tab-stop invariant), `dimension-combobox.test.tsx` and `dimension-selector-switch.test.tsx` (composed accessible names).
- Added: quantile-picker arrow-key navigation and single-tab-stop tests; new `table-size-chip-row.test.tsx` and `stack-by-toggle.test.tsx` covering the shared hook's contract at those call sites (single tab stop, wrap-around, Other-chip skip, null-selection fallback).
- `tsc -b`, full `vitest run` (202 files / 1342 passed, 11 pre-existing skips), `oxlint`, `dprint` all clean.

## Cross-model review
Gemini 3.1 Pro reviewed the diff for APG radiogroup conformance: no blockers/majors/minors. Its one concrete nit (missing accessible name on the StackBy radiogroup) is a false positive — `aria-label="Stack by"` was already present outside the diff. Codex review reported no correctness issues, though it repeatedly drifted to a sibling worktree's diff in this multi-worktree checkout, so treat that signal as weak.

## Open concerns / future work
- **Combobox popover is still not portaled** (`position: absolute`), so an `overflow: hidden` ancestor can clip it. Swapping the bespoke listbox for the app's Radix Popover/Command was not a clean drop-in (the current implementation is an `aria-activedescendant` filter-listbox, not a menu), so it's deferred per the issue's "consider" framing.
- Arrow-key direction is LTR-only (`ArrowRight` = next); would need inverting if the app ever supports RTL.
- The disabled "Other" radio is deliberately *not* arrow-reachable — it can never become enabled, and skipping a permanently-disabled aggregate keeps selection-follows-focus simple. It remains perceivable to AT via its role and `aria-disabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZEaYdKFXuQw2Hf6XpPdEV

Generated by kAIle (Claude Fable 5).