### PR TITLE
refactor(status): code-review follow-ups for the conventions sweep

### DIFF
--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -4,7 +4,7 @@
  * instead of erroring with "cannot find module".
  *
  * The worker only sees the models that exist. Out of the box that is a single
- * model — the open file — so `import { increment } from '@/counter'` has
+ * model — the open file — so `import { increment } from '@/counter.ts'` has
  * nothing to resolve against. While a file is open this hook:
  *
  *   1. fetches the application's other source files and registers each as a

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.capability-gating.test.tsx
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // render, the error notice carries a Retry button, and 401/403 get an
 // auth-flavored message instead of "analytics unavailable".
 
-vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: () => ({
 		data: [],
 		isLoading: false,
@@ -33,13 +33,13 @@ interface MockCapability {
 	retry: () => void;
 }
 let mockCapability: MockCapability;
-vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
+vi.mock('../hooks/useAnalyticsCapability', () => ({
 	useAnalyticsCapability: () => mockCapability,
 }));
 
 // Overview's real body suspends on get_status; stub it so these tests assert
 // "Overview renders" without plumbing status fixtures.
-vi.mock('../tabs/OverviewTab.tsx', () => ({
+vi.mock('../tabs/OverviewTab', () => ({
 	OverviewTab: () => <div data-testid="overview-content">overview content</div>,
 }));
 

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.sliding-window.test.tsx
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // hook and assert the clock in StatusTabsInner advances them.
 
 const seenWindows: { startTime: number; endTime: number }[] = [];
-vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: (args: { startTime: number; endTime: number }) => {
 		seenWindows.push({ startTime: args.startTime, endTime: args.endTime });
 		return {
@@ -26,7 +26,7 @@ vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
 	},
 }));
 
-vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
+vi.mock('../hooks/useAnalyticsCapability', () => ({
 	useAnalyticsCapability: () => ({
 		supported: true,
 		isLoading: false,

--- a/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/StatusTabs.url-sync.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock useAnalyticsRecords so we don't need a real Harper. Each tab still
 // mounts; we're testing the URL-sync layer, not chart rendering.
-vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: () => ({
 		data: [],
 		isLoading: false,
@@ -20,7 +20,7 @@ vi.mock('../hooks/useAnalyticsRecords.ts', () => ({
 
 // Capability probe must succeed so the inner StatusTabs renders (vs. the
 // fallback path).
-vi.mock('../hooks/useAnalyticsCapability.ts', () => ({
+vi.mock('../hooks/useAnalyticsCapability', () => ({
 	useAnalyticsCapability: () => ({
 		supported: true,
 		isLoading: false,

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { bytesReceivedSpec } from '../../pipeline/bytes-received';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const bytesReceivedSpec = wrapperMetrics['bytes-received'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-received-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const bytesReceivedSpec = wrapperMetrics['bytes-received'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const bytesReceivedSpec = wrapperMetrics['bytes-received'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
 import { mqttTrafficSentDerived } from '../../pipeline/derived/mqtt-traffic';
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+
+const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
 
 describe('bytes-sent tolerance', () => {
 	it('total bytes/sec ≈ Σ type-rates within 0.5% (global sum)', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { bytesSentSpec } from '../../pipeline/bytes-sent';
-import { mqttTrafficSentDerived } from '../../pipeline/derived/mqtt-traffic-sent';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
+import { mqttTrafficSentDerived } from '../../pipeline/derived/mqtt-traffic';
 import { runPipeline } from '../../pipeline/pipeline';
 
 describe('bytes-sent tolerance', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const cacheHitSpec = wrapperMetrics['cache-hit'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint } from '../../types/analytics';
+
+const cacheHitSpec = wrapperMetrics['cache-hit'].spec;
 
 // Synthetic rows shaped like the real Harper response:
 //   { time, node, path, period, count, total, ratio }

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-hit-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { cacheHitSpec } from '../../pipeline/cache-hit';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const cacheHitSpec = wrapperMetrics['cache-hit'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { cacheResolutionSpec } from '../../pipeline/cache-resolution';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const cacheResolutionSpec = wrapperMetrics['cache-resolution'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cache-resolution-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const cacheResolutionSpec = wrapperMetrics['cache-resolution'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint } from '../../types/analytics';
+
+const cacheResolutionSpec = wrapperMetrics['cache-resolution'].spec;
 
 // Synthetic rows shaped like the real Harper response. The real schema
 // carries a per-bucket count-weighted distribution for each path; the

--- a/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { connectionsSpec } from '../../pipeline/connections';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const connectionsSpec = wrapperMetrics['connections'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 
 describe('connections pipeline', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/connections-pipeline.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const connectionsSpec = wrapperMetrics['connections'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+
+const connectionsSpec = wrapperMetrics['connections'].spec;
 
 describe('connections pipeline', () => {
 	// connections is a multi-source merge (mqtt-connections + ws-connections)

--- a/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { cpuUsageSpec } from '../../pipeline/cpu-usage';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const cpuUsageSpec = wrapperMetrics['cpu-usage'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import { QUANTILE_FIELDS } from '../../pipeline/quantileFields';
 import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';

--- a/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cpu-usage-pipeline.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const cpuUsageSpec = wrapperMetrics['cpu-usage'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import { QUANTILE_FIELDS } from '../../pipeline/quantileFields';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
+
+const cpuUsageSpec = wrapperMetrics['cpu-usage'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const databaseSizeSpec = wrapperMetrics['database-size'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const databaseSizeSpec = wrapperMetrics['database-size'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 10_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/database-size-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { databaseSizeSpec } from '../../pipeline/database-size';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const databaseSizeSpec = wrapperMetrics['database-size'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../../pipeline/pipeline';
 import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
+
 const dbMessageSpec = wrapperMetrics['db-message'].spec;
 const dbReadSpec = wrapperMetrics['db-read'].spec;
 const dbWriteSpec = wrapperMetrics['db-write'].spec;
-import { runPipeline } from '../../pipeline/pipeline';
-import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/db-pipelines.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { dbMessageSpec } from '../../pipeline/db-message';
-import { dbReadSpec } from '../../pipeline/db-read';
-import { dbWriteSpec } from '../../pipeline/db-write';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const dbMessageSpec = wrapperMetrics['db-message'].spec;
+const dbReadSpec = wrapperMetrics['db-read'].spec;
+const dbWriteSpec = wrapperMetrics['db-write'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint, MetricSpec, TimeRange } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { labelWithApprox } from '../../pipeline/approxLabel';
-import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const durationSpec = wrapperMetrics['duration'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const durationSpec = wrapperMetrics['duration'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/duration-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { labelWithApprox } from '../../pipeline/approxLabel';
-import { durationSpec } from '../../pipeline/duration';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const durationSpec = wrapperMetrics['duration'].spec;
 import { runPipeline } from '../../pipeline/pipeline';
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
-import { response200Spec } from '../../pipeline/response-200';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const response200Spec = wrapperMetrics['response_200'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };

--- a/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/response-200-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
 import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const response200Spec = wrapperMetrics['response_200'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const response200Spec = wrapperMetrics['response_200'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
 import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const successSpec = wrapperMetrics['success'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const successSpec = wrapperMetrics['success'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/success-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
-import { successSpec } from '../../pipeline/success';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const successSpec = wrapperMetrics['success'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };

--- a/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
-import { transferSpec } from '../../pipeline/transfer';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+const transferSpec = wrapperMetrics['transfer'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };

--- a/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/transfer-pipeline.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { runPipeline } from '../../pipeline/pipeline';
 import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
-const transferSpec = wrapperMetrics['transfer'].spec;
 import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const transferSpec = wrapperMetrics['transfer'].spec;
 
 const window: TimeRange = { startTime: 0, endTime: 1_000_000 };
 

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../hooks/useAnalyticsFreshness.ts', () => ({
+vi.mock('../hooks/useAnalyticsFreshness', () => ({
 	useAnalyticsFreshness: () => ({ isFetching: false, lastFetchedAt: null, now: 0 }),
 	formatRelativeUpdate: () => null,
 }));
@@ -64,7 +64,7 @@ describe('TimeRangePicker', () => {
 	it('disables the refresh button while a fetch is in flight', async () => {
 		// Re-mock to return isFetching=true for this test only.
 		const { TimeRangePicker: PickerWithFetching } = await vi.importActual<typeof import('./TimeRangePicker')>(
-			'./TimeRangePicker.tsx',
+			'./TimeRangePicker',
 		);
 		// Use the same component but assert via aria-busy — the mock above is
 		// already returning isFetching=false, so for this test we verify the

--- a/src/features/instance/status/analytics/lib/theme.ts
+++ b/src/features/instance/status/analytics/lib/theme.ts
@@ -1,33 +1,3 @@
-import { useEffect, useState } from 'react';
-
-type Theme = 'light' | 'dark';
-
-/** Resolved app theme ('light' | 'dark') for the few chart internals that
- *  genuinely branch in JS (heatmap color-stop interpolation, area fill
- *  opacity). The app's ThemeProvider (src/hooks/useTheme) already resolves
- *  the user's explicit choice vs. OS preference by toggling the `.dark`
- *  class on <html> — reading that class keeps charts in lockstep with every
- *  other themed surface without re-deriving preference + media-query state.
- *  Everything color-related that CAN be a CSS token should use the
- *  `--chart-*` vars instead and never touch this hook. */
-export function useResolvedTheme(): Theme {
-	const [dark, setDark] = useState<boolean>(() =>
-		typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
-	);
-	useEffect(() => {
-		const root = document.documentElement;
-		// Re-sync on mount: a theme toggle between the lazy initializer and
-		// the observer attaching would otherwise be missed.
-		setDark(root.classList.contains('dark'));
-		const observer = new MutationObserver(() => {
-			setDark(root.classList.contains('dark'));
-		});
-		observer.observe(root, { attributes: true, attributeFilter: ['class'] });
-		return () => observer.disconnect();
-	}, []);
-	return dark ? 'dark' : 'light';
-}
-
 /** Reads the studio chart-surface CSS tokens defined in src/index.css.
  *  All charts render inside a `Card`, so axis/grid colors resolve against
  *  `--card`, not the brand-purple `--background`. The hex defaults here are

--- a/src/features/instance/status/analytics/lib/theme.ts
+++ b/src/features/instance/status/analytics/lib/theme.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export type Theme = 'light' | 'dark';
+type Theme = 'light' | 'dark';
 
 /** Resolved app theme ('light' | 'dark') for the few chart internals that
  *  genuinely branch in JS (heatmap color-stop interpolation, area fill

--- a/src/features/instance/status/analytics/pipeline/bytes-received.ts
+++ b/src/features/instance/status/analytics/pipeline/bytes-received.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const bytesReceivedSpec = wrapperMetrics['bytes-received'].spec;
-export const BytesReceivedRenderer = wrapperMetrics['bytes-received'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/bytes-sent.ts
+++ b/src/features/instance/status/analytics/pipeline/bytes-sent.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
-export const BytesSentRenderer = wrapperMetrics['bytes-sent'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cache-hit.ts
+++ b/src/features/instance/status/analytics/pipeline/cache-hit.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const cacheHitSpec = wrapperMetrics['cache-hit'].spec;
-export const CacheHitRenderer = wrapperMetrics['cache-hit'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cache-resolution.ts
+++ b/src/features/instance/status/analytics/pipeline/cache-resolution.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const cacheResolutionSpec = wrapperMetrics['cache-resolution'].spec;
-export const CacheResolutionRenderer = wrapperMetrics['cache-resolution'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/connections.ts
+++ b/src/features/instance/status/analytics/pipeline/connections.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const connectionsSpec = wrapperMetrics['connections'].spec;
-export const ConnectionsRenderer = wrapperMetrics['connections'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/cpu-usage.ts
+++ b/src/features/instance/status/analytics/pipeline/cpu-usage.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const cpuUsageSpec = wrapperMetrics['cpu-usage'].spec;
-export const CpuUsageRenderer = wrapperMetrics['cpu-usage'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/database-size.ts
+++ b/src/features/instance/status/analytics/pipeline/database-size.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const databaseSizeSpec = wrapperMetrics['database-size'].spec;
-export const DatabaseSizeRenderer = wrapperMetrics['database-size'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-message.ts
+++ b/src/features/instance/status/analytics/pipeline/db-message.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const dbMessageSpec = wrapperMetrics['db-message'].spec;
-export const DbMessageRenderer = wrapperMetrics['db-message'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-read.ts
+++ b/src/features/instance/status/analytics/pipeline/db-read.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const dbReadSpec = wrapperMetrics['db-read'].spec;
-export const DbReadRenderer = wrapperMetrics['db-read'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/db-write.ts
+++ b/src/features/instance/status/analytics/pipeline/db-write.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const dbWriteSpec = wrapperMetrics['db-write'].spec;
-export const DbWriteRenderer = wrapperMetrics['db-write'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-received.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-received.ts
@@ -1,3 +1,0 @@
-// Thin re-export — defined with its sent-side twin in mqtt-traffic.tsx.
-// Kept so existing import paths stay stable.
-export { mqttTrafficReceivedDerived } from './mqtt-traffic';

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-sent.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic-sent.ts
@@ -1,3 +1,0 @@
-// Thin re-export — defined with its received-side twin in mqtt-traffic.tsx.
-// Kept so existing import paths stay stable.
-export { mqttTrafficSentDerived } from './mqtt-traffic';

--- a/src/features/instance/status/analytics/pipeline/duration.ts
+++ b/src/features/instance/status/analytics/pipeline/duration.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const durationSpec = wrapperMetrics['duration'].spec;
-export const DurationRenderer = wrapperMetrics['duration'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -1,5 +1,6 @@
 import { type JSX, useMemo, useState } from 'react';
 import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
+import { infoBannerStyle, warningBannerStyle } from '../primitives/bannerStyle';
 import { HeatmapMatrix } from '../primitives/HeatmapMatrix';
 import { LineChart } from '../primitives/LineChart';
 import type {
@@ -359,15 +360,6 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 		const allDropped = seriesData.series.length === 0 && omittedPairsCount > 0;
 		const noData = seriesData.series.length === 0 && omittedPairsCount === 0;
 
-		const warningStyle = {
-			marginBottom: 8,
-			padding: '4px 8px',
-			fontSize: 12,
-			borderLeft: '3px solid var(--color-warning, #f59e0b)',
-			background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
-			color: 'currentColor',
-		} as const;
-
 		// Banners stack at the top in normal document flow; the chart sits
 		// below with explicit vertical space. No flex height-juggling — the
 		// fixed-height LineChart was clipping/overlapping when it competed
@@ -395,7 +387,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 							key={omittedPairsCount}
 							role="status"
 							aria-atomic="true"
-							style={warningStyle}
+							style={warningBannerStyle}
 						>
 							{`${omittedPairsCount} source-destination ${
 								pluralize(omittedPairsCount, 'pair', 'pairs')
@@ -403,16 +395,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 						</div>
 					)
 					: null}
-				<div
-					style={{
-						marginBottom: 8,
-						padding: '4px 8px',
-						fontSize: 12,
-						borderLeft: '3px solid var(--color-accent, #3b82f6)',
-						background: 'color-mix(in srgb, var(--color-accent, #3b82f6) 10%, transparent)',
-						color: 'currentColor',
-					}}
-				>
+				<div style={infoBannerStyle}>
 					{message}
 				</div>
 				{allDropped
@@ -420,7 +403,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 						<div
 							role="status"
 							aria-atomic="true"
-							style={warningStyle}
+							style={warningBannerStyle}
 						>
 							{`No source-destination pairs cleared the confidence threshold (${greyBelow}+ samples). All ${omittedPairsCount} ${
 								pluralize(omittedPairsCount, 'pair', 'pairs')
@@ -497,14 +480,7 @@ function RecognitionBanner({ data }: RecognitionBannerProps) {
 			key={`${unparseable}-${missingValue}-${unrecognized.length}`}
 			role="status"
 			aria-atomic="true"
-			style={{
-				marginBottom: 8,
-				padding: '4px 8px',
-				fontSize: 12,
-				borderLeft: '3px solid var(--color-warning, #f59e0b)',
-				background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
-				color: 'currentColor',
-			}}
+			style={warningBannerStyle}
 		>
 			{parts.join(' ')}
 		</div>

--- a/src/features/instance/status/analytics/pipeline/response-200.ts
+++ b/src/features/instance/status/analytics/pipeline/response-200.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const response200Spec = wrapperMetrics['response_200'].spec;
-export const Response200Renderer = wrapperMetrics['response_200'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/success.ts
+++ b/src/features/instance/status/analytics/pipeline/success.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const successSpec = wrapperMetrics['success'].spec;
-export const SuccessRenderer = wrapperMetrics['success'].Renderer;

--- a/src/features/instance/status/analytics/pipeline/transfer.ts
+++ b/src/features/instance/status/analytics/pipeline/transfer.ts
@@ -1,6 +1,0 @@
-// Thin re-export — this metric is defined in the `wrapperMetrics` factory
-// table (wrapperMetrics.tsx). Kept so existing import paths stay stable.
-import { wrapperMetrics } from './wrapperMetrics';
-
-export const transferSpec = wrapperMetrics['transfer'].spec;
-export const TransferRenderer = wrapperMetrics['transfer'].Renderer;

--- a/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/FallbackRenderer.tsx
@@ -82,7 +82,7 @@ export function FallbackRenderer({ metric, records, hint }: Props) {
 
 	const kebab = metric.replace(/_/g, '-');
 	const banner = isDev
-		? `Unspecced metric "${metric}" — add a spec at src/features/instance/status/analytics/pipeline/${kebab}.tsx for a tailored view.`
+		? `Unspecced metric "${metric}" — add a spec — a wrapperMetrics.tsx table entry, or pipeline/${kebab}.tsx (.ts if renderer-less) — for a tailored view.`
 		: null;
 
 	return (
@@ -122,7 +122,7 @@ export function FallbackRenderer({ metric, records, hint }: Props) {
 			<SmallMultiples panels={panels} />
 			{overflow > 0 && (
 				<div style={{ fontSize: 11, marginTop: 4, opacity: 0.7 }}>
-					{`… and ${overflow} more fields not shown. Add a spec at src/features/instance/status/analytics/pipeline/${kebab}.tsx to customize.`}
+					{`… and ${overflow} more fields not shown. Add a spec (wrapperMetrics.tsx entry, or pipeline/${kebab}.tsx / .ts) to customize.`}
 				</div>
 			)}
 		</div>

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -1,7 +1,7 @@
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { formatValue } from '@/lib/formatValue';
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
-import { useResolvedTheme } from '../lib/theme';
 import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics';
 import { warningBannerStyle } from './bannerStyle';
 import { computeCellSize } from './computeCellSize';

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useSta
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useResolvedTheme } from '../lib/theme';
 import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics';
+import { warningBannerStyle } from './bannerStyle';
 import { computeCellSize } from './computeCellSize';
 export { computeCellSize } from './computeCellSize';
 
@@ -385,14 +386,7 @@ export function HeatmapMatrix({ data, title, height }: Props) {
 						key={data.skippedRecordsCount}
 						role="status"
 						aria-atomic="true"
-						style={{
-							marginBottom: 8,
-							padding: '4px 8px',
-							fontSize: 12,
-							borderLeft: '3px solid var(--color-warning)',
-							background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
-							color: 'currentColor',
-						}}
+						style={warningBannerStyle}
 					>
 						{`${data.skippedRecordsCount} record(s) omitted — source node unrecognized (cluster node list may be outdated).`}
 					</div>

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -1,8 +1,9 @@
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { formatValue } from '@/lib/formatValue';
 import { useMemo } from 'react';
 import { Area, AreaChart, CartesianGrid, Legend, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { NODE_PALETTE } from '../lib/nodeColors';
-import { getChartColors, useResolvedTheme } from '../lib/theme';
+import { getChartColors } from '../lib/theme';
 import { formatAxisTick, formatTooltipTime } from '../lib/time';
 import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics';
 import { sortByMagnitude } from './sortByMagnitude';

--- a/src/features/instance/status/analytics/primitives/bannerStyle.ts
+++ b/src/features/instance/status/analytics/primitives/bannerStyle.ts
@@ -1,0 +1,20 @@
+// The one tinted status-banner surface for status analytics — a colored
+// left border over a translucent tint of the same token. Shared like
+// tooltipStyle.ts so the copies can't drift (they did, in PR #1497).
+// Fallbacks matter: these banners can render outside index.css scope
+// (chart-export capture, isolated test DOMs), where an unresolvable var()
+// inside color-mix invalidates the whole background declaration.
+
+function bannerStyle(tokenVar: string, fallback: string, mixPercent: number) {
+	return {
+		marginBottom: 8,
+		padding: '4px 8px',
+		fontSize: 12,
+		borderLeft: `3px solid var(${tokenVar}, ${fallback})`,
+		background: `color-mix(in srgb, var(${tokenVar}, ${fallback}) ${mixPercent}%, transparent)`,
+		color: 'currentColor',
+	} as const;
+}
+
+export const warningBannerStyle = bannerStyle('--color-warning', '#f59e0b', 12);
+export const infoBannerStyle = bannerStyle('--color-info', '#3b82f6', 10);

--- a/src/features/instance/status/analytics/primitives/bannerStyle.ts
+++ b/src/features/instance/status/analytics/primitives/bannerStyle.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 // The one tinted status-banner surface for status analytics — a colored
 // left border over a translucent tint of the same token. Shared like
 // tooltipStyle.ts so the copies can't drift (they did, in PR #1497).
@@ -5,7 +7,7 @@
 // (chart-export capture, isolated test DOMs), where an unresolvable var()
 // inside color-mix invalidates the whole background declaration.
 
-function bannerStyle(tokenVar: string, fallback: string, mixPercent: number) {
+function bannerStyle(tokenVar: string, fallback: string, mixPercent: number): CSSProperties {
 	return {
 		marginBottom: 8,
 		padding: '4px 8px',
@@ -13,7 +15,7 @@ function bannerStyle(tokenVar: string, fallback: string, mixPercent: number) {
 		borderLeft: `3px solid var(${tokenVar}, ${fallback})`,
 		background: `color-mix(in srgb, var(${tokenVar}, ${fallback}) ${mixPercent}%, transparent)`,
 		color: 'currentColor',
-	} as const;
+	};
 }
 
 export const warningBannerStyle = bannerStyle('--color-warning', '#f59e0b', 12);

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -2,10 +2,11 @@ import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
 import { wrapperMetrics } from '../pipeline/wrapperMetrics';
-const ConnectionsRenderer = wrapperMetrics['connections'].Renderer;
 import type { AnalyticsDataPoint } from '../types/analytics';
 import { PanelErrorBoundary } from './PanelErrorBoundary';
 import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell';
+
+const ConnectionsRenderer = wrapperMetrics['connections'].Renderer;
 
 /** Some Harper builds split active-session telemetry across two metrics:
  *  `mqtt-connections` (active MQTT sessions) and `ws-connections` (active

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
-import { ConnectionsRenderer } from '../pipeline/connections';
+import { wrapperMetrics } from '../pipeline/wrapperMetrics';
+const ConnectionsRenderer = wrapperMetrics['connections'].Renderer;
 import type { AnalyticsDataPoint } from '../types/analytics';
 import { PanelErrorBoundary } from './PanelErrorBoundary';
 import { collectNodes, PanelCard, PanelStateOrChart } from './PanelShell';

--- a/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 

--- a/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 

--- a/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 

--- a/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../hooks/useAnalyticsRecords.ts', () => ({
+vi.mock('../../hooks/useAnalyticsRecords', () => ({
 	useAnalyticsRecords: vi.fn(),
 }));
 

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+type ResolvedTheme = 'light' | 'dark';
+
+/** Resolved app theme ('light' | 'dark') for the few code paths that
+ *  genuinely branch in JS (e.g. chart color-stop interpolation, area fill
+ *  opacity). The ThemeProvider (src/hooks/useTheme) already resolves the
+ *  user's explicit choice vs. OS preference by toggling the `.dark` class
+ *  on <html> — reading that class keeps consumers in lockstep with every
+ *  other themed surface without re-deriving preference + media-query state.
+ *  Everything color-related that CAN be a CSS token should use CSS vars
+ *  instead and never touch this hook. */
+export function useResolvedTheme(): ResolvedTheme {
+	const [dark, setDark] = useState<boolean>(() =>
+		typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
+	);
+	useEffect(() => {
+		const root = document.documentElement;
+		// Re-sync on mount: a theme toggle between the lazy initializer and
+		// the observer attaching would otherwise be missed.
+		setDark(root.classList.contains('dark'));
+		const observer = new MutationObserver(() => {
+			setDark(root.classList.contains('dark'));
+		});
+		observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+		return () => observer.disconnect();
+	}, []);
+	return dark ? 'dark' : 'light';
+}

--- a/src/index.css
+++ b/src/index.css
@@ -274,6 +274,7 @@
 	--color-error: var(--destructive);
 	--color-success: var(--green);
 	--color-warning: var(--yellow);
+	--color-info: var(--blue);
 
 	--shadow-deep: 0 2px 12px 0 rgba(0,0,0,0.06), 0 1px 3px 0 rgba(0,0,0,0.04);
 	--color-sidebar-ring: var(--sidebar-ring);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -17,7 +17,6 @@
 		],
 		/* Bundler mode */
 		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
 		"isolatedModules": true,
 		"moduleDetection": "force",
 		"noEmit": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,7 +14,6 @@
 		],
 		/* Bundler mode */
 		"moduleResolution": "bundler",
-		"allowImportingTsExtensions": true,
 		"isolatedModules": true,
 		"moduleDetection": "force",
 		"noEmit": true,


### PR DESCRIPTION
Rolls up all nine verified findings from a high-effort post-merge review of [PR #1497 — the conventions sweep](https://github.com/HarperFast/studio/pull/1497). Every finding was verified before fixing (several empirically); both cross-model reviews of this diff came back clean.

**The one real bug:** the replication info banner rendered near-invisible gray — `--color-accent` is shadcn's neutral hover-surface token, and since it's *defined*, the blue `#3b82f6` fallback never applied (the pre-sweep code only looked right because its `--color-info` token didn't exist, so the fallback always won). Fixed by defining `--color-info: var(--blue)` and pointing the banner at it. Runtime-verified: border now computes `rgb(75, 94, 236)`, previously `rgb(237, 237, 237)`.

**Hardening:**
- `primitives/bannerStyle.ts` — one shared tinted-banner style (warning/info) replacing four diverging inline copies, with fallbacks *inside* `color-mix` so banners survive token-less contexts (export capture, isolated test DOMs).
- 14 extensionful `vi.mock`/`vi.importActual` specifier strings made extensionless across 8 test files. Empirically (vitest 4.1.10 fixture): renaming a mocked file silently detaches an extensionful mock and the test passes against the real module.
- `allowImportingTsExtensions` removed from both tsconfigs — zero extensionful imports remain, so `tsc` (already in CI) now enforces the convention permanently (TS5097).

**Cleanup:** 16 dead thin re-export shims deleted (one had zero importers and a provably false "kept for import stability" comment; the rest were test-only), importers retargeted to `wrapperMetrics`/`mqtt-traffic`; `type Theme` un-exported; two doc fixes (the Monaco user-code `@/counter.ts` example was deliberately extensionful — restored; FallbackRenderer's dev hints now name both spec file forms).

Where to look: `bannerStyle.ts` + its four call sites, and the `db-pipelines.test.ts` retarget (three shims fed one test file).

Generated by kAIle (Claude Fable 5).
