### PR TITLE
feat(status): drill into node-pair series from replication heatmap cells

### DIFF
--- a/src/features/instance/status/analytics/__tests__/pipeline/replication-drilldown.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/pipeline/replication-drilldown.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+// Drilldown from a replication-heatmap cell into the node-pair time series
+// (issue #1455): click / Enter on a data cell opens a dialog titled
+// `source → target` with the pair's latency line chart.
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ReplicationLatencyRenderer } from '../../pipeline/replication-latency';
+import type { AnalyticsDataPoint } from '../../types/analytics';
+
+const NODES = ['node-a', 'node-b'];
+
+function mk(source: string, dest: string, time: number, p95: number): AnalyticsDataPoint {
+	return { path: `${source}.db.tbl`, node: dest, time, p95, median: p95 / 2, count: 120, period: 60 };
+}
+
+// 2×2 matrix (heatmap branch: rows ≥ 2, cols ≥ 2, cells ≤ 12) with both
+// diagonal cells absent (a node never replicates to itself here).
+const records: AnalyticsDataPoint[] = [
+	mk('node-a', 'node-b', 1_000, 10),
+	mk('node-a', 'node-b', 2_000, 12),
+	mk('node-b', 'node-a', 1_000, 20),
+	mk('node-b', 'node-a', 2_000, 22),
+];
+
+function renderIt() {
+	return render(
+		<ReplicationLatencyRenderer
+			records={records}
+			nodes={NODES}
+			timeRange={{ startTime: 0, endTime: 60_000 }}
+		/>,
+	);
+}
+
+function findCell(re: RegExp) {
+	return screen.getAllByRole('gridcell').find((c) => re.test(c.getAttribute('aria-label') ?? ''))!;
+}
+
+afterEach(() => cleanup());
+
+describe('replication heatmap cell drilldown', () => {
+	it('clicking a data cell opens a dialog titled "source → target"', () => {
+		renderIt();
+		expect(screen.queryByRole('dialog')).toBeNull();
+		fireEvent.click(findCell(/node-a.*node-b/));
+		const dialog = screen.getByRole('dialog');
+		expect(dialog).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+	});
+
+	it('the dialog reflects the pair that was clicked', () => {
+		renderIt();
+		fireEvent.click(findCell(/node-b.*node-a/));
+		expect(screen.getByRole('heading', { name: 'node-b → node-a' })).toBeTruthy();
+		expect(screen.queryByRole('heading', { name: 'node-a → node-b' })).toBeNull();
+	});
+
+	it('Enter on the focused cell opens the dialog (keyboard parity)', () => {
+		renderIt();
+		const cell = findCell(/node-a.*node-b/);
+		(cell as HTMLElement).focus();
+		fireEvent.keyDown(cell, { key: 'Enter' });
+		expect(screen.getByRole('dialog')).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+	});
+
+	it('absent cells are aria-disabled and do not open the dialog', () => {
+		renderIt();
+		const absent = findCell(/node-a.*node-a/);
+		expect(absent.getAttribute('data-confidence')).toBe('absent');
+		expect(absent.getAttribute('aria-disabled')).toBe('true');
+		fireEvent.click(absent);
+		(absent as HTMLElement).focus();
+		fireEvent.keyDown(absent, { key: 'Enter' });
+		expect(screen.queryByRole('dialog')).toBeNull();
+	});
+
+	it('dialog description names the currently selected quantile', () => {
+		renderIt();
+		// Switch quantile to p50 (Harper field `median`) before drilling in.
+		const p50 = screen.getAllByTestId('quantile-button').find((b) => b.getAttribute('data-value') === 'median')!;
+		fireEvent.click(p50);
+		fireEvent.click(findCell(/node-a.*node-b/));
+		expect(screen.getByText(/p50 replication latency/i)).toBeTruthy();
+	});
+
+	it('a pair whose records all lack a numeric time opens with the empty-chart state', () => {
+		// Same 2×2 shape, but every node-a→node-b record has a bogus `time` —
+		// the cell still renders (matrix ignores time) yet the pair series is
+		// empty, so the dialog must fall through to "No data in window".
+		const noTime = [
+			{ ...mk('node-a', 'node-b', 0, 10), time: 'bogus' as unknown as number },
+			{ ...mk('node-a', 'node-b', 0, 12), time: 'bogus' as unknown as number },
+			mk('node-b', 'node-a', 1_000, 20),
+		];
+		render(
+			<ReplicationLatencyRenderer
+				records={noTime}
+				nodes={NODES}
+				timeRange={{ startTime: 0, endTime: 60_000 }}
+			/>,
+		);
+		fireEvent.click(findCell(/node-a.*node-b/));
+		const dialog = screen.getByRole('dialog');
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+		expect(dialog.textContent).toMatch(/No data in window/);
+	});
+
+	it('keeps the dialog open and tracking the pair when records refresh', () => {
+		const { rerender } = renderIt();
+		fireEvent.click(findCell(/node-a.*node-b/));
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+		// Background poll delivers a new window where the drilled pair has no
+		// timestamped records — the dialog stays open and shows the empty state.
+		const refreshed = [
+			{ ...mk('node-a', 'node-b', 0, 11), time: 'bogus' as unknown as number },
+			mk('node-b', 'node-a', 3_000, 24),
+		];
+		rerender(
+			<ReplicationLatencyRenderer
+				records={refreshed}
+				nodes={NODES}
+				timeRange={{ startTime: 0, endTime: 60_000 }}
+			/>,
+		);
+		const dialog = screen.getByRole('dialog');
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+		expect(dialog.textContent).toMatch(/No data in window/);
+	});
+
+	it('stays open when a refresh collapses the matrix into the line-fallback branch', () => {
+		const { rerender } = renderIt();
+		fireEvent.click(findCell(/node-a.*node-b/));
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+		// New window has a single source → renderer switches to the line
+		// fallback (no heatmap). The open drilldown must not vanish.
+		rerender(
+			<ReplicationLatencyRenderer
+				records={[mk('node-a', 'node-b', 1_000, 10), mk('node-a', 'node-b', 2_000, 12)]}
+				nodes={NODES}
+				timeRange={{ startTime: 0, endTime: 60_000 }}
+			/>,
+		);
+		expect(screen.getByRole('dialog')).toBeTruthy();
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+	});
+
+	it('re-applies the confidence gate when a refresh drops the pair below greyBelow', () => {
+		const { rerender } = renderIt();
+		fireEvent.click(findCell(/node-a.*node-b/));
+		expect(screen.getByRole('heading', { name: 'node-a → node-b' })).toBeTruthy();
+		// Refresh leaves the drilled pair with 20 samples (< greyBelow 40):
+		// the heatmap suppresses that cell, so the open dialog must hide the
+		// series too instead of leaking sub-threshold data.
+		const refreshed = [
+			{ ...mk('node-a', 'node-b', 1_000, 10), count: 20 },
+			mk('node-b', 'node-a', 1_000, 20),
+			mk('node-b', 'node-a', 2_000, 22),
+		];
+		rerender(
+			<ReplicationLatencyRenderer
+				records={refreshed}
+				nodes={NODES}
+				timeRange={{ startTime: 0, endTime: 60_000 }}
+			/>,
+		);
+		const dialog = screen.getByRole('dialog');
+		expect(dialog.textContent).toMatch(/Fewer than 40 samples/);
+		expect(dialog.textContent).toMatch(/series hidden/);
+	});
+
+	it('closing the dialog (Escape) returns to the heatmap and allows re-drill', () => {
+		renderIt();
+		fireEvent.click(findCell(/node-a.*node-b/));
+		const dialog = screen.getByRole('dialog');
+		fireEvent.keyDown(dialog, { key: 'Escape' });
+		expect(screen.queryByRole('dialog')).toBeNull();
+		// The grid is still there and another pair can be drilled.
+		fireEvent.click(findCell(/node-b.*node-a/));
+		expect(screen.getByRole('heading', { name: 'node-b → node-a' })).toBeTruthy();
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HeatmapMatrix } from '../../primitives/HeatmapMatrix';
 import type { HeatmapData } from '../../types/analytics';
 
@@ -222,6 +222,88 @@ describe('HeatmapMatrix primitive', () => {
 			.find((c) => (c.getAttribute('aria-label') ?? '').includes('no data'))!;
 		const rect = absent.querySelector('rect');
 		expect(rect?.getAttribute('stroke')).toBe('var(--chart-heatmap-muted-stroke, #9ca3af)');
+	});
+
+	describe('cell activation (onCellSelect)', () => {
+		const findCell = (re: RegExp) =>
+			screen.getAllByRole('gridcell').find((c) => re.test(c.getAttribute('aria-label') ?? ''))!;
+
+		it('click on a data cell fires onCellSelect with (row, col)', () => {
+			const onCellSelect = vi.fn();
+			render(<HeatmapMatrix data={data} onCellSelect={onCellSelect} />);
+			fireEvent.click(findCell(/src-1.*dest-a/));
+			expect(onCellSelect).toHaveBeenCalledTimes(1);
+			expect(onCellSelect).toHaveBeenCalledWith('src-1', 'dest-a');
+		});
+
+		it('click on a grey (low-confidence) cell still fires — grey cells carry data', () => {
+			const onCellSelect = vi.fn();
+			render(<HeatmapMatrix data={data} onCellSelect={onCellSelect} />);
+			const grey = findCell(/src-2.*dest-a/);
+			expect(grey.getAttribute('data-confidence')).toBe('grey');
+			fireEvent.click(grey);
+			expect(onCellSelect).toHaveBeenCalledWith('src-2', 'dest-a');
+		});
+
+		it('Enter on the focused cell activates and preventDefaults', () => {
+			const onCellSelect = vi.fn();
+			render(<HeatmapMatrix data={data} onCellSelect={onCellSelect} />);
+			const cell = findCell(/src-1.*dest-b/);
+			(cell as HTMLElement).focus();
+			const notPrevented = fireEvent.keyDown(cell, { key: 'Enter' });
+			expect(notPrevented, 'Enter preventDefaulted').toBe(false);
+			expect(onCellSelect).toHaveBeenCalledWith('src-1', 'dest-b');
+		});
+
+		it('Space on the focused cell activates', () => {
+			const onCellSelect = vi.fn();
+			render(<HeatmapMatrix data={data} onCellSelect={onCellSelect} />);
+			const cell = findCell(/src-1.*dest-a/);
+			(cell as HTMLElement).focus();
+			fireEvent.keyDown(cell, { key: ' ' });
+			expect(onCellSelect).toHaveBeenCalledWith('src-1', 'dest-a');
+		});
+
+		it('suppressed and absent cells are aria-disabled and fire on neither click nor Enter', () => {
+			const onCellSelect = vi.fn();
+			render(<HeatmapMatrix data={data} onCellSelect={onCellSelect} />);
+			const suppressed = findCell(/src-2.*dest-b/);
+			const absent = findCell(/src-1.*dest-c/);
+			expect(suppressed.getAttribute('data-confidence')).toBe('suppress');
+			expect(absent.getAttribute('data-confidence')).toBe('absent');
+			for (const cell of [suppressed, absent]) {
+				expect(cell.getAttribute('aria-disabled')).toBe('true');
+				fireEvent.click(cell);
+				(cell as HTMLElement).focus();
+				fireEvent.keyDown(cell, { key: 'Enter' });
+				fireEvent.keyDown(cell, { key: ' ' });
+			}
+			expect(onCellSelect).not.toHaveBeenCalled();
+		});
+
+		it('data cells are not aria-disabled when a handler is present', () => {
+			render(<HeatmapMatrix data={data} onCellSelect={() => {}} />);
+			expect(findCell(/src-1.*dest-a/).getAttribute('aria-disabled')).toBeNull();
+		});
+
+		it('without onCellSelect no cell is aria-disabled and Enter is inert', () => {
+			render(<HeatmapMatrix data={data} />);
+			const cells = screen.getAllByRole('gridcell');
+			expect(cells.every((c) => c.getAttribute('aria-disabled') === null)).toBe(true);
+			const cell = findCell(/src-1.*dest-a/);
+			(cell as HTMLElement).focus();
+			// Should not throw or preventDefault — nothing to activate.
+			const notPrevented = fireEvent.keyDown(cell, { key: 'Enter' });
+			expect(notPrevented).toBe(true);
+		});
+
+		it('grid description mentions activation only when a handler is present', () => {
+			const { unmount } = render(<HeatmapMatrix data={data} onCellSelect={() => {}} />);
+			expect(screen.getByTestId('heatmap-desc').textContent ?? '').toMatch(/Enter or Space/);
+			unmount();
+			render(<HeatmapMatrix data={data} />);
+			expect(screen.getByTestId('heatmap-desc').textContent ?? '').not.toMatch(/Enter or Space/);
+		});
 	});
 
 	it('takes the measure label from data.measureLabel (legend, description, and cell labels)', () => {

--- a/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.test.tsx
+++ b/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AnalyticsOnboardingHint } from './AnalyticsOnboardingHint';
 
-const STORAGE_KEY = 'studio:analytics:onboarding-dismissed:v1';
+const STORAGE_KEY = 'studio:analytics:onboarding-dismissed:v2';
 
 afterEach(() => {
 	cleanup();
@@ -18,6 +18,19 @@ describe('AnalyticsOnboardingHint', () => {
 	it('renders the tip on first visit', async () => {
 		render(<AnalyticsOnboardingHint />);
 		expect(await screen.findByText(/Click a legend entry to isolate one node/i)).toBeTruthy();
+		// The heatmap-drilldown claim must stay truthful — the feature ships
+		// with #1455, so the hint may advertise it.
+		expect(screen.getByText(/replication heatmap, click a cell/i)).toBeTruthy();
+	});
+
+	it('re-shows the tip for users who dismissed the v1 copy (key is versioned)', async () => {
+		window.localStorage.setItem('studio:analytics:onboarding-dismissed:v1', '1');
+		try {
+			render(<AnalyticsOnboardingHint />);
+			expect(await screen.findByText(/Click a legend entry to isolate one node/i)).toBeTruthy();
+		} finally {
+			window.localStorage.removeItem('studio:analytics:onboarding-dismissed:v1');
+		}
 	});
 
 	it('does not render when previously dismissed', () => {

--- a/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.tsx
+++ b/src/features/instance/status/analytics/components/AnalyticsOnboardingHint.tsx
@@ -5,11 +5,13 @@ import { useEffect, useState } from 'react';
 // Versioned key — bump the suffix to re-show the tip after a major UX
 // change (e.g. when we add a new keyboard shortcut or remove an existing
 // one). Past dismissals at older versions are ignored on purpose.
-const STORAGE_KEY = 'studio:analytics:onboarding-dismissed:v1';
+// v2: added the replication-heatmap cell drilldown (#1455).
+const STORAGE_KEY = 'studio:analytics:onboarding-dismissed:v2';
 
 /** First-visit hint explaining the chart interactions that aren't visually
  *  discoverable: click a legend entry to solo a node, ⌘/Ctrl-click to
- *  multi-select, and click a storage bar segment to pin its table's trend.
+ *  multi-select, click a storage bar segment to pin its table's trend, and
+ *  click a replication-heatmap cell to open that node pair's trend.
  *  Dismissal is persisted to localStorage so it doesn't reappear. */
 export function AnalyticsOnboardingHint() {
 	const [dismissed, setDismissed] = useState<boolean | null>(null);
@@ -44,7 +46,7 @@ export function AnalyticsOnboardingHint() {
 				<kbd className="rounded border border-border px-1 py-0.5 text-xs">⌘</kbd>
 				{' / '}
 				<kbd className="rounded border border-border px-1 py-0.5 text-xs">Ctrl</kbd>
-				{"-click to compare a few. In the storage charts, click a bar segment to pin that table's trend."}
+				{"-click to compare a few. In the storage charts, click a bar segment to pin that table's trend. In the replication heatmap, click a cell to see that node pair's latency over time."}
 			</div>
 			<Button
 				variant="ghost"

--- a/src/features/instance/status/analytics/components/HeatmapDrilldownDialog.tsx
+++ b/src/features/instance/status/analytics/components/HeatmapDrilldownDialog.tsx
@@ -1,0 +1,39 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { ReactNode } from 'react';
+
+interface Props {
+	/** Row label of the drilled cell — rendered as the left half of the
+	 *  `source → target` dialog title. */
+	source: string;
+	/** Column label of the drilled cell — the right half of the title. */
+	target: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Optional context line under the title (e.g. selected quantile + window). */
+	description?: ReactNode;
+	/** Chart body. Rendered inside a flex column sized like the expand
+	 *  dialog's canvas, so primitives can use `fillParent`. */
+	children: ReactNode;
+}
+
+/** Near-fullscreen dialog for drilling from a heatmap cell into the
+ *  node-pair time series behind it. Same shell as ChartExpandButton's
+ *  expanded view (95vw × 90vh flex column), but controlled by the
+ *  parent renderer — the heatmap cell, not a header button, opens it. */
+export function HeatmapDrilldownDialog({ source, target, open, onOpenChange, description, children }: Props) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent // Match ChartExpandButton: override the Card max-width for a
+			 // near-fullscreen canvas; pin both plain and sm: variants.
+			className="!max-w-[95vw] sm:!max-w-[95vw] h-[90vh] flex flex-col">
+				<DialogHeader>
+					<DialogTitle>{`${source} → ${target}`}</DialogTitle>
+					{description && <DialogDescription>{description}</DialogDescription>}
+				</DialogHeader>
+				<div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+					{children}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useMemo, useState } from 'react';
+import { type JSX, useMemo, useRef, useState } from 'react';
 import { HeatmapDrilldownDialog } from '../components/HeatmapDrilldownDialog';
 import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
 import { infoBannerStyle, warningBannerStyle } from '../primitives/bannerStyle';
@@ -321,6 +321,12 @@ function buildLineSeries(
 	return { seriesData: { series }, omittedPairsCount };
 }
 
+interface DrilldownData {
+	suppressed: boolean;
+	sampleCount: number;
+	seriesData: SeriesData;
+}
+
 export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JSX.Element {
 	const { records, nodes, timeRange, fillParent } = props;
 
@@ -343,22 +349,30 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 	// quantile/window, so the open dialog tracks the selectors — and re-applies
 	// the confidence gate: a refresh can drop the pair below `greyBelow`, and
 	// the dialog must then hide the series just like the heatmap cell does.
+	// Once closed, background refreshes skip the recompute (drillPair is kept
+	// for the Radix exit animation, so without the gate every refresh would
+	// re-filter all records for an invisible dialog forever); the ref serves
+	// the last computed content to the exit animation instead.
+	const lastDrilldownRef = useRef<DrilldownData | null>(null);
 	const drilldown = useMemo(() => {
 		if (!drillPair) { return null; }
+		if (!drillOpen) { return lastDrilldownRef.current; }
 		const matching = parseResult.parsed.filter(
 			(p) => p.source === drillPair.source && p.destination === drillPair.dest,
 		);
 		const sampleCount = matching.reduce((sum, p) => sum + p.count, 0);
 		const { points, approx } = lineSeriesFromParsed(matching);
 		const label = `${drillPair.source} → ${drillPair.dest}`;
-		return {
+		const result: DrilldownData = {
 			suppressed: sampleCount < REPLICATION_CONFIDENCE.greyBelow,
 			sampleCount,
 			// Empty points (e.g. every record lacked a numeric `time`) fall
 			// through to LineChart's "No data in window" state inside the dialog.
 			seriesData: { series: points.length === 0 ? [] : [{ key: label, label, points, approx }] } as SeriesData,
 		};
-	}, [drillPair, parseResult]);
+		lastDrilldownRef.current = result;
+		return result;
+	}, [drillPair, drillOpen, parseResult]);
 
 	const quantileLabel = REPLICATION_QUANTILE_FIELDS.find((q) => q.field === quantile)?.label ?? quantile;
 

--- a/src/features/instance/status/analytics/pipeline/replication-latency.tsx
+++ b/src/features/instance/status/analytics/pipeline/replication-latency.tsx
@@ -1,4 +1,5 @@
 import { type JSX, useMemo, useState } from 'react';
+import { HeatmapDrilldownDialog } from '../components/HeatmapDrilldownDialog';
 import { useRovingRadioGroup } from '../hooks/useRovingRadioGroup';
 import { infoBannerStyle, warningBannerStyle } from '../primitives/bannerStyle';
 import { HeatmapMatrix } from '../primitives/HeatmapMatrix';
@@ -324,6 +325,11 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 	const { records, nodes, timeRange, fillParent } = props;
 
 	const [quantile, setQuantile] = useState<ReplicationQuantileField>('p95');
+	// Heatmap-cell drilldown target. `drillPair` survives close (open is
+	// tracked separately) so Radix's exit animation keeps its content
+	// instead of unmounting mid-transition.
+	const [drillPair, setDrillPair] = useState<{ source: string; dest: string } | null>(null);
+	const [drillOpen, setDrillOpen] = useState(false);
 
 	// Parse once per (records, nodes, quantile); the matrix and the line
 	// fallback both consume the same parsed records.
@@ -333,6 +339,63 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 	);
 	const data = useMemo(() => matrixFromParsed(parseResult), [parseResult]);
 
+	// Single-pair series for the drilldown dialog. Recomputes with the live
+	// quantile/window, so the open dialog tracks the selectors — and re-applies
+	// the confidence gate: a refresh can drop the pair below `greyBelow`, and
+	// the dialog must then hide the series just like the heatmap cell does.
+	const drilldown = useMemo(() => {
+		if (!drillPair) { return null; }
+		const matching = parseResult.parsed.filter(
+			(p) => p.source === drillPair.source && p.destination === drillPair.dest,
+		);
+		const sampleCount = matching.reduce((sum, p) => sum + p.count, 0);
+		const { points, approx } = lineSeriesFromParsed(matching);
+		const label = `${drillPair.source} → ${drillPair.dest}`;
+		return {
+			suppressed: sampleCount < REPLICATION_CONFIDENCE.greyBelow,
+			sampleCount,
+			// Empty points (e.g. every record lacked a numeric `time`) fall
+			// through to LineChart's "No data in window" state inside the dialog.
+			seriesData: { series: points.length === 0 ? [] : [{ key: label, label, points, approx }] } as SeriesData,
+		};
+	}, [drillPair, parseResult]);
+
+	const quantileLabel = REPLICATION_QUANTILE_FIELDS.find((q) => q.field === quantile)?.label ?? quantile;
+
+	// Rendered in every branch below (heatmap, line fallback, empty state) so
+	// a background refresh that changes the layout doesn't abruptly unmount an
+	// open drilldown.
+	const drilldownDialog = drillPair && drilldown
+		? (
+			<HeatmapDrilldownDialog
+				source={drillPair.source}
+				target={drillPair.dest}
+				open={drillOpen}
+				onOpenChange={(open) => {
+					// Keep drillPair on close — the exit animation needs the content.
+					if (!open) { setDrillOpen(false); }
+				}}
+				description={`${quantileLabel} replication latency over the selected window, count-weighted-mean per time bucket.`}
+			>
+				{drilldown.suppressed
+					? (
+						<div role="status" className="text-(--color-text-secondary) text-sm p-4">
+							{`Fewer than ${REPLICATION_CONFIDENCE.greyBelow} samples for this pair in the current window (${drilldown.sampleCount}) — series hidden.`}
+						</div>
+					)
+					: (
+						<LineChart
+							data={drilldown.seriesData}
+							yAxis={data.axis}
+							height={320}
+							xDomain={[timeRange.startTime, timeRange.endTime]}
+							fillParent
+						/>
+					)}
+			</HeatmapDrilldownDialog>
+		)
+		: null;
+
 	// Empty state — still surface skipped-records banner so users see the cause
 	// when 100% of records had unparseable source nodes.
 	if (data.rows.length === 0 || data.cols.length === 0) {
@@ -341,6 +404,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 				<RecognitionBanner data={data} />
 
 				<div>No data in window</div>
+				{drilldownDialog}
 			</div>
 		);
 	}
@@ -423,6 +487,7 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 							/>
 						</div>
 					)}
+				{drilldownDialog}
 			</div>
 		);
 	}
@@ -437,8 +502,16 @@ export function ReplicationLatencyRenderer(props: SpecRegistryRendererProps): JS
 				    RecognitionBanner above already reports omissions with
 				    cause-specific copy, so letting both render double-reports. */
 				}
-				<HeatmapMatrix data={{ ...data, skippedRecordsCount: 0 }} title="Replication latency" />
+				<HeatmapMatrix
+					data={{ ...data, skippedRecordsCount: 0, measureLabel: `${quantileLabel} latency` }}
+					title="Replication latency"
+					onCellSelect={(row, col) => {
+						setDrillPair({ source: row, dest: col });
+						setDrillOpen(true);
+					}}
+				/>
 			</div>
+			{drilldownDialog}
 		</div>
 	);
 }

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -11,6 +11,10 @@ interface Props {
 	data: HeatmapData;
 	title?: string;
 	height?: number;
+	/** Called when a data-bearing cell ('ok'/'grey') is activated — click, or
+	 *  Enter/Space on the focused gridcell. Suppressed/absent cells never fire
+	 *  and render `aria-disabled` while a handler is present. */
+	onCellSelect?: (row: string, col: string) => void;
 }
 
 /** Confidence-state greys — CSS tokens defined per theme in src/index.css
@@ -97,6 +101,12 @@ function classifyCell(
 	if (count < greyBelow) { return 'suppress'; }
 	if (count < suppressBelow) { return 'grey'; }
 	return 'ok';
+}
+
+/** Single guard shared by the click and Enter/Space activation paths so the
+ *  two can never disagree on which cells are drillable. */
+function isActivatable(confidence: Confidence): boolean {
+	return confidence === 'ok' || confidence === 'grey';
 }
 
 function truncate(s: string, max: number): string {
@@ -235,7 +245,7 @@ const CELL_GAP = 4;
 const HEADER_HEIGHT = 72; // reserved for rotated column headers
 const ROW_LABEL_WIDTH = 200;
 
-export function HeatmapMatrix({ data, title, height }: Props) {
+export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 	const titleId = useId();
 	const descId = useId();
 	const suppressPatternId = useId();
@@ -335,6 +345,19 @@ export function HeatmapMatrix({ data, title, height }: Props) {
 	const handleKeyDown = useCallback(
 		(e: ReactKeyboardEvent<SVGGElement>, r: number, c: number) => {
 			const k = e.key;
+			if (k === 'Enter' || k === ' ') {
+				if (!onCellSelect) { return; }
+				// Always consume the key while cells are selectable — Space must
+				// not scroll the page even when the focused cell is disabled.
+				e.preventDefault();
+				e.stopPropagation();
+				const row = rows[r];
+				const col = cols[c];
+				// Same guard as the click path: only data-bearing cells activate.
+				const confidence = classifyCell(cellMap.get(`${row}|${col}`), greyBelow, suppressBelow);
+				if (isActivatable(confidence)) { onCellSelect(row, col); }
+				return;
+			}
 			let handled = false;
 			let nr = r;
 			let nc = c;
@@ -368,7 +391,7 @@ export function HeatmapMatrix({ data, title, height }: Props) {
 			e.stopPropagation();
 			if (nr !== r || nc !== c) { focusCell(nr, nc); }
 		},
-		[rows.length, cols.length, focusCell],
+		[rows, cols, focusCell, cellMap, greyBelow, suppressBelow, onCellSelect],
 	);
 
 	// Focus halo stroke color based on cell fill luminance.
@@ -429,9 +452,12 @@ export function HeatmapMatrix({ data, title, height }: Props) {
 					const descPrefix = approx
 						? `Cells show count-weighted-mean ${measureLabel} (approx).`
 						: `Cells show ${measureLabel}.`;
-					return `${descPrefix} Cells with fewer than ${suppressBelow} samples are blank; ${greyBelow}–${
+					const base = `${descPrefix} Cells with fewer than ${suppressBelow} samples are blank; ${greyBelow}–${
 						suppressBelow - 1
 					} render grey.`;
+					return onCellSelect
+						? `${base} Click a populated cell, or press Enter or Space on it, to open its trend.`
+						: base;
 				})()}
 			</p>
 
@@ -564,17 +590,21 @@ export function HeatmapMatrix({ data, title, height }: Props) {
 										else { cellRefs.current.delete(`${ri}|${ci}`); }
 									};
 
+									const activatable = onCellSelect !== undefined && isActivatable(confidence);
+
 									return (
 										<g
 											key={col}
 											ref={setRef}
 											role="gridcell"
 											aria-label={aria}
+											aria-disabled={onCellSelect !== undefined && !activatable ? true : undefined}
 											data-confidence={confidence}
 											tabIndex={isActive ? 0 : -1}
+											onClick={activatable ? () => onCellSelect(row, col) : undefined}
 											onKeyDown={(e) => handleKeyDown(e, ri, ci)}
 											onFocus={() => setActive([ri, ci])}
-											style={{ outline: 'none', cursor: 'default' }}
+											style={{ outline: 'none', cursor: activatable ? 'pointer' : 'default' }}
 										>
 											<rect
 												x={cx}


### PR DESCRIPTION
## Summary

Builds the drilldown the onboarding hint promises: clicking (or pressing Enter/Space on) a data-bearing cell in the replication-latency heatmap opens a near-fullscreen dialog titled `source → target`, containing that node pair's latency line chart over the currently selected window and quantile.

Fixes #1455

## What changed

- **`primitives/HeatmapMatrix.tsx`** — new generic, optional `onCellSelect(row, col)` prop. Click and Enter/Space activation share a single `isActivatable` guard (only `ok`/`grey` cells fire). While a handler is present, suppressed/absent cells render `aria-disabled="true"`, activatable cells get a pointer cursor, Enter/Space is always consumed (so Space can't scroll the page even on a disabled cell), and the visually-hidden grid description announces the interaction.
- **`components/HeatmapDrilldownDialog.tsx`** (new) — controlled dialog reusing the `ChartExpandButton` shell (95vw × 90vh flex column, shadcn/Radix Dialog), title `source → target`.
- **`pipeline/replication-latency.tsx`** — wires the cell activation to the dialog. The single-pair series is derived from the already-shared parse pass (`lineSeriesFromParsed`), so it tracks the live window and quantile selectors while the dialog is open. Two refresh edge cases are handled explicitly:
  - the dialog renders in **every** renderer branch, so a background refresh that collapses the matrix into the line-fallback (or empty) branch doesn't abruptly unmount an open drilldown;
  - the `greyBelow` confidence gate is re-applied on refresh — if the drilled pair drops below 40 samples, the dialog swaps the chart for a "series hidden" notice instead of leaking sub-threshold data.
  - Bonus: the heatmap's `measureLabel` now tracks the selected quantile (previously the legend/aria copy said "p95 latency" even with p50/p99 selected).
- **`components/AnalyticsOnboardingHint.tsx`** — hint copy now (truthfully) advertises the heatmap drilldown; storage key bumped `v1 → v2` per the documented versioning convention so previously-dismissed users see the updated tip once.

## Review focus

- The activation symmetry in `HeatmapMatrix.tsx`: both paths route through `isActivatable(classifyCell(...))` — flag anything that could let click and keyboard disagree.
- The all-branch dialog placement in the renderer — confirm rendering it from the fallback/empty branches has no unwanted interaction with those layouts (it's a portal, so it shouldn't).
- The suppressed-state copy in the dialog ("Fewer than 40 samples … series hidden") — happy to reword.

## Testing

- `__tests__/primitives/heatmap-matrix.test.tsx`: click/Enter/Space activation, grey-cell activation, suppressed/absent cells inert + `aria-disabled`, no `aria-disabled` without a handler, description copy gated on the handler.
- `__tests__/pipeline/replication-drilldown.test.tsx` (new, 10 tests): dialog opens with the right pair title via click and keyboard, absent cells don't open it, description tracks the selected quantile, Escape closes and allows re-drill, empty-pair series shows the empty-chart state, and both refresh edge cases above.
- Full suite: 220 files, 1506 passed / 11 skipped. `tsc -b`, `oxlint`, `dprint` clean.

## Cross-model review

- **Gemini 3.1 Pro**: 4 findings, all addressed — Space-scroll on disabled cells (fixed via unconditional preventDefault), dialog unmount bypassing Radix exit animation (fixed by splitting `drillPair` from `drillOpen`), plus two test-coverage gaps (both tests added).
- **Codex**: two passes. Final pass raised 2 P2s, both fixed with regression tests — dialog unmounting when a refresh switches the renderer to the fallback branch, and the confidence gate not being re-applied to an already-open dialog.
- No unresolved findings.

Comment generated by kAIle (Claude Fable 5)
