### PR TITLE
refactor(status): move chart theming onto app tokens and useTheme

### DIFF
--- a/src/features/instance/status/analytics/StatusTabs.tsx
+++ b/src/features/instance/status/analytics/StatusTabs.tsx
@@ -2,7 +2,6 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
-import { useSystemTheme } from '@/hooks/useSystemTheme';
 import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics.ts';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
@@ -13,6 +12,7 @@ import { TimeRangePicker } from './components/TimeRangePicker.tsx';
 import { type AnalyticsContextValue, AnalyticsProvider } from './context/AnalyticsContext.tsx';
 import { getPreset, type TimePresetId } from './context/timePresets.ts';
 import { type AnalyticsCapability, useAnalyticsCapability } from './hooks/useAnalyticsCapability.ts';
+import { useResolvedTheme } from './lib/theme.ts';
 import { DatabaseTab } from './tabs/DatabaseTab.tsx';
 import { HealthTab } from './tabs/HealthTab.tsx';
 import { OverviewTab } from './tabs/OverviewTab.tsx';
@@ -85,7 +85,7 @@ function AnalyticsUnavailableNotice({ capability }: { capability: AnalyticsCapab
 				)}
 			<Button
 				type="button"
-				variant="outline"
+				variant="defaultOutline"
 				size="sm"
 				className="mt-3"
 				onClick={capability.retry}
@@ -155,7 +155,11 @@ function StatusTabsInner({ instanceParams, isLocalStudio, capability }: InnerPro
 		};
 	}, [refreshMs, refresh, queryClient, tick, instanceParams.entityId]);
 
