### PR TITLE
ci: type-check the whole app in Verify PR

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -26,6 +26,12 @@ jobs:
         run: echo "HUSKY=0" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install
+      # Whole-app type-check: vitest only type-checks what tests import, so a
+      # cross-feature break (e.g. an import of a symbol another in-flight PR
+      # deleted) can pass tests and reach stage via the merge queue. tsc -b
+      # sees the merged combination.
+      - name: Type-check
+        run: pnpm exec tsc -b
       - name: Run unit tests
         run: pnpm test:coverage
       - name: Report coverage


### PR DESCRIPTION
Closes the CI gap behind today's `formatBytes` break: `Verify PR` runs vitest, which only type-checks files its tests import — so a cross-feature type break created by two concurrently-merged PRs (the theme PR deleting `formatBytes` while `DatabaseOverview` started importing it) passed both PRs' checks and the merge queue, and landed on stage. Adding `pnpm exec tsc -b` between install and tests makes the queue's build see the merged combination.

Six-line workflow change; cross-model review skipped as CI configuration with no runtime surface — flagging per process.

Generated by kAIle (Claude Fable 5).
