### PR TITLE
fix(preview): make the worktree preview launcher work from a linked worktree

### DIFF
--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -17,6 +17,12 @@ set -e
 root="${CLAUDE_PROJECT_DIR:-$PWD}"
 cd "$root"
 
+# The main checkout is the source of the shared node_modules / .env.local. CLAUDE_PROJECT_DIR is
+# the *current* checkout, which is the worktree itself when we're launched from one — so derive
+# the main checkout from git rather than assuming $root is it. (Assuming $root pointed the
+# symlinks below at a worktree's own node_modules → a self-referential link → ELOOP on start.)
+main_checkout="$(cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
+
 # Read the target worktree from .claude/preview-cwd (repo-relative). `read` trims surrounding
 # whitespace and tolerates a missing trailing newline; fall back to the main checkout when the
 # file is absent or empty.
@@ -35,13 +41,36 @@ fi
 # Guard with both -e and -L so an existing real dir/file AND a dangling symlink are left alone
 # (a broken symlink passes -e but `ln -s` over it would fail with "File exists").
 if [ ! -e node_modules ] && [ ! -L node_modules ]; then
-	ln -s "$root/node_modules" node_modules
+	ln -s "$main_checkout/node_modules" node_modules
 	echo "[preview] Symlinked node_modules from the main checkout." >&2
 fi
-if [ ! -e .env.local ] && [ ! -L .env.local ] && [ -f "$root/.env.local" ]; then
-	ln -s "$root/.env.local" .env.local
+if [ ! -e .env.local ] && [ ! -L .env.local ] && [ -f "$main_checkout/.env.local" ]; then
+	ln -s "$main_checkout/.env.local" .env.local
 	echo "[preview] Symlinked .env.local from the main checkout." >&2
 fi
 
+# The preview launcher may inherit an older default Node than pnpm 11 needs (>=22.13). Prefer the
+# repo's pinned .nvmrc version; otherwise fall back to the newest installed nvm node >=22.
+current_major="$(node -v 2>/dev/null | sed 's/^v//; s/\..*//')"
+if [ -z "$current_major" ] || [ "$current_major" -lt 22 ]; then
+	want=""
+	[ -f "$root/.nvmrc" ] && want="$(tr -d '[:space:]' < "$root/.nvmrc")"
+	if [ -n "$want" ] && [ -d "$HOME/.nvm/versions/node/v${want}/bin" ]; then
+		PATH="$HOME/.nvm/versions/node/v${want}/bin:$PATH"
+	elif [ -d "$HOME/.nvm/versions/node" ]; then
+		for d in $(ls -1 "$HOME/.nvm/versions/node" | sort -Vr); do
+			if [ "$(echo "$d" | sed 's/^v//; s/\..*//')" -ge 22 ]; then
+				PATH="$HOME/.nvm/versions/node/$d/bin:$PATH"
+				break
+			fi
+		done
+	fi
+	export PATH
+	echo "[preview] Adjusted PATH to Node $(node -v 2>/dev/null) for pnpm." >&2
+fi
+
 echo "[preview] Serving $(pwd) on port 5173" >&2
-exec pnpm run dev
+# node_modules is symlinked from the main checkout; skip pnpm's pre-run deps check so it can't
+# try to reinstall/purge it (the workspace state won't match, and a purge would mutate the
+# shared checkout). We just want to run the dev script against the already-installed modules.
+exec pnpm --config.verify-deps-before-run=false run dev

--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -55,12 +55,15 @@ current_major="$(node -v 2>/dev/null | sed 's/^v//; s/\..*//')"
 if [ -z "$current_major" ] || [ "$current_major" -lt 22 ]; then
 	want=""
 	[ -f "$root/.nvmrc" ] && want="$(tr -d '[:space:]' < "$root/.nvmrc")"
+	want="${want#v}" # .nvmrc may write the version with or without a leading `v`.
 	if [ -n "$want" ] && [ -d "$HOME/.nvm/versions/node/v${want}/bin" ]; then
 		PATH="$HOME/.nvm/versions/node/v${want}/bin:$PATH"
 	elif [ -d "$HOME/.nvm/versions/node" ]; then
