### PR TITLE
fix(applications): bound type-acquisition extra libs so the Monaco worker can't OOM (#1499)

### DIFF
--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -16,6 +16,7 @@
  * blocked CDN, unknown package — is swallowed so it can never break editing.
  */
 import { typescript } from '@/lib/monaco/languageServices';
+import { canAdmitExtraLib } from '@/lib/monaco/workerLimits';
 
 /** node builtins are not on npm; their types come from `@types/node` (not acquired here). */
 const NODE_BUILTINS = new Set([
@@ -107,6 +108,14 @@ function createImportScannerShim(): unknown {
 
 let runnerPromise: Promise<(source: string) => Promise<void>> | undefined;
 const acquiredPaths = new Set<string>();
+/**
+ * Running total of chars handed to the worker as extra libs. Session-lifetime
+ * and monotonic — it mirrors the extra libs actually live on the shared
+ * `typescriptDefaults`/`javascriptDefaults` singletons, which are never removed
+ * — so once the budget is spent it stays spent, which is exactly the backstop
+ * against unbounded cross-project accumulation (HarperFast/studio#1499).
+ */
+let acquiredChars = 0;
 
 function getRunner(): Promise<(source: string) => Promise<void>> {
 	if (!runnerPromise) {
@@ -120,7 +129,17 @@ function getRunner(): Promise<(source: string) => Promise<void>> {
 						if (acquiredPaths.has(path)) {
 							return;
 						}
+						// Mark it seen even when rejected, so a skipped lib isn't
+						// reconsidered on every subsequent acquisition pass.
 						acquiredPaths.add(path);
+						// Extra libs are eagerly cloned to the language worker
+						// (setEagerModelSync) and never swept; bound the total so a
+						// large or deep dependency graph — or a long multi-project
+						// session — can't OOM the worker's clone buffer (#1499).
+						if (!canAdmitExtraLib(acquiredChars, code.length)) {
+							return;
+						}
+						acquiredChars += code.length;
 						const uri = `file://${path}`;
 						typescriptDefaults.addExtraLib(code, uri);
 						javascriptDefaults.addExtraLib(code, uri);

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -16,7 +16,7 @@
  * blocked CDN, unknown package — is swallowed so it can never break editing.
  */
 import { typescript } from '@/lib/monaco/languageServices';
-import { canAdmitExtraLib, MAX_EXTRA_LIB_CHARS_TOTAL } from '@/lib/monaco/workerLimits';
+import { ExtraLibBudget } from '@/lib/monaco/workerLimits';
 
 /** node builtins are not on npm; their types come from `@types/node` (not acquired here). */
 const NODE_BUILTINS = new Set([
@@ -109,13 +109,11 @@ function createImportScannerShim(): unknown {
 let runnerPromise: Promise<(source: string) => Promise<void>> | undefined;
 const acquiredPaths = new Set<string>();
 /**
- * Running total of chars handed to the worker as extra libs. Session-lifetime
- * and monotonic — it mirrors the extra libs actually live on the shared
- * `typescriptDefaults`/`javascriptDefaults` singletons, which are never removed
- * — so once the budget is spent it stays spent, which is exactly the backstop
- * against unbounded cross-project accumulation (HarperFast/studio#1499).
+ * Bounds the chars handed to the worker as extra libs. Session-lifetime and
+ * never reclaimed — the backstop against unbounded cross-project accumulation
+ * that would otherwise OOM the language worker (HarperFast/studio#1499).
  */
-let acquiredChars = 0;
+const extraLibBudget = new ExtraLibBudget();
 
 function getRunner(): Promise<(source: string) => Promise<void>> {
 	if (!runnerPromise) {
@@ -136,10 +134,21 @@ function getRunner(): Promise<(source: string) => Promise<void>> {
 						// (setEagerModelSync) and never swept; bound the total so a
 						// large or deep dependency graph — or a long multi-project
 						// session — can't OOM the worker's clone buffer (#1499).
-						if (!canAdmitExtraLib(acquiredChars, code.length)) {
+						const { admitted, justExhausted, oversize } = extraLibBudget.admit(code.length);
+						if (!admitted) {
+							// Leave a breadcrumb: without one, a user whose IntelliSense
+							// quietly stops resolving a package has no signal why.
+							if (justExhausted) {
+								console.warn(
+									'[harper] type acquisition: extra-lib budget exhausted; further packages will report "cannot find module" in this tab',
+								);
+							} else if (oversize) {
+								console.debug(
+									`[harper] type acquisition: skipped oversized declaration ${path} (${code.length} chars)`,
+								);
+							}
 							return;
 						}
-						acquiredChars += code.length;
 						const uri = `file://${path}`;
 						typescriptDefaults.addExtraLib(code, uri);
 						javascriptDefaults.addExtraLib(code, uri);
@@ -159,11 +168,11 @@ export async function acquireApplicationTypes(sources: string[]): Promise<void> 
 	if (sources.length === 0) {
 		return;
 	}
-	// The budget is monotonic and never reclaimed, so once it is spent the
+	// Once the aggregate budget is spent it is never reclaimed, so the
 	// acquisition engine would walk the CDN and parse declarations only for
 	// `receivedFile` to discard every one. Skip the whole pass — including its
 	// network requests — rather than pay for work that can't land.
-	if (acquiredChars >= MAX_EXTRA_LIB_CHARS_TOTAL) {
+	if (extraLibBudget.isSpent) {
 		return;
 	}
 	try {

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -16,7 +16,7 @@
  * blocked CDN, unknown package — is swallowed so it can never break editing.
  */
 import { typescript } from '@/lib/monaco/languageServices';
-import { canAdmitExtraLib } from '@/lib/monaco/workerLimits';
+import { canAdmitExtraLib, MAX_EXTRA_LIB_CHARS_TOTAL } from '@/lib/monaco/workerLimits';
 
 /** node builtins are not on npm; their types come from `@types/node` (not acquired here). */
 const NODE_BUILTINS = new Set([
@@ -157,6 +157,13 @@ function getRunner(): Promise<(source: string) => Promise<void>> {
  */
 export async function acquireApplicationTypes(sources: string[]): Promise<void> {
 	if (sources.length === 0) {
+		return;
+	}
+	// The budget is monotonic and never reclaimed, so once it is spent the
+	// acquisition engine would walk the CDN and parse declarations only for
+	// `receivedFile` to discard every one. Skip the whole pass — including its
+	// network requests — rather than pay for work that can't land.
+	if (acquiredChars >= MAX_EXTRA_LIB_CHARS_TOTAL) {
 		return;
 	}
 	try {

--- a/src/lib/monaco/workerLimits.test.ts
+++ b/src/lib/monaco/workerLimits.test.ts
@@ -1,0 +1,28 @@
+import { canAdmitExtraLib, MAX_EXTRA_LIB_CHARS_TOTAL, MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
+import { describe, expect, it } from 'vitest';
+
+describe('canAdmitExtraLib (HarperFast/studio#1499)', () => {
+	it('admits a normal declaration when the budget is empty', () => {
+		expect(canAdmitExtraLib(0, 10_000)).toBe(true);
+	});
+
+	it('admits a declaration that exactly fills the remaining budget', () => {
+		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL - 100, 100)).toBe(true);
+	});
+
+	it('rejects a single oversized declaration even into an empty budget', () => {
+		// A lib past the per-file worker limit would itself risk the clone crash.
+		expect(canAdmitExtraLib(0, MAX_WORKER_MODEL_CHARS + 1)).toBe(false);
+	});
+
+	it('rejects a declaration that would push the running total past the budget', () => {
+		// The accumulation case: each file is individually fine, but the session
+		// total has reached the cap — the next one must be turned away rather than
+		// cloned to the worker.
+		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL - 50, 51)).toBe(false);
+	});
+
+	it('rejects everything once the budget is already spent', () => {
+		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL, 1)).toBe(false);
+	});
+});

--- a/src/lib/monaco/workerLimits.test.ts
+++ b/src/lib/monaco/workerLimits.test.ts
@@ -1,28 +1,65 @@
-import { canAdmitExtraLib, MAX_EXTRA_LIB_CHARS_TOTAL, MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
+import { ExtraLibBudget, MAX_EXTRA_LIB_CHARS_TOTAL, MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { describe, expect, it } from 'vitest';
 
-describe('canAdmitExtraLib (HarperFast/studio#1499)', () => {
-	it('admits a normal declaration when the budget is empty', () => {
-		expect(canAdmitExtraLib(0, 10_000)).toBe(true);
+/**
+ * Admit declarations up to exactly the aggregate cap, using the largest single
+ * admissible file (`MAX_WORKER_MODEL_CHARS`) so it takes as few calls as
+ * possible. Asserts every one lands and returns the budget at the brink — one
+ * more char will overflow it.
+ */
+function fillToCap(budget: ExtraLibBudget): void {
+	let total = 0;
+	while (total + MAX_WORKER_MODEL_CHARS <= MAX_EXTRA_LIB_CHARS_TOTAL) {
+		expect(budget.admit(MAX_WORKER_MODEL_CHARS).admitted).toBe(true);
+		total += MAX_WORKER_MODEL_CHARS;
+	}
+	const remainder = MAX_EXTRA_LIB_CHARS_TOTAL - total;
+	if (remainder > 0) {
+		expect(budget.admit(remainder).admitted).toBe(true);
+	}
+}
+
+describe('ExtraLibBudget (HarperFast/studio#1499)', () => {
+	it('admits normal declarations and accumulates their size without sealing', () => {
+		const budget = new ExtraLibBudget();
+		expect(budget.admit(10_000)).toEqual({ admitted: true, justExhausted: false, oversize: false });
+		expect(budget.admit(10_000)).toEqual({ admitted: true, justExhausted: false, oversize: false });
+		expect(budget.isSpent).toBe(false);
 	});
 
-	it('admits a declaration that exactly fills the remaining budget', () => {
-		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL - 100, 100)).toBe(true);
+	it('admits declarations up to exactly the aggregate cap without sealing', () => {
+		const budget = new ExtraLibBudget();
+		fillToCap(budget);
+		// The cap is a ceiling that can be reached, not crossed — reaching it exactly
+		// does not spend the budget; only an overflow does.
+		expect(budget.isSpent).toBe(false);
 	});
 
-	it('rejects a single oversized declaration even into an empty budget', () => {
-		// A lib past the per-file worker limit would itself risk the clone crash.
-		expect(canAdmitExtraLib(0, MAX_WORKER_MODEL_CHARS + 1)).toBe(false);
+	it('rejects a single oversized declaration without spending the budget', () => {
+		const budget = new ExtraLibBudget();
+		expect(budget.admit(MAX_WORKER_MODEL_CHARS + 1)).toEqual({
+			admitted: false,
+			justExhausted: false,
+			oversize: true,
+		});
+		expect(budget.isSpent).toBe(false);
+		// A file within the per-file limit still fits — an oversize file is not the aggregate cap.
+		expect(budget.admit(10_000).admitted).toBe(true);
 	});
 
-	it('rejects a declaration that would push the running total past the budget', () => {
-		// The accumulation case: each file is individually fine, but the session
-		// total has reached the cap — the next one must be turned away rather than
-		// cloned to the worker.
-		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL - 50, 51)).toBe(false);
+	it('seals the budget on the first aggregate overflow and flags the transition once', () => {
+		const budget = new ExtraLibBudget();
+		fillToCap(budget);
+		expect(budget.admit(1)).toEqual({ admitted: false, justExhausted: true, oversize: false });
+		expect(budget.isSpent).toBe(true);
 	});
 
-	it('rejects everything once the budget is already spent', () => {
-		expect(canAdmitExtraLib(MAX_EXTRA_LIB_CHARS_TOTAL, 1)).toBe(false);
+	it('rejects everything once sealed — even a declaration that would have fit — without re-flagging', () => {
+		const budget = new ExtraLibBudget();
+		fillToCap(budget);
+		budget.admit(1); // overflows and seals (justExhausted: true)
+		// A tiny file is now turned away and the exhaustion transition is not re-reported.
+		expect(budget.admit(1)).toEqual({ admitted: false, justExhausted: false, oversize: false });
+		expect(budget.isSpent).toBe(true);
 	});
 });

--- a/src/lib/monaco/workerLimits.ts
+++ b/src/lib/monaco/workerLimits.ts
@@ -36,14 +36,66 @@ export const MAX_WORKER_MODEL_CHARS = 512 * 1024;
  */
 export const MAX_EXTRA_LIB_CHARS_TOTAL = 8 * 1024 * 1024;
 
+/** The outcome of offering one acquired declaration to {@link ExtraLibBudget}. */
+export interface ExtraLibAdmission {
+	/** Whether the declaration was admitted (and the running total advanced). */
+	admitted: boolean;
+	/**
+	 * Set only on the single call that first exhausts the aggregate budget, so
+	 * the caller can log the transition once and short-circuit later passes.
+	 */
+	justExhausted: boolean;
+	/**
+	 * Set when the declaration was rejected solely because it exceeds the
+	 * per-file limit — smaller declarations can still be admitted afterward, so
+	 * this does not spend the budget.
+	 */
+	oversize: boolean;
+}
+
 /**
- * Whether an acquired declaration file may be handed to the worker as an extra
- * lib, given the total chars already admitted this session. Rejects a single
- * oversized declaration and anything that would push the running total past the
- * budget. A rejected lib degrades that package to "cannot find module" — the
- * same acceptable degradation `selectFilesWithinModelBudget` chose for skipped
+ * Session-lifetime accounting for the `@types` declarations handed to the
+ * language worker as extra libs (`addExtraLib`). `setEagerModelSync(true)`
+ * clones every extra lib to the worker, the model budget can't see them, and
+ * they are never swept on project switch — so this is the sole bound on their
+ * unbounded, cross-project accumulation (HarperFast/studio#1499).
+ *
+ * Kept free of any Monaco dependency so the accumulation logic is unit-testable
+ * on its own. A rejected declaration degrades its package to "cannot find
+ * module" — the same tradeoff `selectFilesWithinModelBudget` makes for skipped
  * sibling models — which beats crashing the worker for the whole tab.
  */
-export function canAdmitExtraLib(currentTotalChars: number, incomingChars: number): boolean {
-	return incomingChars <= MAX_WORKER_MODEL_CHARS && currentTotalChars + incomingChars <= MAX_EXTRA_LIB_CHARS_TOTAL;
+export class ExtraLibBudget {
+	private totalChars = 0;
+	private spent = false;
+
+	/**
+	 * Whether the aggregate budget is exhausted. Once true it stays true: the
+	 * budget is never reclaimed, so a whole acquisition pass can be skipped
+	 * rather than woken to walk the CDN only for every file to be rejected.
+	 */
+	get isSpent(): boolean {
+		return this.spent;
+	}
+
+	/**
+	 * Offer a declaration of `chars` characters. Admits it (advancing the running
+	 * total) when it fits both the per-file and aggregate limits; otherwise
+	 * reports why it was turned away. The first aggregate overflow seals the
+	 * budget so every later offer is rejected without further arithmetic.
+	 */
+	admit(chars: number): ExtraLibAdmission {
+		if (this.spent) {
+			return { admitted: false, justExhausted: false, oversize: false };
+		}
+		if (chars > MAX_WORKER_MODEL_CHARS) {
+			return { admitted: false, justExhausted: false, oversize: true };
+		}
+		if (this.totalChars + chars > MAX_EXTRA_LIB_CHARS_TOTAL) {
+			this.spent = true;
+			return { admitted: false, justExhausted: true, oversize: false };
+		}
+		this.totalChars += chars;
+		return { admitted: true, justExhausted: false, oversize: false };
+	}
 }

--- a/src/lib/monaco/workerLimits.ts
+++ b/src/lib/monaco/workerLimits.ts
@@ -16,3 +16,34 @@
  * payloads that add nothing to highlighting or IntelliSense.
  */
 export const MAX_WORKER_MODEL_CHARS = 512 * 1024;
+
+/**
+ * Total-character budget for automatically-acquired `@types` declarations
+ * (`addExtraLib`), across the whole session.
+ *
+ * `setEagerModelSync(true)` clones *both* models *and* every extra lib to the
+ * language worker over `postMessage`. The model budget
+ * (`MAX_APPLICATION_MODEL_CHARS_TOTAL`) only sees `file:///` models — extra libs
+ * are invisible to it — and, unlike models, extra libs are never swept when the
+ * open project changes, so Automatic Type Acquisition accumulates them
+ * monotonically across every project opened in a session. Left unbounded, that
+ * volume eventually overflows the clone buffer and crashes the worker with
+ * "DataCloneError: Data cannot be cloned, out of memory." (HarperFast/studio#1499,
+ * a recurrence of #1370 through the extra-lib path the model guards don't cover).
+ *
+ * 8 MB comfortably fits a typical app's real dependency `@types` (react,
+ * react-dom, and friends) while still capping the pathological accumulation.
+ */
+export const MAX_EXTRA_LIB_CHARS_TOTAL = 8 * 1024 * 1024;
+
+/**
+ * Whether an acquired declaration file may be handed to the worker as an extra
+ * lib, given the total chars already admitted this session. Rejects a single
+ * oversized declaration and anything that would push the running total past the
+ * budget. A rejected lib degrades that package to "cannot find module" — the
+ * same acceptable degradation `selectFilesWithinModelBudget` chose for skipped
+ * sibling models — which beats crashing the worker for the whole tab.
+ */
+export function canAdmitExtraLib(currentTotalChars: number, incomingChars: number): boolean {
+	return incomingChars <= MAX_WORKER_MODEL_CHARS && currentTotalChars + incomingChars <= MAX_EXTRA_LIB_CHARS_TOTAL;
+}


### PR DESCRIPTION
## What

Bound the `@types` extra libs that Automatic Type Acquisition feeds the Monaco language worker, so a large/deep dependency graph or a long multi-project session can't OOM the worker's structured-clone buffer.

Closes #1499 (a recurrence of #1370 through the one worker-clone path the earlier fixes never covered).

## Why

`setEagerModelSync(true)` clones **both** models **and** every `addExtraLib` declaration to the TS/JS worker over `postMessage`. The guards added for #1370 / #1407 bound **models** only:

- per-file `MAX_WORKER_MODEL_CHARS` (512 KB → plaintext),
- aggregate `MAX_APPLICATION_MODEL_CHARS_TOTAL` (4 MB across live `file:///` models),
- `MAX_LIVE_APPLICATION_MODELS` (150).

`acquireApplicationTypes → receivedFile` called `addExtraLib` for **every** declaration file `@typescript/ata` walks, with no per-file cap, no aggregate budget, and a module-level `acquiredPaths` set that never resets — and extra libs are never swept on project switch. So they accumulate **monotonically across every project opened in a session**, invisible to the model budget (`getModels()` doesn't include extra libs), until the clone overflows → `DataCloneError: Data cannot be cloned, out of memory.` → `FAILED to post message to worker`, repeated on every subsequent sync (the runaway per-session flood).

## RUM evidence (last 24h, app `f590deee-…`)

- 1,560 combined occurrences (780 + 780) — the entire 24h error spike (prior 24h baseline: 25).
- 2 sessions / 2 users, ~400 errors each within a single hour; two bursts on 2026-07-13, then zero.
- Views: applications code editor (`…/apps/`, `…/instance/$instanceId/`) — a different surface than the log viewer #1370 originally hit.

## Change

- `src/lib/monaco/workerLimits.ts`: add `MAX_EXTRA_LIB_CHARS_TOTAL` (8 MB) and the pure `canAdmitExtraLib(currentTotalChars, incomingChars)` guard.
- `typeAcquisition.ts`: track a session-lifetime `acquiredChars` and enforce the guard in `receivedFile` — skip any single declaration over the per-file limit, stop admitting once the total is spent. A rejected lib degrades that package to "cannot find module" (the same tradeoff `selectFilesWithinModelBudget` already makes) instead of crashing the tab.
- `workerLimits.test.ts`: covers empty budget, exact-fit, single-oversized rejection, running-total overflow, and spent budget.

## Not in this PR (follow-up, noted in #1499)

Extra libs are never removed on project switch (only models are swept), so a long multi-project session can still exhaust the budget and then acquire no further types. A fuller fix evicts stale extra libs when the active project changes to reclaim budget.

## Test

- New unit test green; existing `modelHousekeeping` / `logEditorLanguage` suites green.
- Full pre-commit run: **1487 tests passed**, oxlint + dprint clean, `tsc --noEmit` clean (Node 24).
- Not browser-verified: reproducing the OOM needs a pathological large-dependency project against a live cluster; the fix is a pure, unit-tested accounting guard on the worker-clone path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
