### PR TITLE
fix(databases): restore stage build — use formatValue for byte sizes in DatabaseOverview

### DIFF
--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { TableRowContextMenu } from '@/features/instance/databases/components/TableRowContextMenu';
-import { formatBytes } from '@/features/instance/status/analytics/lib/time';
+import { formatValue } from '@/features/instance/status/analytics/primitives/formatValue';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
 import { getDescribeTableQueryOptions } from '@/integrations/api/instance/database/getDescribeTable';
@@ -12,6 +12,9 @@ import { useQueries } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { CloudUploadIcon, EllipsisIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { useCallback } from 'react';
+
+/** One byte-format path for every chart — see status/analytics/primitives/formatValue.ts. */
+const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 
 function Stat({ label, value }: { label: string; value: string }) {
 	return (


### PR DESCRIPTION
## What

Fixes the broken `stage` build ([run 29280109211](https://github.com/HarperFast/studio/actions/runs/29280109211)):

```
src/features/instance/databases/components/DatabaseOverview.tsx(5,10): error TS2305:
Module '"@/features/instance/status/analytics/lib/time"' has no exported member 'formatBytes'.
```

## Why — two PRs merged, one moved the ground out from under the other

- The **status-analytics refactor** (`0d57f1c7`, "move chart theming onto app tokens and useTheme") deleted the duplicate `formatBytes` from `analytics/lib/time.ts` and consolidated it into the single `formatValue(v, 'bytes-si')` code path in `analytics/primitives/formatValue.ts`.
- The **databases feature** (`125b6e57`, "tree nav, database overview, and shared table actions") landed `DatabaseOverview.tsx`, which imported that now-deleted `formatBytes`.

Each PR type-checked against its own base, but neither saw the other's change. Once both were on `stage`, the import referenced a symbol that no longer exists → `tsc` failed the `Verify stage can build` step.

## Fix

Import `formatValue` and define the same local `formatBytes` alias the sibling `TableSizeSnapshot`/`TableSizeTrend` charts already use, keeping one byte-format code path. `formatValue(bytes, 'bytes-si')` is the intended replacement (SI units, same adaptive rounding as the old helper).

```ts
const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
```

## Verification

- `pnpm build --mode stage` (`tsc -b && vite build`) — passes, no type errors.
- `pnpm lint` — clean.
- Full unit suite via pre-commit — 1482 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)