-		for d in $(ls -1 "$HOME/.nvm/versions/node" | sort -Vr); do
-			if [ "$(echo "$d" | sed 's/^v//; s/\..*//')" -ge 22 ]; then
-				PATH="$HOME/.nvm/versions/node/$d/bin:$PATH"
+		# Newest installed >=22. Portable numeric sort (descending) instead of `sort -V`, which is a
+		# GNU/newer-BSD extension missing from older `sort` (e.g. stock macOS).
+		for v in $(ls -1 "$HOME/.nvm/versions/node" | sed 's/^v//' | sort -t. -k1,1rn -k2,2rn -k3,3rn); do
+			if [ "${v%%.*}" -ge 22 ]; then
+				PATH="$HOME/.nvm/versions/node/v$v/bin:$PATH"
 				break
 			fi
 		done

--- a/.claude/preview-worktree.sh
+++ b/.claude/preview-worktree.sh
@@ -56,20 +56,28 @@ if [ -z "$current_major" ] || [ "$current_major" -lt 22 ]; then
 	want=""
 	[ -f "$root/.nvmrc" ] && want="$(tr -d '[:space:]' < "$root/.nvmrc")"
 	want="${want#v}" # .nvmrc may write the version with or without a leading `v`.
+	adjusted=""
 	if [ -n "$want" ] && [ -d "$HOME/.nvm/versions/node/v${want}/bin" ]; then
 		PATH="$HOME/.nvm/versions/node/v${want}/bin:$PATH"
+		adjusted=1
 	elif [ -d "$HOME/.nvm/versions/node" ]; then
 		# Newest installed >=22. Portable numeric sort (descending) instead of `sort -V`, which is a
 		# GNU/newer-BSD extension missing from older `sort` (e.g. stock macOS).
 		for v in $(ls -1 "$HOME/.nvm/versions/node" | sed 's/^v//' | sort -t. -k1,1rn -k2,2rn -k3,3rn); do
 			if [ "${v%%.*}" -ge 22 ]; then
 				PATH="$HOME/.nvm/versions/node/v$v/bin:$PATH"
+				adjusted=1
 				break
 			fi
 		done
 	fi
-	export PATH
-	echo "[preview] Adjusted PATH to Node $(node -v 2>/dev/null) for pnpm." >&2
+	# Only claim an adjustment when PATH actually changed; otherwise warn (pnpm will likely fail).
+	if [ -n "$adjusted" ]; then
+		export PATH
+		echo "[preview] Adjusted PATH to Node $(node -v 2>/dev/null) for pnpm." >&2
+	else
+		echo "[preview] Warning: Node $(node -v 2>/dev/null) is older than pnpm 11 needs (>=22.13) and no nvm Node >=22 was found — pnpm may fail." >&2
+	fi
 fi
 
 echo "[preview] Serving $(pwd) on port 5173" >&2


### PR DESCRIPTION
## What

Three fixes to `.claude/preview-worktree.sh` (the `studio (worktree)` preview launch helper) so the dev server actually starts when launched from a **linked worktree** on port 5173.

Each bug independently prevented the preview from starting from a fresh worktree this session:

1. **Self-referential `node_modules` symlink → `ELOOP`.** The helper symlinks `node_modules`/`.env.local` "from the main checkout," but it used `$root = CLAUDE_PROJECT_DIR`, which is the *current* checkout — i.e. the worktree itself. So the link pointed a worktree at its own `node_modules` and pnpm crashed with `ELOOP: too many symbolic links`. Now derives the real main checkout from `git rev-parse --git-common-dir`.
2. **Old default Node vs pnpm 11.** The launcher can inherit an older default Node than pnpm 11 requires (`>=22.13`); a v20 default crashed pnpm at import (`node:util … styleText`). Now prepends the repo's pinned `.nvmrc` Node (or the newest installed nvm Node `>=22`) to `PATH` when the active node is too old.
3. **pnpm purging the shared `node_modules`.** pnpm's pre-run deps check saw a workspace-state mismatch (the symlink points at the main checkout) and tried to reinstall/**purge** `node_modules` — which would mutate the *shared* main checkout. Now skipped via `--config.verify-deps-before-run=false`.

## Why

Discovered while using `preview_start "studio (worktree)"` to review another PR — the launcher failed on all three in sequence from a clean worktree, and #3 risked mutating the shared main-checkout `node_modules`.

## Testing

- `bash -n` clean; `git rev-parse --git-common-dir` resolves the main checkout correctly from a worktree.
- The pre-commit hook suite ran green on this tree (218 files / 1482 tests, oxlint, dprint, commitlint).
- Verified live earlier: with all three fixes the worktree preview comes up on :5173 and backend auth carries over.

## Notes

- Touches only `.claude/preview-worktree.sh` (dev tooling; no product/runtime code).
- The commit is unsigned — GPG couldn't prompt for a passphrase in the non-interactive session it was created in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)