### PR TITLE
refactor(lib): promote formatValue out of status analytics internals

### DIFF
--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -2,18 +2,18 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { TableRowContextMenu } from '@/features/instance/databases/components/TableRowContextMenu';
-import { formatValue } from '@/features/instance/status/analytics/primitives/formatValue';
 import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
 import { getDescribeTableQueryOptions } from '@/integrations/api/instance/database/getDescribeTable';
 import { setWatchedValue } from '@/lib/events/watcher';
+import { formatValue } from '@/lib/formatValue';
 import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
 import { useQueries } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { CloudUploadIcon, EllipsisIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { useCallback } from 'react';
 
-/** One byte-format path for every chart — see status/analytics/primitives/formatValue.ts. */
+/** One byte-format path for every chart — see src/lib/formatValue.ts. */
 const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 
 function Stat({ label, value }: { label: string; value: string }) {

--- a/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
@@ -1,15 +1,15 @@
+import { formatValue } from '@/lib/formatValue';
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { useNodeSelection } from '../hooks/useNodeSelection.ts';
 import { getTableColor, OTHER_COLOR } from '../lib/tableColors.ts';
 import { OTHER_KEY, type Snapshot } from '../lib/tableSize.ts';
 import { getChartColors, type Theme } from '../lib/theme.ts';
-import { formatValue } from '../primitives/formatValue.ts';
 import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
 import type { ViewMode } from '../types/analytics.ts';
 import { NodeLegend } from './NodeLegend.tsx';
 import { TableSizeChipRow } from './TableSizeChipRow.tsx';
 
-/** One byte-format path for every chart — see primitives/formatValue.ts. */
+/** One byte-format path for every chart — see src/lib/formatValue.ts. */
 const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 
 interface Props {

--- a/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
@@ -1,3 +1,4 @@
+import { formatValue } from '@/lib/formatValue';
 import { useMemo } from 'react';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { useNodeSelection } from '../hooks/useNodeSelection.ts';
@@ -5,13 +6,12 @@ import { getNodeColor } from '../lib/nodeColors.ts';
 import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize.ts';
 import { getChartColors, type Theme } from '../lib/theme.ts';
 import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
-import { formatValue } from '../primitives/formatValue.ts';
 import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
 import type { TimeRange, ViewMode } from '../types/analytics.ts';
 import { NodeLegend } from './NodeLegend.tsx';
 import { TableSizeChipRow } from './TableSizeChipRow.tsx';
 
-/** One byte-format path for every chart — see primitives/formatValue.ts. */
+/** One byte-format path for every chart — see src/lib/formatValue.ts. */
 const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 
 interface Props {

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -1,9 +1,9 @@
+import { formatValue } from '@/lib/formatValue';
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useResolvedTheme } from '../lib/theme.ts';
 import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics.ts';
 import { computeCellSize } from './computeCellSize.ts';
-import { formatValue } from './formatValue.ts';
 export { computeCellSize } from './computeCellSize.ts';
 
 interface Props {

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -1,3 +1,4 @@
+import { formatValue } from '@/lib/formatValue';
 import {
 	CartesianGrid,
 	Legend,
@@ -13,7 +14,6 @@ import { NODE_PALETTE } from '../lib/nodeColors.ts';
 import { getChartColors } from '../lib/theme.ts';
 import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
 import type { AxisSpec, SeriesData, Threshold } from '../types/analytics.ts';
-import { formatValue } from './formatValue.ts';
 import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle.ts';
 
 interface Props {

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -1,10 +1,10 @@
+import { formatValue } from '@/lib/formatValue';
 import { useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { NODE_PALETTE } from '../lib/nodeColors.ts';
 import { getChartColors, useResolvedTheme } from '../lib/theme.ts';
 import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
 import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics.ts';
-import { formatValue } from './formatValue.ts';
 import { sortByMagnitude } from './sortByMagnitude.ts';
 import { tooltipContentStyle, tooltipLabelStyle } from './tooltipStyle.ts';
 

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -1,3 +1,4 @@
+import type { ValueFormatter } from '@/lib/formatValue';
 import type { ComponentType, JSX } from 'react';
 
 export interface AnalyticsDataPoint {
@@ -81,7 +82,7 @@ export interface Threshold {
 	scope?: Partial<Record<string, string | number>>;
 }
 
-export type AxisFormatter = 'bytes-si' | 'bytes-iec' | 'ms' | 'percent' | 'cores' | 'count' | 'count-si';
+export type AxisFormatter = ValueFormatter;
 
 export interface AxisSpec {
 	unit: string;

--- a/src/lib/formatValue.test.ts
+++ b/src/lib/formatValue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatValue } from '../../primitives/formatValue.ts';
+import { formatValue } from './formatValue';
 
 describe('formatValue count-si', () => {
 	it('renders single-digit values without suffix', () => {

--- a/src/lib/formatValue.ts
+++ b/src/lib/formatValue.ts
@@ -15,7 +15,7 @@ export type ValueFormatter = 'bytes-si' | 'bytes-iec' | 'ms' | 'percent' | 'core
  * tick labels aligned and unambiguous at small font sizes.
  */
 export function formatValue(
-	v: number,
+	v: number | null | undefined,
 	formatter?: ValueFormatter,
 	unitSuffix?: string,
 ): string {

--- a/src/lib/formatValue.ts
+++ b/src/lib/formatValue.ts
@@ -1,11 +1,11 @@
-import type { AxisSpec } from '../types/analytics.ts';
+export type ValueFormatter = 'bytes-si' | 'bytes-iec' | 'ms' | 'percent' | 'cores' | 'count' | 'count-si';
 
 /**
- * THE value formatter for chart axes and tooltips in Status analytics. Every
+ * THE value formatter for chart axes and tooltips. Every Status-analytics
  * chart — metric panels and the table-size charts alike — formats through
  * this one code path, so the same byte/count value can never render two
- * different ways on two panels (lib/time.ts used to carry a duplicate
- * `formatBytes` with different rounding; it's gone).
+ * different ways on two panels — and it lives in src/lib because other
+ * features (e.g. the databases overview) format the same values.
  *
  * Deliberately NOT delegated to the app-wide helpers
  * (src/lib/humanFileSize.ts / src/lib/humanNumber.ts): those are
@@ -16,7 +16,7 @@ import type { AxisSpec } from '../types/analytics.ts';
  */
 export function formatValue(
 	v: number,
-	formatter?: AxisSpec['formatter'],
+	formatter?: ValueFormatter,
 	unitSuffix?: string,
 ): string {
 	if (v === null || v === undefined || !Number.isFinite(v)) { return '—'; }
@@ -29,7 +29,7 @@ export function formatValue(
 	return unitSuffix ? `${base}${unitSuffix}` : base;
 }
 
-function formatBase(v: number, formatter?: AxisSpec['formatter']): string {
+function formatBase(v: number, formatter?: ValueFormatter): string {
 	switch (formatter) {
 		case 'percent':
 			return `${(v * 100).toFixed(1)}%`;


### PR DESCRIPTION
Follow-up to Dawson's report of the `formatBytes` type break and his ask to move shared libs out of `analytics/`.

`formatValue` is an app-generic value formatter (bytes/counts/durations/percent) that gained a second consumer when `DatabaseOverview` needed byte formatting — first via the since-deleted `formatBytes` (which broke stage's type-check when the theme PR landed concurrently), then via a reach into `analytics/primitives` in the hotfix. It now lives at `src/lib/formatValue.ts` with a chart-agnostic `ValueFormatter` union; analytics' `AxisFormatter` becomes an alias (so no churn in spec types), and all seven consumers import from the lib. Pure move — no formatting behavior changes (both cross-model reviews verified this independently).

Deliberately NOT moved: chart palettes, `theme.ts`, tooltip styles, time-axis formatters — those stay in analytics until a second feature actually renders charts (YAGNI). The systemic guard for this failure class is the sibling CI PR adding `tsc -b` to Verify PR.

Generated by kAIle (Claude Fable 5).
