### PR TITLE
refactor(status): sweep file conventions and dead theme plumbing

### DIFF
--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -4,7 +4,7 @@
  * instead of erroring with "cannot find module".
  *
  * The worker only sees the models that exist. Out of the box that is a single
- * model — the open file — so `import { increment } from '@/counter.ts'` has
+ * model — the open file — so `import { increment } from '@/counter'` has
  * nothing to resolve against. While a file is open this hook:
  *
  *   1. fetches the application's other source files and registers each as a

--- a/src/features/instance/status/analytics/StatusTabs.tsx
+++ b/src/features/instance/status/analytics/StatusTabs.tsx
@@ -1,25 +1,24 @@
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
-import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { type StatusTabId, validateStatusSearch } from '../statusSearch.ts';
-import { AnalyticsOnboardingHint } from './components/AnalyticsOnboardingHint.tsx';
-import { TimeRangePicker } from './components/TimeRangePicker.tsx';
-import { type AnalyticsContextValue, AnalyticsProvider } from './context/AnalyticsContext.tsx';
-import { getPreset, type TimePresetId } from './context/timePresets.ts';
-import { type AnalyticsCapability, useAnalyticsCapability } from './hooks/useAnalyticsCapability.ts';
-import { useResolvedTheme } from './lib/theme.ts';
-import { DatabaseTab } from './tabs/DatabaseTab.tsx';
-import { HealthTab } from './tabs/HealthTab.tsx';
-import { OverviewTab } from './tabs/OverviewTab.tsx';
-import { ReplicationTab } from './tabs/ReplicationTab.tsx';
-import { RequestsTab } from './tabs/RequestsTab.tsx';
-import { StorageTab } from './tabs/StorageTab.tsx';
-import { TrafficTab } from './tabs/TrafficTab.tsx';
+import { type StatusTabId, validateStatusSearch } from '../statusSearch';
+import { AnalyticsOnboardingHint } from './components/AnalyticsOnboardingHint';
+import { TimeRangePicker } from './components/TimeRangePicker';
+import { type AnalyticsContextValue, AnalyticsProvider } from './context/AnalyticsContext';
+import { getPreset, type TimePresetId } from './context/timePresets';
+import { type AnalyticsCapability, useAnalyticsCapability } from './hooks/useAnalyticsCapability';
+import { DatabaseTab } from './tabs/DatabaseTab';
+import { HealthTab } from './tabs/HealthTab';
+import { OverviewTab } from './tabs/OverviewTab';
+import { ReplicationTab } from './tabs/ReplicationTab';
+import { RequestsTab } from './tabs/RequestsTab';
+import { StorageTab } from './tabs/StorageTab';
+import { TrafficTab } from './tabs/TrafficTab';
 
 interface Props {
 	instanceParams: InstanceClientIdConfig & InstanceTypeConfig;
@@ -155,12 +154,6 @@ function StatusTabsInner({ instanceParams, isLocalStudio, capability }: InnerPro
 		};
 	}, [refreshMs, refresh, queryClient, tick, instanceParams.entityId]);
 
-	// Resolved app theme (user's explicit choice, not raw OS preference) —
-	// kept in the context only for the consumers that still read it there
-	// (StorageTab's table-size charts, ConnectionsPanel). Chart primitives
-	// re-theme via `--chart-*` CSS tokens without any prop.
-	const theme = useResolvedTheme();
-
 	const updatePreset = useCallback((id: TimePresetId) => {
 		void navigate({ to: '.', search: { tab, range: id, refresh: refreshMs } });
 	}, [navigate, tab, refreshMs]);
@@ -201,10 +194,9 @@ function StatusTabsInner({ instanceParams, isLocalStudio, capability }: InnerPro
 		return {
 			timeRange: { startTime, endTime },
 			bucketMs: preset.bucketMs,
-			theme,
 			instanceParams,
 		};
-	}, [presetId, theme, instanceParams, tick]);
+	}, [presetId, instanceParams, tick]);
 
 	const showTimePicker = tab !== 'overview';
 	const picker = showTimePicker

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
@@ -76,7 +76,7 @@ beforeEach(() => {
 	});
 });
 
-import { StatusTabs } from '../StatusTabs.tsx';
+import { StatusTabs } from '../StatusTabs';
 
 const instanceParams = {
 	instanceClient: { post: vi.fn(async () => ({ data: [] })) } as never,

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
@@ -49,8 +49,8 @@ vi.mock('@tanstack/react-router', () => ({
 	useNavigate: () => navigateMock,
 }));
 
-import { DEFAULT_REFRESH_MS } from '../context/timePresets.ts';
-import { StatusTabs } from '../StatusTabs.tsx';
+import { DEFAULT_REFRESH_MS } from '../context/timePresets';
+import { StatusTabs } from '../StatusTabs';
 
 const instanceParams = {
 	instanceClient: { post: vi.fn(async () => ({ data: [] })) } as never,

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
@@ -65,7 +65,7 @@ beforeEach(() => {
 	});
 });
 