-	const theme = useSystemTheme();
+	// Resolved app theme (user's explicit choice, not raw OS preference) —
+	// kept in the context only for the consumers that still read it there
+	// (StorageTab's table-size charts, ConnectionsPanel). Chart primitives
+	// re-theme via `--chart-*` CSS tokens without any prop.
+	const theme = useResolvedTheme();
 
 	const updatePreset = useCallback((id: TimePresetId) => {
 		void navigate({ to: '.', search: { tab, range: id, refresh: refreshMs } });

--- a/src/features/instance/status/analytics/__tests__/paletteDisjointness.test.ts
+++ b/src/features/instance/status/analytics/__tests__/paletteDisjointness.test.ts
@@ -1,16 +1,54 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { TYPE_PALETTE } from '../lib/colorAllocators/typeColors.ts';
 import { NODE_PALETTE } from '../lib/nodeColors.ts';
-import { TABLE_PALETTE } from '../lib/tableColors.ts';
+import { OTHER_COLOR, TABLE_PALETTE } from '../lib/tableColors.ts';
+
+// The palettes are now CSS custom properties (`var(--chart-…)`), so the
+// disjointness invariant is enforced against their definitions in
+// src/index.css rather than against literal hex in the TS modules.
+const cssPath = new URL('../../../../../index.css', import.meta.url);
+const css = readFileSync(cssPath, 'utf8');
+
+/** All `--name: value;` declarations in the stylesheet, keyed by var name.
+ *  The categorical palettes are defined once in :root (shared by light and
+ *  dark), so a flat scan is sufficient; if a palette var were ever
+ *  re-declared per theme this collapses to the last definition and the
+ *  disjointness check below should be widened to per-scope parsing. */
+function cssVarDefinitions(): Map<string, string> {
+	const defs = new Map<string, string>();
+	for (const m of css.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+		defs.set(m[1], m[2].trim().toLowerCase());
+	}
+	return defs;
+}
+
+/** Resolve a palette entry like `var(--chart-node-1)` to its CSS value. */
+function resolve(entry: string, defs: Map<string, string>): string {
+	const m = entry.match(/^var\((--[\w-]+)\)$/);
+	expect(m, `palette entry "${entry}" must be a bare var(--…) reference`).toBeTruthy();
+	const value = defs.get(m![1]);
+	expect(value, `${m![1]} must be defined in src/index.css`).toBeDefined();
+	return value!;
+}
 
 describe('categorical palettes', () => {
+	it('every palette entry references a var defined in src/index.css', () => {
+		const defs = cssVarDefinitions();
+		for (const entry of [...NODE_PALETTE, ...TABLE_PALETTE, ...TYPE_PALETTE, OTHER_COLOR]) {
+			const value = resolve(entry, defs);
+			expect(value, `${entry} should resolve to a 6-digit hex color`).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+
 	it('node, table, and type palettes are pairwise disjoint', () => {
+		const defs = cssVarDefinitions();
 		const palettes = { NODE_PALETTE, TABLE_PALETTE, TYPE_PALETTE };
 		const seen = new Map<string, string>();
 		for (const [name, palette] of Object.entries(palettes)) {
-			for (const color of palette) {
-				const key = color.toLowerCase();
-				expect(seen.get(key), `${color} appears in both ${seen.get(key)} and ${name}`).toBeUndefined();
+			for (const entry of palette) {
+				const key = resolve(entry, defs);
+				expect(seen.get(key), `${key} (${entry}) appears in both ${seen.get(key)} and ${name}`).toBeUndefined();
 				seen.set(key, name);
 			}
 		}

--- a/src/features/instance/status/analytics/__tests__/pipeline/formatValue.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/formatValue.test.ts
@@ -26,3 +26,24 @@ describe('formatValue count-si', () => {
 		expect(formatValue(1.5, 'count-si')).toBe('1.5');
 	});
 });
+
+describe('formatValue bytes (shared by metric and table-size charts)', () => {
+	it('keeps one decimal below 10 in the scaled unit', () => {
+		expect(formatValue(1_500_000_000, 'bytes-si')).toBe('1.5 GB');
+		expect(formatValue(2.5, 'bytes-si')).toBe('2.5 B');
+	});
+	it('rounds to integers at 10+ in the scaled unit (adaptive precision)', () => {
+		expect(formatValue(512_000_000, 'bytes-si')).toBe('512 MB');
+		expect(formatValue(15_000_000_000, 'bytes-si')).toBe('15 GB');
+	});
+	it('renders zero without a decimal', () => {
+		expect(formatValue(0, 'bytes-si')).toBe('0 B');
+	});
+	it('uses IEC units with base 1024 for bytes-iec', () => {
+		expect(formatValue(1024 * 1024, 'bytes-iec')).toBe('1.0 MiB');
+		expect(formatValue(512 * 1024 * 1024, 'bytes-iec')).toBe('512 MiB');
+	});
+	it('composes the unit suffix after the byte unit', () => {
+		expect(formatValue(1_500_000, 'bytes-si', '/s')).toBe('1.5 MB/s');
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
@@ -45,7 +45,6 @@ describe('DimensionSelectorRenderer with a dimension value containing "|"', () =
 				records={records}
 				timeRange={range}
 				nodes={['n1.example.com', 'n2.example.com']}
-				theme="light"
 			/>,
 		);
 		const chips = await screen.findAllByRole('radio');
@@ -62,7 +61,6 @@ describe('DimensionSelectorRenderer with a dimension value containing "|"', () =
 				records={records}
 				timeRange={range}
 				nodes={['n1.example.com', 'n2.example.com']}
-				theme="light"
 			/>,
 		);
 		const pipeChip = await screen.findByRole('radio', { name: PIPE_PATH });

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
@@ -48,7 +48,6 @@ describe('DimensionSelectorRenderer chip↔combobox auto-switch', () => {
 				records={recordsForN(12)}
 				timeRange={range}
 				nodes={['n1']}
-				theme="light"
 			/>,
 		);
 		const chips = await screen.findAllByRole('radio');
@@ -64,7 +63,6 @@ describe('DimensionSelectorRenderer chip↔combobox auto-switch', () => {
 				records={recordsForN(13)}
 				timeRange={range}
 				nodes={['n1']}
-				theme="light"
 			/>,
 		);
 		// DimensionCombobox uses APG button-pattern: trigger is a button with
@@ -101,7 +99,6 @@ describe('DimensionSelectorRenderer quantile picker radiogroup', () => {
 				records={recordsForN(3)}
 				timeRange={range}
 				nodes={['n1']}
-				theme="light"
 			/>,
 		);
 		return screen.getAllByTestId('quantile-button');

--- a/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { HeatmapMatrix } from '../../primitives/HeatmapMatrix.tsx';
 import type { HeatmapData } from '../../types/analytics.ts';
@@ -177,5 +177,64 @@ describe('HeatmapMatrix primitive', () => {
 		const svg = container.querySelector('svg[role="grid"]');
 		const cellSize = Number(svg?.getAttribute('data-cell-size'));
 		expect(Number.isFinite(cellSize) && cellSize >= 40 && cellSize <= 80).toBeTruthy();
+	});
+
+	it('uses the light color ramp by default and the dark ramp when the app root has .dark', () => {
+		// The ramp branches on the resolved app theme (the `.dark` class the
+		// ThemeProvider toggles on <html>) — not on a prop or the OS setting.
+		const { container, unmount } = render(<HeatmapMatrix data={data} />);
+		const lightStops = Array.from(container.querySelectorAll('linearGradient stop'))
+			.map((el) => el.getAttribute('stop-color'));
+		expect(lightStops[0]).toBe('#fef3c7'); // LIGHT_STOPS ramp start (pale)
+		expect(lightStops.at(-1)).toBe('#7f1d1d'); // deep red
+		unmount();
+
+		document.documentElement.classList.add('dark');
+		try {
+			const { container: darkContainer } = render(<HeatmapMatrix data={data} />);
+			const darkStops = Array.from(darkContainer.querySelectorAll('linearGradient stop'))
+				.map((el) => el.getAttribute('stop-color'));
+			expect(darkStops[0]).toBe('#713f12'); // DARK_STOPS ramp start (muted amber)
+			expect(darkStops.at(-1)).toBe('#fef3c7'); // cream
+		} finally {
+			document.documentElement.classList.remove('dark');
+		}
+	});
+
+	it('re-renders onto the other ramp when .dark is toggled while mounted', async () => {
+		const { container } = render(<HeatmapMatrix data={data} />);
+		document.documentElement.classList.add('dark');
+		try {
+			// The MutationObserver → setState round-trip is async; poll for it.
+			await waitFor(() => {
+				const stops = Array.from(container.querySelectorAll('linearGradient stop'))
+					.map((el) => el.getAttribute('stop-color'));
+				expect(stops[0]).toBe('#713f12');
+			});
+		} finally {
+			document.documentElement.classList.remove('dark');
+		}
+	});
+
+	it('confidence-state greys come from --chart-heatmap-* tokens (theme-agnostic markup)', () => {
+		render(<HeatmapMatrix data={data} />);
+		const absent = screen.getAllByRole('gridcell')
+			.find((c) => (c.getAttribute('aria-label') ?? '').includes('no data'))!;
+		const rect = absent.querySelector('rect');
+		expect(rect?.getAttribute('stroke')).toBe('var(--chart-heatmap-muted-stroke, #9ca3af)');
+	});
+
+	it('takes the measure label from data.measureLabel (legend, description, and cell labels)', () => {
+		render(<HeatmapMatrix data={{ ...data, approx: false, measureLabel: 'p50 latency' }} />);
+		const legend = screen.getByRole('img', { name: /p50 latency/i });
+		expect(legend).toBeTruthy();
+		const desc = screen.getByTestId('heatmap-desc');
+		expect(desc.textContent ?? '').toMatch(/p50 latency/);
+		// Populated cells must announce the same quantile as the legend —
+		// contradictory copy would misinform screen-reader users.
+		const okCell = screen.getAllByRole('gridcell')
+			.find((c) => /src-1.*dest-a/.test(c.getAttribute('aria-label') ?? ''))!;
+		expect(okCell.getAttribute('aria-label')).toMatch(/p50 latency/);
+		expect(okCell.getAttribute('aria-label')).not.toMatch(/p95/);
 	});
 });

--- a/src/features/instance/status/analytics/__tests__/primitives/small-multiples.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/small-multiples.test.tsx
@@ -20,12 +20,12 @@ describe('SmallMultiples primitive', () => {
 	afterEach(() => cleanup());
 
 	it('renders one mini-panel per input entry', () => {
-		render(<SmallMultiples panels={panels} theme="light" />);
+		render(<SmallMultiples panels={panels} />);
 		const headings = document.querySelectorAll('[data-testid="small-multiple-title"]');
 		expect(headings.length).toBe(3);
 	});
 	it('includes each panel title', () => {
-		const { container } = render(<SmallMultiples panels={panels} theme="light" />);
+		const { container } = render(<SmallMultiples panels={panels} />);
 		expect(
 			container.querySelector('[data-testid="small-multiple-title"]:first-child')
 				|| container.textContent?.includes('CPU'),
@@ -42,7 +42,7 @@ describe('SmallMultiples primitive', () => {
 				yAxis: { unit: '/s', formatter: 'count' },
 			},
 		];
-		const { container } = render(<SmallMultiples panels={perAxisPanels} theme="light" />);
+		const { container } = render(<SmallMultiples panels={perAxisPanels} />);
 		await waitFor(() => {
 			const tickEls = container.querySelectorAll('.recharts-cartesian-axis-tick-value, .recharts-yAxis text');
 			const labels = Array.from(tickEls).map((t) => t.textContent ?? '');

--- a/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
@@ -42,7 +42,6 @@ function renderToggle() {
 			records={records}
 			timeRange={range}
 			nodes={['n1', 'n2']}
-			theme="light"
 		/>,
 	);
 	return screen.getAllByTestId('stack-by-button');

--- a/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
@@ -22,33 +22,33 @@ describe('StackedAreaChart primitive', () => {
 	afterEach(() => cleanup());
 
 	it('exposes role=img with composed aria-label', () => {
-		render(<StackedAreaChart data={stacked} theme="light" />);
+		render(<StackedAreaChart data={stacked} />);
 		const img = screen.getByRole('img');
 		expect(img.getAttribute('aria-label') ?? '').toMatch(/Stacked area chart with 3 series/);
 	});
 
 	it('empty-state uses role=status for live-region announcement', () => {
-		render(<StackedAreaChart data={{ series: [] }} theme="light" />);
+		render(<StackedAreaChart data={{ series: [] }} />);
 		const status = screen.getByRole('status');
 		expect(status.textContent ?? '').toMatch(/no data in window/i);
 	});
 
 	it.skip('mounts an svg container', async () => {
-		render(<StackedAreaChart data={stacked} theme="light" />);
+		render(<StackedAreaChart data={stacked} />);
 		await waitFor(() => {
 			const svg = document.querySelector('.recharts-wrapper svg');
 			expect(svg, 'Recharts svg rendered').toBeTruthy();
 		});
 	});
 	it.skip('renders three area layers', async () => {
-		render(<StackedAreaChart data={stacked} theme="light" />);
+		render(<StackedAreaChart data={stacked} />);
 		await waitFor(() => {
 			const areas = document.querySelectorAll('.recharts-area');
 			expect(areas.length).toBe(3);
 		});
 	});
 	it('renders empty-state when series is empty', () => {
-		render(<StackedAreaChart data={{ series: [] }} theme="light" />);
+		render(<StackedAreaChart data={{ series: [] }} />);
 		expect(screen.getByText(/no data in window/i)).toBeTruthy();
 	});
 	it.skip('honors per-series color on the rendered area', async () => {
@@ -57,7 +57,7 @@ describe('StackedAreaChart primitive', () => {
 				{ key: 'a', label: 'A', color: '#ff00ff', points: [{ x: 1, y: 10 }, { x: 2, y: 20 }] },
 			],
 		};
-		const { container } = render(<StackedAreaChart data={data} theme="light" />);
+		const { container } = render(<StackedAreaChart data={data} />);
 		await waitFor(() => {
 			const area = container.querySelector('.recharts-area-area');
 			expect(area, 'area path rendered').toBeTruthy();
@@ -68,7 +68,7 @@ describe('StackedAreaChart primitive', () => {
 	it.skip('appends unit suffix to Y-axis tick labels', async () => {
 		const data: SeriesData = { series: [{ key: 'a', label: 'A', points: [{ x: 0, y: 1024 * 1024 }] }] };
 		const { container } = render(
-			<StackedAreaChart data={data} theme="light" yAxis={{ unit: '/s', formatter: 'bytes-si' }} />,
+			<StackedAreaChart data={data} yAxis={{ unit: '/s', formatter: 'bytes-si' }} />,
 		);
 		await waitFor(() => {
 			const tickEls = container.querySelectorAll('.recharts-cartesian-axis-tick-value, .recharts-yAxis text');
@@ -84,7 +84,7 @@ describe('StackedAreaChart primitive', () => {
 			...stacked,
 			ceiling: { key: 'cap', label: 'Max', points: [{ x: 1, y: 100 }, { x: 2, y: 100 }] },
 		};
-		const { container } = render(<StackedAreaChart data={withCeiling} theme="light" />);
+		const { container } = render(<StackedAreaChart data={withCeiling} />);
 		await waitFor(() => {
 			// Without ceiling, StackedAreaChart renders N area paths. With ceiling,
 			// there should be at least one additional `.recharts-line`.
@@ -113,7 +113,7 @@ describe('StackedAreaChart Step 3.5 polish', () => {
 				{ key: 'b', label: 'B', points: [{ x: 0, y: 20 }, { x: 1, y: 22 }] },
 			],
 		};
-		const { container } = render(<StackedAreaChart data={data} theme="light" />);
+		const { container } = render(<StackedAreaChart data={data} />);
 		await waitFor(() => {
 			const areas = Array.from(container.querySelectorAll<SVGPathElement>('.recharts-area-area, path'));
 			const opacities = areas.map((p) => p.getAttribute('fill-opacity') ?? p.style.fillOpacity ?? '');
@@ -123,14 +123,18 @@ describe('StackedAreaChart Step 3.5 polish', () => {
 	});
 
 	it.skip('renders <Area> with fillOpacity 0.5 in dark theme', async () => {
+		// Dark mode resolves from the app's `.dark` root class (useResolvedTheme),
+		// not a prop.
+		document.documentElement.classList.add('dark');
 		const data: SeriesData = { series: [{ key: 'a', label: 'A', points: [{ x: 0, y: 10 }, { x: 1, y: 12 }] }] };
-		const { container } = render(<StackedAreaChart data={data} theme="dark" />);
+		const { container } = render(<StackedAreaChart data={data} />);
 		await waitFor(() => {
 			const areas = Array.from(container.querySelectorAll<SVGPathElement>('.recharts-area-area, path'));
 			const opacities = areas.map((p) => p.getAttribute('fill-opacity') ?? p.style.fillOpacity ?? '');
 			expect(opacities.some((o) => o === '0.5' || o === '.5'), `expected 0.5; got ${JSON.stringify(opacities)}`)
 				.toBeTruthy();
 		});
+		document.documentElement.classList.remove('dark');
 	});
 });
 

--- a/src/features/instance/status/analytics/__tests__/tableColors.test.ts
+++ b/src/features/instance/status/analytics/__tests__/tableColors.test.ts
@@ -18,7 +18,7 @@ describe('getTableColor', () => {
 		expect(getTableColor(3)).toBe(getTableColor(3));
 	});
 
-	it('exports OTHER_COLOR as a neutral greyscale value', () => {
-		expect(OTHER_COLOR).toMatch(/^#[0-9a-f]{6}$/i);
+	it('exports OTHER_COLOR as a chart-token reference (value checked in paletteDisjointness)', () => {
+		expect(OTHER_COLOR).toMatch(/^var\(--chart-[\w-]+\)$/);
 	});
 });

--- a/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
@@ -3,16 +3,23 @@ import { useNodeSelection } from '../hooks/useNodeSelection.ts';
 import { getTableColor, OTHER_COLOR } from '../lib/tableColors.ts';
 import { OTHER_KEY, type Snapshot } from '../lib/tableSize.ts';
 import { getChartColors, type Theme } from '../lib/theme.ts';
-import { formatBytes } from '../lib/time.ts';
+import { formatValue } from '../primitives/formatValue.ts';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
 import type { ViewMode } from '../types/analytics.ts';
 import { NodeLegend } from './NodeLegend.tsx';
 import { TableSizeChipRow } from './TableSizeChipRow.tsx';
+
+/** One byte-format path for every chart — see primitives/formatValue.ts. */
+const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 
 interface Props {
 	snapshot: Snapshot;
 	/** Display mode: 'per-node' → Absolute (raw bytes), 'aggregate' → Normalized (percent of cluster max). */
 	viewMode: ViewMode;
-	theme: Theme;
+	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
+	 *  Kept optional only while StorageTab (owned by a parallel refactor)
+	 *  still passes it. */
+	theme?: Theme;
 	/** Snapshot's own highlight — drives chip `aria-checked` + bar-segment outline. */
 	selectedTable: string | null;
 	/** Chip click / Enter / Space / arrow-nav — local to this panel; should NOT
@@ -60,13 +67,12 @@ function toRows(
 export function TableSizeSnapshot({
 	snapshot,
 	viewMode,
-	theme,
 	selectedTable,
 	onChipSelect,
 	onBarClick,
 	allOtherHint,
 }: Props) {
-	const colors = getChartColors(theme);
+	const colors = getChartColors();
 	// The full cluster node list, used both for the legend and for color
 	// assignment so the same node gets the same color on both panels.
 	const clusterNodeIds = snapshot.byNode.map((n) => n.node);
@@ -109,12 +115,9 @@ export function TableSizeSnapshot({
 							domain={normalized ? [0, clusterMaxTotal] : ['auto', 'auto']}
 						/>
 						<Tooltip
-							contentStyle={{
-								backgroundColor: colors.tooltipBg,
-								border: `1px solid ${colors.tooltipBorder}`,
-								borderRadius: 8,
-								fontSize: 12,
-							}}
+							contentStyle={tooltipContentStyle}
+							labelStyle={tooltipLabelStyle}
+							itemStyle={tooltipItemStyle}
 							formatter={(value, name, ctx) => {
 								const nameStr = String(name);
 								const label = nameStr === OTHER_KEY ? 'Other' : nameStr;

--- a/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
@@ -4,15 +4,23 @@ import { useNodeSelection } from '../hooks/useNodeSelection.ts';
 import { getNodeColor } from '../lib/nodeColors.ts';
 import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize.ts';
 import { getChartColors, type Theme } from '../lib/theme.ts';
-import { formatAxisTick, formatBytes, formatTooltipTime } from '../lib/time.ts';
+import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
+import { formatValue } from '../primitives/formatValue.ts';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
 import type { TimeRange, ViewMode } from '../types/analytics.ts';
 import { NodeLegend } from './NodeLegend.tsx';
 import { TableSizeChipRow } from './TableSizeChipRow.tsx';
 
+/** One byte-format path for every chart — see primitives/formatValue.ts. */
+const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
+
 interface Props {
 	derived: TableSizeDerived;
 	viewMode: ViewMode;
-	theme: Theme;
+	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
+	 *  Kept optional only while StorageTab (owned by a parallel refactor)
+	 *  still passes it. */
+	theme?: Theme;
 	selectedTable: string | null;
 	/** Trend chip click — local to this panel; should NOT touch the Snapshot. */
 	onChipSelect: (tableKey: string) => void;
@@ -32,7 +40,6 @@ interface Props {
 export function TableSizeTrend({
 	derived,
 	viewMode,
-	theme,
 	selectedTable,
 	onChipSelect,
 	manualSelection,
@@ -41,7 +48,7 @@ export function TableSizeTrend({
 	rankBy,
 	onRankChange,
 }: Props) {
-	const colors = getChartColors(theme);
+	const colors = getChartColors();
 
 	const points = useMemo(
 		() => (selectedTable ? derived.trend(selectedTable) : []),
@@ -168,12 +175,9 @@ export function TableSizeTrend({
 							allowDataOverflow
 						/>
 						<Tooltip
-							contentStyle={{
-								backgroundColor: colors.tooltipBg,
-								border: `1px solid ${colors.tooltipBorder}`,
-								borderRadius: 8,
-								fontSize: 12,
-							}}
+							contentStyle={tooltipContentStyle}
+							labelStyle={tooltipLabelStyle}
+							itemStyle={tooltipItemStyle}
 							labelFormatter={(label) => formatTooltipTime(Number(label))}
 							formatter={(value) => formatBytes(Number(value))}
 						/>

--- a/src/features/instance/status/analytics/context/AnalyticsContext.tsx
+++ b/src/features/instance/status/analytics/context/AnalyticsContext.tsx
@@ -7,6 +7,11 @@ export type AnalyticsTheme = 'light' | 'dark';
 export interface AnalyticsContextValue {
 	timeRange: TimeRange;
 	bucketMs: number;
+	/** Resolved app theme. Chart primitives no longer read this — they theme
+	 *  via `--chart-*` CSS tokens (and useResolvedTheme() for the few JS
+	 *  branches). Kept only for StorageTab / ConnectionsPanel, which still
+	 *  pass it into the pipeline-owned renderer signatures; remove once that
+	 *  parallel refactor drops their `theme` props. */
 	theme: AnalyticsTheme;
 	instanceParams: InstanceClientIdConfig & InstanceTypeConfig;
 }

--- a/src/features/instance/status/analytics/lib/colorAllocators/typeColors.ts
+++ b/src/features/instance/status/analytics/lib/colorAllocators/typeColors.ts
@@ -1,13 +1,15 @@
 /** Protocol / type series colors. Six hues spread across the color wheel for
- *  accessibility and colorblind-friendliness. Disjoint from NODE_PALETTE and
- *  TABLE_PALETTE (enforced in __tests__/paletteDisjointness.test.ts). */
+ *  accessibility and colorblind-friendliness; values live as `--chart-type-*`
+ *  CSS vars in src/index.css. Disjoint from NODE_PALETTE and TABLE_PALETTE
+ *  (enforced in __tests__/paletteDisjointness.test.ts against the CSS
+ *  definitions). */
 export const TYPE_PALETTE: readonly string[] = [
-	'#0d9488', // teal-600
-	'#dc2626', // red-600
-	'#7c3aed', // violet-600
-	'#d97706', // amber-600
-	'#db2777', // pink-600
-	'#0284c7', // sky-600
+	'var(--chart-type-1)', // teal-600
+	'var(--chart-type-2)', // red-600
+	'var(--chart-type-3)', // violet-600
+	'var(--chart-type-4)', // amber-600
+	'var(--chart-type-5)', // pink-600
+	'var(--chart-type-6)', // sky-600
 ];
 
 export function getTypeColor(typeKey: string, allKeys: readonly string[]): string {

--- a/src/features/instance/status/analytics/lib/nodeColors.ts
+++ b/src/features/instance/status/analytics/lib/nodeColors.ts
@@ -1,14 +1,20 @@
+/**
+ * Categorical palette for per-node series. The actual color values live as
+ * `--chart-node-*` CSS vars in src/index.css (single definition for light and
+ * dark). Disjoint from TABLE_PALETTE and TYPE_PALETTE — enforced by
+ * `__tests__/paletteDisjointness.test.ts`, which parses the CSS definitions.
+ */
 export const NODE_PALETTE = [
-	'#58a6ff', // blue
-	'#3fb950', // green
-	'#f0883e', // orange
-	'#bc8cff', // purple
-	'#f778ba', // pink
-	'#79c0ff', // light blue
-	'#d2a8ff', // lavender
-	'#ffa657', // amber
-	'#ff7b72', // red
-	'#7ee787', // lime
+	'var(--chart-node-1)', // blue
+	'var(--chart-node-2)', // green
+	'var(--chart-node-3)', // orange
+	'var(--chart-node-4)', // purple
+	'var(--chart-node-5)', // pink
+	'var(--chart-node-6)', // light blue
+	'var(--chart-node-7)', // lavender
+	'var(--chart-node-8)', // amber
+	'var(--chart-node-9)', // red
+	'var(--chart-node-10)', // lime
 ] as const;
 
 export function getNodeColor(nodeId: string, allNodeIds: string[]): string {

--- a/src/features/instance/status/analytics/lib/tableColors.ts
+++ b/src/features/instance/status/analytics/lib/tableColors.ts
@@ -1,25 +1,27 @@
 /**
- * Categorical palette for tables in the table-size dashboard.
+ * Categorical palette for tables in the table-size dashboard. The color
+ * values live as `--chart-table-*` CSS vars in src/index.css, chosen to meet
+ * WCAG AA contrast on both dark and light card surfaces.
  *
  * Deliberately distinct from NODE_PALETTE in `nodeColors.ts` so the two
- * categorical encodings (nodes and tables) don't visually collide.
- * Chosen to meet WCAG AA contrast on both dark and light backgrounds.
+ * categorical encodings (nodes and tables) don't visually collide — enforced
+ * by `__tests__/paletteDisjointness.test.ts` against the CSS definitions.
  */
 export const TABLE_PALETTE = [
-	'#e45756', // red
-	'#f58518', // orange
-	'#eeca3b', // yellow
-	'#54a24b', // green
-	'#4c78a8', // blue
-	'#b279a2', // mauve
-	'#9d755d', // brown
-	'#17becf', // cyan
-	'#72b7b2', // teal
-	'#bab0ac', // grey
+	'var(--chart-table-1)', // red
+	'var(--chart-table-2)', // orange
+	'var(--chart-table-3)', // yellow
+	'var(--chart-table-4)', // green
+	'var(--chart-table-5)', // blue
+	'var(--chart-table-6)', // mauve
+	'var(--chart-table-7)', // brown
+	'var(--chart-table-8)', // cyan
+	'var(--chart-table-9)', // teal
+	'var(--chart-table-10)', // grey
 ] as const;
 
 /** Colour for the rolled-up "Other" stack — neutral grey so it reads as an aggregate. */
-export const OTHER_COLOR = '#6b7280';
+export const OTHER_COLOR = 'var(--chart-other)';
 
 export function getTableColor(index: number): string {
 	return TABLE_PALETTE[index % TABLE_PALETTE.length];

--- a/src/features/instance/status/analytics/lib/theme.ts
+++ b/src/features/instance/status/analytics/lib/theme.ts
@@ -16,6 +16,9 @@ export function useResolvedTheme(): Theme {
 	);
 	useEffect(() => {
 		const root = document.documentElement;
+		// Re-sync on mount: a theme toggle between the lazy initializer and
+		// the observer attaching would otherwise be missed.
+		setDark(root.classList.contains('dark'));
 		const observer = new MutationObserver(() => {
 			setDark(root.classList.contains('dark'));
 		});

--- a/src/features/instance/status/analytics/lib/theme.ts
+++ b/src/features/instance/status/analytics/lib/theme.ts
@@ -1,15 +1,38 @@
+import { useEffect, useState } from 'react';
+
 export type Theme = 'light' | 'dark';
 
+/** Resolved app theme ('light' | 'dark') for the few chart internals that
+ *  genuinely branch in JS (heatmap color-stop interpolation, area fill
+ *  opacity). The app's ThemeProvider (src/hooks/useTheme) already resolves
+ *  the user's explicit choice vs. OS preference by toggling the `.dark`
+ *  class on <html> — reading that class keeps charts in lockstep with every
+ *  other themed surface without re-deriving preference + media-query state.
+ *  Everything color-related that CAN be a CSS token should use the
+ *  `--chart-*` vars instead and never touch this hook. */
+export function useResolvedTheme(): Theme {
+	const [dark, setDark] = useState<boolean>(() =>
+		typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+	);
+	useEffect(() => {
+		const root = document.documentElement;
+		const observer = new MutationObserver(() => {
+			setDark(root.classList.contains('dark'));
+		});
+		observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+		return () => observer.disconnect();
+	}, []);
+	return dark ? 'dark' : 'light';
+}
+
 /** Reads the studio chart-surface CSS tokens defined in src/index.css.
- *  All charts render inside a `Card`, so axis/grid/tooltip colors resolve
- *  against `--card`, not the brand-purple `--background`. The hex defaults
- *  here are fallbacks for non-DOM environments (tests). */
-export function getChartColors(_theme: Theme) {
+ *  All charts render inside a `Card`, so axis/grid colors resolve against
+ *  `--card`, not the brand-purple `--background`. The hex defaults here are
+ *  fallbacks for non-DOM environments (tests). Tooltip styling lives in
+ *  primitives/tooltipStyle.ts — the one tooltip surface for all charts. */
+export function getChartColors() {
 	return {
 		axisColor: 'var(--chart-axis, #6b7280)',
 		gridColor: 'var(--chart-grid, #e5e7eb)',
-		tooltipBg: 'var(--chart-tooltip-bg, #ffffff)',
-		tooltipBorder: 'var(--chart-grid, #d1d5db)',
-		textColor: 'var(--chart-tooltip-fg, #1f2937)',
 	};
 }

--- a/src/features/instance/status/analytics/lib/time.ts
+++ b/src/features/instance/status/analytics/lib/time.ts
@@ -42,12 +42,3 @@ export function getTimezoneAbbr(): string {
 	const tz = parts.find((p) => p.type === 'timeZoneName');
 	return tz?.value ?? 'UTC';
 }
-
-export function formatBytes(bytes: number): string {
-	if (bytes === 0) { return '0 B'; }
-	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-	const k = 1000; // SI
-	const i = Math.floor(Math.log(bytes) / Math.log(k));
-	const value = bytes / k ** i;
-	return `${value.toFixed(value < 10 ? 1 : 0)} ${units[i]}`;
-}

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -29,7 +29,6 @@ interface Props {
 	records: AnalyticsDataPoint[];
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	ariaLabel?: string;
 	/** 'per-node' (default) breaks each chip-selected dimension into one
 	 *  line per node; 'aggregate' folds nodes into one cluster series per
@@ -45,7 +44,6 @@ export function DimensionSelectorRenderer({
 	records,
 	timeRange,
 	nodes,
-	theme,
 	ariaLabel = 'Dimension',
 	viewMode = 'per-node',
 	fillParent,
@@ -169,7 +167,6 @@ export function DimensionSelectorRenderer({
 			<div className="min-h-0 flex-1" style={{ marginTop: 8 }}>
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={spec.yAxis}
 					xDomain={[timeRange.startTime, timeRange.endTime]}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
@@ -31,7 +31,6 @@ interface Props {
 	 *  those callsites are next touched. */
 	window?: TimeRange;
 	nodes?: string[];
-	theme: 'light' | 'dark';
 	/** Optional inline banner shown above the dev hint — used by callers that
 	 *  fell through to FallbackRenderer for a known reason (e.g. legacy chart
 	 *  failed to load), so users see the cause. */
@@ -83,7 +82,7 @@ export function buildFallbackPanels(
 	return { panels, overflowCount: fields.length - visibleFields.length };
 }
 
-export function FallbackRenderer({ metric, records, theme, hint }: Props) {
+export function FallbackRenderer({ metric, records, hint }: Props) {
 	const { panels, overflowCount: overflow } = buildFallbackPanels(records);
 
 	const kebab = metric.replace(/_/g, '-');
@@ -125,7 +124,7 @@ export function FallbackRenderer({ metric, records, theme, hint }: Props) {
 					{banner}
 				</div>
 			)}
-			<SmallMultiples panels={panels} theme={theme} />
+			<SmallMultiples panels={panels} />
 			{overflow > 0 && (
 				<div style={{ fontSize: 11, marginTop: 4, opacity: 0.7 }}>
 					{`… and ${overflow} more fields not shown. Add a spec at src/features/instance/status/analytics/pipeline/${kebab}.tsx to customize.`}

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useResolvedTheme } from '../lib/theme.ts';
 import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics.ts';
 import { computeCellSize } from './computeCellSize.ts';
 import { formatValue } from './formatValue.ts';
@@ -7,13 +8,29 @@ export { computeCellSize } from './computeCellSize.ts';
 
 interface Props {
 	data: HeatmapData;
-	theme: 'light' | 'dark';
+	/** @deprecated Ignored — the color-stop ramp branches on the resolved app
+	 *  theme via useResolvedTheme(), and the confidence greys are
+	 *  `--chart-heatmap-*` CSS tokens. Kept optional only while the pipeline
+	 *  renderers (owned by a parallel refactor) still pass it. */
+	theme?: 'light' | 'dark';
 	title?: string;
 	height?: number;
 }
 
+/** Confidence-state greys — CSS tokens defined per theme in src/index.css
+ *  (`--chart-heatmap-*`), so suppressed/absent/grey cells re-theme without a
+ *  JS branch. Hex fallbacks are the light-theme values, for non-DOM tests. */
+const MUTED_BG = 'var(--chart-heatmap-muted-bg, #f3f4f6)';
+const MUTED_STROKE = 'var(--chart-heatmap-muted-stroke, #9ca3af)';
+const GREY_STROKE = 'var(--chart-heatmap-grey-stroke, #9ca3af)';
+
 type Confidence = 'ok' | 'grey' | 'suppress' | 'absent';
 
+// Color-ramp stops stay literal hex (not CSS vars): the cell fill is
+// interpolated between stops in JS (interpolateStops) and the focus-halo
+// color is derived from the fill's WCAG relative luminance — both need
+// concrete RGB values, which `var(--…)` strings can't provide. The
+// light/dark ramp is selected via useResolvedTheme().
 // Light theme: pale → deep red (low → high latency).
 const LIGHT_STOPS = ['#fef3c7', '#fcd34d', '#f59e0b', '#dc2626', '#7f1d1d'];
 // Dark theme: muted amber → cream.
@@ -98,6 +115,7 @@ function cellAriaLabel(
 	unit: string,
 	suppressBelow: number,
 	approx: boolean,
+	measureLabel: string,
 ): string {
 	const prefix = `${row} → ${col}: `;
 	const approxTag = approx ? ' (approx)' : '';
@@ -110,9 +128,9 @@ function cellAriaLabel(
 	const value = cell?.value ?? 0;
 	const count = cell?.count ?? 0;
 	if (confidence === 'grey') {
-		return `${prefix}${value} ${unit} p95 (approx, low-confidence: ${count} samples below threshold)`;
+		return `${prefix}${value} ${unit} ${measureLabel} (approx, low-confidence: ${count} samples below threshold)`;
 	}
-	return `${prefix}${value} ${unit} p95${approxTag}, ${count} samples`;
+	return `${prefix}${value} ${unit} ${measureLabel}${approxTag}, ${count} samples`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -126,16 +144,18 @@ interface LegendProps {
 	width: number;
 	axis?: AxisSpec;
 	approx: boolean;
+	/** What the cells measure (e.g. "p95 latency"). */
+	measureLabel: string;
 }
 
-function HeatmapColorLegend({ stops, vmin, vmax, width, axis, approx }: LegendProps) {
+function HeatmapColorLegend({ stops, vmin, vmax, width, axis, approx, measureLabel }: LegendProps) {
 	const gradientId = useId();
 	const unit = axis?.unit ?? '';
 	const fmt = (v: number) => formatValue(v, axis?.formatter);
 	const median = (vmin + vmax) / 2;
 	const stripWidth = Math.max(200, Math.min(width, 480));
 	const stripHeight = 12;
-	const labelPrefix = approx ? 'p95 latency (count-weighted-mean, approx)' : 'p95 latency';
+	const labelPrefix = approx ? `${measureLabel} (count-weighted-mean, approx)` : measureLabel;
 	const label = `${labelPrefix}: ${fmt(vmin)}–${fmt(vmax)} ${unit}. Higher value = worse latency.`;
 	return (
 		<svg
@@ -219,16 +239,21 @@ const CELL_GAP = 4;
 const HEADER_HEIGHT = 72; // reserved for rotated column headers
 const ROW_LABEL_WIDTH = 200;
 
-export function HeatmapMatrix({ data, theme, title, height }: Props) {
+export function HeatmapMatrix({ data, title, height }: Props) {
 	const titleId = useId();
 	const descId = useId();
 	const suppressPatternId = useId();
+	const theme = useResolvedTheme();
 
 	const greyBelow = data.confidence?.greyBelow ?? 0;
 	const suppressBelow = data.confidence?.suppressBelow ?? 0;
 	const stops = theme === 'dark' ? DARK_STOPS : LIGHT_STOPS;
 	const approx = data.approx === true;
 	const unit = data.axis?.unit ?? '';
+	// What the cells measure. Falls back to the historical copy; renderers
+	// can override via HeatmapData.measureLabel (e.g. when a quantile
+	// selector swaps p95 for p50/p99).
+	const measureLabel = data.measureLabel ?? 'p95 latency';
 
 	// Build a (row,col) -> cell index for O(1) lookup.
 	const cellMap = useMemo(() => {
@@ -296,9 +321,11 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 	// Roving tabindex state: [rowIdx, colIdx]. Clamped at render time so the
 	// active cell stays in range when rows/cols shrink after a data refresh
 	// (otherwise no cell gets tabIndex=0 and the grid leaves the tab order).
+	// The Math.max(0, …) keeps the derived indices valid positions even when
+	// rows/cols are momentarily empty (Math.min alone would yield -1).
 	const [active, setActive] = useState<[number, number]>([0, 0]);
-	const activeRow = Math.min(active[0], rows.length - 1);
-	const activeCol = Math.min(active[1], cols.length - 1);
+	const activeRow = Math.max(0, Math.min(active[0], rows.length - 1));
+	const activeCol = Math.max(0, Math.min(active[1], cols.length - 1));
 	const cellRefs = useRef<Map<string, HTMLElement>>(new Map());
 
 	const focusCell = useCallback((r: number, c: number) => {
@@ -411,8 +438,8 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 			>
 				{(() => {
 					const descPrefix = approx
-						? 'Cells show count-weighted-mean p95 latency (approx).'
-						: 'Cells show p95 latency.';
+						? `Cells show count-weighted-mean ${measureLabel} (approx).`
+						: `Cells show ${measureLabel}.`;
 					return `${descPrefix} Cells with fewer than ${suppressBelow} samples are blank; ${greyBelow}–${
 						suppressBelow - 1
 					} render grey.`;
@@ -438,13 +465,13 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 							height={8}
 							patternTransform="rotate(45)"
 						>
-							<rect width={8} height={8} fill={theme === 'dark' ? '#1f2937' : '#f3f4f6'} />
+							<rect width={8} height={8} fill={MUTED_BG} />
 							<line
 								x1={0}
 								y1={0}
 								x2={0}
 								y2={8}
-								stroke={theme === 'dark' ? '#4b5563' : '#9ca3af'}
+								stroke={MUTED_STROKE}
 								strokeWidth={2}
 							/>
 						</pattern>
@@ -506,7 +533,7 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 									const confidence = classifyCell(cell, greyBelow, suppressBelow);
 									const cx = ROW_LABEL_WIDTH + ci * (cellSize + CELL_GAP);
 									const cy = y;
-									const aria = cellAriaLabel(row, col, cell, confidence, unit, suppressBelow, approx);
+									const aria = cellAriaLabel(row, col, cell, confidence, unit, suppressBelow, approx, measureLabel);
 
 									const isActive = activeRow === ri && activeCol === ci;
 
@@ -520,12 +547,12 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 									if (confidence === 'absent') {
 										fill = 'transparent';
 										strokeDasharray = '3 3';
-										stroke = theme === 'dark' ? '#4b5563' : '#9ca3af';
+										stroke = MUTED_STROKE;
 										rectStrokeWidth = 1;
 									} else if (confidence === 'suppress') {
 										fill = `url(#${suppressPatternId})`;
 										strokeDasharray = '3 3';
-										stroke = theme === 'dark' ? '#4b5563' : '#9ca3af';
+										stroke = MUTED_STROKE;
 										rectStrokeWidth = 1;
 									} else {
 										const t = vmax > vmin ? ((cell?.value ?? 0) - vmin) / (vmax - vmin) : 0;
@@ -533,7 +560,7 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 										if (confidence === 'grey') {
 											opacity = 0.55;
 											strokeDasharray = '4 2';
-											stroke = theme === 'dark' ? '#6b7280' : '#9ca3af';
+											stroke = GREY_STROKE;
 											rectStrokeWidth = 1;
 										}
 									}
@@ -623,6 +650,7 @@ export function HeatmapMatrix({ data, theme, title, height }: Props) {
 					width={gridWidth}
 					axis={data.axis}
 					approx={approx}
+					measureLabel={measureLabel}
 				/>
 			</div>
 		</div>

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -9,6 +9,8 @@ import {
 	XAxis,
 	YAxis,
 } from 'recharts';
+import { NODE_PALETTE } from '../lib/nodeColors.ts';
+import { getChartColors } from '../lib/theme.ts';
 import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
 import type { AxisSpec, SeriesData, Threshold } from '../types/analytics.ts';
 import { formatValue } from './formatValue.ts';
@@ -16,7 +18,10 @@ import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tool
 
 interface Props {
 	data: SeriesData;
-	theme: 'light' | 'dark';
+	/** @deprecated Ignored — colors resolve via `--chart-*` CSS tokens, so the
+	 *  chart re-themes with the app automatically. Kept optional only while
+	 *  the pipeline renderers (owned by a parallel refactor) still pass it. */
+	theme?: 'light' | 'dark';
 	yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec };
 	height?: number;
 	/** Optional accessible label override; otherwise composed from series labels. */
@@ -63,7 +68,7 @@ function composeAriaLabel(data: SeriesData): string {
 }
 
 export function LineChart(
-	{ data, theme: _theme, yAxis, height = 240, ariaLabel, hideLegend, xDomain, fillParent }: Props,
+	{ data, yAxis, height = 240, ariaLabel, hideLegend, xDomain, fillParent }: Props,
 ) {
 	if (data.series.length === 0) {
 		return (
@@ -80,7 +85,7 @@ export function LineChart(
 	const leftAxis = isDual ? yAxis.left : (yAxis as AxisSpec | undefined);
 	const rightAxis = isDual ? yAxis.right : undefined;
 
-	const colors = ['#58a6ff', '#3fb950', '#f0883e', '#bc8cff', '#f778ba'];
+	const chartColors = getChartColors();
 
 	return (
 		<div
@@ -98,7 +103,7 @@ export function LineChart(
 			<div aria-hidden="true" style={{ width: '100%', height: '100%' }}>
 				<ResponsiveContainer width="100%" height="100%">
 					<RLineChart margin={{ top: 12, right: 12, bottom: 8, left: 8 }}>
-						<CartesianGrid stroke="var(--chart-grid)" strokeDasharray="3 3" />
+						<CartesianGrid stroke={chartColors.gridColor} strokeDasharray="3 3" />
 						<XAxis
 							dataKey="x"
 							type="number"
@@ -106,6 +111,7 @@ export function LineChart(
 							allowDataOverflow={!!xDomain}
 							allowDuplicatedCategory={false}
 							tickFormatter={formatAxisTick}
+							stroke={chartColors.axisColor}
 							tick={{ fontSize: 11 }}
 						/>
 						<YAxis
@@ -113,6 +119,7 @@ export function LineChart(
 							tickFormatter={(v) => formatValue(v, leftAxis?.formatter, leftAxis?.unit)}
 							scale={leftAxis?.scale ?? 'linear'}
 							domain={leftAxis?.domain as [number | string, number | string] | undefined}
+							stroke={chartColors.axisColor}
 							tick={{ fontSize: 11 }}
 							// Wider than Recharts' ~60px default so e.g. '2400.0 ms'
 							// or '1.5 GB' doesn't wrap onto two lines per tick.
@@ -126,6 +133,7 @@ export function LineChart(
 									tickFormatter={(v) => formatValue(v, rightAxis.formatter, rightAxis.unit)}
 									scale={rightAxis.scale ?? 'linear'}
 									domain={rightAxis.domain as [number | string, number | string] | undefined}
+									stroke={chartColors.axisColor}
 									tick={{ fontSize: 11 }}
 									width={70}
 								/>
@@ -181,7 +189,7 @@ export function LineChart(
 									dataKey="y"
 									name={s.label}
 									yAxisId={s.axis === 'right' ? 'right' : 'left'}
-									stroke={s.color ?? colors[idx % colors.length]}
+									stroke={s.color ?? NODE_PALETTE[idx % NODE_PALETTE.length]}
 									strokeWidth={2}
 									strokeOpacity={s.opacity ?? 1}
 									dot={showDots ? { r: 2 } : false}

--- a/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
@@ -13,7 +13,6 @@ import { LineChart } from './LineChart.tsx';
 
 interface Props {
 	data: SeriesData;
-	theme: 'light' | 'dark';
 	yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec };
 	xDomain?: [number, number];
 	fillParent?: boolean;
@@ -31,7 +30,7 @@ function legendGroup(s: Series): string {
 	return s.node ?? s.key;
 }
 
-export function LineChartWithNodeLegend({ data, theme, yAxis, xDomain, fillParent }: Props) {
+export function LineChartWithNodeLegend({ data, yAxis, xDomain, fillParent }: Props) {
 	const nodeIds = useMemo(() => {
 		const set = new Set<string>();
 		for (const s of data.series) {
@@ -46,15 +45,8 @@ export function LineChartWithNodeLegend({ data, theme, yAxis, xDomain, fillParen
 	const filteredData = useMemo<SeriesData>(() => ({
 		...data,
 		series: data.series
-			.filter((s) => {
-				const group = legendGroup(s);
-				return group === '' || isActive(group);
-			})
-			.map((s) => {
-				const group = legendGroup(s);
-				if (!group) { return s; }
-				return { ...s, color: s.color ?? getNodeColor(group, nodeIds) };
-			}),
+			.filter((s) => isActive(legendGroup(s)))
+			.map((s) => ({ ...s, color: s.color ?? getNodeColor(legendGroup(s), nodeIds) })),
 	}), [data, isActive, nodeIds]);
 
 	return (
@@ -62,7 +54,6 @@ export function LineChartWithNodeLegend({ data, theme, yAxis, xDomain, fillParen
 			<div className="min-h-0 flex-1">
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={yAxis}
 					xDomain={xDomain}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from 'react';
+import { useResolvedTheme } from '../lib/theme.ts';
 import { derivedRegistry } from '../pipeline/derived/index.ts';
 import { specRegistry } from '../pipeline/index.ts';
 import { runPipeline } from '../pipeline/pipeline.ts';
@@ -11,21 +12,17 @@ import { StackedAreaChart } from './StackedAreaChart.tsx';
 function renderPrimitive(
 	primitive: MetricSpec['primitive'],
 	data: SeriesData,
-	theme: 'light' | 'dark',
 	yAxis: MetricSpec['yAxis'],
 	xDomain?: [number, number],
 	fillParent?: boolean,
 ) {
 	switch (primitive) {
 		case 'line':
-			return (
-				<LineChartWithNodeLegend data={data} theme={theme} yAxis={yAxis} xDomain={xDomain} fillParent={fillParent} />
-			);
+			return <LineChartWithNodeLegend data={data} yAxis={yAxis} xDomain={xDomain} fillParent={fillParent} />;
 		case 'stacked-area':
 			return (
 				<StackedAreaChart
 					data={data}
-					theme={theme}
 					yAxis={yAxis as AxisSpec}
 					xDomain={xDomain}
 					fillParent={fillParent}
@@ -38,6 +35,43 @@ function renderPrimitive(
 		default:
 			throw new Error(`Unknown primitive: ${primitive as string}`);
 	}
+}
+
+// ─── Generic-dispatch predicates ─────────────────────────────────────────────
+// Named guards for the spec-dispatch branches below, so each condition reads
+// as intent instead of a wall of `&&`s.
+
+/** Stacked-area spec grouped on a non-node dimension while the user asked for
+ *  per-node view — restack the same field by node instead. */
+function wantsStackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+	return spec.primitive === 'stacked-area'
+		&& isPerNodeMode
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension !== 'node';
+}
+
+/** Line spec grouped BY node while the user asked for the aggregate view —
+ *  fold the nodes into a single cluster-wide line. */
+function wantsClusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+	return spec.primitive === 'line'
+		&& !isPerNodeMode
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension === 'node';
+}
+
+/** Line spec grouped on a non-node dimension (e.g. database-size groupBy
+ *  'database'). The default per-node split emits one series per (dim, node)
+ *  and the LineChartWithNodeLegend wrapper extracts only the node id from the
+ *  key — so two dimension values on a single-node Harper render as two lines
+ *  sharing the same color and a single legend entry. Run the pipeline with
+ *  perNode=false so series keys are just the dimension values; the wrapper
+ *  then renders one legend chip per dimension value (colored via
+ *  getNodeColor's deterministic hash). The crossNode aggregator on the spec
+ *  folds nodes into the cluster-wide line per dimension. */
+function wantsDimensionLineSplit(spec: MetricSpec): boolean {
+	return spec.primitive === 'line'
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension !== 'node';
 }
 
 interface MetricErrorBoundaryProps {
@@ -63,7 +97,6 @@ interface Props {
 	records: AnalyticsDataPoint[];
 	window: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	/** When true, the chart fills its parent's vertical space (used by the
 	 *  expand-to-fullscreen dialog). The parent must be a definite-height
@@ -76,17 +109,20 @@ export function MetricRenderer({
 	records,
 	window: timeRange,
 	nodes,
-	theme,
 	viewMode,
 	fillParent,
 }: Props) {
+	// Only the registry Renderers still take a theme prop (their signatures
+	// live in pipeline/, owned by a parallel refactor); primitives re-theme
+	// via CSS tokens and need nothing passed.
+	const theme = useResolvedTheme();
+
 	const errorFallback = (
 		<FallbackRenderer
 			metric={metric}
 			records={records}
 			window={timeRange}
 			nodes={nodes}
-			theme={theme}
 			hint="Render failed — showing fallback."
 		/>
 	);
@@ -108,7 +144,7 @@ export function MetricRenderer({
 			);
 		} else {
 			const seriesData = derived.recompute(records, timeRange, nodes, viewMode);
-			body = renderPrimitive(derived.primitive, seriesData, theme, derived.yAxis, xDomain, fillParent);
+			body = renderPrimitive(derived.primitive, seriesData, derived.yAxis, xDomain, fillParent);
 		}
 	} else {
 		const entry = specRegistry[metric];
@@ -146,62 +182,37 @@ export function MetricRenderer({
 						yAxis: field.yAxis ?? outerSpec.yAxis,
 					};
 				});
-				body = <SmallMultiples panels={panels} theme={theme} xDomain={xDomain} fillParent={fillParent} />;
-			} else if (
-				entry.spec.primitive === 'stacked-area'
-				&& isPerNodeMode
-				&& entry.spec.series.kind === 'groupBy'
-				&& entry.spec.series.dimension !== 'node'
-			) {
+				body = <SmallMultiples panels={panels} xDomain={xDomain} fillParent={fillParent} />;
+			} else if (wantsStackedAreaNodeRemap(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
 				const remapped: MetricSpec = {
 					...entry.spec,
 					series: { ...entry.spec.series, dimension: 'node' },
 				};
 				const seriesData = runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true });
-				body = renderPrimitive('stacked-area', seriesData, theme, entry.spec.yAxis, xDomain, fillParent);
-			} else if (
-				entry.spec.primitive === 'line'
-				&& !isPerNodeMode
-				&& entry.spec.series.kind === 'groupBy'
-				&& entry.spec.series.dimension === 'node'
-			) {
+				body = renderPrimitive('stacked-area', seriesData, entry.spec.yAxis, xDomain, fillParent);
+			} else if (wantsClusterLineFold(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
 				const groupSrc = entry.spec.series;
 				const inner: MetricSpec = {
 					...entry.spec,
 					series: { kind: 'field', fields: [{ ...groupSrc.field, label: 'cluster' }] },
 				};
 				const seriesData = runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true });
-				body = renderPrimitive(entry.spec.primitive, seriesData, theme, entry.spec.yAxis, xDomain, fillParent);
-			} else if (
-				// `primitive: 'line'` + `groupBy` on a non-node dimension (e.g.
-				// database-size groupBy 'database'). The default per-node split
-				// emits one series per (dim, node) and the LineChartWithNodeLegend
-				// wrapper extracts only the node id from the key — so two
-				// dimension values on a single-node Harper render as two lines
-				// sharing the same color and a single legend entry. Run the
-				// pipeline with perNode=false so series keys are just the
-				// dimension values; the wrapper then renders one legend chip
-				// per dimension value (colored via getNodeColor's deterministic
-				// hash). The crossNode aggregator on the spec folds nodes into
-				// the cluster-wide line per dimension.
-				entry.spec.primitive === 'line'
-				&& entry.spec.series.kind === 'groupBy'
-				&& entry.spec.series.dimension !== 'node'
-			) {
+				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
+			} else if (wantsDimensionLineSplit(entry.spec)) {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: false,
 					snapToPeriod: true,
 				});
-				body = renderPrimitive('line', seriesData, theme, entry.spec.yAxis, xDomain, fillParent);
+				body = renderPrimitive('line', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: isPerNodeMode,
 					snapToPeriod: true,
 				});
-				body = renderPrimitive(entry.spec.primitive, seriesData, theme, entry.spec.yAxis, xDomain, fillParent);
+				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}
 		} else {
-			body = <FallbackRenderer metric={metric} records={records} window={timeRange} nodes={nodes} theme={theme} />;
+			body = <FallbackRenderer metric={metric} records={records} window={timeRange} nodes={nodes} />;
 		}
 	}
 

--- a/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
@@ -18,7 +18,10 @@ interface Props {
 	records: AnalyticsDataPoint[];
 	timeRange?: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
+	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
+	 *  Kept optional only while pipeline renderers (owned by a parallel
+	 *  refactor) still pass it. */
+	theme?: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec };
 	thresholds?: Threshold[];
@@ -37,7 +40,6 @@ export function PerPathRateRenderer({
 	records,
 	timeRange,
 	nodes,
-	theme,
 	viewMode = 'per-node',
 	yAxis,
 	thresholds,
@@ -105,7 +107,6 @@ export function PerPathRateRenderer({
 			<div className="min-h-0 flex-1" style={{ marginTop: paths.length > 0 ? 8 : 0 }}>
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={yAxis}
 					xDomain={xDomain}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
+++ b/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
@@ -13,7 +13,6 @@ interface Panel {
 
 interface Props {
 	panels: Panel[];
-	theme: 'light' | 'dark';
 	/** Minimum width per mini-panel (px). Grid auto-fits. Default 320. */
 	minPanelWidth?: number;
 	/** Height per mini-panel (px). Default 240. */
@@ -25,7 +24,7 @@ interface Props {
 }
 
 export function SmallMultiples(
-	{ panels, theme, minPanelWidth = 320, panelHeight = 240, xDomain, fillParent }: Props,
+	{ panels, minPanelWidth = 320, panelHeight = 240, xDomain, fillParent }: Props,
 ) {
 	// Union of node ids across all panels' per-node series (structured
 	// `Series.node`). Cluster-aggregate series (no `node`) don't participate
@@ -76,7 +75,6 @@ export function SmallMultiples(
 							</div>
 							<LineChart
 								data={panel.data}
-								theme={theme}
 								yAxis={panel.yAxis}
 								xDomain={xDomain}
 								height={panelHeight}

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { NODE_PALETTE } from '../lib/nodeColors.ts';
+import { getChartColors, useResolvedTheme } from '../lib/theme.ts';
 import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
 import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics.ts';
 import { formatValue } from './formatValue.ts';
@@ -8,7 +10,6 @@ import { tooltipContentStyle, tooltipLabelStyle } from './tooltipStyle.ts';
 
 interface Props {
 	data: SeriesData;
-	theme: 'light' | 'dark';
 	yAxis?: AxisSpec;
 	height?: number;
 	/** Optional accessible label override; otherwise composed from series labels. */
@@ -90,9 +91,12 @@ export function StackedAreaTooltip({ active, payload, label, formatter, unitSuff
 }
 
 export function StackedAreaChart(
-	{ data, theme, yAxis, height = 240, ariaLabel, xDomain, fillParent, lineOnly }: Props,
+	{ data, yAxis, height = 240, ariaLabel, xDomain, fillParent, lineOnly }: Props,
 ) {
 	const sortedSeries = useMemo(() => sortByMagnitude(data.series), [data.series]);
+	// Fill opacity is the one genuinely theme-branched value here — dark mode
+	// needs denser fills to stay legible against the dark card surface.
+	const theme = useResolvedTheme();
 
 	if (data.series.length === 0) {
 		return (
@@ -102,7 +106,7 @@ export function StackedAreaChart(
 		);
 	}
 
-	const colors = ['#58a6ff', '#3fb950', '#f0883e', '#bc8cff', '#f778ba', '#79c0ff'];
+	const chartColors = getChartColors();
 
 	// Merge points by x across series. Series often emit at slightly
 	// staggered timestamps (e.g. Harper emits per-node records at different
@@ -156,17 +160,19 @@ export function StackedAreaChart(
 			<div aria-hidden="true" style={{ width: '100%', height: '100%' }}>
 				<ResponsiveContainer width="100%" height="100%">
 					<AreaChart data={merged}>
-						<CartesianGrid stroke="var(--chart-grid)" strokeDasharray="3 3" />
+						<CartesianGrid stroke={chartColors.gridColor} strokeDasharray="3 3" />
 						<XAxis
 							dataKey="x"
 							type="number"
 							domain={xDomain ?? ['dataMin', 'dataMax']}
 							allowDataOverflow={!!xDomain}
 							tickFormatter={formatAxisTick}
+							stroke={chartColors.axisColor}
 							tick={{ fontSize: 11 }}
 						/>
 						<YAxis
 							tickFormatter={(v) => formatValue(v, resolvedFormatter, resolvedUnit)}
+							stroke={chartColors.axisColor}
 							tick={{ fontSize: 11 }}
 							width={70}
 						/>
@@ -179,9 +185,9 @@ export function StackedAreaChart(
 								dataKey={s.key}
 								name={s.label}
 								stackId="1"
-								stroke={s.color ?? colors[idx % colors.length]}
+								stroke={s.color ?? NODE_PALETTE[idx % NODE_PALETTE.length]}
 								strokeWidth={lineOnly ? 2 : 1}
-								fill={lineOnly ? 'none' : (s.color ?? colors[idx % colors.length])}
+								fill={lineOnly ? 'none' : (s.color ?? NODE_PALETTE[idx % NODE_PALETTE.length])}
 								fillOpacity={lineOnly ? 0 : fillOpacity}
 								connectNulls={false}
 							/>
@@ -192,7 +198,7 @@ export function StackedAreaChart(
 									type="monotone"
 									dataKey="__ceiling__"
 									name={data.ceiling.label}
-									stroke="#8b949e"
+									stroke={chartColors.axisColor}
 									strokeWidth={2}
 									strokeDasharray="6 3"
 									dot={false}

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -35,7 +35,6 @@ interface Props {
 	records: AnalyticsDataPoint[];
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	/** Initial stack-by mode. Defaults to 'type' so the chart matches the
 	 *  panel name's "by type" framing. The user-facing toggle is rendered
 	 *  inside the renderer when nodes.length > 1. */
@@ -51,7 +50,6 @@ export function TrafficByTypeRenderer({
 	records,
 	timeRange,
 	nodes,
-	theme,
 	viewMode = 'aggregate',
 	fillParent,
 }: Props) {
@@ -138,6 +136,10 @@ export function TrafficByTypeRenderer({
 
 	const showStackByToggle = nodes.length > 1;
 	const xDomain: [number, number] = [timeRange.startTime, timeRange.endTime];
+	// Stacked-area specs always carry a single AxisSpec, but MetricSpec.yAxis
+	// is a union with the dual-axis form — narrow to the left axis instead of
+	// casting.
+	const yAxis = 'left' in spec.yAxis ? spec.yAxis.left : spec.yAxis;
 
 	return (
 		<div className="flex h-full flex-col">
@@ -154,7 +156,6 @@ export function TrafficByTypeRenderer({
 					? (
 						<SmallMultiples
 							panels={gridPanels}
-							theme={theme}
 							xDomain={xDomain}
 							fillParent={fillParent}
 						/>
@@ -162,8 +163,7 @@ export function TrafficByTypeRenderer({
 					: (
 						<StackedAreaChart
 							data={coloredData}
-							theme={theme}
-							yAxis={spec.yAxis as any}
+							yAxis={yAxis}
 							xDomain={xDomain}
 							fillParent={fillParent}
 							lineOnly={lineOnly}

--- a/src/features/instance/status/analytics/primitives/formatValue.ts
+++ b/src/features/instance/status/analytics/primitives/formatValue.ts
@@ -1,5 +1,19 @@
 import type { AxisSpec } from '../types/analytics.ts';
 
+/**
+ * THE value formatter for chart axes and tooltips in Status analytics. Every
+ * chart — metric panels and the table-size charts alike — formats through
+ * this one code path, so the same byte/count value can never render two
+ * different ways on two panels (lib/time.ts used to carry a duplicate
+ * `formatBytes` with different rounding; it's gone).
+ *
+ * Deliberately NOT delegated to the app-wide helpers
+ * (src/lib/humanFileSize.ts / src/lib/humanNumber.ts): those are
+ * prose-oriented — they round to integers and insert locale group separators
+ * via Intl ("1,234 MB"), which is right for body copy but wrong for axis
+ * ticks, where compact fixed-precision short forms ("1.2 GB", "50k") keep
+ * tick labels aligned and unambiguous at small font sizes.
+ */
 export function formatValue(
 	v: number,
 	formatter?: AxisSpec['formatter'],
@@ -52,7 +66,12 @@ function formatBase(v: number, formatter?: AxisSpec['formatter']): string {
 				scaled /= base;
 				i++;
 			}
-			return `${scaled.toFixed(1)} ${units[i]}`;
+			// Adaptive precision: one decimal only where it carries signal
+			// (|scaled| < 10, e.g. "1.5 GB"); integers above that ("512 MB")
+			// and for exact zero ("0 B"). Matches the rounding the table-size
+			// charts always used, now shared by every byte axis/tooltip.
+			const digits = scaled !== 0 && Math.abs(scaled) < 10 ? 1 : 0;
+			return `${scaled.toFixed(digits)} ${units[i]}`;
 		}
 		default:
 			return `${v}`;

--- a/src/features/instance/status/analytics/tabs/MetricPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/MetricPanel.tsx
@@ -26,7 +26,7 @@ export function MetricPanel({ metric, titleOverride }: Props) {
 }
 
 function MetricPanelInner({ metric, titleOverride }: Props) {
-	const { timeRange, bucketMs, theme, instanceParams } = useAnalyticsContext();
+	const { timeRange, bucketMs, instanceParams } = useAnalyticsContext();
 	const sourceMetric = derivedRegistry[metric]?.sourceMetric ?? metric;
 	const requiredFields = getSpecRequiredFields(metric);
 	const { data, isLoading, isError, error, isEmpty, missingFields, refetch } = useAnalyticsRecords({
@@ -51,7 +51,6 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 			records={data}
 			window={timeRange}
 			nodes={nodes}
-			theme={theme}
 			fillParent={opts.fillParent}
 		/>
 	);

--- a/src/features/instance/status/analytics/tabs/PanelShell.tsx
+++ b/src/features/instance/status/analytics/tabs/PanelShell.tsx
@@ -107,7 +107,7 @@ export function PanelStateOrChart({
 		return (
 			<div className="h-64 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive flex flex-col items-start justify-center gap-3">
 				<div>{`Failed to load: ${errorText(error) ?? 'unknown error'}`}</div>
-				<Button variant="outline" size="sm" onClick={onRetry}>Retry</Button>
+				<Button variant="defaultOutline" size="sm" onClick={onRetry}>Retry</Button>
 			</div>
 		);
 	}

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -282,6 +282,11 @@ export interface HeatmapData {
 	 *  (e.g. count-weighted-mean). Primitive does not introspect the
 	 *  aggregator — the renderer sets this. */
 	approx?: boolean;
+	/** What the cells measure, for the color-scale legend and description
+	 *  (e.g. "p95 latency", "p50 latency"). Defaults to "p95 latency" in the
+	 *  primitive for backward compatibility; renderers with a quantile
+	 *  selector should set it to match the selected quantile. */
+	measureLabel?: string;
 }
 
 export interface SpecRegistryRendererProps {

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,49 @@
 	--chart-tooltip-bg: var(--popover);
 	--chart-tooltip-fg: var(--popover-foreground);
 
+	/* Categorical chart palettes (Status analytics). Three disjoint palettes
+	 * so the three categorical encodings (nodes / tables / protocol types)
+	 * never collide visually — enforced by
+	 * src/features/instance/status/analytics/__tests__/paletteDisjointness.test.ts,
+	 * which parses these definitions. Values are shared by light and dark
+	 * (chosen for AA contrast against both --card surfaces); override in
+	 * .dark if the palettes ever need to diverge per theme. */
+	--chart-node-1: #58a6ff;   /* blue */
+	--chart-node-2: #3fb950;   /* green */
+	--chart-node-3: #f0883e;   /* orange */
+	--chart-node-4: #bc8cff;   /* purple */
+	--chart-node-5: #f778ba;   /* pink */
+	--chart-node-6: #79c0ff;   /* light blue */
+	--chart-node-7: #d2a8ff;   /* lavender */
+	--chart-node-8: #ffa657;   /* amber */
+	--chart-node-9: #ff7b72;   /* red */
+	--chart-node-10: #7ee787;  /* lime */
+
+	--chart-table-1: #e45756;  /* red */
+	--chart-table-2: #f58518;  /* orange */
+	--chart-table-3: #eeca3b;  /* yellow */
+	--chart-table-4: #54a24b;  /* green */
+	--chart-table-5: #4c78a8;  /* blue */
+	--chart-table-6: #b279a2;  /* mauve */
+	--chart-table-7: #9d755d;  /* brown */
+	--chart-table-8: #17becf;  /* cyan */
+	--chart-table-9: #72b7b2;  /* teal */
+	--chart-table-10: #bab0ac; /* grey */
+
+	--chart-type-1: #0d9488;   /* teal-600 */
+	--chart-type-2: #dc2626;   /* red-600 */
+	--chart-type-3: #7c3aed;   /* violet-600 */
+	--chart-type-4: #d97706;   /* amber-600 */
+	--chart-type-5: #db2777;   /* pink-600 */
+	--chart-type-6: #0284c7;   /* sky-600 */
+
+	/* Rolled-up "Other" stack — neutral grey so it reads as an aggregate. */
+	--chart-other: #6b7280;
+
+	/* Heatmap confidence-state greys (suppressed hatch / absent-cell strokes). */
+	--chart-heatmap-muted-bg: #f3f4f6;
+	--chart-heatmap-muted-stroke: #9ca3af;
+	--chart-heatmap-grey-stroke: #9ca3af;
 }
 
 .dark {
@@ -139,6 +182,13 @@
 		--chart-axis: hsl(0 0% 70%);
 		--chart-tooltip-bg: var(--popover);
 		--chart-tooltip-fg: var(--popover-foreground);
+
+		/* Categorical palettes (--chart-node/table/type/other) are inherited
+		 * from :root — the same values are contrast-checked for both surfaces.
+		 * Heatmap confidence greys do differ per theme: */
+		--chart-heatmap-muted-bg: #1f2937;
+		--chart-heatmap-muted-stroke: #4b5563;
+		--chart-heatmap-grey-stroke: #6b7280;
 
 		--shadow-deep: 0 2px 8px 0 rgba(0,0,0,0.4), 0 1px 2px 0 rgba(0,0,0,0.3);
 }


### PR DESCRIPTION
Fixes [#1451 — Align Status charts with app theming: useTheme, chart CSS tokens, shared formatters](https://github.com/HarperFast/studio/issues/1451).

## Theme source

`StatusTabs` used `useSystemTheme()` (raw OS preference), so charts could disagree with the surrounding UI when the user picked an explicit theme. Charts now follow the app's actual resolved theme via a new `useResolvedTheme()` in `lib/theme.ts`, which watches the `.dark` class that `ThemeProvider` (`src/hooks/useTheme`) toggles on `<html>` — one source of truth, no re-derived preference/media-query state.

The mostly-dead `theme` prop chain is gone from everything this PR owns:

- Removed outright from `StackedAreaChart`, `SmallMultiples`, `LineChartWithNodeLegend`, `DimensionSelectorRenderer`, `TrafficByTypeRenderer`, `FallbackRenderer`, and `MetricRenderer` (which now resolves the theme itself and passes it only to the registry `Renderer`s, whose signatures live in `pipeline/`).
- Kept as a **deprecated, ignored optional prop** on `LineChart`, `HeatmapMatrix`, `PerPathRateRenderer`, `TableSizeSnapshot`, and `TableSizeTrend` — pipeline renderers and `StorageTab` (owned by a parallel PR) still pass it explicitly; the props and `AnalyticsContext.theme` are documented for removal once that lands.
- The two components that genuinely branch on theme in JS — `HeatmapMatrix` (color-stop interpolation + luminance-derived focus halo need concrete RGB) and `StackedAreaChart` (fill opacity) — read `useResolvedTheme()` directly.

## Hex → chart CSS tokens

`src/index.css` gains `--chart-node-1..10`, `--chart-table-1..10`, `--chart-type-1..6`, `--chart-other`, and `--chart-heatmap-{muted-bg,muted-stroke,grey-stroke}`. The categorical palettes keep their exact previous values and are defined once in `:root` (they were chosen for AA contrast on both card surfaces; a `.dark` override point is documented). The heatmap greys differ per theme and are defined in both blocks — same values as the old inline branches, so no visual change there.

`NODE_PALETTE` / `TABLE_PALETTE` / `TYPE_PALETTE` / `OTHER_COLOR` are now `var(--chart-*)` references; the inline fallback arrays in `LineChart` / `StackedAreaChart` (re-typed copies of `NODE_PALETTE[0..4/5]`) now use `NODE_PALETTE` itself. The heatmap's WCAG contrast-table rationale stays in `HeatmapMatrix`, plus a note on why the ramp stops remain literal hex (JS interpolation + luminance math).

`paletteDisjointness.test.ts` keeps the disjointness invariant enforced — it now parses the `src/index.css` definitions, and additionally asserts every palette entry resolves to a defined var with a 6-digit hex value (no dangling references).

## Chart chrome

- One tooltip surface: `TableSizeSnapshot` / `TableSizeTrend` now use `primitives/tooltipStyle.ts` instead of their inline near-duplicates (radius 8 → 6, `--border` border, same popover tokens, plus the shared label/item styles).
- One axis treatment: `LineChart` / `StackedAreaChart` axes now take `stroke: var(--chart-axis)` via `getChartColors()` — previously only the TableSize charts did, so axis lines differed across panels.
- `getChartColors()` slims to axis/grid (tooltip fields were only feeding the duplicate styles) and drops its unused `theme` parameter.

## Formatters

`lib/time.ts#formatBytes` duplicated `formatValue`'s `bytes-si` branch with different rounding, so table-size axes and metric axes formatted the same byte value differently. It's deleted; both chart families now format through `formatValue`, whose bytes branch adopts the table-size charts' adaptive precision. `formatValue`'s header documents why it doesn't delegate to `src/lib/humanFileSize.ts` / `humanNumber.ts` (those are prose-oriented: integer rounding + locale group separators; axis ticks need compact fixed-precision short forms).

**Visible format changes** (metric charts only; table-size charts keep their existing rendering):

- byte values ≥ 10 in their scaled unit: `512.0 MB` → `512 MB`
- zero: `0.0 B` → `0 B`

## Other visible changes

- Charts follow the user's explicit light/dark choice (the headline fix) instead of the OS setting.
- `StackedAreaChart`'s ceiling line: hardcoded `#8b949e` → `var(--chart-axis)` (theme-aware; previously one grey for both modes).
- Un-colored series beyond the 5th/6th in `LineChart` / `StackedAreaChart` fallbacks now draw from the full 10-color node palette instead of cycling early.
- Both Retry buttons (`PanelShell` error state, `StatusTabs` capability notice) move to the `defaultOutline` variant, as deferred to this issue in the [#1476](https://github.com/HarperFast/studio/pull/1476)/[#1481](https://github.com/HarperFast/studio/pull/1481) review threads.

## Rider items from [#1453 — Status tabs review: copy fixes, dead code, type tightening](https://github.com/HarperFast/studio/issues/1453) (partial; does not close it)

- `HeatmapMatrix` legend/description no longer hardcode "p95 latency" — they read a new optional `HeatmapData.measureLabel` (default preserves current copy).
- `HeatmapMatrix` roving-focus clamp now uses `Math.max(0, Math.min(…))` so derived indices are always valid positions.
- Dropped the unreachable `group === ''` branch in `LineChartWithNodeLegend`.
- `TrafficByTypeRenderer`'s `yAxis={spec.yAxis as any}` cast replaced with proper `'left' in` narrowing.
- `MetricRenderer`'s dense dispatch predicates extracted into named guards (`wantsStackedAreaNodeRemap`, `wantsClusterLineFold`, `wantsDimensionLineSplit`).

## Deferred (files owned by a parallel PR)

- `pipeline/**` renderers (`connection`, `memory`, `main-thread-utilization`, `request-rate`, `replication-latency`, `connections`) still declare/pass `theme` — the deprecated optional props above exist solely for them and can be deleted when that PR drops the pass-through. `replication-latency`'s `RecognitionBanner` inline hex branches are also theirs.
- `StorageTab` / `ConnectionsPanel` still read `theme` from `AnalyticsContext` (now correctly sourced, so behavior is right — just not yet prop-free).
- Wiring `HeatmapData.measureLabel` from the replication-latency quantile selector (p50/p95/p99) lives in `pipeline/replication-latency.tsx`.

## Tests

- New: dark/light ramp selection + live `.dark` toggle re-render for `HeatmapMatrix`, heatmap confidence greys sourced from tokens, `measureLabel` threading, `formatValue` bytes adaptive-precision cases, palette-token resolution.
- Updated: `paletteDisjointness` (reads CSS definitions), `tableColors` `OTHER_COLOR` shape, removed `theme` props where the prop itself was removed.
- `tsc -b`, full `vitest run` (210 files / 1434 passed, 11 pre-existing skips), `dprint fmt`, `oxlint` all clean.

Generated by kAIle (Claude Fable 5).
