### PR TITLE
feat(databases): resizable browse-table columns + draggable sidebar

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -145,7 +145,8 @@ export function TableHeadSortable<TData extends RowData>({
 			style={{ width: `${size}px`, maxWidth: `${size}px` }}
 			// relative (not overflow-hidden) so the absolute resize handle can render past the edge
 			// while dragging; the inner content div does the truncation instead.
-			className={cn('relative', enableSorting ? 'px-0' : 'px-2', className)}
+			// select-none on resizable headers so dragging the handle can't text-select the title.
+			className={cn('relative', enableResizing && 'select-none', enableSorting ? 'px-0' : 'px-2', className)}
 		>
 			{/* pr leaves room for the right-edge resize handle so the title never sits under it. */}
 			<div className={cn('flex items-center min-w-0 overflow-hidden', enableResizing && 'pr-4')}>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -5,6 +5,14 @@ import { ArrowDown, ArrowUp, ArrowUpDown, GripVerticalIcon } from 'lucide-react'
 import * as React from 'react';
 import { useCallback } from 'react';
 
+// Upper bound for double-click auto-fit so a very long value (e.g. a stringified object) can't
+// stretch a column across the whole viewport.
+const AUTO_FIT_MAX_SIZE = 500;
+// Horizontal cell padding (px-2 => 8px each side) added back after measuring bare content.
+const CELL_HORIZONTAL_PADDING = 16;
+// Width of the right-edge resize handle strip; reserved when auto-fitting so it never overlaps the title.
+const RESIZE_HANDLE_WIDTH = 16;
+
 export interface TableProps extends React.ComponentProps<'table'> {
 	containerClassName?: string;
 	containerRef?: React.Ref<HTMLDivElement>;
@@ -79,58 +87,102 @@ export function TableHeadSortable<TData extends RowData>({
 		onColumnClick?.(header.column.columnDef.accessorKey, willSortByAscending);
 	}, [header, onColumnClick]);
 	const enableSorting = header.column.columnDef.enableSorting;
-	const enableResizing = header.column.columnDef.enableResizing;
+	// Respect the table-level `enableColumnResizing` flag (via getCanResize) rather than the
+	// per-column columnDef so resizing turns on without annotating every column definition.
+	const enableResizing = header.column.getCanResize();
 	const content = header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext());
-	const resetSize = useCallback(() => {
-		header.column.resetSize();
-	}, [header]);
+	const table = header.getContext().table;
+	const size = header.getSize();
+	const minSize = header.column.columnDef.minSize ?? table.options.defaultColumn?.minSize ?? 20;
+	// Double-click the handle to fit the column to its widest value rather than snapping back to the
+	// default width. Content width is measured with a Range (the tight bounding box of the actual
+	// text) so it works even when the cell is wider than its content; capped by AUTO_FIT_MAX_SIZE so
+	// a huge value can't blow the column out.
+	const autoFitColumn = useCallback((e: React.MouseEvent<HTMLElement>) => {
+		const tableEl = e.currentTarget.closest('table');
+		if (!tableEl) {
+			header.column.resetSize();
+			return;
+		}
+		const selector = `[data-col-id="${CSS.escape(header.column.id)}"]`;
+		const range = document.createRange();
+		const measure = (el: Element) => {
+			range.selectNodeContents(el);
+			return range.getBoundingClientRect().width;
+		};
+		let widest = 0;
+		tableEl.querySelectorAll(`tbody ${selector}`).forEach((cell) => {
+			widest = Math.max(widest, measure(cell));
+		});
+		// The header's flex row fills the cell, so derive its intrinsic width from the title's own
+		// text width plus the width of the sort/resize controls beside it. `controls` is measured as
+		// (all children) - (current title box), which is invariant to the title being truncated.
+		const headerRow = tableEl.querySelector(`thead ${selector} > div`);
+		const titleEl = headerRow?.querySelector('.truncate');
+		if (headerRow && titleEl) {
+			const childrenWidth = Array.from(headerRow.children).reduce(
+				(sum, child) => sum + child.getBoundingClientRect().width,
+				0,
+			);
+			const controls = childrenWidth - titleEl.getBoundingClientRect().width;
+			widest = Math.max(widest, measure(titleEl) + controls + RESIZE_HANDLE_WIDTH);
+		}
+		const fitted = Math.min(Math.max(Math.ceil(widest) + CELL_HORIZONTAL_PADDING, minSize), AUTO_FIT_MAX_SIZE);
+		table.setColumnSizing((old) => ({ ...old, [header.column.id]: fitted }));
+	}, [header, table, minSize]);
+	// Clamp the resize preview so the handle stops at the column's min width instead of sliding left
+	// across the title while dragging (the actual resize commits on release).
+	const previewOffset = header.column.getIsResizing()
+		? Math.max(table.getState().columnSizingInfo.deltaOffset ?? 0, minSize - size)
+		: 0;
 	return (
 		<TableHead
 			{...props}
-			style={{ width: `${header.getSize()}px` }}
-			className={cn(enableSorting ? 'px-0' : 'px-2', className)}
+			data-col-id={header.column.id}
+			style={{ width: `${size}px`, maxWidth: `${size}px` }}
+			// relative (not overflow-hidden) so the absolute resize handle can render past the edge
+			// while dragging; the inner content div does the truncation instead.
+			className={cn('relative', enableSorting ? 'px-0' : 'px-2', className)}
 		>
-			<div className="flex items-center justify-between">
+			{/* pr leaves room for the right-edge resize handle so the title never sits under it. */}
+			<div className={cn('flex items-center min-w-0 overflow-hidden', enableResizing && 'pr-3')}>
 				{enableSorting
 					? (
 						<Button
 							type="button"
 							variant="ghost"
 							className={cn(
-								'rounded-none',
+								'rounded-none min-w-0',
 								!header.column.getIsSorted() || header.column.getIsSorted() === 'asc'
 									? 'cursor-n-resize'
 									: 'cursor-s-resize',
 							)}
 							onClick={onClickSort}
 						>
-							{content}
+							<span className="truncate">{content}</span>
 							{header.column.getIsSorted() === 'asc'
-								? <ArrowUp />
+								? <ArrowUp className="shrink-0" />
 								: header.column.getIsSorted() === 'desc'
-								? <ArrowDown />
-								: <ArrowUpDown className="text-gray-600" />}
+								? <ArrowDown className="shrink-0" />
+								: <ArrowUpDown className="shrink-0 text-gray-600" />}
 						</Button>
 					)
-					: content}
-				{enableResizing && (
-					<Button
-						type="button"
-						variant="ghost"
-						className="cursor-col-resize"
-						onMouseDown={header.getResizeHandler()} // for desktop
-						onTouchStart={header.getResizeHandler()} // for mobile
-						onDoubleClick={resetSize}
-						style={{
-							transform: header.column.getIsResizing()
-								? `translateX(${header.getContext().table.getState().columnSizingInfo.deltaOffset}px)`
-								: '',
-						}}
-					>
-						<GripVerticalIcon />
-					</Button>
-				)}
+					: <span className="truncate">{content}</span>}
 			</div>
+			{enableResizing && (
+				<div
+					aria-hidden
+					className="absolute top-0 right-0 z-10 flex h-full w-3 cursor-col-resize items-center justify-center text-gray-600 hover:text-foreground"
+					onMouseDown={header.getResizeHandler()} // for desktop
+					onTouchStart={header.getResizeHandler()} // for mobile
+					onDoubleClick={autoFitColumn}
+					style={{
+						transform: header.column.getIsResizing() ? `translateX(${previewOffset}px)` : '',
+					}}
+				>
+					<GripVerticalIcon className="size-3.5" />
+				</div>
+			)}
 		</TableHead>
 	);
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -148,7 +148,7 @@ export function TableHeadSortable<TData extends RowData>({
 			className={cn('relative', enableSorting ? 'px-0' : 'px-2', className)}
 		>
 			{/* pr leaves room for the right-edge resize handle so the title never sits under it. */}
-			<div className={cn('flex items-center min-w-0 overflow-hidden', enableResizing && 'pr-3')}>
+			<div className={cn('flex items-center min-w-0 overflow-hidden', enableResizing && 'pr-4')}>
 				{enableSorting
 					? (
 						<Button
@@ -175,7 +175,9 @@ export function TableHeadSortable<TData extends RowData>({
 			{enableResizing && (
 				<div
 					aria-hidden
-					className="absolute top-0 right-0 z-10 flex h-full w-3 cursor-col-resize items-center justify-center text-gray-600 hover:text-foreground"
+					// w-4 hit area (wider than the visible grip); text-muted-foreground so the grip is
+					// visible at rest in both light and dark themes (was gray-600, near-invisible until hover).
+					className="absolute top-0 right-0 z-10 flex h-full w-4 cursor-col-resize items-center justify-center text-muted-foreground hover:text-foreground"
 					onMouseDown={header.getResizeHandler()} // for desktop
 					onTouchStart={header.getResizeHandler()} // for mobile
 					onDoubleClick={autoFitColumn}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -87,9 +87,12 @@ export function TableHeadSortable<TData extends RowData>({
 		onColumnClick?.(header.column.columnDef.accessorKey, willSortByAscending);
 	}, [header, onColumnClick]);
 	const enableSorting = header.column.columnDef.enableSorting;
-	// Respect the table-level `enableColumnResizing` flag (via getCanResize) rather than the
-	// per-column columnDef so resizing turns on without annotating every column definition.
-	const enableResizing = header.column.getCanResize();
+	// Only render resize handles for tables that explicitly opt in via `enableColumnResizing`.
+	// TableHeadSortable is shared (e.g. SimpleBrowseDataTable), and TanStack's getCanResize()
+	// defaults to enabled — so gating on getCanResize() alone would sprinkle handles onto every
+	// table that uses this header, not just the browse table that wires up sizing + persistence.
+	const enableResizing = header.getContext().table.options.enableColumnResizing === true
+		&& header.column.getCanResize();
 	const content = header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext());
 	const table = header.getContext().table;
 	const size = header.getSize();

--- a/src/features/instance/databases/components/DatabaseTableView.tsx
+++ b/src/features/instance/databases/components/DatabaseTableView.tsx
@@ -36,7 +36,7 @@ import { onClickStopPropagation } from '@/lib/onClickStopPropagation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useParams, useSearch } from '@tanstack/react-router';
-import { Row, VisibilityState } from '@tanstack/react-table';
+import { ColumnSizingState, Row, VisibilityState } from '@tanstack/react-table';
 import {
 	BrushCleaningIcon,
 	CircleCheckBigIcon,
@@ -407,6 +407,11 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 		...storedColumnVisibility,
 	}), [relationshipInfoMap, storedColumnVisibility]);
 
+	const [columnSizing, setColumnSizing] = useSessionStorage(
+		`ColumnSizing/${databaseName}/${tableName}` as 'ColumnSizing/{database}/{table}',
+		{} satisfies ColumnSizingState,
+	);
+
 	return (
 		<>
 			<div className="flex flex-col md:flex-row items-center justify-between space-y-3 md:space-y-0 md:space-x-3 pt-15 pb-4 pr-4">
@@ -557,6 +562,8 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 				filtersToggled={filtersToggled}
 				columns={dataTableColumns}
 				columnVisibility={columnVisibility}
+				columnSizing={columnSizing}
+				setColumnSizing={setColumnSizing}
 				onRowClick={onRowClick}
 				onColumnClick={onColumnClick}
 				totalPages={totalPages}

--- a/src/features/instance/databases/components/TableView.test.tsx
+++ b/src/features/instance/databases/components/TableView.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { ColumnDef, VisibilityState } from '@tanstack/react-table';
+import { ColumnDef, ColumnSizingState, VisibilityState } from '@tanstack/react-table';
 import { cleanup, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
@@ -31,12 +32,15 @@ const data: Record<string, unknown>[] = [{ id: 'abc-123', type: 'demo' }];
 
 function Harness({ columnVisibility }: { columnVisibility: VisibilityState }) {
 	const columnFiltersForm = useForm<z.infer<typeof ColumnFiltersSchema>>({ defaultValues: {} });
+	const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 	return (
 		<TableView<Record<string, unknown>, unknown>
 			applyFilters={() => undefined}
 			columnFiltersForm={columnFiltersForm}
 			columns={columns}
 			columnVisibility={columnVisibility}
+			columnSizing={columnSizing}
+			setColumnSizing={setColumnSizing}
 			data={data}
 			pageIndex={0}
 			pageSize={20}
@@ -64,5 +68,15 @@ describe('TableView column visibility', () => {
 		// the body row used to keep rendering the stale cell, misaligning columns).
 		expect(screen.queryByText('abc-123')).toBeNull();
 		expect(screen.getByText('demo')).toBeTruthy();
+	});
+});
+
+describe('TableView column resizing', () => {
+	it('renders a resize handle for each column header', () => {
+		// Regression: the handle used to be gated on columnDef.enableResizing (never set), so it
+		// never rendered. It is now gated on getCanResize(), driven by the table-level flag.
+		const { container } = render(<Harness columnVisibility={{}} />);
+		const handles = container.querySelectorAll('svg.lucide-grip-vertical');
+		expect(handles.length).toBe(columns.length);
 	});
 });

--- a/src/features/instance/databases/components/TableView.tsx
+++ b/src/features/instance/databases/components/TableView.tsx
@@ -1,14 +1,24 @@
 'use client';
 
 import { LoadingSubtle } from '@/components/LoadingSubtle';
-import { Table, TableBody, TableCell, TableHeader, TableHeadSortable, TableRow } from '@/components/ui/table';
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableHeadSortable,
+	TableRow,
+} from '@/components/ui/table';
 import { cn } from '@/lib/cn';
 import {
 	Cell,
 	ColumnDef,
+	ColumnSizingState,
 	flexRender,
 	getCoreRowModel,
 	getPaginationRowModel,
+	OnChangeFn,
 	Row,
 	useReactTable,
 	VisibilityState,
@@ -24,6 +34,8 @@ interface BrowseDataTableProps<TData, TValue> {
 	columnFiltersForm: UseFormReturn<z.infer<typeof ColumnFiltersSchema>>;
 	columns: ColumnDef<TData, TValue>[];
 	columnVisibility: VisibilityState;
+	columnSizing: ColumnSizingState;
+	setColumnSizing: OnChangeFn<ColumnSizingState>;
 	data?: TData[];
 	isFetching?: boolean;
 	onColumnClick?: (accessorKey: string, isDescending: boolean) => void;
@@ -48,6 +60,8 @@ export function TableView<TData, TValue>({
 	columnFiltersForm,
 	columns,
 	columnVisibility,
+	columnSizing,
+	setColumnSizing,
 	data,
 	isFetching,
 	onColumnClick,
@@ -72,12 +86,15 @@ export function TableView<TData, TValue>({
 		manualPagination: true,
 		enableColumnResizing: true,
 		columnResizeMode: 'onEnd',
+		onColumnSizingChange: setColumnSizing,
 		pageCount: totalPages,
 		defaultColumn: {
-			minSize: 1,
+			// Wide enough that the header title + sort/resize controls never collide when shrinking.
+			minSize: 80,
 		},
 		state: {
 			columnVisibility,
+			columnSizing,
 		},
 		rowCount: totalRecords,
 		getCoreRowModel: getCoreRowModel(),
@@ -86,7 +103,13 @@ export function TableView<TData, TValue>({
 
 	return (
 		<>
-			<Table containerClassName="rounded-md bg-card dark:bg-black-dark grow overflow-visible">
+			<Table
+				containerClassName="rounded-md bg-card dark:bg-black-dark grow overflow-visible"
+				// table-fixed so columns hold their set/resized width exactly (content doesn't stretch
+				// them); the trailing filler column below absorbs any leftover width so the rows still
+				// reach the edge instead of leaving dead space.
+				className="table-fixed"
+			>
 				<TableHeader>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<TableRow key={headerGroup.id} className="border-none">
@@ -98,6 +121,11 @@ export function TableView<TData, TValue>({
 									className="sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
 								/>
 							))}
+							{/* Filler column: takes the remaining width so real columns stay tight. */}
+							<TableHead
+								aria-hidden
+								className="w-full p-0 sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
+							/>
 						</TableRow>
 					))}
 				</TableHeader>
@@ -120,7 +148,7 @@ export function TableView<TData, TValue>({
 						)))
 						: (
 							<TableRow>
-								<TableCell colSpan={columns.length} className="h-24 text-center">
+								<TableCell colSpan={columns.length + 1} className="h-24 text-center">
 									{isFetching || data === undefined
 										? <LoadingSubtle className="opacity-50 inline-block" />
 										: <span>No results.</span>}
@@ -178,15 +206,21 @@ function TableBodyRow<TData>(
 			className={cn('hover:bg-muted/10 data-[state=selected]:bg-muted', onRowClick && 'cursor-pointer')}
 		>
 			{cells}
+			{/* Filler cell matching the header's filler column. */}
+			<TableCell aria-hidden className="p-0" />
 		</TableRow>
 	);
 }
 
 function TableBodyRowCell<TData>({ cell }: { cell: Cell<TData, unknown> }) {
+	const size = cell.column.getSize();
 	return (
 		<TableCell
-			style={{ width: `${cell.column.getSize()}px` }}
-			className="px-2 py-2 overflow-x-hidden max-w-32 text-ellipsis whitespace-nowrap"
+			data-col-id={cell.column.id}
+			// maxWidth pins the cell to the (resizable) column width so wider values truncate instead
+			// of forcing the column open; width keeps narrow columns from collapsing below it.
+			style={{ width: `${size}px`, maxWidth: `${size}px` }}
+			className="px-2 py-2 overflow-hidden text-ellipsis whitespace-nowrap"
 		>
 			{/* Object/array stringification lives in the column defs (renderPlainCell / RelationshipCell). */}
 			{flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/src/features/instance/databases/components/TableView.tsx
+++ b/src/features/instance/databases/components/TableView.tsx
@@ -101,62 +101,91 @@ export function TableView<TData, TValue>({
 		getPaginationRowModel: getPaginationRowModel(),
 	});
 
+	// During a column resize, preview where the new right edge will land with a full-height guide line.
+	// columnResizeMode is 'onEnd', so the column width doesn't change until release -- the guide is the
+	// live feedback. Its x is the sum of column widths up to the resizing one, plus the (clamped) drag delta.
+	const columnSizingInfo = table.getState().columnSizingInfo;
+	const resizingColumnId = columnSizingInfo.isResizingColumn;
+	let resizeGuideLeft: number | null = null;
+	if (resizingColumnId) {
+		const minSize = table.options.defaultColumn?.minSize ?? 20;
+		const startSize = table.getColumn(resizingColumnId)?.getSize() ?? 0;
+		let edge = 0;
+		for (const leafColumn of table.getVisibleLeafColumns()) {
+			edge += leafColumn.getSize();
+			if (leafColumn.id === resizingColumnId) {
+				break;
+			}
+		}
+		// Clamp to match the handle's own preview: the column can't shrink below minSize.
+		resizeGuideLeft = edge + Math.max(columnSizingInfo.deltaOffset ?? 0, minSize - startSize);
+	}
+
 	return (
 		<>
-			<Table
-				containerClassName="rounded-md bg-card dark:bg-black-dark grow overflow-visible"
-				// table-fixed so columns hold their set/resized width exactly (content doesn't stretch
-				// them); the trailing filler column below absorbs any leftover width so the rows still
-				// reach the edge instead of leaving dead space.
-				className="table-fixed"
-			>
-				<TableHeader>
-					{table.getHeaderGroups().map((headerGroup) => (
-						<TableRow key={headerGroup.id} className="border-none">
-							{headerGroup.headers.map((header) => (
-								<TableHeadSortable
-									key={header.id}
-									header={header}
-									onColumnClick={onColumnClick}
-									className="sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
+			<div className="relative flex flex-col grow">
+				<Table
+					containerClassName="rounded-md bg-card dark:bg-black-dark grow overflow-visible"
+					// table-fixed so columns hold their set/resized width exactly (content doesn't stretch
+					// them); the trailing filler column below absorbs any leftover width so the rows still
+					// reach the edge instead of leaving dead space.
+					className="table-fixed"
+				>
+					<TableHeader>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id} className="border-none">
+								{headerGroup.headers.map((header) => (
+									<TableHeadSortable
+										key={header.id}
+										header={header}
+										onColumnClick={onColumnClick}
+										className="sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
+									/>
+								))}
+								{/* Filler column: takes the remaining width so real columns stay tight. */}
+								<TableHead
+									aria-hidden
+									className="w-full p-0 sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
 								/>
-							))}
-							{/* Filler column: takes the remaining width so real columns stay tight. */}
-							<TableHead
-								aria-hidden
-								className="w-full p-0 sticky top-32 z-10 bg-card dark:bg-black-dark border-b border-border"
-							/>
-						</TableRow>
-					))}
-				</TableHeader>
-				{filtersToggled && (
-					<ColumnFilters
-						applyFilters={applyFilters}
-						columnFiltersForm={columnFiltersForm}
-						headerGroups={table.getHeaderGroups()}
+							</TableRow>
+						))}
+					</TableHeader>
+					{filtersToggled && (
+						<ColumnFilters
+							applyFilters={applyFilters}
+							columnFiltersForm={columnFiltersForm}
+							headerGroups={table.getHeaderGroups()}
+						/>
+					)}
+					<TableBody className="bg-background dark:bg-black border border-border dark:border-grey-700">
+						{table.getRowModel().rows?.length
+							? (table.getRowModel().rows.map((row) => (
+								<TableBodyRow
+									key={row.id}
+									row={row}
+									onRowClick={onRowClick}
+									primaryKey={primaryKey}
+								/>
+							)))
+							: (
+								<TableRow>
+									<TableCell colSpan={columns.length + 1} className="h-24 text-center">
+										{isFetching || data === undefined
+											? <LoadingSubtle className="opacity-50 inline-block" />
+											: <span>No results.</span>}
+									</TableCell>
+								</TableRow>
+							)}
+					</TableBody>
+				</Table>
+				{resizeGuideLeft !== null && (
+					<div
+						aria-hidden
+						className="pointer-events-none absolute top-0 bottom-0 z-20 w-0.5 bg-primary"
+						style={{ left: `${resizeGuideLeft}px` }}
 					/>
 				)}
-				<TableBody className="bg-background dark:bg-black border border-border dark:border-grey-700">
-					{table.getRowModel().rows?.length
-						? (table.getRowModel().rows.map((row) => (
-							<TableBodyRow
-								key={row.id}
-								row={row}
-								onRowClick={onRowClick}
-								primaryKey={primaryKey}
-							/>
-						)))
-						: (
-							<TableRow>
-								<TableCell colSpan={columns.length + 1} className="h-24 text-center">
-									{isFetching || data === undefined
-										? <LoadingSubtle className="opacity-50 inline-block" />
-										: <span>No results.</span>}
-								</TableCell>
-							</TableRow>
-						)}
-				</TableBody>
-			</Table>
+			</div>
 			<TablePagination
 				pageIndex={pageIndex}
 				pageSize={pageSize}

--- a/src/features/instance/databases/functions/formatBrowseDataTableHeader.ts
+++ b/src/features/instance/databases/functions/formatBrowseDataTableHeader.ts
@@ -52,7 +52,6 @@ export function formatBrowseDataTableHeader(
 			// Relationship columns are filterable via sub-properties (`.name value`), which the
 			// server executes as a join against the related table.
 			enableColumnFilter: Boolean(is_primary_key || indexed || relationshipInfo),
-			// enableResizing: true,
 			size: sizeByAttributeType(type),
 			cell: relationshipInfo ? relationshipCell(relationshipInfo) : renderPlainCell,
 			meta: relationshipInfo ? { relationshipInfo } : undefined,
@@ -108,21 +107,24 @@ function renderPlainCell(context: CellContext<Record<string, unknown>, unknown>)
 	return String(value);
 }
 
+// Default column widths (px). These are just starting points -- every column is resizable, and a
+// user's adjustments are persisted per table, so these only need to be reasonable defaults.
 function sizeByAttributeType(type: InstanceAttribute['type']) {
 	switch (type) {
 		case 'Id':
 		case 'ID':
-			return 1;
+			return 220;
 		case 'Boolean':
-			return 1;
+			return 90;
 		case 'Int':
 		case 'Long':
 		case 'Float':
 		case 'BigInt':
-			return 1;
+			return 120;
 		case 'Date':
+			return 190;
 		case 'String':
 		default:
-			return Math.round(window.innerWidth * 0.1);
+			return 200;
 	}
 }

--- a/src/features/instance/databases/hooks/useResizableDatabasesSidebar.test.ts
+++ b/src/features/instance/databases/hooks/useResizableDatabasesSidebar.test.ts
@@ -1,0 +1,89 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from '@testing-library/react';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	clampWidth,
+	DEFAULT_DATABASES_SIDEBAR_WIDTH,
+	maxSidebarWidth,
+	MIN_SIDEBAR_WIDTH,
+	useResizableDatabasesSidebar,
+} from './useResizableDatabasesSidebar';
+
+function setViewportWidth(width: number) {
+	(window as unknown as { innerWidth: number }).innerWidth = width;
+}
+
+afterEach(() => {
+	localStorage.clear();
+	setViewportWidth(1024); // jsdom default
+});
+
+describe('clampWidth', () => {
+	it('raises a too-small width up to the minimum', () => {
+		expect(clampWidth(50, 1024)).toBe(MIN_SIDEBAR_WIDTH);
+	});
+	it('caps a too-large width at half the viewport', () => {
+		expect(clampWidth(9999, 1000)).toBe(500);
+	});
+	it('passes a mid-range width through, rounded', () => {
+		expect(clampWidth(321.6, 1024)).toBe(322);
+	});
+	it('never lets the max fall below the minimum on a tiny viewport', () => {
+		expect(maxSidebarWidth(100)).toBe(MIN_SIDEBAR_WIDTH);
+		expect(clampWidth(10, 100)).toBe(MIN_SIDEBAR_WIDTH);
+	});
+});
+
+describe('useResizableDatabasesSidebar', () => {
+	it('sizes the rendered width from the drag delta and persists it on release', () => {
+		const { result } = renderHook(() => useResizableDatabasesSidebar());
+		expect(result.current.width).toBe(DEFAULT_DATABASES_SIDEBAR_WIDTH);
+
+		act(() => {
+			result.current.startResizing({ clientX: 300, preventDefault() {} } as unknown as ReactMouseEvent);
+		});
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mousemove', { clientX: 400 }));
+		});
+		expect(result.current.width).toBe(DEFAULT_DATABASES_SIDEBAR_WIDTH + 100);
+
+		act(() => {
+			window.dispatchEvent(new MouseEvent('mouseup'));
+		});
+		// Persisted preference survives a remount.
+		const { result: remounted } = renderHook(() => useResizableDatabasesSidebar());
+		expect(remounted.current.width).toBe(DEFAULT_DATABASES_SIDEBAR_WIDTH + 100);
+	});
+
+	it('re-clamps the rendered width on viewport resize without clobbering the saved preference', () => {
+		const { result } = renderHook(() => useResizableDatabasesSidebar());
+		expect(result.current.width).toBe(320);
+
+		// Shrink the window so 320 no longer fits (half of 500 is 250).
+		act(() => {
+			setViewportWidth(500);
+			window.dispatchEvent(new Event('resize'));
+		});
+		expect(result.current.width).toBe(250);
+
+		// Grow it back: the preferred 320 is restored (proving resize never overwrote it).
+		act(() => {
+			setViewportWidth(1024);
+			window.dispatchEvent(new Event('resize'));
+		});
+		expect(result.current.width).toBe(320);
+	});
+
+	it('nudges the width in 10px steps with Arrow keys', () => {
+		const { result } = renderHook(() => useResizableDatabasesSidebar());
+		act(() => {
+			result.current.handleKeyDown({ key: 'ArrowRight', preventDefault() {} } as unknown as ReactKeyboardEvent);
+		});
+		expect(result.current.width).toBe(330);
+		act(() => {
+			result.current.handleKeyDown({ key: 'ArrowLeft', preventDefault() {} } as unknown as ReactKeyboardEvent);
+		});
+		expect(result.current.width).toBe(320);
+	});
+});

--- a/src/features/instance/databases/hooks/useResizableDatabasesSidebar.ts
+++ b/src/features/instance/databases/hooks/useResizableDatabasesSidebar.ts
@@ -1,0 +1,88 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Roughly the old fixed `lg:col-span-3` feel, so first load is close to unchanged. */
+export const DEFAULT_DATABASES_SIDEBAR_WIDTH = 320;
+/** Narrowest the sidebar may be dragged — below this the tree labels are unusable. */
+const MIN_SIDEBAR_WIDTH = 200;
+
+/** Clamp to a usable range: never below the minimum, never past half the viewport. */
+function clampWidth(width: number, viewportWidth: number): number {
+	const max = Math.max(MIN_SIDEBAR_WIDTH, Math.floor(viewportWidth / 2));
+	return Math.round(Math.min(Math.max(width, MIN_SIDEBAR_WIDTH), max));
+}
+
+/**
+ * Drag-to-resize state for the databases sidebar. Mirrors the applications file tray
+ * (see `ApplicationsSidebar/SidebarResizeHandle.tsx`): mousedown arms the gesture, then window
+ * `mousemove`/`mouseup` listeners track it so the cursor can leave the handle. Unlike that tray
+ * (anchored at the viewport's left edge, so its width is just the cursor X), this sidebar sits
+ * in-flow with page padding to its left, so we track the delta from where the drag started.
+ *
+ * Width updates once per render during the drag and commits to local storage once on release —
+ * writing localStorage on every `mousemove` would stutter.
+ */
+export function useResizableDatabasesSidebar() {
+	const [persistedWidth, setPersistedWidth] = useLocalStorage(
+		LocalStorageKeys.DatabasesSidebarWidth,
+		DEFAULT_DATABASES_SIDEBAR_WIDTH,
+	);
+	const [isResizing, setIsResizing] = useState(false);
+	const [width, setWidth] = useState(() => clampWidth(persistedWidth, window.innerWidth));
+	const widthRef = useRef(width);
+	widthRef.current = width;
+	// The cursor X and sidebar width captured at mousedown, so mousemove can size from the delta.
+	const gestureRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+	// When not actively dragging, keep the rendered width in sync with the persisted value
+	// (e.g. after a viewport-resize clamp below).
+	useEffect(() => {
+		if (!isResizing) {
+			setWidth(clampWidth(persistedWidth, window.innerWidth));
+		}
+	}, [persistedWidth, isResizing]);
+
+	// If the viewport shrank since the width was stored, pull it back into range.
+	useEffect(() => {
+		const onResize = () => setPersistedWidth((current) => clampWidth(current, window.innerWidth));
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, [setPersistedWidth]);
+
+	const startResizing = useCallback((event: React.MouseEvent) => {
+		event.preventDefault();
+		gestureRef.current = { startX: event.clientX, startWidth: widthRef.current };
+		setIsResizing(true);
+	}, []);
+
+	useEffect(() => {
+		if (!isResizing) {
+			return;
+		}
+		const onMouseMove = (event: MouseEvent) => {
+			const gesture = gestureRef.current;
+			if (!gesture) {
+				return;
+			}
+			setWidth(clampWidth(gesture.startWidth + (event.clientX - gesture.startX), window.innerWidth));
+		};
+		const onMouseUp = () => {
+			setIsResizing(false);
+			// Persist the final width once, instead of on every mousemove.
+			setPersistedWidth(widthRef.current);
+		};
+		// Suppress text selection across the page while dragging.
+		const previousUserSelect = document.body.style.userSelect;
+		document.body.style.userSelect = 'none';
+		window.addEventListener('mousemove', onMouseMove);
+		window.addEventListener('mouseup', onMouseUp);
+		return () => {
+			document.body.style.userSelect = previousUserSelect;
+			window.removeEventListener('mousemove', onMouseMove);
+			window.removeEventListener('mouseup', onMouseUp);
+		};
+	}, [isResizing, setPersistedWidth]);
+
+	return { width, isResizing, startResizing };
+}

--- a/src/features/instance/databases/hooks/useResizableDatabasesSidebar.ts
+++ b/src/features/instance/databases/hooks/useResizableDatabasesSidebar.ts
@@ -5,12 +5,18 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 /** Roughly the old fixed `lg:col-span-3` feel, so first load is close to unchanged. */
 export const DEFAULT_DATABASES_SIDEBAR_WIDTH = 320;
 /** Narrowest the sidebar may be dragged — below this the tree labels are unusable. */
-const MIN_SIDEBAR_WIDTH = 200;
+export const MIN_SIDEBAR_WIDTH = 200;
+/** Width nudge per Arrow key press when the separator is focused. */
+const KEYBOARD_STEP = 10;
+
+/** Widest the sidebar may be — half the viewport, so the content pane keeps the larger share. */
+export function maxSidebarWidth(viewportWidth: number): number {
+	return Math.max(MIN_SIDEBAR_WIDTH, Math.floor(viewportWidth / 2));
+}
 
 /** Clamp to a usable range: never below the minimum, never past half the viewport. */
-function clampWidth(width: number, viewportWidth: number): number {
-	const max = Math.max(MIN_SIDEBAR_WIDTH, Math.floor(viewportWidth / 2));
-	return Math.round(Math.min(Math.max(width, MIN_SIDEBAR_WIDTH), max));
+export function clampWidth(width: number, viewportWidth: number): number {
+	return Math.round(Math.min(Math.max(width, MIN_SIDEBAR_WIDTH), maxSidebarWidth(viewportWidth)));
 }
 
 /**
@@ -43,12 +49,18 @@ export function useResizableDatabasesSidebar() {
 		}
 	}, [persistedWidth, isResizing]);
 
-	// If the viewport shrank since the width was stored, pull it back into range.
+	// On viewport resize, re-clamp only the *rendered* width — never the persisted preference. Writing
+	// localStorage on every resize event stutters, and clamping the stored value down would permanently
+	// lose the user's preferred width once they shrink then re-widen the window.
 	useEffect(() => {
-		const onResize = () => setPersistedWidth((current) => clampWidth(current, window.innerWidth));
+		const onResize = () => {
+			if (!isResizing) {
+				setWidth(clampWidth(persistedWidth, window.innerWidth));
+			}
+		};
 		window.addEventListener('resize', onResize);
 		return () => window.removeEventListener('resize', onResize);
-	}, [setPersistedWidth]);
+	}, [persistedWidth, isResizing]);
 
 	const startResizing = useCallback((event: React.MouseEvent) => {
 		event.preventDefault();
@@ -84,5 +96,16 @@ export function useResizableDatabasesSidebar() {
 		};
 	}, [isResizing, setPersistedWidth]);
 
-	return { width, isResizing, startResizing };
+	// Keyboard resize for the focused separator: Arrow keys nudge the persisted width in fixed steps.
+	const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+		if (event.key === 'ArrowLeft') {
+			event.preventDefault();
+			setPersistedWidth((current) => clampWidth(current - KEYBOARD_STEP, window.innerWidth));
+		} else if (event.key === 'ArrowRight') {
+			event.preventDefault();
+			setPersistedWidth((current) => clampWidth(current + KEYBOARD_STEP, window.innerWidth));
+		}
+	}, [setPersistedWidth]);
+
+	return { width, isResizing, startResizing, handleKeyDown };
 }

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -10,7 +10,7 @@ import { DatabaseOverview } from './components/DatabaseOverview';
 import { DatabasesSidebar } from './components/DatabasesSidebar';
 import { DatabaseTableView } from './components/DatabaseTableView';
 import { resolveDatabasesRedirect } from './functions/resolveDatabasesRedirect';
-import { useResizableDatabasesSidebar } from './hooks/useResizableDatabasesSidebar';
+import { maxSidebarWidth, MIN_SIDEBAR_WIDTH, useResizableDatabasesSidebar } from './hooks/useResizableDatabasesSidebar';
 
 export function Databases() {
 	const params: {
@@ -28,7 +28,7 @@ export function Databases() {
 		getDescribeAllQueryOptions({ ...instanceParams, skipRecordCount: true }),
 	);
 
-	const { width: sidebarWidth, isResizing, startResizing } = useResizableDatabasesSidebar();
+	const { width: sidebarWidth, isResizing, startResizing, handleKeyDown } = useResizableDatabasesSidebar();
 	// Drive the width through a CSS variable so it only applies at md+ (mobile stays full-width, stacked).
 	const sidebarWidthVar = { '--db-sidebar-width': `${sidebarWidth}px` } as CSSProperties;
 
@@ -52,15 +52,23 @@ export function Databases() {
 					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden"
 				>
 					<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
-					{/* Drag the right edge to resize the sidebar (md+ only; mobile stacks full-width). */}
+					{
+						/* Drag (or focus + Arrow keys) the right edge to resize the sidebar (md+ only; mobile
+					    stacks full-width). */
+					}
 					<div
 						role="separator"
+						tabIndex={0}
 						aria-orientation="vertical"
 						aria-label="Resize sidebar"
+						aria-valuenow={sidebarWidth}
+						aria-valuemin={MIN_SIDEBAR_WIDTH}
+						aria-valuemax={maxSidebarWidth(window.innerWidth)}
 						onMouseDown={startResizing}
+						onKeyDown={handleKeyDown}
 						className={cn(
-							'hidden md:block absolute top-0 right-0 bottom-0 w-1 z-40 cursor-col-resize',
-							'hover:bg-violet-400/60 dark:hover:bg-violet-500/60 transition-colors',
+							'hidden md:block absolute top-0 right-0 bottom-0 w-1 z-40 cursor-col-resize outline-none',
+							'hover:bg-violet-400/60 dark:hover:bg-violet-500/60 focus-visible:bg-violet-500/80 transition-colors',
 							isResizing && 'bg-violet-400/60 dark:bg-violet-500/60',
 						)}
 					/>

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -1,13 +1,16 @@
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { getDescribeAllQueryOptions } from '@/integrations/api/instance/database/getDescribeAll';
+import { cn } from '@/lib/cn';
 import { buildAbsoluteLinkToDatabasePage } from '@/lib/urls/buildAbsoluteLinkToDatabasePage';
 import { useQuery } from '@tanstack/react-query';
 import { Navigate, useParams } from '@tanstack/react-router';
+import { CSSProperties } from 'react';
 import { DatabaseActionModals } from './components/DatabaseActionModals';
 import { DatabaseOverview } from './components/DatabaseOverview';
 import { DatabasesSidebar } from './components/DatabasesSidebar';
 import { DatabaseTableView } from './components/DatabaseTableView';
 import { resolveDatabasesRedirect } from './functions/resolveDatabasesRedirect';
+import { useResizableDatabasesSidebar } from './hooks/useResizableDatabasesSidebar';
 
 export function Databases() {
 	const params: {
@@ -25,6 +28,10 @@ export function Databases() {
 		getDescribeAllQueryOptions({ ...instanceParams, skipRecordCount: true }),
 	);
 
+	const { width: sidebarWidth, isResizing, startResizing } = useResizableDatabasesSidebar();
+	// Drive the width through a CSS variable so it only applies at md+ (mobile stays full-width, stacked).
+	const sidebarWidthVar = { '--db-sidebar-width': `${sidebarWidth}px` } as CSSProperties;
+
 	// Land on the first database's overview when nothing is selected, and recover from stale links to a
 	// dropped database/table (see resolveDatabasesRedirect for the exact rules + loop-freedom).
 	const redirect = resolveDatabasesRedirect(instanceDatabaseMap, params);
@@ -39,11 +46,26 @@ export function Databases() {
 
 	return (
 		<>
-			<main className="grid grid-cols-1 gap-4 md:grid-cols-12 md:items-start">
-				<section className="col-span-1 text-foreground md:col-span-4 lg:col-span-3 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden">
+			<main className="flex flex-col gap-4 md:flex-row md:items-start">
+				<section
+					style={sidebarWidthVar}
+					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden"
+				>
 					<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
+					{/* Drag the right edge to resize the sidebar (md+ only; mobile stacks full-width). */}
+					<div
+						role="separator"
+						aria-orientation="vertical"
+						aria-label="Resize sidebar"
+						onMouseDown={startResizing}
+						className={cn(
+							'hidden md:block absolute top-0 right-0 bottom-0 w-1 z-40 cursor-col-resize',
+							'hover:bg-violet-400/60 dark:hover:bg-violet-500/60 transition-colors',
+							isResizing && 'bg-violet-400/60 dark:bg-violet-500/60',
+						)}
+					/>
 				</section>
-				<section className="col-span-1 text-foreground md:col-span-8 lg:col-span-9 flex flex-col min-h-0">
+				<section className="text-foreground w-full md:flex-1 md:min-w-0 flex flex-col min-h-0">
 					{params.databaseName && params.tableName
 						? (
 							<DatabaseTableView

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -51,7 +51,7 @@ export function Databases() {
 					style={sidebarWidthVar}
 					// overflow-y-clip (not overflow-hidden) so the tree is still clipped vertically while the
 					// resize handle can extend horizontally into the gap between the panes.
-					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-y-clip"
+					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 md:border-r border-border flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-y-clip"
 				>
 					<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
 					{

--- a/src/features/instance/databases/index.tsx
+++ b/src/features/instance/databases/index.tsx
@@ -49,12 +49,15 @@ export function Databases() {
 			<main className="flex flex-col gap-4 md:flex-row md:items-start">
 				<section
 					style={sidebarWidthVar}
-					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-hidden"
+					// overflow-y-clip (not overflow-hidden) so the tree is still clipped vertically while the
+					// resize handle can extend horizontally into the gap between the panes.
+					className="relative text-foreground w-full md:w-[var(--db-sidebar-width)] md:shrink-0 flex flex-col min-h-0 md:sticky md:top-32 md:h-[calc(100vh-(--spacing(32)))] md:max-h-[calc(100vh-(--spacing(32)))] overflow-y-clip"
 				>
 					<DatabasesSidebar instanceDatabaseMap={instanceDatabaseMap} />
 					{
-						/* Drag (or focus + Arrow keys) the right edge to resize the sidebar (md+ only; mobile
-					    stacks full-width). */
+						/* Drag (or focus + Arrow keys) to resize the sidebar (md+ only; mobile stacks full-width).
+					    The grab zone straddles the edge into the inter-pane gap so it doesn't fight the tree's
+					    scrollbar; only the thin centered line is visible (on hover / drag / focus). */
 					}
 					<div
 						role="separator"
@@ -66,12 +69,16 @@ export function Databases() {
 						aria-valuemax={maxSidebarWidth(window.innerWidth)}
 						onMouseDown={startResizing}
 						onKeyDown={handleKeyDown}
-						className={cn(
-							'hidden md:block absolute top-0 right-0 bottom-0 w-1 z-40 cursor-col-resize outline-none',
-							'hover:bg-violet-400/60 dark:hover:bg-violet-500/60 focus-visible:bg-violet-500/80 transition-colors',
-							isResizing && 'bg-violet-400/60 dark:bg-violet-500/60',
-						)}
-					/>
+						className="group hidden md:block absolute top-0 bottom-0 right-0 w-4 translate-x-1/2 z-40 cursor-col-resize outline-none"
+					>
+						<div
+							className={cn(
+								'absolute inset-y-0 left-1/2 w-1 -translate-x-1/2 transition-colors',
+								'group-hover:bg-violet-400/60 dark:group-hover:bg-violet-500/60 group-focus-visible:bg-violet-500/80',
+								isResizing && 'bg-violet-400/60 dark:bg-violet-500/60',
+							)}
+						/>
+					</div>
 				</section>
 				<section className="text-foreground w-full md:flex-1 md:min-w-0 flex flex-col min-h-0">
 					{params.databaseName && params.tableName

--- a/src/lib/storage/localStorageKeys.ts
+++ b/src/lib/storage/localStorageKeys.ts
@@ -3,6 +3,7 @@ export const enum LocalStorageKeys {
 	'ApplicationChatWidth' = 'ApplicationChatWidth',
 	'ApplicationsSidebarWidth' = 'ApplicationsSidebarWidth',
 	'ChatAlwaysApprovedTools' = 'ChatAlwaysApprovedTools',
+	'DatabasesSidebarWidth' = 'DatabasesSidebarWidth',
 	'LastUsedSignInMethod' = 'LastUsedSignInMethod',
 	'LogsOrderReversed' = 'LogsOrderReversed',
 	'RememberSignInMethod' = 'RememberSignInMethod',

--- a/src/lib/storage/sessionStorageKeys.ts
+++ b/src/lib/storage/sessionStorageKeys.ts
@@ -10,5 +10,6 @@ export interface SessionStorageKeys {
 	'FileSelected/{entityId}': true;
 	'DatabaseTreeExpanded/{entityId}': true;
 	'ColumnDisplayed/{database}/{table}': true;
+	'ColumnSizing/{database}/{table}': true;
 	'ShowAllOrganizations': true;
 }


### PR DESCRIPTION
Two related enhancements to the Databases browse view, one per commit (plus one review fix).

Closes #1287 and partially fulfills #1262 

## What

1. **Resizable table columns** — drag a column header's handle to resize; double-click the handle to auto-fit the column to its widest value (capped at 500px so a giant value can't blow it out); widths persist per table (sessionStorage). Columns hold their width via `table-fixed`, and a trailing filler column absorbs the leftover so rows still reach the edge instead of stretching the real columns.
2. **Draggable sidebar** — drag the sidebar's right edge to resize the DB/table tree pane; width clamps to `200px .. half the viewport` and persists (localStorage). Mirrors the existing applications file-tray resize pattern.

## Why

Make the Studio browse view more dynamic — resizable columns first, then a resizable sidebar so long table names aren't stuck truncated.

## Where to look

- **`ui/table.tsx`** is the bulk of commit 1: the resize handle, the double-click auto-fit (measured with a `Range` so it works even when the cell is wider than its content), and the drag-preview clamp. It's a shared component — see the review fix below.
- **Layout change** (commit 2): the databases page moved from a 12-col grid to flex so the sidebar can take an explicit, draggable width. The sticky, full-height sidebar behavior is preserved; worth confirming it feels right across widths and on mobile (handle is md+ only; mobile stays stacked full-width).
- **Default column widths** are per-type defaults; `id`/`__*time__` resolve to 200px because Harper reports them as `Any` — resize/auto-fit is the escape hatch rather than clever type sizing.

## Notes

- **Cross-model review done.** Codex flagged one real issue — because `TableHeadSortable` is shared with `SimpleBrowseDataTable` (roles / users / invoices / config / secrets), gating the handle on TanStack's `getCanResize()` (defaults enabled) put resize handles on *those* tables too. Fixed in `788edad7` by only rendering handles when the table opts in via `enableColumnResizing === true` (only `TableView` does). **Open caveat:** the Gemini (`agy`) leg failed to run (timeout, twice), so there was **no second-model perf/maintainability pass** — a manual skim of the drag handlers + auto-fit measurement would be a reasonable backstop.
- No docs change (Studio UI micro-interaction).
- Verified live (drag / auto-fit / persistence / clamp) + full unit suite green. Generated by an LLM — model: Claude Opus 4.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