-import { StatusTabs } from '../StatusTabs.tsx';
+import { StatusTabs } from '../StatusTabs';
 
 const instanceParams = {
 	instanceClient: { post: vi.fn(async () => ({ data: [] })) } as never,

--- a/src/features/instance/status/analytics/__tests__/charts/table-size-chip-row.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/charts/table-size-chip-row.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { TableSizeChipRow } from '../../charts/TableSizeChipRow.tsx';
-import { OTHER_KEY } from '../../lib/tableSize.ts';
+import { TableSizeChipRow } from '../../charts/TableSizeChipRow';
+import { OTHER_KEY } from '../../lib/tableSize';
 
 describe('TableSizeChipRow radiogroup (shared roving-tabindex primitive)', () => {
 	afterEach(() => cleanup());

--- a/src/features/instance/status/analytics/__tests__/nodeColors.test.ts
+++ b/src/features/instance/status/analytics/__tests__/nodeColors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getNodeColor, NODE_PALETTE } from '../lib/nodeColors.ts';
+import { getNodeColor, NODE_PALETTE } from '../lib/nodeColors';
 
 describe('getNodeColor', () => {
 	it('assigns colors based on sorted node order', () => {

--- a/src/features/instance/status/analytics/__tests__/paletteDisjointness.test.ts
+++ b/src/features/instance/status/analytics/__tests__/paletteDisjointness.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { TYPE_PALETTE } from '../lib/colorAllocators/typeColors.ts';
-import { NODE_PALETTE } from '../lib/nodeColors.ts';
-import { OTHER_COLOR, TABLE_PALETTE } from '../lib/tableColors.ts';
+import { TYPE_PALETTE } from '../lib/colorAllocators/typeColors';
+import { NODE_PALETTE } from '../lib/nodeColors';
+import { OTHER_COLOR, TABLE_PALETTE } from '../lib/tableColors';
 
 // The palettes are now CSS custom properties (`var(--chart-…)`), so the
 // disjointness invariant is enforced against their definitions in

--- a/src/features/instance/status/analytics/__tests__/pipeline/aggregators.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/aggregators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type AggInput, aggregate } from '../../pipeline/aggregators.ts';
+import { type AggInput, aggregate } from '../../pipeline/aggregators';
 
 describe('aggregate', () => {
 	it('sum', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/approxLabel.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/approxLabel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isApproxAggregator, labelWithApprox } from '../../pipeline/approxLabel.ts';
+import { isApproxAggregator, labelWithApprox } from '../../pipeline/approxLabel';
 
 describe('approxLabel', () => {
 	it('appends " (approx)" when aggregator is count-weighted-mean', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { bytesReceivedSpec } from '../../pipeline/bytes-received.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { bytesReceivedSpec } from '../../pipeline/bytes-received';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { bytesSentSpec } from '../../pipeline/bytes-sent.tsx';
-import { mqttTrafficSentDerived } from '../../pipeline/derived/mqtt-traffic-sent.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
+import { bytesSentSpec } from '../../pipeline/bytes-sent';
+import { mqttTrafficSentDerived } from '../../pipeline/derived/mqtt-traffic-sent';
+import { runPipeline } from '../../pipeline/pipeline';
 
 describe('bytes-sent tolerance', () => {
 	it('total bytes/sec ≈ Σ type-rates within 0.5% (global sum)', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { cacheHitSpec } from '../../pipeline/cache-hit.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { cacheHitSpec } from '../../pipeline/cache-hit';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 // Synthetic rows shaped like the real Harper response:
 //   { time, node, path, period, count, total, ratio }

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { cacheResolutionSpec } from '../../pipeline/cache-resolution.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { cacheResolutionSpec } from '../../pipeline/cache-resolution';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 // Synthetic rows shaped like the real Harper response. The real schema
 // carries a per-bucket count-weighted distribution for each path; the

--- a/src/features/instance/status/analytics/__tests__/pipeline/compute-cell-size.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/compute-cell-size.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeCellSize } from '../../primitives/computeCellSize.ts';
+import { computeCellSize } from '../../primitives/computeCellSize';
 
 describe('computeCellSize', () => {
 	it('returns MAX when container is wide enough', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/confidence.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/confidence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { classifyConfidence } from '../../pipeline/confidence.ts';
+import { classifyConfidence } from '../../pipeline/confidence';
 
 describe('classifyConfidence (post-aggregation windowed count)', () => {
 	const rule = { greyBelow: 40, suppressBelow: 100 };

--- a/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { connectionsSpec } from '../../pipeline/connections.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
+import { connectionsSpec } from '../../pipeline/connections';
+import { runPipeline } from '../../pipeline/pipeline';
 
 describe('connections pipeline', () => {
 	// connections is a multi-source merge (mqtt-connections + ws-connections)

--- a/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { cpuUsageSpec } from '../../pipeline/cpu-usage.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { QUANTILE_FIELDS } from '../../pipeline/quantileFields.ts';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+import { cpuUsageSpec } from '../../pipeline/cpu-usage';
+import { runPipeline } from '../../pipeline/pipeline';
+import { QUANTILE_FIELDS } from '../../pipeline/quantileFields';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { databaseSizeSpec } from '../../pipeline/database-size.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { databaseSizeSpec } from '../../pipeline/database-size';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { dbMessageSpec } from '../../pipeline/db-message.tsx';
-import { dbReadSpec } from '../../pipeline/db-read.tsx';
-import { dbWriteSpec } from '../../pipeline/db-write.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+import { dbMessageSpec } from '../../pipeline/db-message';
+import { dbReadSpec } from '../../pipeline/db-read';
+import { dbWriteSpec } from '../../pipeline/db-write';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { labelWithApprox } from '../../pipeline/approxLabel.ts';
-import { durationSpec } from '../../pipeline/duration.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { labelWithApprox } from '../../pipeline/approxLabel';
+import { durationSpec } from '../../pipeline/duration';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/fieldExpr.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/fieldExpr.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { evalFieldExpr } from '../../pipeline/fieldExpr.ts';
-import type { FieldExpr } from '../../types/analytics.ts';
+import { evalFieldExpr } from '../../pipeline/fieldExpr';
+import type { FieldExpr } from '../../types/analytics';
 
 const record = {
 	count: 100,

--- a/src/features/instance/status/analytics/__tests__/pipeline/main-thread-utilization-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/main-thread-utilization-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { mainThreadUtilizationSpec } from '../../pipeline/main-thread-utilization.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { mainThreadUtilizationSpec } from '../../pipeline/main-thread-utilization';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/memory-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/memory-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { memorySpec } from '../../pipeline/memory.tsx';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { memorySpec } from '../../pipeline/memory';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/pathParser.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/pathParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseReplicationPath } from '../../pipeline/pathParser.ts';
+import { parseReplicationPath } from '../../pipeline/pathParser';
 
 const NODES = [
 	'xb6-us-west-1.prod.ibm.harperfabric.com',

--- a/src/features/instance/status/analytics/__tests__/pipeline/pipeline-per-node.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/pipeline-per-node.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { makeSeriesKey, runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+import { makeSeriesKey, runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/pipeline-time-buckets.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/pipeline-time-buckets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics';
 
 const baseSpec: MetricSpec = {
 	title: 'test',

--- a/src/features/instance/status/analytics/__tests__/pipeline/pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const spec: MetricSpec = {
 	title: 'Bytes (test)',

--- a/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/rate-period-fallback.test.ts
@@ -3,8 +3,8 @@
 // transforms. The pipeline resolves the effective period via the same
 // `spec.bucket.fallbackMs ?? 60_000` convention snapToBucketTime uses.
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 1_000_000, endTime: 1_060_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/replication-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/replication-pipeline.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { aggregateReplicationMatrix, bucketLineSeries } from '../../pipeline/replication-latency.tsx';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { aggregateReplicationMatrix, bucketLineSeries } from '../../pipeline/replication-latency';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 const multi = JSON.parse(
 	readFileSync(join(import.meta.dirname, '../fixtures/replication-latency/multi-source.json'), 'utf8'),

--- a/src/features/instance/status/analytics/__tests__/pipeline/resource-usage-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/resource-usage-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { resourceUsageSpec } from '../../pipeline/resource-usage.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { resourceUsageSpec } from '../../pipeline/resource-usage';
 
 const records = [
 	{

--- a/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { response200Spec } from '../../pipeline/response-200.tsx';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { response200Spec } from '../../pipeline/response-200';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/runTransform.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/runTransform.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { runTransform } from '../../pipeline/runTransform.ts';
-import type { Transform } from '../../types/analytics.ts';
+import { runTransform } from '../../pipeline/runTransform';
+import type { Transform } from '../../types/analytics';
 
 describe('runTransform', () => {
 	it('raw returns input unchanged', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/sort-by-magnitude.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/sort-by-magnitude.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sortByMagnitude } from '../../primitives/sortByMagnitude.ts';
+import { sortByMagnitude } from '../../primitives/sortByMagnitude';
 
 describe('sortByMagnitude', () => {
 	it('orders series by sum across all points (descending)', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/spec-registry.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/spec-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { derivedRegistry } from '../../pipeline/derived/index.ts';
-import { specRegistry } from '../../pipeline/index.ts';
+import { derivedRegistry } from '../../pipeline/derived/index';
+import { specRegistry } from '../../pipeline/index';
 
 // Pins the full registry contents so a typo in the wrapperMetrics factory
 // table (or a dropped line in the registry) can't silently lose a metric.

--- a/src/features/instance/status/analytics/__tests__/pipeline/storage-volume-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/storage-volume-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { storageVolumeSpec } from '../../pipeline/storage-volume.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { storageVolumeSpec } from '../../pipeline/storage-volume';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { successSpec } from '../../pipeline/success.tsx';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { successSpec } from '../../pipeline/success';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/tls-reused-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/tls-reused-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { tlsReusedSpec } from '../../pipeline/tls-reused.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { tlsReusedSpec } from '../../pipeline/tls-reused';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/transaction-log-growth.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/transaction-log-growth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { recomputeTransactionLogGrowth } from '../../pipeline/derived/transaction-log-growth.tsx';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { recomputeTransactionLogGrowth } from '../../pipeline/derived/transaction-log-growth';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 const range = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { transferSpec } from '../../pipeline/transfer.tsx';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { transferSpec } from '../../pipeline/transfer';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/transforms.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/transforms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type NamedTransformKey, namedTransforms } from '../../pipeline/transforms.ts';
+import { type NamedTransformKey, namedTransforms } from '../../pipeline/transforms';
 
 describe('namedTransforms registry', () => {
 	it('exports percent-of-core that multiplies by 100', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/utilization-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/utilization-pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { runPipeline } from '../../pipeline/pipeline.ts';
-import { utilizationSpec } from '../../pipeline/utilization.ts';
-import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics.ts';
+import { runPipeline } from '../../pipeline/pipeline';
+import { utilizationSpec } from '../../pipeline/utilization';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-chip-row.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-chip-row.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DimensionChipRow } from '../../primitives/DimensionChipRow.tsx';
+import { DimensionChipRow } from '../../primitives/DimensionChipRow';
 
 describe('DimensionChipRow primitive', () => {
 	afterEach(() => cleanup());

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-combobox.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-combobox.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { useState } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DimensionCombobox } from '../../primitives/DimensionCombobox.tsx';
+import { DimensionCombobox } from '../../primitives/DimensionCombobox';
 
 function Harness(props: { values: readonly string[]; initial: string; otherKey?: string }) {
 	const [sel, setSel] = useState(props.initial);

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-pipe-dim.test.tsx
@@ -6,8 +6,8 @@
 // reads the structured Series.dim/Series.node fields.
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer.tsx';
-import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics';
 
 const range = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/dimension-selector-switch.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer.tsx';
-import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+import { DimensionSelectorRenderer } from '../../primitives/DimensionSelectorRenderer';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics';
 
 const range = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/primitives/fallback-renderer.test.ts
+++ b/src/features/instance/status/analytics/__tests__/primitives/fallback-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildFallbackPanels } from '../../primitives/FallbackRenderer.tsx';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { buildFallbackPanels } from '../../primitives/FallbackRenderer';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 describe('buildFallbackPanels', () => {
 	it('drops records lacking a numeric time instead of plotting them at x=0 (1970)', () => {

--- a/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { HeatmapMatrix } from '../../primitives/HeatmapMatrix.tsx';
-import type { HeatmapData } from '../../types/analytics.ts';
+import { HeatmapMatrix } from '../../primitives/HeatmapMatrix';
+import type { HeatmapData } from '../../types/analytics';
 
 const data: HeatmapData = {
 	rows: ['src-1', 'src-2'],
@@ -26,7 +26,7 @@ const data: HeatmapData = {
 describe('HeatmapMatrix primitive', () => {
 	afterEach(() => cleanup());
 	it('renders a grid with one row per data row', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const grid = screen.getByRole('grid');
 		expect(grid).toBeTruthy();
 		// 2 data rows + 1 header row
@@ -35,7 +35,7 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('includes "(approx)" and "p95" in cell aria-labels when approx flag is set', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		const okCell = cells.find((c) => /src-1.*dest-a|30/.test(c.getAttribute('aria-label') ?? ''))!;
 		expect(okCell).toBeTruthy();
@@ -45,39 +45,39 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('absent cells announce "no data"', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cell = screen.getAllByRole('gridcell').find((c) => (c.getAttribute('aria-label') ?? '').includes('no data'));
 		expect(cell).toBeTruthy();
 	});
 
 	it('suppresses cells below suppressBelow as data-confidence="suppress"', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		const suppressed = cells.filter((c) => c.getAttribute('data-confidence') === 'suppress');
 		expect(suppressed.length >= 1).toBeTruthy();
 	});
 
 	it('greys cells where greyBelow ≤ count < suppressBelow', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		const grey = cells.filter((c) => c.getAttribute('data-confidence') === 'grey');
 		expect(grey.length >= 1).toBeTruthy();
 	});
 
 	it('renders rowheader + columnheader cells', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		expect(screen.getByRole('rowheader', { name: /src-1/i })).toBeTruthy();
 		expect(screen.getByRole('columnheader', { name: /dest-a/i })).toBeTruthy();
 	});
 
 	it('renders a color-scale legend', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const legend = screen.getByRole('img', { name: /color scale|p95 latency/i });
 		expect(legend).toBeTruthy();
 	});
 
 	it('ArrowRight moves focus one column right and preventDefaults', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		// Find src-1 → dest-a
 		const first = cells.find((c) =>
@@ -94,7 +94,7 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('ArrowRight on rightmost cell is a no-op (no wrap)', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		const last = cells.find((c) =>
 			/src-1/.test(c.getAttribute('aria-label') ?? '') && /dest-c/.test(c.getAttribute('aria-label') ?? '')
@@ -106,7 +106,7 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('Home/End jump to row start/end', () => {
-		render(<HeatmapMatrix data={data} theme="light" />);
+		render(<HeatmapMatrix data={data} />);
 		const cells = screen.getAllByRole('gridcell');
 		const mid = cells.find((c) =>
 			/src-1/.test(c.getAttribute('aria-label') ?? '') && /dest-b/.test(c.getAttribute('aria-label') ?? '')
@@ -120,20 +120,20 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('omits "(approx)" from description when data.approx is false', () => {
-		render(<HeatmapMatrix data={{ ...data, approx: false }} theme="light" />);
+		render(<HeatmapMatrix data={{ ...data, approx: false }} />);
 		const desc = screen.getByTestId('heatmap-desc');
 		expect(desc.textContent ?? '').not.toMatch(/\(approx\)/i);
 		expect(desc.textContent ?? '').not.toMatch(/count-weighted-mean/i);
 	});
 
 	it('omits "(count-weighted-mean, approx)" from color-legend aria-label when data.approx is false', () => {
-		render(<HeatmapMatrix data={{ ...data, approx: false }} theme="light" />);
+		render(<HeatmapMatrix data={{ ...data, approx: false }} />);
 		const legend = screen.getByRole('img', { name: /p95 latency/i });
 		expect(legend.getAttribute('aria-label') ?? '').not.toMatch(/count-weighted-mean.*approx/i);
 	});
 
 	it('clamps the roving tabindex when the matrix shrinks (regression #1443)', () => {
-		const { rerender } = render(<HeatmapMatrix data={data} theme="light" />);
+		const { rerender } = render(<HeatmapMatrix data={data} />);
 		// Move the active cell to the last row/col via keyboard: End then
 		// ArrowDown lands on src-2 → dest-c ([1, 2]).
 		const cells = screen.getAllByRole('gridcell');
@@ -156,7 +156,7 @@ describe('HeatmapMatrix primitive', () => {
 				{ row: 'src-1', col: 'dest-b', value: 60, count: 300 },
 			],
 		};
-		rerender(<HeatmapMatrix data={shrunk} theme="light" />);
+		rerender(<HeatmapMatrix data={shrunk} />);
 
 		const shrunkCells = screen.getAllByRole('gridcell');
 		expect(shrunkCells.length).toBe(2);
@@ -173,7 +173,7 @@ describe('HeatmapMatrix primitive', () => {
 	});
 
 	it('exposes data-cell-size attribute as a number on the SVG root', () => {
-		const { container } = render(<HeatmapMatrix data={data} theme="light" />);
+		const { container } = render(<HeatmapMatrix data={data} />);
 		const svg = container.querySelector('svg[role="grid"]');
 		const cellSize = Number(svg?.getAttribute('data-cell-size'));
 		expect(Number.isFinite(cellSize) && cellSize >= 40 && cellSize <= 80).toBeTruthy();

--- a/src/features/instance/status/analytics/__tests__/primitives/line-chart.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/line-chart.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { LineChart } from '../../primitives/LineChart.tsx';
-import type { SeriesData } from '../../types/analytics.ts';
+import { LineChart } from '../../primitives/LineChart';
+import type { SeriesData } from '../../types/analytics';
 
 const singleSeries: SeriesData = {
 	series: [{ key: 's1', label: 'Series One', points: [{ x: 1, y: 10 }, { x: 2, y: 20 }] }],
@@ -18,18 +18,18 @@ describe('LineChart primitive', () => {
 	afterEach(() => cleanup());
 
 	it('renders empty-state when series is empty', () => {
-		render(<LineChart data={{ series: [] }} theme="light" />);
+		render(<LineChart data={{ series: [] }} />);
 		expect(screen.getByText(/no data in window/i)).toBeTruthy();
 	});
 
 	it('mounts a Recharts wrapper', () => {
-		render(<LineChart data={singleSeries} theme="light" />);
+		render(<LineChart data={singleSeries} />);
 		const container = document.querySelector('.recharts-responsive-container');
 		expect(container, 'ResponsiveContainer mounted').toBeTruthy();
 	});
 
 	it('exposes role=img with a composed aria-label so screen readers see the chart', () => {
-		render(<LineChart data={singleSeries} theme="light" />);
+		render(<LineChart data={singleSeries} />);
 		const img = screen.getByRole('img');
 		expect(img.getAttribute('aria-label') ?? '').toMatch(/Series One/);
 	});
@@ -41,7 +41,7 @@ describe('LineChart primitive', () => {
 				{ value: 0.999, label: '99.9% SLO', direction: 'below-is-bad' },
 			],
 		};
-		render(<LineChart data={withThreshold} theme="light" yAxis={{ unit: '', formatter: 'percent' }} />);
+		render(<LineChart data={withThreshold} yAxis={{ unit: '', formatter: 'percent' }} />);
 		// Recharts renders the label text somewhere in the SVG. Search the
 		// whole rendered DOM for a string containing label + direction marker.
 		await waitFor(() => {
@@ -52,7 +52,7 @@ describe('LineChart primitive', () => {
 	});
 
 	it('empty-state uses role=status for live-region announcement', () => {
-		render(<LineChart data={{ series: [] }} theme="light" />);
+		render(<LineChart data={{ series: [] }} />);
 		const status = screen.getByRole('status');
 		expect(status.textContent ?? '').toMatch(/no data in window/i);
 	});
@@ -67,7 +67,6 @@ describe('LineChart primitive', () => {
 		render(
 			<LineChart
 				data={dual}
-				theme="light"
 				yAxis={{
 					left: { unit: '%', formatter: 'percent' },
 					right: { unit: 'ms', formatter: 'ms' },
@@ -88,7 +87,7 @@ describe('LineChart primitive', () => {
 				{ key: 'b', label: 'B', points: [{ x: 0, y: 15 }, { x: 1, y: 25 }], opacity: 0.55 },
 			],
 		};
-		const { container } = render(<LineChart data={data} theme="light" />);
+		const { container } = render(<LineChart data={data} />);
 		// Recharts emits <path class="recharts-line-curve" stroke-opacity="...">
 		// after ResponsiveContainer sizes via ResizeObserver. Wait for the dimmed
 		// line to assert it carries the explicit opacity.
@@ -103,7 +102,7 @@ describe('LineChart primitive', () => {
 			...singleSeries,
 			thresholds: [{ value: 15, label: 'max', direction: 'above-is-bad' }],
 		};
-		render(<LineChart data={withThresh} theme="light" />);
+		render(<LineChart data={withThresh} />);
 		// Recharts renders ReferenceLine inside the svg after ResponsiveContainer sizes.
 		await waitFor(() => {
 			const lines = document.querySelectorAll('.recharts-reference-line');
@@ -114,7 +113,7 @@ describe('LineChart primitive', () => {
 	it.skip('appends unit suffix to Y-axis tick labels', async () => {
 		// Use formatter='count' so the suffix is the only decoration on values.
 		const data: SeriesData = { series: [{ key: 'a', label: 'A', points: [{ x: 0, y: 50 }, { x: 1, y: 100 }] }] };
-		const { container } = render(<LineChart data={data} theme="light" yAxis={{ unit: '/s', formatter: 'count' }} />);
+		const { container } = render(<LineChart data={data} yAxis={{ unit: '/s', formatter: 'count' }} />);
 		await waitFor(() => {
 			const tickEls = container.querySelectorAll('.recharts-cartesian-axis-tick-value, .recharts-yAxis text');
 			const labels = Array.from(tickEls).map((t) => t.textContent ?? '');

--- a/src/features/instance/status/analytics/__tests__/primitives/small-multiples.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/small-multiples.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { SmallMultiples } from '../../primitives/SmallMultiples.tsx';
-import type { AxisSpec, SeriesData } from '../../types/analytics.ts';
+import { SmallMultiples } from '../../primitives/SmallMultiples';
+import type { AxisSpec, SeriesData } from '../../types/analytics';
 
 const panels: { title: string; data: SeriesData; yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec } }[] = [
 	{ title: 'CPU', data: { series: [{ key: 'cpu', label: 'cpu', points: [{ x: 1, y: 10 }] }] } },

--- a/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stack-by-toggle.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { TrafficByTypeRenderer } from '../../primitives/TrafficByTypeRenderer.tsx';
-import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics.ts';
+import { TrafficByTypeRenderer } from '../../primitives/TrafficByTypeRenderer';
+import type { AnalyticsDataPoint, MetricSpec } from '../../types/analytics';
 
 const range = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { StackedAreaChart, StackedAreaTooltip } from '../../primitives/StackedAreaChart.tsx';
-import type { SeriesData } from '../../types/analytics.ts';
+import { StackedAreaChart, StackedAreaTooltip } from '../../primitives/StackedAreaChart';
+import type { SeriesData } from '../../types/analytics';
 
 const stacked: SeriesData = {
 	series: [

--- a/src/features/instance/status/analytics/__tests__/tableColors.test.ts
+++ b/src/features/instance/status/analytics/__tests__/tableColors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getTableColor, OTHER_COLOR, TABLE_PALETTE } from '../lib/tableColors.ts';
+import { getTableColor, OTHER_COLOR, TABLE_PALETTE } from '../lib/tableColors';
 
 describe('getTableColor', () => {
 	it('returns distinct colors for the first 8 indices', () => {

--- a/src/features/instance/status/analytics/__tests__/tableSize.test.ts
+++ b/src/features/instance/status/analytics/__tests__/tableSize.test.ts
@@ -16,8 +16,8 @@ import {
 	type Snapshot,
 	TOP_N,
 	toTableKey,
-} from '../lib/tableSize.ts';
-import type { TableSizeRecord } from '../types/analytics.ts';
+} from '../lib/tableSize';
+import type { TableSizeRecord } from '../types/analytics';
 
 function fixture(name: string): TableSizeRecord[] {
 	const path = join(import.meta.dirname, 'fixtures', 'table-size', `${name}.json`);

--- a/src/features/instance/status/analytics/__tests__/time.test.ts
+++ b/src/features/instance/status/analytics/__tests__/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatAxisTick, formatTooltipTime, getTimezoneAbbr } from '../lib/time.ts';
+import { formatAxisTick, formatTooltipTime, getTimezoneAbbr } from '../lib/time';
 
 describe('formatAxisTick', () => {
 	it('formats a timestamp to local time string', () => {

--- a/src/features/instance/status/analytics/charts/NodeLegend.tsx
+++ b/src/features/instance/status/analytics/charts/NodeLegend.tsx
@@ -1,4 +1,4 @@
-import { getNodeColor } from '../lib/nodeColors.ts';
+import { getNodeColor } from '../lib/nodeColors';
 
 interface NodeLegendProps {
 	nodeIds: string[];

--- a/src/features/instance/status/analytics/charts/TableSizeChipRow.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeChipRow.tsx
@@ -1,6 +1,6 @@
-import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
-import { getTableColor, OTHER_COLOR } from '../lib/tableColors.ts';
-import { OTHER_KEY } from '../lib/tableSize.ts';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
+import { getTableColor, OTHER_COLOR } from '../lib/tableColors';
+import { OTHER_KEY } from '../lib/tableSize';
 
 interface TableSizeChipRowProps {
 	/** Selectable table keys, in display order. */

--- a/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeSnapshot.tsx
@@ -1,13 +1,13 @@
 import { formatValue } from '@/lib/formatValue';
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getTableColor, OTHER_COLOR } from '../lib/tableColors.ts';
-import { OTHER_KEY, type Snapshot } from '../lib/tableSize.ts';
-import { getChartColors, type Theme } from '../lib/theme.ts';
-import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
-import type { ViewMode } from '../types/analytics.ts';
-import { NodeLegend } from './NodeLegend.tsx';
-import { TableSizeChipRow } from './TableSizeChipRow.tsx';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { getTableColor, OTHER_COLOR } from '../lib/tableColors';
+import { OTHER_KEY, type Snapshot } from '../lib/tableSize';
+import { getChartColors } from '../lib/theme';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle';
+import type { ViewMode } from '../types/analytics';
+import { NodeLegend } from './NodeLegend';
+import { TableSizeChipRow } from './TableSizeChipRow';
 
 /** One byte-format path for every chart — see src/lib/formatValue.ts. */
 const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
@@ -16,10 +16,6 @@ interface Props {
 	snapshot: Snapshot;
 	/** Display mode: 'per-node' → Absolute (raw bytes), 'aggregate' → Normalized (percent of cluster max). */
 	viewMode: ViewMode;
-	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
-	 *  Kept optional only while StorageTab (owned by a parallel refactor)
-	 *  still passes it. */
-	theme?: Theme;
 	/** Snapshot's own highlight — drives chip `aria-checked` + bar-segment outline. */
 	selectedTable: string | null;
 	/** Chip click / Enter / Space / arrow-nav — local to this panel; should NOT

--- a/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
@@ -1,15 +1,15 @@
 import { formatValue } from '@/lib/formatValue';
 import { useMemo } from 'react';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize.ts';
-import { getChartColors, type Theme } from '../lib/theme.ts';
-import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
-import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle.ts';
-import type { TimeRange, ViewMode } from '../types/analytics.ts';
-import { NodeLegend } from './NodeLegend.tsx';
-import { TableSizeChipRow } from './TableSizeChipRow.tsx';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { getNodeColor } from '../lib/nodeColors';
+import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize';
+import { getChartColors } from '../lib/theme';
+import { formatAxisTick, formatTooltipTime } from '../lib/time';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle';
+import type { TimeRange, ViewMode } from '../types/analytics';
+import { NodeLegend } from './NodeLegend';
+import { TableSizeChipRow } from './TableSizeChipRow';
 
 /** One byte-format path for every chart — see src/lib/formatValue.ts. */
 const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
@@ -17,10 +17,6 @@ const formatBytes = (bytes: number) => formatValue(bytes, 'bytes-si');
 interface Props {
 	derived: TableSizeDerived;
 	viewMode: ViewMode;
-	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
-	 *  Kept optional only while StorageTab (owned by a parallel refactor)
-	 *  still passes it. */
-	theme?: Theme;
 	selectedTable: string | null;
 	/** Trend chip click — local to this panel; should NOT touch the Snapshot. */
 	onChipSelect: (tableKey: string) => void;

--- a/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.test.tsx
+++ b/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { AnalyticsOnboardingHint } from './AnalyticsOnboardingHint.tsx';
+import { AnalyticsOnboardingHint } from './AnalyticsOnboardingHint';
 
 const STORAGE_KEY = 'studio:analytics:onboarding-dismissed:v1';
 

--- a/src/features/instance/status/analytics/components/ChartCopyButton.test.tsx
+++ b/src/features/instance/status/analytics/components/ChartCopyButton.test.tsx
@@ -15,8 +15,8 @@ vi.mock('sonner', () => ({
 	toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
 
-import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers.tsx';
-import { ChartCopyButton } from './ChartCopyButton.tsx';
+import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers';
+import { ChartCopyButton } from './ChartCopyButton';
 
 afterEach(() => {
 	cleanup();

--- a/src/features/instance/status/analytics/components/ChartCopyButton.tsx
+++ b/src/features/instance/status/analytics/components/ChartCopyButton.tsx
@@ -3,7 +3,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { ClipboardCopy } from 'lucide-react';
 import { type RefObject, useState } from 'react';
 import { toast } from 'sonner';
-import { copyChartToClipboard } from '../lib/chartExport.ts';
+import { copyChartToClipboard } from '../lib/chartExport';
 
 interface Props {
 	/** The DOM node that should be captured. Usually the chart's outer Card. */

--- a/src/features/instance/status/analytics/components/ChartExpandButton.test.tsx
+++ b/src/features/instance/status/analytics/components/ChartExpandButton.test.tsx
@@ -13,8 +13,8 @@ vi.mock('sonner', () => ({
 	toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
 
-import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers.tsx';
-import { ChartExpandButton } from './ChartExpandButton.tsx';
+import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers';
+import { ChartExpandButton } from './ChartExpandButton';
 
 afterEach(() => {
 	cleanup();

--- a/src/features/instance/status/analytics/components/ChartExpandButton.tsx
+++ b/src/features/instance/status/analytics/components/ChartExpandButton.tsx
@@ -3,8 +3,8 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Maximize2 } from 'lucide-react';
 import { type ReactNode, useRef, useState } from 'react';
-import { ChartCopyButton } from './ChartCopyButton.tsx';
-import { ChartExportButton } from './ChartExportButton.tsx';
+import { ChartCopyButton } from './ChartCopyButton';
+import { ChartExportButton } from './ChartExportButton';
 
 interface Props {
 	/** Slug for the export filename if the user exports from the expanded view. */

--- a/src/features/instance/status/analytics/components/ChartExportButton.test.tsx
+++ b/src/features/instance/status/analytics/components/ChartExportButton.test.tsx
@@ -16,8 +16,8 @@ vi.mock('sonner', () => ({
 	toast: { success: mocks.toastSuccess, error: mocks.toastError },
 }));
 
-import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers.tsx';
-import { ChartExportButton } from './ChartExportButton.tsx';
+import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers';
+import { ChartExportButton } from './ChartExportButton';
 
 afterEach(() => {
 	cleanup();

--- a/src/features/instance/status/analytics/components/ChartExportButton.tsx
+++ b/src/features/instance/status/analytics/components/ChartExportButton.tsx
@@ -3,8 +3,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Download } from 'lucide-react';
 import { type RefObject, useState } from 'react';
 import { toast } from 'sonner';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { downloadChart, makeExportFilename } from '../lib/chartExport.ts';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { downloadChart, makeExportFilename } from '../lib/chartExport';
 
 interface Props {
 	/** The DOM node that should be captured. Usually the chart's outer Card. */

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -7,8 +7,8 @@ vi.mock('../hooks/useAnalyticsFreshness.ts', () => ({
 	formatRelativeUpdate: () => null,
 }));
 
-import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers.tsx';
-import { TimeRangePicker } from './TimeRangePicker.tsx';
+import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers';
+import { TimeRangePicker } from './TimeRangePicker';
 
 afterEach(cleanup);
 
@@ -63,7 +63,7 @@ describe('TimeRangePicker', () => {
 
 	it('disables the refresh button while a fetch is in flight', async () => {
 		// Re-mock to return isFetching=true for this test only.
-		const { TimeRangePicker: PickerWithFetching } = await vi.importActual<typeof import('./TimeRangePicker.tsx')>(
+		const { TimeRangePicker: PickerWithFetching } = await vi.importActual<typeof import('./TimeRangePicker')>(
 			'./TimeRangePicker.tsx',
 		);
 		// Use the same component but assert via aria-busy — the mock above is

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -2,9 +2,9 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets.ts';
-import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness.ts';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
+import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness';
 
 interface Props {
 	presetId: TimePresetId;

--- a/src/features/instance/status/analytics/context/AnalyticsContext.tsx
+++ b/src/features/instance/status/analytics/context/AnalyticsContext.tsx
@@ -1,18 +1,10 @@
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { createContext, type ReactNode, useContext, useMemo } from 'react';
-import type { TimeRange } from '../types/analytics.ts';
-
-export type AnalyticsTheme = 'light' | 'dark';
+import type { TimeRange } from '../types/analytics';
 
 export interface AnalyticsContextValue {
 	timeRange: TimeRange;
 	bucketMs: number;
-	/** Resolved app theme. Chart primitives no longer read this — they theme
-	 *  via `--chart-*` CSS tokens (and useResolvedTheme() for the few JS
-	 *  branches). Kept only for StorageTab / ConnectionsPanel, which still
-	 *  pass it into the pipeline-owned renderer signatures; remove once that
-	 *  parallel refactor drops their `theme` props. */
-	theme: AnalyticsTheme;
 	instanceParams: InstanceClientIdConfig & InstanceTypeConfig;
 }
 
@@ -28,7 +20,6 @@ export function AnalyticsProvider({ value, children }: ProviderProps) {
 		value.timeRange.startTime,
 		value.timeRange.endTime,
 		value.bucketMs,
-		value.theme,
 		value.instanceParams.entityId,
 	]);
 	return <Ctx.Provider value={memo}>{children}</Ctx.Provider>;

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -6,7 +6,7 @@ import {
 	REFRESH_OPTIONS,
 	TIME_PRESETS,
 	type TimePresetId,
-} from './timePresets.ts';
+} from './timePresets';
 
 describe('timePresets', () => {
 	it('exposes all five preset ids in stable order', () => {

--- a/src/features/instance/status/analytics/hooks/useAnalyticsCapability.test.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsCapability.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { useAnalyticsCapability } from './useAnalyticsCapability.ts';
+import { useAnalyticsCapability } from './useAnalyticsCapability';
 
 function makeParams(post: ReturnType<typeof vi.fn>): InstanceClientIdConfig & InstanceTypeConfig {
 	return {

--- a/src/features/instance/status/analytics/hooks/useAnalyticsCapability.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsCapability.ts
@@ -1,4 +1,4 @@
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { useQuery } from '@tanstack/react-query';
 
 export interface AnalyticsCapability {

--- a/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.test.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { formatRelativeUpdate, useAnalyticsFreshness } from './useAnalyticsFreshness.ts';
+import { formatRelativeUpdate, useAnalyticsFreshness } from './useAnalyticsFreshness';
 
 /** Panel-shaped key per getAnalytics.ts: [prefix, entityId, metric, start, end, bucket, conditions]. */
 const analyticsKey = (entityId: string) => ['get_analytics_raw', entityId, 'cpu-usage', 0, 60_000, null, null];

--- a/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsFreshness.ts
@@ -1,5 +1,5 @@
 import type { EntityIds } from '@/features/auth/store/authStore';
-import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics.ts';
+import { ANALYTICS_QUERY_KEY_PREFIX } from '@/integrations/api/instance/status/getAnalytics';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 

--- a/src/features/instance/status/analytics/hooks/useAnalyticsRecords.test.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsRecords.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { useAnalyticsRecords } from './useAnalyticsRecords.ts';
+import { useAnalyticsRecords } from './useAnalyticsRecords';
 
 interface AxiosLike {
 	post: ReturnType<typeof vi.fn>;

--- a/src/features/instance/status/analytics/hooks/useAnalyticsRecords.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsRecords.ts
@@ -1,11 +1,8 @@
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
-import {
-	type AnalyticsCondition,
-	getRawAnalyticsQueryOptions,
-} from '@/integrations/api/instance/status/getAnalytics.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import { type AnalyticsCondition, getRawAnalyticsQueryOptions } from '@/integrations/api/instance/status/getAnalytics';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
-import type { AnalyticsDataPoint } from '../types/analytics.ts';
+import type { AnalyticsDataPoint } from '../types/analytics';
 
 export interface UseAnalyticsRecordsArgs {
 	metric: string;

--- a/src/features/instance/status/analytics/hooks/useNodeFilteredSeries.ts
+++ b/src/features/instance/status/analytics/hooks/useNodeFilteredSeries.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import { shortenNodeLabel } from '../lib/nodeLabels.ts';
-import type { SeriesData } from '../types/analytics.ts';
-import { useNodeSelection } from './useNodeSelection.ts';
+import { getNodeColor } from '../lib/nodeColors';
+import { shortenNodeLabel } from '../lib/nodeLabels';
+import type { SeriesData } from '../types/analytics';
+import { useNodeSelection } from './useNodeSelection';
 
 /** Shared per-node scaffolding for chip-selector panels (connection, memory,
  *  main-thread, DimensionSelectorRenderer): relabels each per-node series

--- a/src/features/instance/status/analytics/hooks/useNodeSelection.ts
+++ b/src/features/instance/status/analytics/hooks/useNodeSelection.ts
@@ -2,7 +2,7 @@
 // wrapper because many chart/renderer call sites destructure
 // `handleLegendClick`.
 
-import { useSoloToggleSelection } from './useSoloToggleSelection.ts';
+import { useSoloToggleSelection } from './useSoloToggleSelection';
 
 export function useNodeSelection(nodeIds: string[]) {
 	const { isActive, handleClick, activeSet } = useSoloToggleSelection(nodeIds);

--- a/src/features/instance/status/analytics/lib/specRequiredFields.test.ts
+++ b/src/features/instance/status/analytics/lib/specRequiredFields.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { recomputeErrorRate } from '../pipeline/derived/error-rate.tsx';
-import type { AnalyticsDataPoint, TimeRange } from '../types/analytics.ts';
-import { getSpecRequiredFields } from './specRequiredFields.ts';
+import { recomputeErrorRate } from '../pipeline/derived/error-rate';
+import type { AnalyticsDataPoint, TimeRange } from '../types/analytics';
+import { getSpecRequiredFields } from './specRequiredFields';
 
 describe('getSpecRequiredFields', () => {
 	it('returns [] for an unknown metric', () => {

--- a/src/features/instance/status/analytics/lib/specRequiredFields.ts
+++ b/src/features/instance/status/analytics/lib/specRequiredFields.ts
@@ -1,6 +1,6 @@
-import { derivedRegistry } from '../pipeline/derived/index.ts';
-import { specRegistry } from '../pipeline/index.ts';
-import type { FieldExpr, FieldSpec, MetricSpec, Transform } from '../types/analytics.ts';
+import { derivedRegistry } from '../pipeline/derived/index';
+import { specRegistry } from '../pipeline/index';
+import type { FieldExpr, FieldSpec, MetricSpec, Transform } from '../types/analytics';
 
 /** Per-derived-metric required-field overrides. Derived specs read raw
  *  source-metric columns directly (their `recompute` doesn't go through

--- a/src/features/instance/status/analytics/lib/tableSize.ts
+++ b/src/features/instance/status/analytics/lib/tableSize.ts
@@ -1,4 +1,4 @@
-import type { TableSizeRecord, TimeRange } from '../types/analytics.ts';
+import type { TableSizeRecord, TimeRange } from '../types/analytics';
 
 export type RankBy = 'bytes' | 'percent';
 export type EmptyCause = 'upstream-empty' | 'all-other' | null;

--- a/src/features/instance/status/analytics/pipeline/aggregators.ts
+++ b/src/features/instance/status/analytics/pipeline/aggregators.ts
@@ -3,7 +3,7 @@
 // p50 of [10, 20] = 10 (the lower of two medians). No interpolation. If a
 // future spec needs interpolated quantiles, add `p50-interp` etc. to the
 // Aggregator union rather than silently changing this behavior.
-import type { Aggregator } from '../types/analytics.ts';
+import type { Aggregator } from '../types/analytics';
 
 export interface AggInput {
 	value: number | null;

--- a/src/features/instance/status/analytics/pipeline/approxLabel.ts
+++ b/src/features/instance/status/analytics/pipeline/approxLabel.ts
@@ -1,4 +1,4 @@
-import type { Aggregator } from '../types/analytics.ts';
+import type { Aggregator } from '../types/analytics';
 
 export function isApproxAggregator(op: Aggregator): boolean {
 	return op === 'count-weighted-mean';

--- a/src/features/instance/status/analytics/pipeline/bytes-received.ts
+++ b/src/features/instance/status/analytics/pipeline/bytes-received.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const bytesReceivedSpec = wrapperMetrics['bytes-received'].spec;
 export const BytesReceivedRenderer = wrapperMetrics['bytes-received'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/bytes-sent.ts
+++ b/src/features/instance/status/analytics/pipeline/bytes-sent.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
 export const BytesSentRenderer = wrapperMetrics['bytes-sent'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cache-hit.ts
+++ b/src/features/instance/status/analytics/pipeline/cache-hit.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const cacheHitSpec = wrapperMetrics['cache-hit'].spec;
 export const CacheHitRenderer = wrapperMetrics['cache-hit'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cache-resolution.ts
+++ b/src/features/instance/status/analytics/pipeline/cache-resolution.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const cacheResolutionSpec = wrapperMetrics['cache-resolution'].spec;
 export const CacheResolutionRenderer = wrapperMetrics['cache-resolution'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/confidence.ts
+++ b/src/features/instance/status/analytics/pipeline/confidence.ts
@@ -1,4 +1,4 @@
-import type { MetricSpec } from '../types/analytics.ts';
+import type { MetricSpec } from '../types/analytics';
 
 type Confidence = NonNullable<MetricSpec['confidence']>;
 export type ConfidenceClass = 'ok' | 'grey' | 'suppress';

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
-import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
-import { LineChart } from '../primitives/LineChart.tsx';
-import type { AnalyticsDataPoint, MetricSpec, SeriesData, Threshold, TimeRange } from '../types/analytics.ts';
-import { runPipeline } from './pipeline.ts';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries';
+import { DimensionChipRow } from '../primitives/DimensionChipRow';
+import { LineChart } from '../primitives/LineChart';
+import type { AnalyticsDataPoint, MetricSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
+import { runPipeline } from './pipeline';
 
 const COMPOSITE_FIELD = 'pathMethod';
 const SEPARATOR = ' · ';
@@ -49,7 +49,6 @@ interface RendererProps {
 	records: AnalyticsDataPoint[];
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	fillParent?: boolean;
 }
@@ -90,7 +89,7 @@ function preprocess(records: AnalyticsDataPoint[]): Preprocessed {
 }
 
 export function ConnectionRenderer(
-	{ records, timeRange, nodes, theme, viewMode = 'per-node', fillParent }: RendererProps,
+	{ records, timeRange, nodes, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
 	const perNode = viewMode === 'per-node';
 	const { records: processed, dimParts } = useMemo(() => preprocess(records), [records]);
@@ -146,7 +145,6 @@ export function ConnectionRenderer(
 			<div className="min-h-0 flex-1" style={{ marginTop: 8 }}>
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={connectionSpec.yAxis}
 					xDomain={[timeRange.startTime, timeRange.endTime]}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/pipeline/connections.ts
+++ b/src/features/instance/status/analytics/pipeline/connections.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const connectionsSpec = wrapperMetrics['connections'].spec;
 export const ConnectionsRenderer = wrapperMetrics['connections'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cpu-usage.ts
+++ b/src/features/instance/status/analytics/pipeline/cpu-usage.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const cpuUsageSpec = wrapperMetrics['cpu-usage'].spec;
 export const CpuUsageRenderer = wrapperMetrics['cpu-usage'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/database-size.ts
+++ b/src/features/instance/status/analytics/pipeline/database-size.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const databaseSizeSpec = wrapperMetrics['database-size'].spec;
 export const DatabaseSizeRenderer = wrapperMetrics['database-size'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-message.ts
+++ b/src/features/instance/status/analytics/pipeline/db-message.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const dbMessageSpec = wrapperMetrics['db-message'].spec;
 export const DbMessageRenderer = wrapperMetrics['db-message'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-read.ts
+++ b/src/features/instance/status/analytics/pipeline/db-read.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const dbReadSpec = wrapperMetrics['db-read'].spec;
 export const DbReadRenderer = wrapperMetrics['db-read'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-write.ts
+++ b/src/features/instance/status/analytics/pipeline/db-write.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const dbWriteSpec = wrapperMetrics['db-write'].spec;
 export const DbWriteRenderer = wrapperMetrics['db-write'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
@@ -1,4 +1,4 @@
-import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics.ts';
+import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics';
 
 /**
  * Derived: per-(path, time) error rate computed from raw `count` and `total`

--- a/src/features/instance/status/analytics/pipeline/derived/index.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/index.ts
@@ -6,11 +6,11 @@
 // Step 6A adds `request-rate` (from `duration`) and `error-rate` (from
 // `success`) — the first derived metrics that read raw columns directly
 // instead of delegating to runPipeline.
-import type { DerivedMetricSpec } from '../../types/analytics.ts';
-import { errorRateDerived } from './error-rate.tsx';
-import { mqttTrafficReceivedDerived, mqttTrafficSentDerived } from './mqtt-traffic.tsx';
-import { requestRateDerived } from './request-rate.tsx';
-import { transactionLogGrowthDerived } from './transaction-log-growth.tsx';
+import type { DerivedMetricSpec } from '../../types/analytics';
+import { errorRateDerived } from './error-rate';
+import { mqttTrafficReceivedDerived, mqttTrafficSentDerived } from './mqtt-traffic';
+import { requestRateDerived } from './request-rate';
+import { transactionLogGrowthDerived } from './transaction-log-growth';
 
 export const derivedRegistry: Record<string, DerivedMetricSpec> = {
 	'mqtt-traffic-sent': mqttTrafficSentDerived,

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-received.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-received.ts
@@ -1,3 +1,3 @@
 // Thin re-export — defined with its sent-side twin in mqtt-traffic.tsx.
 // Kept so existing import paths stay stable.
-export { mqttTrafficReceivedDerived } from './mqtt-traffic.tsx';
+export { mqttTrafficReceivedDerived } from './mqtt-traffic';

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-sent.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-sent.ts
@@ -1,3 +1,3 @@
 // Thin re-export — defined with its received-side twin in mqtt-traffic.tsx.
 // Kept so existing import paths stay stable.
-export { mqttTrafficSentDerived } from './mqtt-traffic.tsx';
+export { mqttTrafficSentDerived } from './mqtt-traffic';

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
@@ -1,6 +1,6 @@
-import { TrafficByTypeRenderer } from '../../primitives/TrafficByTypeRenderer.tsx';
-import type { DerivedMetricSpec, MetricSpec } from '../../types/analytics.ts';
-import { runPipeline } from '../pipeline.ts';
+import { TrafficByTypeRenderer } from '../../primitives/TrafficByTypeRenderer';
+import type { DerivedMetricSpec, MetricSpec } from '../../types/analytics';
+import { runPipeline } from '../pipeline';
 
 interface MqttTrafficConfig {
 	id: string;

--- a/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
@@ -1,5 +1,5 @@
-import { PerPathRateRenderer } from '../../primitives/PerPathRateRenderer.tsx';
-import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics.ts';
+import { PerPathRateRenderer } from '../../primitives/PerPathRateRenderer';
+import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics';
 
 /**
  * Derived: request-rate per (path, time) bucket. Reads raw `count` and `period`
@@ -104,12 +104,11 @@ export const requestRateDerived: DerivedMetricSpec = {
 	tab: 'requests',
 	sourceMetric: 'duration',
 	recompute: recomputeRequestRate,
-	Renderer: ({ records, timeRange, nodes, theme, viewMode }) => (
+	Renderer: ({ records, timeRange, nodes, viewMode }) => (
 		<PerPathRateRenderer
 			records={records}
 			timeRange={timeRange}
 			nodes={nodes}
-			theme={theme}
 			viewMode={viewMode}
 			yAxis={{ unit: '/s', formatter: 'count-si' }}
 			compute={computeForRenderer}

--- a/src/features/instance/status/analytics/pipeline/derived/transaction-log-growth.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/transaction-log-growth.ts
@@ -1,4 +1,4 @@
-import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics.ts';
+import type { AnalyticsDataPoint, DerivedMetricSpec, Series, SeriesData, TimeRange } from '../../types/analytics';
 
 /**
  * Derived metric: per-database transaction-log write rate (bytes/sec).

--- a/src/features/instance/status/analytics/pipeline/duration.ts
+++ b/src/features/instance/status/analytics/pipeline/duration.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const durationSpec = wrapperMetrics['duration'].spec;
 export const DurationRenderer = wrapperMetrics['duration'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/fieldExpr.ts
+++ b/src/features/instance/status/analytics/pipeline/fieldExpr.ts
@@ -1,4 +1,4 @@
-import type { FieldExpr } from '../types/analytics.ts';
+import type { FieldExpr } from '../types/analytics';
 
 export function evalFieldExpr(
 	expr: FieldExpr,

--- a/src/features/instance/status/analytics/pipeline/index.ts
+++ b/src/features/instance/status/analytics/pipeline/index.ts
@@ -4,22 +4,24 @@
 // Everything is registered in `specRegistry` below — the registry keys are
 // the canonical metric names.
 
-import type { SpecRegistryEntry } from '../types/analytics.ts';
-import { ConnectionRenderer, connectionSpec } from './connection.tsx';
-import { MainThreadRenderer, mainThreadUtilizationSpec } from './main-thread-utilization.tsx';
-import { MemoryRenderer, memorySpec } from './memory.tsx';
-import { ReplicationLatencyRenderer, replicationLatencySpec } from './replication-latency.tsx';
-import { resourceUsageSpec } from './resource-usage.ts';
-import { storageVolumeSpec } from './storage-volume.ts';
-import { tlsReusedSpec } from './tls-reused.ts';
-import { utilizationSpec } from './utilization.ts';
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import type { SpecRegistryEntry } from '../types/analytics';
+import { ConnectionRenderer, connectionSpec } from './connection';
+import { MainThreadRenderer, mainThreadUtilizationSpec } from './main-thread-utilization';
+import { MemoryRenderer, memorySpec } from './memory';
+import { ReplicationLatencyRenderer, replicationLatencySpec } from './replication-latency';
+import { resourceUsageSpec } from './resource-usage';
+import { storageVolumeSpec } from './storage-volume';
+import { tlsReusedSpec } from './tls-reused';
+import { utilizationSpec } from './utilization';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const specRegistry: Record<string, SpecRegistryEntry> = {
 	'replication-latency': { spec: replicationLatencySpec, Renderer: ReplicationLatencyRenderer },
 	'bytes-sent': wrapperMetrics['bytes-sent'],
 	'bytes-received': wrapperMetrics['bytes-received'],
 	'resource-usage': { spec: resourceUsageSpec },
+	// 'connections' = active MQTT/WS session counts; distinct from
+	// 'connection' below (per-path/method connect-success ratios).
 	'connections': wrapperMetrics['connections'],
 	'duration': wrapperMetrics['duration'],
 	'success': wrapperMetrics['success'],
@@ -30,6 +32,8 @@ export const specRegistry: Record<string, SpecRegistryEntry> = {
 	'db-read': wrapperMetrics['db-read'],
 	'db-write': wrapperMetrics['db-write'],
 	'db-message': wrapperMetrics['db-message'],
+	// snake_case matches Harper's wire metric name (response_200) — the one
+	// exception to the kebab-case registry keys; do not normalize.
 	'response_200': wrapperMetrics['response_200'],
 	'utilization': { spec: utilizationSpec },
 	'database-size': wrapperMetrics['database-size'],

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
-import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
-import { LineChart } from '../primitives/LineChart.tsx';
-import type { AnalyticsDataPoint, AxisSpec, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
-import { runPipeline } from './pipeline.ts';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries';
+import { DimensionChipRow } from '../primitives/DimensionChipRow';
+import { LineChart } from '../primitives/LineChart';
+import type { AnalyticsDataPoint, AxisSpec, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
+import { runPipeline } from './pipeline';
 
 // Field-selector pattern (mirrors memory.tsx). Records expose
 // `active`, `idle`, and `taskQueueLatency`; we surface 4 operator-
@@ -82,13 +82,12 @@ interface RendererProps {
 	records: AnalyticsDataPoint[];
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	fillParent?: boolean;
 }
 
 export function MainThreadRenderer(
-	{ records, timeRange, nodes, theme, viewMode = 'per-node', fillParent }: RendererProps,
+	{ records, timeRange, nodes, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
 	const perNode = viewMode === 'per-node';
 	const [selectedKey, setSelectedKey] = useState<string>(FIELDS[0].key);
@@ -120,7 +119,6 @@ export function MainThreadRenderer(
 			<div className="min-h-0 flex-1" style={{ marginTop: 8 }}>
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={selected.yAxis}
 					xDomain={[timeRange.startTime, timeRange.endTime]}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
-import { DimensionChipRow } from '../primitives/DimensionChipRow.tsx';
-import { LineChart } from '../primitives/LineChart.tsx';
-import type { AnalyticsDataPoint, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
-import { runPipeline } from './pipeline.ts';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries';
+import { DimensionChipRow } from '../primitives/DimensionChipRow';
+import { LineChart } from '../primitives/LineChart';
+import type { AnalyticsDataPoint, FieldSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
+import { runPipeline } from './pipeline';
 
 // Field-selector pattern (cousin of DimensionSelectorRenderer): chip-row
 // picks one memory field at a time and the chart shows that one with the
@@ -39,7 +39,6 @@ interface RendererProps {
 	records: AnalyticsDataPoint[];
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	fillParent?: boolean;
 }
@@ -47,7 +46,7 @@ interface RendererProps {
 const FIELD_LABELS = MEMORY_FIELDS.map((f) => f.label);
 
 export function MemoryRenderer(
-	{ records, timeRange, nodes, theme, viewMode = 'per-node', fillParent }: RendererProps,
+	{ records, timeRange, nodes, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
 	const perNode = viewMode === 'per-node';
 	const [selectedLabel, setSelectedLabel] = useState<string>(MEMORY_FIELDS[0].label);
@@ -75,7 +74,6 @@ export function MemoryRenderer(
 			<div className="min-h-0 flex-1" style={{ marginTop: 8 }}>
 				<LineChart
 					data={filteredData}
-					theme={theme}
 					yAxis={memorySpec.yAxis}
 					xDomain={[timeRange.startTime, timeRange.endTime]}
 					fillParent={fillParent}

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -31,12 +31,12 @@ import type {
 	SeriesData,
 	SeriesPoint,
 	TimeRange,
-} from '../types/analytics.ts';
-import { type AggInput, aggregate } from './aggregators.ts';
-import { labelWithApprox } from './approxLabel.ts';
-import { classifyConfidence } from './confidence.ts';
-import { evalFieldExpr } from './fieldExpr.ts';
-import { runTransform } from './runTransform.ts';
+} from '../types/analytics';
+import { type AggInput, aggregate } from './aggregators';
+import { labelWithApprox } from './approxLabel';
+import { classifyConfidence } from './confidence';
+import { evalFieldExpr } from './fieldExpr';
+import { runTransform } from './runTransform';
 
 export interface RunPipelineOptions {
 	/** When true, runGroupBy emits one Series per (dim, node) instead of

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -1,7 +1,7 @@
 import { type JSX, useMemo, useState } from 'react';
-import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
-import { HeatmapMatrix } from '../primitives/HeatmapMatrix.tsx';
-import { LineChart } from '../primitives/LineChart.tsx';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
+import { HeatmapMatrix } from '../primitives/HeatmapMatrix';
+import { LineChart } from '../primitives/LineChart';
 import type {
 	AnalyticsDataPoint,
 	HeatmapCell,
@@ -11,10 +11,10 @@ import type {
 	SeriesData,
 	SeriesPoint,
 	SpecRegistryRendererProps,
-} from '../types/analytics.ts';
-import { type AggInput, aggregate } from './aggregators.ts';
-import { parseReplicationPath } from './pathParser.ts';
-import { QUANTILE_FIELDS as REPLICATION_QUANTILE_FIELDS, type QuantileField } from './quantileFields.ts';
+} from '../types/analytics';
+import { type AggInput, aggregate } from './aggregators';
+import { parseReplicationPath } from './pathParser';
+import { QUANTILE_FIELDS as REPLICATION_QUANTILE_FIELDS, type QuantileField } from './quantileFields';
 
 export { REPLICATION_QUANTILE_FIELDS };
 export type ReplicationQuantileField = QuantileField['field'];
@@ -320,7 +320,7 @@ function buildLineSeries(
 }
 
 export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JSX.Element {
-	const { records, nodes, theme, timeRange, fillParent } = props;
+	const { records, nodes, timeRange, fillParent } = props;
 
 	const [quantile, setQuantile] = useState<ReplicationQuantileField>('p95');
 
@@ -337,7 +337,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 	if (data.rows.length === 0 || data.cols.length === 0) {
 		return (
 			<div>
-				<RecognitionBanner data={data} theme={theme} />
+				<RecognitionBanner data={data} />
 
 				<div>No data in window</div>
 			</div>
@@ -364,7 +364,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 			padding: '4px 8px',
 			fontSize: 12,
 			borderLeft: '3px solid var(--color-warning, #f59e0b)',
-			background: theme === 'dark' ? '#1f2937' : '#fffbeb',
+			background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
 			color: 'currentColor',
 		} as const;
 
@@ -383,7 +383,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 				>
 					Showing as lines
 				</div>
-				<RecognitionBanner data={data} theme={theme} />
+				<RecognitionBanner data={data} />
 				{
 					/* Suppress the omitted-pairs banner when all-dropped fires — the
 				    all-dropped banner already cites the count, so showing both is
@@ -409,7 +409,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 						padding: '4px 8px',
 						fontSize: 12,
 						borderLeft: '3px solid var(--color-info, #3b82f6)',
-						background: theme === 'dark' ? '#0f172a' : '#eff6ff',
+						background: 'color-mix(in srgb, var(--color-accent, #3b82f6) 10%, transparent)',
 						color: 'currentColor',
 					}}
 				>
@@ -433,7 +433,6 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 						<div style={{ marginTop: 20 }}>
 							<LineChart
 								data={seriesData}
-								theme={theme}
 								yAxis={data.axis}
 								height={320}
 								xDomain={[timeRange.startTime, timeRange.endTime]}
@@ -448,14 +447,14 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 	return (
 		<div className="flex h-full flex-col">
 			<QuantileSelector value={quantile} onChange={setQuantile} />
-			<RecognitionBanner data={data} theme={theme} />
+			<RecognitionBanner data={data} />
 			<div className="min-h-0 flex-1">
 				{
 					/* Zero the primitive's generic skipped-count banner — the
 				    RecognitionBanner above already reports omissions with
 				    cause-specific copy, so letting both render double-reports. */
 				}
-				<HeatmapMatrix data={{ ...data, skippedRecordsCount: 0 }} theme={theme} title="Replication latency" />
+				<HeatmapMatrix data={{ ...data, skippedRecordsCount: 0 }} title="Replication latency" />
 			</div>
 		</div>
 	);
@@ -463,13 +462,12 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 
 interface RecognitionBannerProps {
 	data: HeatmapData;
-	theme: 'light' | 'dark';
 }
 
 /** Renders a single role='status' banner combining the two omission causes
  *  (unparseable path vs. missing percentile value) and the
  *  heuristic-recovered source count. Any subset may be present. */
-function RecognitionBanner({ data, theme }: RecognitionBannerProps) {
+function RecognitionBanner({ data }: RecognitionBannerProps) {
 	const unparseable = data.unparseablePathCount ?? 0;
 	const missingValue = data.missingValueCount ?? 0;
 	const unrecognized = data.unrecognizedSources ?? [];
@@ -504,7 +502,7 @@ function RecognitionBanner({ data, theme }: RecognitionBannerProps) {
 				padding: '4px 8px',
 				fontSize: 12,
 				borderLeft: '3px solid var(--color-warning, #f59e0b)',
-				background: theme === 'dark' ? '#1f2937' : '#fffbeb',
+				background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
 				color: 'currentColor',
 			}}
 		>

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -408,7 +408,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 						marginBottom: 8,
 						padding: '4px 8px',
 						fontSize: 12,
-						borderLeft: '3px solid var(--color-info, #3b82f6)',
+						borderLeft: '3px solid var(--color-accent, #3b82f6)',
 						background: 'color-mix(in srgb, var(--color-accent, #3b82f6) 10%, transparent)',
 						color: 'currentColor',
 					}}

--- a/src/features/instance/status/analytics/pipeline/resource-usage.ts
+++ b/src/features/instance/status/analytics/pipeline/resource-usage.ts
@@ -1,4 +1,4 @@
-import type { MetricSpec } from '../types/analytics.ts';
+import type { MetricSpec } from '../types/analytics';
 
 // Per-field `crossNode` aggregator overrides (e.g. cpuUtilization's
 // `crossNode: 'max'`) are honored by pipeline.ts as of Step 4.5: the

--- a/src/features/instance/status/analytics/pipeline/response-200.ts
+++ b/src/features/instance/status/analytics/pipeline/response-200.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const response200Spec = wrapperMetrics['response_200'].spec;
 export const Response200Renderer = wrapperMetrics['response_200'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/runTransform.ts
+++ b/src/features/instance/status/analytics/pipeline/runTransform.ts
@@ -1,5 +1,5 @@
-import type { Transform } from '../types/analytics.ts';
-import { type NamedTransformKey, namedTransforms } from './transforms.ts';
+import type { Transform } from '../types/analytics';
+import { type NamedTransformKey, namedTransforms } from './transforms';
 
 /** Apply a Transform to a scalar. `period` is the record's period in ms; only
  *  `rate` consults it. Null input short-circuits to null. The pipeline resolves

--- a/src/features/instance/status/analytics/pipeline/storage-volume.ts
+++ b/src/features/instance/status/analytics/pipeline/storage-volume.ts
@@ -1,4 +1,4 @@
-import type { MetricSpec } from '../types/analytics.ts';
+import type { MetricSpec } from '../types/analytics';
 
 export const storageVolumeSpec: MetricSpec = {
 	title: 'Storage volume (available)',

--- a/src/features/instance/status/analytics/pipeline/success.ts
+++ b/src/features/instance/status/analytics/pipeline/success.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const successSpec = wrapperMetrics['success'].spec;
 export const SuccessRenderer = wrapperMetrics['success'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/tls-reused.ts
+++ b/src/features/instance/status/analytics/pipeline/tls-reused.ts
@@ -1,4 +1,4 @@
-import type { MetricSpec } from '../types/analytics.ts';
+import type { MetricSpec } from '../types/analytics';
 
 export const tlsReusedSpec: MetricSpec = {
 	title: 'TLS session reuse ratio',

--- a/src/features/instance/status/analytics/pipeline/transfer.ts
+++ b/src/features/instance/status/analytics/pipeline/transfer.ts
@@ -1,6 +1,6 @@
 // Thin re-export — this metric is defined in the `wrapperMetrics` factory
 // table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics.tsx';
+import { wrapperMetrics } from './wrapperMetrics';
 
 export const transferSpec = wrapperMetrics['transfer'].spec;
 export const TransferRenderer = wrapperMetrics['transfer'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/utilization.ts
+++ b/src/features/instance/status/analytics/pipeline/utilization.ts
@@ -1,4 +1,4 @@
-import type { MetricSpec } from '../types/analytics.ts';
+import type { MetricSpec } from '../types/analytics';
 
 export const utilizationSpec: MetricSpec = {
 	title: 'Cluster utilization',

--- a/src/features/instance/status/analytics/pipeline/wrapperMetrics.tsx
+++ b/src/features/instance/status/analytics/pipeline/wrapperMetrics.tsx
@@ -10,10 +10,10 @@
 // `index.ts#specRegistry`.
 
 import type { ComponentType } from 'react';
-import { DimensionSelectorRenderer } from '../primitives/DimensionSelectorRenderer.tsx';
-import { TrafficByTypeRenderer } from '../primitives/TrafficByTypeRenderer.tsx';
-import type { MetricSpec, SpecRegistryRendererProps } from '../types/analytics.ts';
-import { QUANTILE_DEFAULT, QUANTILE_FIELDS } from './quantileFields.ts';
+import { DimensionSelectorRenderer } from '../primitives/DimensionSelectorRenderer';
+import { TrafficByTypeRenderer } from '../primitives/TrafficByTypeRenderer';
+import type { MetricSpec, SpecRegistryRendererProps } from '../types/analytics';
+import { QUANTILE_DEFAULT, QUANTILE_FIELDS } from './quantileFields';
 
 export interface WrapperMetric {
 	spec: MetricSpec;

--- a/src/features/instance/status/analytics/primitives/DimensionChipRow.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionChipRow.tsx
@@ -6,7 +6,7 @@
 // active at a time, arrow keys move focus and selection
 // (useRovingRadioGroup).
 
-import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
 
 interface DimensionChipRowProps {
 	/** Selectable dimension values, in display order. */

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -12,14 +12,14 @@
 //      chart. The pipeline re-runs with the chosen field substituted.
 
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries.ts';
-import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
-import { runPipeline } from '../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
-import { DimensionChipRow } from './DimensionChipRow.tsx';
-import { DimensionCombobox } from './DimensionCombobox.tsx';
-import { LineChart } from './LineChart.tsx';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeFilteredSeries } from '../hooks/useNodeFilteredSeries';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
+import { runPipeline } from '../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
+import { DimensionChipRow } from './DimensionChipRow';
+import { DimensionCombobox } from './DimensionCombobox';
+import { LineChart } from './LineChart';
 
 const OTHER_KEY = 'Other';
 const CHIP_LIMIT = 12;

--- a/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
@@ -1,5 +1,5 @@
-import type { AnalyticsDataPoint, SeriesData, TimeRange } from '../types/analytics.ts';
-import { SmallMultiples } from './SmallMultiples.tsx';
+import type { AnalyticsDataPoint, SeriesData } from '../types/analytics';
+import { SmallMultiples } from './SmallMultiples';
 
 const isDev = import.meta.env?.DEV ?? false;
 
@@ -26,11 +26,6 @@ const MAX_FALLBACK_PANELS = 8;
 interface Props {
 	metric: string;
 	records: AnalyticsDataPoint[];
-	/** Unused by this renderer — accepted (optionally) only because
-	 *  MetricRenderer's callsites still pass them; drop from both sides when
-	 *  those callsites are next touched. */
-	window?: TimeRange;
-	nodes?: string[];
 	/** Optional inline banner shown above the dev hint — used by callers that
 	 *  fell through to FallbackRenderer for a known reason (e.g. legacy chart
 	 *  failed to load), so users see the cause. */

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -1,18 +1,13 @@
 import { formatValue } from '@/lib/formatValue';
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
-import { useResolvedTheme } from '../lib/theme.ts';
-import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics.ts';
-import { computeCellSize } from './computeCellSize.ts';
-export { computeCellSize } from './computeCellSize.ts';
+import { useResolvedTheme } from '../lib/theme';
+import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics';
+import { computeCellSize } from './computeCellSize';
+export { computeCellSize } from './computeCellSize';
 
 interface Props {
 	data: HeatmapData;
-	/** @deprecated Ignored — the color-stop ramp branches on the resolved app
-	 *  theme via useResolvedTheme(), and the confidence greys are
-	 *  `--chart-heatmap-*` CSS tokens. Kept optional only while the pipeline
-	 *  renderers (owned by a parallel refactor) still pass it. */
-	theme?: 'light' | 'dark';
 	title?: string;
 	height?: number;
 }

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -10,18 +10,14 @@ import {
 	XAxis,
 	YAxis,
 } from 'recharts';
-import { NODE_PALETTE } from '../lib/nodeColors.ts';
-import { getChartColors } from '../lib/theme.ts';
-import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
-import type { AxisSpec, SeriesData, Threshold } from '../types/analytics.ts';
-import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle.ts';
+import { NODE_PALETTE } from '../lib/nodeColors';
+import { getChartColors } from '../lib/theme';
+import { formatAxisTick, formatTooltipTime } from '../lib/time';
+import type { AxisSpec, SeriesData, Threshold } from '../types/analytics';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle';
 
 interface Props {
 	data: SeriesData;
-	/** @deprecated Ignored — colors resolve via `--chart-*` CSS tokens, so the
-	 *  chart re-themes with the app automatically. Kept optional only while
-	 *  the pipeline renderers (owned by a parallel refactor) still pass it. */
-	theme?: 'light' | 'dark';
 	yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec };
 	height?: number;
 	/** Optional accessible label override; otherwise composed from series labels. */

--- a/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChartWithNodeLegend.tsx
@@ -5,11 +5,11 @@
 // behavior as the chip-selector panels and small-multiples grids.
 
 import { useMemo } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import type { AxisSpec, Series, SeriesData } from '../types/analytics.ts';
-import { LineChart } from './LineChart.tsx';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { getNodeColor } from '../lib/nodeColors';
+import type { AxisSpec, Series, SeriesData } from '../types/analytics';
+import { LineChart } from './LineChart';
 
 interface Props {
 	data: SeriesData;

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -1,13 +1,12 @@
 import { Component, type ReactNode } from 'react';
-import { useResolvedTheme } from '../lib/theme.ts';
-import { derivedRegistry } from '../pipeline/derived/index.ts';
-import { specRegistry } from '../pipeline/index.ts';
-import { runPipeline } from '../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, AxisSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics.ts';
-import { FallbackRenderer } from './FallbackRenderer.tsx';
-import { LineChartWithNodeLegend } from './LineChartWithNodeLegend.tsx';
-import { SmallMultiples } from './SmallMultiples.tsx';
-import { StackedAreaChart } from './StackedAreaChart.tsx';
+import { derivedRegistry } from '../pipeline/derived/index';
+import { specRegistry } from '../pipeline/index';
+import { runPipeline } from '../pipeline/pipeline';
+import type { AnalyticsDataPoint, AxisSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
+import { FallbackRenderer } from './FallbackRenderer';
+import { LineChartWithNodeLegend } from './LineChartWithNodeLegend';
+import { SmallMultiples } from './SmallMultiples';
+import { StackedAreaChart } from './StackedAreaChart';
 
 function renderPrimitive(
 	primitive: MetricSpec['primitive'],
@@ -112,17 +111,10 @@ export function MetricRenderer({
 	viewMode,
 	fillParent,
 }: Props) {
-	// Only the registry Renderers still take a theme prop (their signatures
-	// live in pipeline/, owned by a parallel refactor); primitives re-theme
-	// via CSS tokens and need nothing passed.
-	const theme = useResolvedTheme();
-
 	const errorFallback = (
 		<FallbackRenderer
 			metric={metric}
 			records={records}
-			window={timeRange}
-			nodes={nodes}
 			hint="Render failed — showing fallback."
 		/>
 	);
@@ -137,7 +129,6 @@ export function MetricRenderer({
 					records={records}
 					timeRange={timeRange}
 					nodes={nodes}
-					theme={theme}
 					viewMode={viewMode}
 					fillParent={fillParent}
 				/>
@@ -154,7 +145,6 @@ export function MetricRenderer({
 					records={records}
 					timeRange={timeRange}
 					nodes={nodes}
-					theme={theme}
 					viewMode={viewMode}
 					fillParent={fillParent}
 				/>
@@ -212,7 +202,7 @@ export function MetricRenderer({
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}
 		} else {
-			body = <FallbackRenderer metric={metric} records={records} window={timeRange} nodes={nodes} />;
+			body = <FallbackRenderer metric={metric} records={records} />;
 		}
 	}
 

--- a/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
@@ -6,22 +6,18 @@
 // the path-discovery + viewMode threading.
 
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import { shortenNodeLabel } from '../lib/nodeLabels.ts';
-import type { AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics.ts';
-import { DimensionChipRow } from './DimensionChipRow.tsx';
-import { LineChart } from './LineChart.tsx';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { getNodeColor } from '../lib/nodeColors';
+import { shortenNodeLabel } from '../lib/nodeLabels';
+import type { AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
+import { DimensionChipRow } from './DimensionChipRow';
+import { LineChart } from './LineChart';
 
 interface Props {
 	records: AnalyticsDataPoint[];
 	timeRange?: TimeRange;
 	nodes: string[];
-	/** @deprecated Ignored — theming resolves via `--chart-*` CSS tokens.
-	 *  Kept optional only while pipeline renderers (owned by a parallel
-	 *  refactor) still pass it. */
-	theme?: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	yAxis?: AxisSpec | { left: AxisSpec; right?: AxisSpec };
 	thresholds?: Threshold[];

--- a/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
+++ b/src/features/instance/status/analytics/primitives/SmallMultiples.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import type { AxisSpec, SeriesData } from '../types/analytics.ts';
-import { LineChart } from './LineChart.tsx';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { getNodeColor } from '../lib/nodeColors';
+import type { AxisSpec, SeriesData } from '../types/analytics';
+import { LineChart } from './LineChart';
 
 interface Panel {
 	title: string;

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -1,12 +1,12 @@
 import { formatValue } from '@/lib/formatValue';
 import { useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-import { NODE_PALETTE } from '../lib/nodeColors.ts';
-import { getChartColors, useResolvedTheme } from '../lib/theme.ts';
-import { formatAxisTick, formatTooltipTime } from '../lib/time.ts';
-import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics.ts';
-import { sortByMagnitude } from './sortByMagnitude.ts';
-import { tooltipContentStyle, tooltipLabelStyle } from './tooltipStyle.ts';
+import { NODE_PALETTE } from '../lib/nodeColors';
+import { getChartColors, useResolvedTheme } from '../lib/theme';
+import { formatAxisTick, formatTooltipTime } from '../lib/time';
+import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics';
+import { sortByMagnitude } from './sortByMagnitude';
+import { tooltipContentStyle, tooltipLabelStyle } from './tooltipStyle';
 
 interface Props {
 	data: SeriesData;

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -15,17 +15,17 @@
 //     the stack pre-pipeline.
 
 import { useMemo, useState } from 'react';
-import { NodeLegend } from '../charts/NodeLegend.tsx';
-import { useNodeSelection } from '../hooks/useNodeSelection.ts';
-import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup.ts';
-import { useSoloToggleSelection } from '../hooks/useSoloToggleSelection.ts';
-import { getTypeColor } from '../lib/colorAllocators/typeColors.ts';
-import { getNodeColor } from '../lib/nodeColors.ts';
-import { runPipeline } from '../pipeline/pipeline.ts';
-import type { AnalyticsDataPoint, MetricSpec, Series, SeriesData, TimeRange } from '../types/analytics.ts';
-import { SmallMultiples } from './SmallMultiples.tsx';
-import { StackedAreaChart } from './StackedAreaChart.tsx';
-import { TypeFilterChipRow } from './TypeFilterChipRow.tsx';
+import { NodeLegend } from '../charts/NodeLegend';
+import { useNodeSelection } from '../hooks/useNodeSelection';
+import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
+import { useSoloToggleSelection } from '../hooks/useSoloToggleSelection';
+import { getTypeColor } from '../lib/colorAllocators/typeColors';
+import { getNodeColor } from '../lib/nodeColors';
+import { runPipeline } from '../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, Series, SeriesData, TimeRange } from '../types/analytics';
+import { SmallMultiples } from './SmallMultiples';
+import { StackedAreaChart } from './StackedAreaChart';
+import { TypeFilterChipRow } from './TypeFilterChipRow';
 
 interface Props {
 	/** Underlying spec (groupBy on `typeField`, primitive `stacked-area`). */

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords.ts';
-import { ConnectionsRenderer } from '../pipeline/connections.tsx';
-import type { AnalyticsDataPoint } from '../types/analytics.ts';
-import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
-import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell.tsx';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
+import { ConnectionsRenderer } from '../pipeline/connections';
+import type { AnalyticsDataPoint } from '../types/analytics';
+import { PanelErrorBoundary } from './PanelErrorBoundary';
+import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell';
 
 /** Some Harper builds split active-session telemetry across two metrics:
  *  `mqtt-connections` (active MQTT sessions) and `ws-connections` (active
@@ -27,7 +27,7 @@ export function ConnectionsPanel() {
 }
 
 function ConnectionsPanelInner() {
-	const { timeRange, bucketMs, theme, instanceParams } = useAnalyticsContext();
+	const { timeRange, bucketMs, instanceParams } = useAnalyticsContext();
 
 	const mqtt = useAnalyticsRecords({
 		metric: 'mqtt-connections',
@@ -64,7 +64,6 @@ function ConnectionsPanelInner() {
 			records={merged}
 			timeRange={timeRange}
 			nodes={nodes}
-			theme={theme}
 			fillParent={opts.fillParent}
 		/>
 	);

--- a/src/features/instance/status/analytics/tabs/DatabaseTab.tsx
+++ b/src/features/instance/status/analytics/tabs/DatabaseTab.tsx
@@ -1,4 +1,4 @@
-import { MetricPanel } from './MetricPanel.tsx';
+import { MetricPanel } from './MetricPanel';
 
 const METRICS = ['db-read', 'db-write', 'db-message'] as const;
 

--- a/src/features/instance/status/analytics/tabs/HealthTab.tsx
+++ b/src/features/instance/status/analytics/tabs/HealthTab.tsx
@@ -1,4 +1,4 @@
-import { MetricPanel } from './MetricPanel.tsx';
+import { MetricPanel } from './MetricPanel';
 
 const METRICS = [
 	'resource-usage',

--- a/src/features/instance/status/analytics/tabs/MetricPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/MetricPanel.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords.ts';
-import { getSpecRequiredFields } from '../lib/specRequiredFields.ts';
-import { derivedRegistry } from '../pipeline/derived/index.ts';
-import { specRegistry } from '../pipeline/index.ts';
-import { MetricRenderer } from '../primitives/MetricRenderer.tsx';
-import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
-import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell.tsx';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
+import { getSpecRequiredFields } from '../lib/specRequiredFields';
+import { derivedRegistry } from '../pipeline/derived/index';
+import { specRegistry } from '../pipeline/index';
+import { MetricRenderer } from '../primitives/MetricRenderer';
+import { PanelErrorBoundary } from './PanelErrorBoundary';
+import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell';
 
 interface Props {
 	metric: string;

--- a/src/features/instance/status/analytics/tabs/OverviewTab.tsx
+++ b/src/features/instance/status/analytics/tabs/OverviewTab.tsx
@@ -1,13 +1,13 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { getStatusQueryOptions } from '@/integrations/api/instance/status/getStatus';
 import { getSystemInformationQueryOptions } from '@/integrations/api/instance/status/getSystemInformation';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Suspense, useMemo } from 'react';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { crawlData, hasTitle } from './crawlData.ts';
-import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { crawlData, hasTitle } from './crawlData';
+import { PanelErrorBoundary } from './PanelErrorBoundary';
 
 interface Props {
 	instanceParams: InstanceClientIdConfig & InstanceTypeConfig;

--- a/src/features/instance/status/analytics/tabs/PanelShell.tsx
+++ b/src/features/instance/status/analytics/tabs/PanelShell.tsx
@@ -2,9 +2,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { errorText } from '@/lib/errorText';
 import { type ReactNode, useRef } from 'react';
-import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
-import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
-import { ChartExportButton } from '../components/ChartExportButton.tsx';
+import { ChartCopyButton } from '../components/ChartCopyButton';
+import { ChartExpandButton } from '../components/ChartExpandButton';
+import { ChartExportButton } from '../components/ChartExportButton';
 
 interface PanelCardProps {
 	title: string;

--- a/src/features/instance/status/analytics/tabs/ReplicationTab.tsx
+++ b/src/features/instance/status/analytics/tabs/ReplicationTab.tsx
@@ -1,4 +1,4 @@
-import { MetricPanel } from './MetricPanel.tsx';
+import { MetricPanel } from './MetricPanel';
 
 export function ReplicationTab() {
 	return (

--- a/src/features/instance/status/analytics/tabs/RequestsTab.tsx
+++ b/src/features/instance/status/analytics/tabs/RequestsTab.tsx
@@ -1,4 +1,4 @@
-import { MetricPanel } from './MetricPanel.tsx';
+import { MetricPanel } from './MetricPanel';
 
 const METRICS = [
 	'request-rate',

--- a/src/features/instance/status/analytics/tabs/StorageTab.tsx
+++ b/src/features/instance/status/analytics/tabs/StorageTab.tsx
@@ -1,16 +1,16 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useMemo, useRef, useState } from 'react';
-import { TableSizeSnapshot } from '../charts/TableSizeSnapshot.tsx';
-import { TableSizeTrend } from '../charts/TableSizeTrend.tsx';
-import { ChartCopyButton } from '../components/ChartCopyButton.tsx';
-import { ChartExpandButton } from '../components/ChartExpandButton.tsx';
-import { ChartExportButton } from '../components/ChartExportButton.tsx';
-import { useAnalyticsContext } from '../context/AnalyticsContext.tsx';
-import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords.ts';
-import { buildDerived, type RankBy, type TableSizeDerived } from '../lib/tableSize.ts';
-import type { TableSizeRecord } from '../types/analytics.ts';
-import { MetricPanel } from './MetricPanel.tsx';
-import { PanelErrorBoundary } from './PanelErrorBoundary.tsx';
+import { TableSizeSnapshot } from '../charts/TableSizeSnapshot';
+import { TableSizeTrend } from '../charts/TableSizeTrend';
+import { ChartCopyButton } from '../components/ChartCopyButton';
+import { ChartExpandButton } from '../components/ChartExpandButton';
+import { ChartExportButton } from '../components/ChartExportButton';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
+import { buildDerived, type RankBy, type TableSizeDerived } from '../lib/tableSize';
+import type { TableSizeRecord } from '../types/analytics';
+import { MetricPanel } from './MetricPanel';
+import { PanelErrorBoundary } from './PanelErrorBoundary';
 
 function derivedClusterNodes(derived: TableSizeDerived): string[] {
 	return derived.snapshot.byNode.map((b) => b.node);
@@ -32,7 +32,7 @@ export function StorageTab() {
 }
 
 function TableSizePanels() {
-	const { timeRange, bucketMs, theme, instanceParams } = useAnalyticsContext();
+	const { timeRange, bucketMs, instanceParams } = useAnalyticsContext();
 	const { data, isLoading, isError } = useAnalyticsRecords({
 		metric: 'table-size',
 		startTime: timeRange.startTime,
@@ -134,7 +134,6 @@ function TableSizePanels() {
 		<TableSizeSnapshot
 			snapshot={derived.snapshot}
 			viewMode="per-node"
-			theme={theme}
 			selectedTable={effectiveSelection}
 			onChipSelect={setSelected}
 			onBarClick={setSelected}
@@ -147,7 +146,6 @@ function TableSizePanels() {
 				<TableSizeTrend
 					derived={derived}
 					viewMode="per-node"
-					theme={theme}
 					selectedTable={effectiveSelection}
 					onChipSelect={setSelected}
 					manualSelection={selected !== null}

--- a/src/features/instance/status/analytics/tabs/TrafficTab.tsx
+++ b/src/features/instance/status/analytics/tabs/TrafficTab.tsx
@@ -1,5 +1,5 @@
-import { ConnectionsPanel } from './ConnectionsPanel.tsx';
-import { MetricPanel } from './MetricPanel.tsx';
+import { ConnectionsPanel } from './ConnectionsPanel';
+import { MetricPanel } from './MetricPanel';
 
 // Connections is rendered by a custom panel because it merges two source
 // metrics (mqtt-connections + ws-connections) — the generic MetricPanel

--- a/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
@@ -6,9 +6,9 @@ vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 
-import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords.ts';
-import { ConnectionsPanel } from '../ConnectionsPanel.tsx';
-import { AnalyticsTestWrapper, makeRows } from './testHelpers.tsx';
+import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords';
+import { ConnectionsPanel } from '../ConnectionsPanel';
+import { AnalyticsTestWrapper, makeRows } from './testHelpers';
 
 const mockHook = vi.mocked(useAnalyticsRecords);
 

--- a/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
@@ -6,9 +6,9 @@ vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 
-import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords.ts';
-import { MetricPanel } from '../MetricPanel.tsx';
-import { AnalyticsTestWrapper, makeRows } from './testHelpers.tsx';
+import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords';
+import { MetricPanel } from '../MetricPanel';
+import { AnalyticsTestWrapper, makeRows } from './testHelpers';
 
 const mockHook = vi.mocked(useAnalyticsRecords);
 

--- a/src/features/instance/status/analytics/tabs/__tests__/OverviewTab.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/OverviewTab.test.tsx
@@ -31,8 +31,8 @@ vi.mock('@/integrations/api/instance/status/getStatus', () => ({
 	}),
 }));
 
-import { OverviewTab } from '../OverviewTab.tsx';
-import { AnalyticsTestWrapper } from './testHelpers.tsx';
+import { OverviewTab } from '../OverviewTab';
+import { AnalyticsTestWrapper } from './testHelpers';
 
 const instanceParams = {
 	instanceClient: { post: vi.fn() } as never,

--- a/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
@@ -6,10 +6,10 @@ vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 
-import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords.ts';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
-import { StorageTab } from '../StorageTab.tsx';
-import { AnalyticsTestWrapper } from './testHelpers.tsx';
+import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords';
+import type { AnalyticsDataPoint } from '../../types/analytics';
+import { StorageTab } from '../StorageTab';
+import { AnalyticsTestWrapper } from './testHelpers';
 
 const mockHook = vi.mocked(useAnalyticsRecords);
 

--- a/src/features/instance/status/analytics/tabs/__tests__/groupSections.test.ts
+++ b/src/features/instance/status/analytics/tabs/__tests__/groupSections.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { groupSections } from '../OverviewTab.tsx';
+import { groupSections } from '../OverviewTab';
 
 describe('groupSections', () => {
 	it('returns an empty list for empty input', () => {

--- a/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
@@ -6,14 +6,14 @@ vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 
-import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords.ts';
-import { DatabaseTab } from '../DatabaseTab.tsx';
-import { HealthTab } from '../HealthTab.tsx';
-import { ReplicationTab } from '../ReplicationTab.tsx';
-import { RequestsTab } from '../RequestsTab.tsx';
-import { StorageTab } from '../StorageTab.tsx';
-import { TrafficTab } from '../TrafficTab.tsx';
-import { AnalyticsTestWrapper, makeRows } from './testHelpers.tsx';
+import { useAnalyticsRecords } from '../../hooks/useAnalyticsRecords';
+import { DatabaseTab } from '../DatabaseTab';
+import { HealthTab } from '../HealthTab';
+import { ReplicationTab } from '../ReplicationTab';
+import { RequestsTab } from '../RequestsTab';
+import { StorageTab } from '../StorageTab';
+import { TrafficTab } from '../TrafficTab';
+import { AnalyticsTestWrapper, makeRows } from './testHelpers';
 
 const mockHook = vi.mocked(useAnalyticsRecords);
 

--- a/src/features/instance/status/analytics/tabs/__tests__/testHelpers.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/testHelpers.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
-import { type AnalyticsContextValue, AnalyticsProvider } from '../../context/AnalyticsContext.tsx';
-import type { AnalyticsDataPoint } from '../../types/analytics.ts';
+import { type AnalyticsContextValue, AnalyticsProvider } from '../../context/AnalyticsContext';
+import type { AnalyticsDataPoint } from '../../types/analytics';
 
 export function makeInstanceParams(): InstanceClientIdConfig & InstanceTypeConfig {
 	return {
@@ -17,7 +17,6 @@ export function makeContextValue(overrides: Partial<AnalyticsContextValue> = {})
 	return {
 		timeRange: { startTime: 0, endTime: 60_000 },
 		bucketMs: 60_000,
-		theme: 'light',
 		instanceParams: makeInstanceParams(),
 		...overrides,
 	};

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -295,7 +295,6 @@ export interface SpecRegistryRendererProps {
 	/** Renamed from `window` to avoid shadowing the DOM `window`. */
 	timeRange: TimeRange;
 	nodes: string[];
-	theme: 'light' | 'dark';
 	viewMode?: 'per-node' | 'aggregate';
 	/** When true, charts fill parent vertical space (expand dialog). */
 	fillParent?: boolean;

--- a/src/features/instance/status/index.tsx
+++ b/src/features/instance/status/index.tsx
@@ -1,6 +1,6 @@
 import { isLocalStudio } from '@/config/constants';
-import { useInstanceClientIdParams } from '@/config/useInstanceClient.tsx';
-import { StatusTabs } from '@/features/instance/status/analytics/StatusTabs.tsx';
+import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { StatusTabs } from '@/features/instance/status/analytics/StatusTabs';
 
 export function StatusIndex() {
 	const instanceParams = useInstanceClientIdParams();

--- a/src/features/instance/status/routes.ts
+++ b/src/features/instance/status/routes.ts
@@ -1,5 +1,5 @@
 import { createInstanceLayoutRoute } from '@/features/instance/instanceLayoutRoute';
-import { STATUS_SEARCH_DEFAULTS, validateStatusSearch } from '@/features/instance/status/statusSearch.ts';
+import { STATUS_SEARCH_DEFAULTS, validateStatusSearch } from '@/features/instance/status/statusSearch';
 import { createRoute, lazyRouteComponent, stripSearchParams } from '@tanstack/react-router';
 
 export function createStatusRouteTree(instanceLayoutRoute: ReturnType<typeof createInstanceLayoutRoute>) {

--- a/src/features/instance/status/statusSearch.test.ts
+++ b/src/features/instance/status/statusSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { STATUS_SEARCH_DEFAULTS, validateStatusSearch } from './statusSearch.ts';
+import { STATUS_SEARCH_DEFAULTS, validateStatusSearch } from './statusSearch';
 
 describe('validateStatusSearch', () => {
 	it('passes through valid values', () => {

--- a/src/features/instance/status/statusSearch.ts
+++ b/src/features/instance/status/statusSearch.ts
@@ -4,7 +4,7 @@ import {
 	REFRESH_OPTIONS,
 	TIME_PRESETS,
 	type TimePresetId,
-} from './analytics/context/timePresets.ts';
+} from './analytics/context/timePresets';
 
 /** Search-param schema for the instance Status route (`?tab&range&refresh`).
  *  Lives outside analytics/ so the route definition can validate search

--- a/src/integrations/api/instance/status/getAnalytics.ts
+++ b/src/integrations/api/instance/status/getAnalytics.ts
@@ -1,5 +1,5 @@
-import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig.ts';
-import type { AnalyticsDataPoint } from '@/features/instance/status/analytics/types/analytics.ts';
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import type { AnalyticsDataPoint } from '@/features/instance/status/analytics/types/analytics';
 import { queryOptions } from '@tanstack/react-query';
 
 // Analytics query feeding the spec-driven pipeline. Returns rows verbatim

--- a/src/lib/humanFileSize.ts
+++ b/src/lib/humanFileSize.ts
@@ -1,4 +1,4 @@
-import { determineUnits, scaleValueToUnits } from '@/lib/units.ts';
+import { determineUnits, scaleValueToUnits } from '@/lib/units';
 
 export function humanFileSize(input: number, multiplierFromBytes: number = 1) {
 	const initialValue = input * multiplierFromBytes;

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,4 +1,4 @@
-import { determineUnits, scaleValueToUnits } from '@/lib/units.ts';
+import { determineUnits, scaleValueToUnits } from '@/lib/units';
 import { describe, expect, it } from 'vitest';
 
 describe('determineUnits', () => {


### PR DESCRIPTION
Fixes [#1452 — Status feature file conventions: extensionless imports, .ts for JSX-free modules, test colocation](https://github.com/HarperFast/studio/issues/1452). Run solo by design — it touches 154 files, almost all mechanically.

**Mechanical (safe to skim):**
- 411 extensionful imports → extensionless, repo-wide (the status feature was the only holdout; tsc-verified, zero remain)
- 18 JSX-free `.tsx` modules → `.ts` (factory re-export shims + derived recompute modules); `request-rate` stays `.tsx` — it renders JSX
- Registry comments: `response_200` is the wire-name exception to kebab-case; `connections` (session counts) vs `connection` (per-path success ratios) disambiguated

**Substantive (please review these):**
- The deprecated no-op `theme` prop chain is removed end to end: `SpecRegistryRendererProps.theme`, MetricRenderer's pass-through, the pipeline renderers' local props, `AnalyticsContext.theme` + the `AnalyticsTheme` type, StatusTabs/ConnectionsPanel/StorageTab, and the TableSize charts. `HeatmapMatrix` keeps `useResolvedTheme` internally (its color ramp genuinely branches on theme).
- `replication-latency`'s three theme-conditional banner backgrounds now use `color-mix` over CSS tokens — Gemini's review rated the dark-mode results a semantic improvement (warning/accent-tinted surfaces instead of neutral gray blocks); light mode is visually equivalent to the old hex values.
- `FallbackRenderer`'s vestigial `window`/`nodes` props are gone from both sides (the deferred crumb from the batch-four split).

**Decision recorded:** colocated `*.test.tsx` is the going-forward test convention; the existing `__tests__` tree stays put — moving ~70 passing test files is churn without value.

Cross-model reviews: Codex clean; Gemini clean with one trivial finding (orphaned doc blocks) fixed pre-commit and independently verified the color-mix values for both themes.

Generated by kAIle (Claude Fable 5).
