### PR TITLE
refactor(status): carry series dim/node structurally instead of the dim|node string

### DIFF
--- a/src/features/instance/status/analytics/__tests__/pipeline/pipeline-per-node.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/pipeline-per-node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
+import { makeSeriesKey, runPipeline } from '../../pipeline/pipeline.ts';
 import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
@@ -35,6 +35,55 @@ describe('runPipeline { perNode: true }', () => {
 		expect(keys).toEqual(['/a|n1', '/a|n2', '/b|n1', '/b|n2']);
 	});
 
+	it('carries dim/node as structured fields on every per-node series', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 100_000, node: 'n1', path: '/a', p95: 10, count: 100, period: 60_000 } as any,
+			{ time: 100_000, node: 'n2', path: '/a', p95: 20, count: 100, period: 60_000 } as any,
+		];
+		const out = runPipeline(baseSpec, records, window, ['n1', 'n2'], { perNode: true });
+		const pairs = out.series.map((s) => ({ dim: s.dim, node: s.node })).sort((a, b) =>
+			(a.node ?? '').localeCompare(b.node ?? '')
+		);
+		expect(pairs).toEqual([{ dim: '/a', node: 'n1' }, { dim: '/a', node: 'n2' }]);
+	});
+
+	it('a dimension value containing "|" survives per-node mode uncorrupted', () => {
+		// Regression for #1450: URL paths can contain '|'; splitting the old
+		// `${dim}|${node}` key at the first '|' truncated the dim and mangled
+		// the node. The structured fields must round-trip the value exactly.
+		const path = '/api|v2/x';
+		const records: AnalyticsDataPoint[] = [
+			{ time: 100_000, node: 'n1', path, p95: 10, count: 100, period: 60_000 } as any,
+			{ time: 100_000, node: 'n2', path, p95: 20, count: 100, period: 60_000 } as any,
+		];
+		const out = runPipeline(baseSpec, records, window, ['n1', 'n2'], { perNode: true });
+		expect(out.series.length).toBe(2);
+		for (const s of out.series) {
+			expect(s.dim).toBe(path);
+			expect(['n1', 'n2']).toContain(s.node);
+			expect(s.key).toBe(makeSeriesKey(path, s.node!));
+		}
+	});
+
+	it('cluster-aggregate series carry dim (and node only for groupBy-node specs)', () => {
+		const records: AnalyticsDataPoint[] = [
+			{ time: 100_000, node: 'n1', path: '/a', p95: 10, count: 100, period: 60_000 } as any,
+			{ time: 100_000, node: 'n2', path: '/a', p95: 20, count: 100, period: 60_000 } as any,
+		];
+		const out = runPipeline(baseSpec, records, window, ['n1', 'n2']);
+		expect(out.series[0].dim).toBe('/a');
+		expect(out.series[0].node).toBeUndefined();
+
+		const nodeSpec: MetricSpec = {
+			...baseSpec,
+			series: { kind: 'groupBy', dimension: 'node', field: { field: 'p95', label: 'p95' } },
+		};
+		const perNodeOut = runPipeline(nodeSpec, records, window, ['n1', 'n2'], { perNode: true });
+		const nodes = perNodeOut.series.map((s) => s.node).sort();
+		expect(nodes).toEqual(['n1', 'n2']);
+		expect(perNodeOut.series.every((s) => s.key === s.node && s.dim === s.node)).toBe(true);
+	});
+
 	it('skips crossNode pass — each node series carries its own raw value', () => {
 		// Without perNode: cluster CWM = (10·100 + 20·100)/200 = 15.
 		// With perNode: n1 series = 10, n2 series = 20.
@@ -60,6 +109,25 @@ describe('runPipeline { perNode: true }', () => {
 		expect(out.series[0].key).toBe('/a');
 		// Cluster CWM across nodes.
 		expect(out.series[0].points[0].y).toBe(15);
+	});
+
+	it('field-mode per-node series carry the field key as dim plus the node', () => {
+		const fieldSpec: MetricSpec = {
+			...baseSpec,
+			series: { kind: 'field', fields: [{ field: 'p95', label: 'p95' }] },
+		};
+		const records: AnalyticsDataPoint[] = [
+			{ time: 100_000, node: 'n1', path: '/a', p95: 10, count: 100, period: 60_000 } as any,
+			{ time: 100_000, node: 'n2', path: '/a', p95: 20, count: 100, period: 60_000 } as any,
+		];
+		const out = runPipeline(fieldSpec, records, window, ['n1', 'n2'], { perNode: true });
+		const pairs = out.series.map((s) => ({ key: s.key, dim: s.dim, node: s.node })).sort((a, b) =>
+			(a.node ?? '').localeCompare(b.node ?? '')
+		);
+		expect(pairs).toEqual([
+			{ key: makeSeriesKey('p95', 'n1'), dim: 'p95', node: 'n1' },
+			{ key: makeSeriesKey('p95', 'n2'), dim: 'p95', node: 'n2' },
+		]);
 	});
 
 	it('node-series labels include (approx) when aggregator is count-weighted-mean', () => {

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+// Regression for #1450: a dimension value containing '|' (URL paths can)
+// used to be corrupted by renderers splitting the `${dim}|${node}` series
+// key at the first '|' — the chip row showed the truncated prefix and the
+// node legend/colors keyed off the mangled remainder. The renderer now
+// reads the structured Series.dim/Series.node fields.
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer.tsx';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+
+const range = { startTime: 0, endTime: 10_000_000 };
+
+const PIPE_PATH = '/api|v2/x';
+
+const spec: MetricSpec = {
+	title: 'pipe-dim test',
+	description: '',
+	tab: 'requests',
+	primaryDimension: 'path',
+	series: {
+		kind: 'groupBy',
+		dimension: 'path',
+		field: { field: 'value', label: 'value' },
+	},
+	timestamp: 'time',
+	bucket: { source: 'period-field', fallbackMs: 60000 },
+	aggregator: { temporal: 'mean', crossNode: 'mean' },
+	primitive: 'line',
+	yAxis: { unit: '', formatter: 'count' },
+};
+
+const records: AnalyticsDataPoint[] = (['n1.example.com', 'n2.example.com'] as const).flatMap((node) => [
+	{ time: 100_000, node, path: PIPE_PATH, value: 1, count: 100, period: 60_000 } as any,
+	{ time: 100_000, node, path: '/plain', value: 2, count: 100, period: 60_000 } as any,
+]);
+
+describe('DimensionSelectorRenderer with a dimension value containing "|"', () => {
+	afterEach(() => cleanup());
+
+	it('lists the full dimension value as one chip (no split at the pipe)', async () => {
+		render(
+			<DimensionSelectorRenderer
+				spec={spec}
+				records={records}
+				timeRange={range}
+				nodes={['n1.example.com', 'n2.example.com']}
+				theme="light"
+			/>,
+		);
+		const chips = await screen.findAllByRole('radio');
+		const labels = chips.map((c) => c.textContent);
+		// Exactly the two real paths — no truncated '/api' chip, no phantom
+		// 'v2/x|…' entries.
+		expect(labels.sort()).toEqual(['/api|v2/x', '/plain']);
+	});
+
+	it('selecting the pipe-dim chip keeps one cleanly-labeled line per node', async () => {
+		render(
+			<DimensionSelectorRenderer
+				spec={spec}
+				records={records}
+				timeRange={range}
+				nodes={['n1.example.com', 'n2.example.com']}
+				theme="light"
+			/>,
+		);
+		const pipeChip = await screen.findByRole('radio', { name: PIPE_PATH });
+		fireEvent.click(pipeChip);
+		// The chart's aria-label enumerates the filtered series labels. With
+		// the old first-'|' split this came out as one series labeled
+		// 'v2/x|n1' — the node id mangled with the dim's tail.
+		const chart = await screen.findByRole('img');
+		expect(chart.getAttribute('aria-label')).toBe('Chart with 2 series: n1, n2');
+	});
+});

--- a/src/features/instance/status/analytics/hooks/useNodeFilteredSeries.ts
+++ b/src/features/instance/status/analytics/hooks/useNodeFilteredSeries.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { getNodeColor } from '../lib/nodeColors.ts';
+import { shortenNodeLabel } from '../lib/nodeLabels.ts';
+import type { SeriesData } from '../types/analytics.ts';
+import { useNodeSelection } from './useNodeSelection.ts';
+
+/** Shared per-node scaffolding for chip-selector panels (connection, memory,
+ *  main-thread, DimensionSelectorRenderer): relabels each per-node series
+ *  (`Series.node` set by the pipeline) with the short node name + the node's
+ *  stable color, then filters by the NodeLegend's active-node set.
+ *  Cluster-aggregate series (no `node`) pass through untouched.
+ *  `isActive`/`handleLegendClick` feed the panel's <NodeLegend>. */
+export function useNodeFilteredSeries(data: SeriesData, nodes: string[]) {
+	const { isActive, handleLegendClick } = useNodeSelection(nodes);
+	const filteredData = useMemo<SeriesData>(() => ({
+		...data,
+		series: data.series
+			.map((s) =>
+				s.node === undefined
+					? s
+					: { ...s, label: shortenNodeLabel(s.node), color: getNodeColor(s.node, nodes) }
+			)
+			.filter((s) => s.node === undefined || isActive(s.node)),
+	}), [data, nodes, isActive]);
+	return { data: filteredData, isActive, handleLegendClick };
+}

--- a/src/features/instance/status/analytics/lib/nodeLabels.ts
+++ b/src/features/instance/status/analytics/lib/nodeLabels.ts
@@ -1,0 +1,7 @@
+/** Last segment of an FQDN as a stable short label.
+ *  e.g. 'xb6-us-west-1.prod.ibm.harperfabric.com' → 'xb6-us-west-1'.
+ *  Falls back to the full string if there's no dot. */
+export function shortenNodeLabel(node: string): string {
+	const dot = node.indexOf('.');
+	return dot === -1 ? node : node.slice(0, dot);
+}

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -123,7 +123,8 @@ export function ConnectionRenderer(
 			if (!t.scope) { return true; }
 			if (!selectedDims) { return false; }
 			for (const [dim, want] of Object.entries(t.scope)) {
-				if (selectedDims[dim] !== want) { return false; }
+				// dimParts values are String()-cast; Threshold.scope allows numbers.
+				if (selectedDims[dim] !== String(want)) { return false; }
 			}
 			return true;
 		}

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
 import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
 import { LineChart } from '../primitives/LineChart.tsx';
 import type { AnalyticsDataPoint, MetricSpec, SeriesData, Threshold, TimeRange } from '../types/analytics.ts';
@@ -61,13 +60,25 @@ function compositeKey(path: unknown, method: unknown): string | null {
 	return `${path}${SEPARATOR}${method}`;
 }
 
-function preprocess(records: AnalyticsDataPoint[]): AnalyticsDataPoint[] {
+interface Preprocessed {
+	records: AnalyticsDataPoint[];
+	/** Composite chip value → its source dimensions. The composite string is
+	 *  display-only; recovering {path, method} from it by splitting on ' · '
+	 *  would corrupt values that contain the separator, so carry the parts. */
+	dimParts: Map<string, Record<string, string>>;
+}
+
+function preprocess(records: AnalyticsDataPoint[]): Preprocessed {
 	const out: AnalyticsDataPoint[] = [];
+	const dimParts = new Map<string, Record<string, string>>();
 	for (const r of records) {
 		const path = (r as any).path;
 		const method = (r as any).method;
 		const key = compositeKey(path, method);
 		if (key === null) { continue; }
+		if (!dimParts.has(key)) {
+			dimParts.set(key, { path: String(path), method: String(method) });
+		}
 		const total = (r as any).total;
 		const count = (r as any).count;
 		const nullGap = total === 0 && typeof count === 'number' && count > 0;
@@ -77,79 +88,53 @@ function preprocess(records: AnalyticsDataPoint[]): AnalyticsDataPoint[] {
 			ratio: nullGap ? null : (r as any).ratio,
 		} as any);
 	}
-	return out;
-}
-
-function shortenNodeLabel(node: string): string {
-	const dot = node.indexOf('.');
-	return dot === -1 ? node : node.slice(0, dot);
+	return { records: out, dimParts };
 }
 
 export function ConnectionRenderer(
 	{ records, timeRange, nodes, theme, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
 	const perNode = viewMode === 'per-node';
-	const processed = useMemo(() => preprocess(records), [records]);
+	const { records: processed, dimParts } = useMemo(() => preprocess(records), [records]);
 
 	const fullData = useMemo<SeriesData>(
 		() => runPipeline(connectionSpec, processed, timeRange, nodes, { perNode, snapToPeriod: true }),
 		[processed, timeRange, nodes, perNode],
 	);
 
-	// Per-node series keys are `${pathMethod}|${node}`. The chip selector
-	// picks one composite (pathMethod) value; filter by prefix.
+	// The chip selector picks one composite (pathMethod) dimension value;
+	// per-node series carry it on the structured `dim` field.
 	const selectable = useMemo(() => {
 		const seen = new Set<string>();
 		for (const s of fullData.series) {
-			const sep = s.key.indexOf('|');
-			seen.add(sep === -1 ? s.key : s.key.slice(0, sep));
+			seen.add(s.dim ?? s.key);
 		}
 		return [...seen];
 	}, [fullData.series]);
 	const [selected, setSelected] = useState<string>(() => selectable[0] ?? '');
 	const effectiveSelected = selectable.includes(selected) ? selected : (selectable[0] ?? '');
 
-	const selectedDims = useMemo(() => {
-		if (!effectiveSelected) { return null; }
-		const [path, method] = effectiveSelected.split(SEPARATOR);
-		return { path, method } as Record<string, string>;
-	}, [effectiveSelected]);
+	const selectedDims = dimParts.get(effectiveSelected) ?? null;
 
-	const { isActive, handleLegendClick } = useNodeSelection(nodes);
-
-	const filteredData: SeriesData = useMemo(() => {
+	const dimFilteredData: SeriesData = useMemo(() => {
 		function thresholdMatches(t: Threshold): boolean {
-			if (!selectedDims) { return false; }
+			// Scope-less thresholds are global — keep them even when the
+			// selected dim has no dimParts entry (e.g. an Other bucket).
 			if (!t.scope) { return true; }
+			if (!selectedDims) { return false; }
 			for (const [dim, want] of Object.entries(t.scope)) {
 				if (selectedDims[dim] !== want) { return false; }
 			}
 			return true;
 		}
-		const prefix = `${effectiveSelected}|`;
-		const series = fullData.series
-			.filter((s) => s.key === effectiveSelected || s.key.startsWith(prefix))
-			.map((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				if (!node) { return s; }
-				return {
-					...s,
-					label: shortenNodeLabel(node),
-					color: getNodeColor(node, nodes),
-				};
-			})
-			.filter((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				return node === '' || isActive(node);
-			});
 		return {
 			...fullData,
-			series,
+			series: fullData.series.filter((s) => (s.dim ?? s.key) === effectiveSelected),
 			thresholds: (fullData.thresholds ?? []).filter(thresholdMatches),
 		};
-	}, [fullData, effectiveSelected, selectedDims, nodes, isActive]);
+	}, [fullData, effectiveSelected, selectedDims]);
+
+	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(dimFilteredData, nodes);
 
 	return (
 		<div className="flex h-full flex-col">

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
 import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
 import { LineChart } from '../primitives/LineChart.tsx';
 import type { AnalyticsDataPoint, AxisSpec, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
@@ -88,11 +87,6 @@ interface RendererProps {
 	fillParent?: boolean;
 }
 
-function shortenNodeLabel(node: string): string {
-	const dot = node.indexOf('.');
-	return dot === -1 ? node : node.slice(0, dot);
-}
-
 export function MainThreadRenderer(
 	{ records, timeRange, nodes, theme, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
@@ -110,23 +104,7 @@ export function MainThreadRenderer(
 		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
 	}, [selected, records, timeRange, nodes, perNode]);
 
-	const { isActive, handleLegendClick } = useNodeSelection(nodes);
-
-	const filteredData: SeriesData = useMemo(() => ({
-		...data,
-		series: data.series
-			.map((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				if (!node) { return s; }
-				return { ...s, label: shortenNodeLabel(node), color: getNodeColor(node, nodes) };
-			})
-			.filter((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				return node === '' || isActive(node);
-			}),
-	}), [data, nodes, isActive]);
+	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 
 	return (
 		<div className="flex h-full flex-col">

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
 import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
 import { LineChart } from '../primitives/LineChart.tsx';
 import type { AnalyticsDataPoint, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
@@ -45,11 +44,6 @@ interface RendererProps {
 	fillParent?: boolean;
 }
 
-function shortenNodeLabel(node: string): string {
-	const dot = node.indexOf('.');
-	return dot === -1 ? node : node.slice(0, dot);
-}
-
 const FIELD_LABELS = MEMORY_FIELDS.map((f) => f.label);
 
 export function MemoryRenderer(
@@ -68,23 +62,7 @@ export function MemoryRenderer(
 		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
 	}, [selectedField, records, timeRange, nodes, perNode]);
 
-	const { isActive, handleLegendClick } = useNodeSelection(nodes);
-
-	const filteredData: SeriesData = useMemo(() => ({
-		...data,
-		series: data.series
-			.map((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				if (!node) { return s; }
-				return { ...s, label: shortenNodeLabel(node), color: getNodeColor(node, nodes) };
-			})
-			.filter((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				return node === '' || isActive(node);
-			}),
-	}), [data, nodes, isActive]);
+	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 
 	return (
 		<div className="flex h-full flex-col">

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -41,9 +41,10 @@ import { runTransform } from './runTransform.ts';
 
 export interface RunPipelineOptions {
 	/** When true, runGroupBy emits one Series per (dim, node) instead of
-	 *  collapsing nodes via the crossNode aggregator. The series key is
-	 *  `${dim}|${node}` so consumers (e.g. DimensionSelectorRenderer) can
-	 *  filter by selected dim while keeping per-node detail. No-op for
+	 *  collapsing nodes via the crossNode aggregator. Each series carries
+	 *  structured `dim`/`node` fields so consumers (e.g.
+	 *  DimensionSelectorRenderer) can filter by selected dim while keeping
+	 *  per-node detail. No-op for
 	 *  `kind: 'field'` series sources or for the OTHER bucket.
 	 *  Used by chip-selector panels (duration, success, transfer, db-*,
 	 *  connection, response_200) so the operator can spot a hot node
@@ -57,6 +58,14 @@ export interface RunPipelineOptions {
 	 *  rendering; pipeline tests that use synthetic small-integer times
 	 *  leave it off so they keep their distinct buckets. */
 	snapToPeriod?: boolean;
+}
+
+/** Composite string key for a per-node series — React key / recharts name
+ *  only. Never split it back apart: a dimension value containing '|' (URL
+ *  paths can) makes the string ambiguous. Consumers read the structured
+ *  `Series.dim` / `Series.node` fields instead. */
+export function makeSeriesKey(dim: string, node: string): string {
+	return `${dim}|${node}`;
 }
 
 export function runPipeline(
@@ -226,8 +235,8 @@ function runGroupBy(
 		if (perNode && !dimensionIsNode) {
 			// Emit one Series per (dim, node). Skip the crossNode pass; each
 			// node's points come from the inner temporal aggregation alone.
-			// Series key is `${dim}|${node}` so renderers can filter by dim
-			// prefix; label is the node name.
+			// Renderers filter/color via the structured dim/node fields; the
+			// composite key only keeps React/recharts ids unique.
 			const nodeBuckets = new Map<string, Map<number, NodeBucket>>();
 			for (const [time, byNode] of perTime) {
 				for (const [node, nb] of byNode) {
@@ -248,8 +257,10 @@ function runGroupBy(
 					points.push({ x: time, y, count: nb.totalCount });
 				}
 				series.push({
-					key: `${String(key)}|${node}`,
+					key: makeSeriesKey(String(key), node),
 					label: labelWithApprox(node, tempAgg),
+					dim: String(key),
+					node,
 					points,
 					approx: isApprox,
 				});
@@ -267,6 +278,10 @@ function runGroupBy(
 			series.push({
 				key: String(key),
 				label: labelWithApprox(String(key), tempAgg),
+				dim: String(key),
+				// For groupBy-'node' specs each dimension value IS a node id —
+				// surface it so node legends need no key heuristics.
+				...(dimensionIsNode ? { node: String(key) } : {}),
 				points,
 				approx: isApprox,
 			});
@@ -317,6 +332,7 @@ function runGroupBy(
 			series.push({
 				key: 'Other',
 				label: labelWithApprox('Other', tempAgg),
+				dim: 'Other',
 				points: otherPoints,
 				approx: isApprox,
 			});
@@ -382,9 +398,9 @@ function runFieldSpecs(
 		const fieldKey = typeof f.field === 'string' ? f.field : f.label;
 
 		if (perNode) {
-			// Emit one Series per (field, node). Series key is
-			// `${fieldKey}|${node}` so callers can identify both axes; label is
-			// `${fieldLabel} — ${node}` so legends stay readable.
+			// Emit one Series per (field, node) — both axes carried on the
+			// structured dim/node fields; label is `${fieldLabel} — ${node}`
+			// so legends stay readable.
 			const nodeBuckets = new Map<string, Map<number, NodeBucket>>();
 			for (const [time, byNode] of buckets) {
 				for (const [node, nb] of byNode) {
@@ -406,8 +422,10 @@ function runFieldSpecs(
 					points.push({ x: time, y, count: nb.totalCount });
 				}
 				out.push({
-					key: `${fieldKey}|${node}`,
+					key: makeSeriesKey(fieldKey, node),
 					label: labelWithApprox(`${f.label} — ${node}`, tempAgg),
+					dim: fieldKey,
+					node,
 					axis: f.axis,
 					points,
 					approx: isApprox,
@@ -427,6 +445,7 @@ function runFieldSpecs(
 		return [{
 			key: fieldKey,
 			label: labelWithApprox(f.label, tempAgg),
+			dim: fieldKey,
 			axis: f.axis,
 			points,
 			approx: isApprox,

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -13,8 +13,7 @@
 
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
 import { runPipeline } from '../pipeline/pipeline.ts';
 import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
 import { DimensionChipRow } from './DimensionChipRow.tsx';
@@ -38,14 +37,6 @@ interface Props {
 	/** When true, the chart inside this renderer fills its parent's
 	 *  vertical space — used by the expand-to-fullscreen dialog. */
 	fillParent?: boolean;
-}
-
-/** Last segment of an FQDN as a stable short label.
- *  e.g. 'xb6-us-west-1.prod.ibm.harperfabric.com' → 'xb6-us-west-1'.
- *  Falls back to the full string if there's no dot. */
-function shortenNodeLabel(node: string): string {
-	const dot = node.indexOf('.');
-	return dot === -1 ? node : node.slice(0, dot);
 }
 
 export function DimensionSelectorRenderer({
@@ -88,51 +79,30 @@ export function DimensionSelectorRenderer({
 		[runtimeSpec, records, timeRange, nodes, perNode],
 	);
 
-	// In perNode mode series keys are `${dim}|${node}`. Build the dimension
-	// list (the chip-row values) by collecting the prefix part of each key,
-	// excluding the special OTHER aggregate.
+	// Build the dimension list (the chip-row values) from each series's
+	// structured `dim` field, excluding the special OTHER aggregate.
 	const dimValues = useMemo(() => {
 		const seen = new Set<string>();
 		for (const s of fullData.series) {
-			if (s.key === OTHER_KEY) { continue; }
-			const sep = s.key.indexOf('|');
-			seen.add(sep === -1 ? s.key : s.key.slice(0, sep));
+			const dim = s.dim ?? s.key;
+			if (dim === OTHER_KEY) { continue; }
+			seen.add(dim);
 		}
 		return [...seen];
 	}, [fullData.series]);
 
-	const hasOther = fullData.series.some((s) => s.key === OTHER_KEY);
+	const hasOther = fullData.series.some((s) => (s.dim ?? s.key) === OTHER_KEY);
 	const [selectedDim, setSelectedDim] = useState<string>(() => dimValues[0] ?? '');
 	const effectiveDim = dimValues.includes(selectedDim) ? selectedDim : (dimValues[0] ?? '');
 
-	// Per-node legend filter — shared across this panel's lines so the
-	// per-Recharts <Legend> can be hidden and the chart area gets full
-	// vertical real estate.
-	const { isActive, handleLegendClick } = useNodeSelection(nodes);
-
-	// Filter to (dim|*) prefix; apply per-node coloring so the same node
-	// keeps the same hue across panels. Then filter by the active-node set.
-	const filteredData: SeriesData = useMemo(() => {
-		const prefix = `${effectiveDim}|`;
-		const filtered = fullData.series
-			.filter((s) => s.key === effectiveDim || s.key.startsWith(prefix))
-			.map((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				if (!node) { return s; }
-				return {
-					...s,
-					label: shortenNodeLabel(node),
-					color: getNodeColor(node, nodes),
-				};
-			})
-			.filter((s) => {
-				const sep = s.key.indexOf('|');
-				const node = sep === -1 ? '' : s.key.slice(sep + 1);
-				return node === '' || isActive(node);
-			});
-		return { ...fullData, series: filtered };
-	}, [fullData, effectiveDim, nodes, isActive]);
+	// Keep only the selected dimension's series, then apply the shared
+	// per-node relabel/color/legend-filter scaffolding — the per-Recharts
+	// <Legend> is hidden so the chart area gets full vertical real estate.
+	const dimFilteredData: SeriesData = useMemo(() => ({
+		...fullData,
+		series: fullData.series.filter((s) => (s.dim ?? s.key) === effectiveDim),
+	}), [fullData, effectiveDim]);
+	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(dimFilteredData, nodes);
 
 	return (
 		<div className="flex h-full flex-col">

--- a/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
 import { useNodeSelection } from '../hooks/useNodeSelection.ts';
 import { getNodeColor } from '../lib/nodeColors.ts';
-import type { AxisSpec, SeriesData } from '../types/analytics.ts';
+import type { AxisSpec, Series, SeriesData } from '../types/analytics.ts';
 import { LineChart } from './LineChart.tsx';
 
 interface Props {
@@ -19,23 +19,24 @@ interface Props {
 	fillParent?: boolean;
 }
 
-function extractNode(seriesKey: string): string | null {
-	const sep = seriesKey.indexOf('|');
-	if (sep !== -1) { return seriesKey.slice(sep + 1); }
-	// Some specs (utilization, tls-reused, storage-volume) groupBy 'node'
-	// directly — the series key IS the node id, no separator.
-	return seriesKey;
+/** Legend/filter group for a series: the structured `node` when present
+ *  (per-node pipeline output — including groupBy-'node' specs like
+ *  utilization / tls-reused / storage-volume), else the whole key. The
+ *  fallback is deliberate: generic 'line' dispatch also feeds this wrapper
+ *  cluster-aggregate series keyed by dimension value (e.g. database-size
+ *  groupBy 'database' with perNode=false) and derived per-node series keyed
+ *  by node id — both want one legend chip per key. Contrast SmallMultiples,
+ *  which legends per-node series only. */
+function legendGroup(s: Series): string {
+	return s.node ?? s.key;
 }
 
 export function LineChartWithNodeLegend({ data, theme, yAxis, xDomain, fillParent }: Props) {
-	// All series are per-node when this component is used (either via
-	// pipeline perNode mode or groupBy:'node'). Collect node ids from
-	// series keys.
 	const nodeIds = useMemo(() => {
 		const set = new Set<string>();
 		for (const s of data.series) {
-			const node = extractNode(s.key);
-			if (node) { set.add(node); }
+			const group = legendGroup(s);
+			if (group) { set.add(group); }
 		}
 		return [...set].sort();
 	}, [data]);
@@ -46,13 +47,13 @@ export function LineChartWithNodeLegend({ data, theme, yAxis, xDomain, fillParen
 		...data,
 		series: data.series
 			.filter((s) => {
-				const node = extractNode(s.key);
-				return node === null || isActive(node);
+				const group = legendGroup(s);
+				return group === '' || isActive(group);
 			})
 			.map((s) => {
-				const node = extractNode(s.key);
-				if (!node) { return s; }
-				return { ...s, color: s.color ?? getNodeColor(node, nodeIds) };
+				const group = legendGroup(s);
+				if (!group) { return s; }
+				return { ...s, color: s.color ?? getNodeColor(group, nodeIds) };
 			}),
 	}), [data, isActive, nodeIds]);
 

--- a/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend.tsx';
 import { useNodeSelection } from '../hooks/useNodeSelection.ts';
 import { getNodeColor } from '../lib/nodeColors.ts';
+import { shortenNodeLabel } from '../lib/nodeLabels.ts';
 import type { AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics.ts';
 import { DimensionChipRow } from './DimensionChipRow.tsx';
 import { LineChart } from './LineChart.tsx';
@@ -30,11 +31,6 @@ interface Props {
 		records: AnalyticsDataPoint[],
 		options: { perNode: boolean; selectedPath: string | null },
 	) => SeriesData;
-}
-
-function shortenNodeLabel(node: string): string {
-	const dot = node.indexOf('.');
-	return dot === -1 ? node : node.slice(0, dot);
 }
 
 export function PerPathRateRenderer({

--- a/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
+++ b/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
@@ -24,22 +24,17 @@ interface Props {
 	fillParent?: boolean;
 }
 
-function extractNode(seriesKey: string): string | null {
-	const sep = seriesKey.indexOf('|');
-	return sep === -1 ? null : seriesKey.slice(sep + 1);
-}
-
 export function SmallMultiples(
 	{ panels, theme, minPanelWidth = 320, panelHeight = 240, xDomain, fillParent }: Props,
 ) {
-	// Union of node ids across all panels' per-node series. Cluster-aggregate
-	// series (no '|') don't participate in the legend.
+	// Union of node ids across all panels' per-node series (structured
+	// `Series.node`). Cluster-aggregate series (no `node`) don't participate
+	// in the legend.
 	const nodeIds = useMemo(() => {
 		const set = new Set<string>();
 		for (const p of panels) {
 			for (const s of p.data.series) {
-				const node = extractNode(s.key);
-				if (node) { set.add(node); }
+				if (s.node) { set.add(s.node); }
 			}
 		}
 		return [...set].sort();
@@ -53,15 +48,8 @@ export function SmallMultiples(
 			data: {
 				...p.data,
 				series: p.data.series
-					.filter((s) => {
-						const node = extractNode(s.key);
-						return node === null || isActive(node);
-					})
-					.map((s) => {
-						const node = extractNode(s.key);
-						if (!node) { return s; }
-						return { ...s, color: s.color ?? getNodeColor(node, nodeIds) };
-					}),
+					.filter((s) => s.node === undefined || isActive(s.node))
+					.map((s) => s.node === undefined ? s : { ...s, color: s.color ?? getNodeColor(s.node, nodeIds) }),
 			},
 		})), [panels, isActive, nodeIds]);
 

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -192,8 +192,20 @@ export interface SeriesPoint {
 }
 
 export interface Series {
+	/** Unique id within a SeriesData — used as React key / recharts series
+	 *  name. For per-node pipeline output it is `makeSeriesKey(dim, node)`;
+	 *  never parse it back (a dim containing '|' makes the string ambiguous).
+	 *  Read the structured `dim`/`node` fields instead. */
 	key: string;
 	label: string;
+	/** Dimension value (groupBy) or field key (field mode) this series was
+	 *  bucketed under. Always set by runPipeline; may be absent on series
+	 *  built outside the generic pipeline (derived metrics). */
+	dim?: string;
+	/** Node id when this series is a per-node breakdown (pipeline perNode
+	 *  mode, or a groupBy-'node' spec where each dimension value IS a node).
+	 *  Unset on cluster-aggregate series. */
+	node?: string;
 	color?: string;
 	axis?: 'left' | 'right';
 	points: SeriesPoint[];


### PR DESCRIPTION
Closes [#1450 — Use structured series keys instead of the dim|node string protocol](https://github.com/HarperFast/studio/issues/1450).

## The corruption class this closes

The pipeline encoded per-node series identity as a `` `${dim}|${node}` `` string, and six consumers re-derived `dim`/`node` from it — four with hand-rolled first-`|` splits, two via forked `extractNode` copies. Any dimension value containing `|` (URL paths can) truncated the dim and mangled the node — e.g. dim `/api|v2/x` on node `n1.example.com` produced a chip labeled `/api` and a series labeled `v2/x|n1`. `connection.tsx` layered a second string protocol on top, splitting its composite chip value on `' · '` to recover `{path, method}` for threshold scoping — same corruption class.

Now `Series` carries structured `dim` and `node` fields, populated by `runPipeline` on every path (groupBy per-node, groupBy cluster, groupBy-`'node'`, Other bucket, field mode per-node and cluster). The composite key still exists — as a React key / recharts series name, built by the exported `makeSeriesKey(dim, node)` — but it is documented as write-only and **no consumer parses it back**. Hand-rolled `indexOf('|')`/`slice` parsing is gone from `connection.tsx`, `memory.tsx`, `main-thread-utilization.tsx`, `DimensionSelectorRenderer`, `SmallMultiples`, and `LineChartWithNodeLegend`; `connection.tsx`'s `' · '` split is replaced by a composite-value → `{path, method}` map built during preprocessing.

## extractNode unification

The two forked parsers now share one vocabulary — the structured fields — with the divergence made explicit instead of accidental:

- `SmallMultiples` legends **per-node series only**: it reads `Series.node` and cluster-aggregate series (no `node`) stay out of the legend, exactly as before.
- `LineChartWithNodeLegend` keeps its deliberate fallback via a documented `legendGroup(s) = s.node ?? s.key`: generic `'line'` dispatch also feeds it cluster series keyed by dimension value (database-size with `perNode: false`) and derived series keyed by node id, both of which want one legend chip per key. Previously this fallback was an undocumented divergence in a copy-pasted `extractNode`.

groupBy-`'node'` specs (utilization, tls-reused, storage-volume) now get `node` set by the pipeline itself, so the fallback is only exercised by the two key-per-legend-chip cases above.

## Shared per-node scaffolding

The ~15-line filter/relabel/color block (and the 5× copy-pasted `shortenNodeLabel`) collapse into:

- `hooks/useNodeFilteredSeries(data, nodes)` — relabels per-node series with the short node name + stable node color, filters by the NodeLegend active-set, and returns `isActive`/`handleLegendClick` for the legend. Adopted by `connection`, `memory`, `main-thread-utilization`, and `DimensionSelectorRenderer`.
- `lib/nodeLabels.ts` `shortenNodeLabel` — single definition, also adopted by `PerPathRateRenderer` (which had its own copy).

The surrounding chip/legend JSX was left in place — each renderer's layout differs enough (quantile radios, combobox switch, threshold filtering) that a shared layout component would have needed as many props as it saved lines.

## Tests

- `pipeline-per-node.test.ts`: new assertions that structured `dim`/`node` are populated on the groupBy per-node, field-mode per-node, cluster, and groupBy-`'node'` paths, plus the regression the issue was filed for — a dim of `/api|v2/x` round-trips uncorrupted.
- New `dimension-selector-pipe-dim.test.tsx`: renderer-layer regression — with records whose path contains `|`, the chip row shows the full value as one chip, and selecting it yields one cleanly-labeled line per node (asserted via the chart's aria-label, which the old first-`|` split rendered as `v2/x|n1`).
- Full suite: 201 files / 1336 passed, 11 skipped. `tsc -b`, `oxlint`, `dprint` clean.

## Open concerns

- `makeSeriesKey` output is still ambiguous as a *string* (dim `a|b` + node `c` collides with dim `a` + node `b|c`). It is only a React/recharts id now, so a collision would need two series in the same panel with that exact overlap — accepted as out of scope; making the key collision-proof (e.g. length-prefixing) would churn the keys pinned in tests for no user-visible gain.
- Derived metrics (`request-rate`, `error-rate`, etc.) still emit `Series` without `dim`/`node`; consumers use the `?? s.key` fallback for them. Migrating derived producers is follow-up material.
- `connection.tsx`'s composite chip value (`path · method`) can theoretically collide if a path contains `' · '` — but that collision already merges the records in the pipeline's groupBy dimension itself, so it predates this PR and isn't made worse by the new `dimParts` map (Gemini review nit, acknowledged).

## Cross-model review

- **Codex** (`review --uncommitted`): no actionable correctness issues.
- **Gemini 3.1 Pro**: one accepted finding — `thresholdMatches` checked `!selectedDims` before `!t.scope`, so scope-less (global) thresholds would vanish when the selected dim had no `dimParts` entry (e.g. a future `Other` bucket); fixed by testing `!t.scope` first. Its remaining notes verified the legend-semantics preservation in both primitives and confirmed no lingering `|` parsers anywhere in the analytics tree.

Generated by kAIle (Claude Fable 5).
