### PR TITLE
feat(status): add CSV export beside the chart PNG export buttons

### DIFF
--- a/src/features/instance/status/analytics/components/ChartCsvButton.test.tsx
+++ b/src/features/instance/status/analytics/components/ChartCsvButton.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	toastSuccess: vi.fn(),
+	toastError: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+	toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}));
+
+import type { ChartCsvData } from '../lib/csvExport';
+import { AnalyticsTestWrapper } from '../tabs/__tests__/testHelpers';
+import { ChartCsvButton } from './ChartCsvButton';
+
+afterEach(() => {
+	cleanup();
+	mocks.toastSuccess.mockClear();
+	mocks.toastError.mockClear();
+});
+
+const seriesData: ChartCsvData = {
+	kind: 'series',
+	data: { series: [{ key: 'a', label: 'alpha', points: [{ x: 0, y: 1 }] }] },
+};
+
+function Harness({ getCsvData }: { getCsvData: () => ChartCsvData | null }) {
+	return (
+		<AnalyticsTestWrapper>
+			<ChartCsvButton exportSlug="connections" getCsvData={getCsvData} />
+		</AnalyticsTestWrapper>
+	);
+}
+
+describe('ChartCsvButton', () => {
+	it('renders an accessible label', () => {
+		render(<Harness getCsvData={() => seriesData} />);
+		expect(screen.getByLabelText(/Download connections as CSV/i)).toBeTruthy();
+	});
+
+	it('downloads a text/csv blob named <metric>-<start>-<end>.csv and toasts success', () => {
+		// jsdom's URL.createObjectURL doesn't exist by default.
+		const origCreate = URL.createObjectURL;
+		const origRevoke = URL.revokeObjectURL;
+		const createObjectURL = vi.fn((_obj: Blob | MediaSource) => 'blob:mock');
+		URL.createObjectURL = createObjectURL;
+		URL.revokeObjectURL = vi.fn();
+		const clicks: Array<{ download: string }> = [];
+		const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click')
+			.mockImplementation(function(this: HTMLAnchorElement) {
+				clicks.push({ download: this.download });
+			});
+		try {
+			render(<Harness getCsvData={() => seriesData} />);
+			fireEvent.click(screen.getByLabelText(/Download connections as CSV/i));
+
+			expect(createObjectURL).toHaveBeenCalledTimes(1);
+			const blob = createObjectURL.mock.calls[0]?.[0] as Blob;
+			expect(blob.type).toContain('text/csv');
+			// AnalyticsTestWrapper's timeRange is 0 → 60_000.
+			const expected = 'connections-1970-01-01T00-00-00-000Z-1970-01-01T00-01-00-000Z.csv';
+			expect(clicks).toEqual([{ download: expected }]);
+			expect(mocks.toastSuccess).toHaveBeenCalledWith(`Saved ${expected}`);
+			expect(mocks.toastError).not.toHaveBeenCalled();
+		} finally {
+			clickSpy.mockRestore();
+			URL.createObjectURL = origCreate;
+			URL.revokeObjectURL = origRevoke;
+		}
+	});
+
+	it('shows an error toast and downloads nothing when there is no data', () => {
+		const origCreate = URL.createObjectURL;
+		const createObjectURL = vi.fn(() => 'blob:mock');
+		URL.createObjectURL = createObjectURL;
+		try {
+			render(<Harness getCsvData={() => null} />);
+			fireEvent.click(screen.getByLabelText(/Download connections as CSV/i));
+			expect(mocks.toastError).toHaveBeenCalledWith('No data to export');
+			expect(createObjectURL).not.toHaveBeenCalled();
+			expect(mocks.toastSuccess).not.toHaveBeenCalled();
+		} finally {
+			URL.createObjectURL = origCreate;
+		}
+	});
+
+	it('shows an error toast when serialization throws', () => {
+		render(
+			<Harness
+				getCsvData={() => {
+					throw new Error('boom');
+				}}
+			/>,
+		);
+		fireEvent.click(screen.getByLabelText(/Download connections as CSV/i));
+		expect(mocks.toastError).toHaveBeenCalledWith('Could not export CSV', { description: 'boom' });
+	});
+});

--- a/src/features/instance/status/analytics/components/ChartCsvButton.tsx
+++ b/src/features/instance/status/analytics/components/ChartCsvButton.tsx
@@ -1,0 +1,58 @@
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { FileSpreadsheet } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAnalyticsContext } from '../context/AnalyticsContext';
+import { chartCsv, type ChartCsvData, downloadCsv, makeCsvFilename } from '../lib/csvExport';
+
+interface Props {
+	/** Slug used as the filename prefix (e.g. metric id or panel title). */
+	exportSlug: string;
+	/** Lazily produces the chart data to serialize — called on click so the
+	 *  CSV always reflects the panel's current records. Return null when
+	 *  there is nothing to export (the button then shows an error toast). */
+	getCsvData: () => ChartCsvData | null;
+}
+
+/** Downloads the panel's rendered data as CSV. Sits beside ChartCopyButton /
+ *  ChartExportButton in the panel-header action row and shares their
+ *  gating: the parent only renders the row when there is data on screen.
+ *  Serialization is synchronous and recomputes from records already fetched
+ *  — no network. */
+export function ChartCsvButton({ exportSlug, getCsvData }: Props) {
+	const { timeRange } = useAnalyticsContext();
+
+	const onClick = () => {
+		const filename = makeCsvFilename(exportSlug, timeRange);
+		try {
+			const data = getCsvData();
+			if (!data) {
+				toast.error('No data to export');
+				return;
+			}
+			downloadCsv(chartCsv(data), filename);
+			toast.success(`Saved ${filename}`);
+		} catch (err) {
+			console.error('[chart-csv] export failed', err);
+			toast.error('Could not export CSV', {
+				description: err instanceof Error ? err.message : 'Unknown error',
+			});
+		}
+	};
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onClick}
+					aria-label={`Download ${exportSlug} as CSV`}
+				>
+					<FileSpreadsheet className="h-4 w-4" />
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="top">Download as CSV</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/src/features/instance/status/analytics/components/ChartExpandButton.tsx
+++ b/src/features/instance/status/analytics/components/ChartExpandButton.tsx
@@ -3,7 +3,9 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Maximize2 } from 'lucide-react';
 import { type ReactNode, useRef, useState } from 'react';
+import type { ChartCsvData } from '../lib/csvExport';
 import { ChartCopyButton } from './ChartCopyButton';
+import { ChartCsvButton } from './ChartCsvButton';
 import { ChartExportButton } from './ChartExportButton';
 
 interface Props {
@@ -20,13 +22,17 @@ interface Props {
 	 *  parent and grows the chart. The `fillParent` arg lets primitives
 	 *  switch from a fixed `height` to filling the dialog's `h-[90vh]`. */
 	renderChart: (opts: { fillParent: boolean }) => ReactNode;
+	/** When provided, the dialog's action row also offers a CSV download of
+	 *  the rendered data (same output as the panel-header CSV button, so the
+	 *  filename keeps the plain slug). */
+	getCsvData?: () => ChartCsvData | null;
 }
 
 /** Adds an "Expand" icon next to other panel-header actions. Click opens
  *  a near-fullscreen Radix Dialog containing the same chart re-rendered
  *  at full size, plus its own export button so the capture grabs the
  *  bigger DOM (and therefore produces a higher-resolution PNG). */
-export function ChartExpandButton({ exportSlug, title, description, renderChart }: Props) {
+export function ChartExpandButton({ exportSlug, title, description, renderChart, getCsvData }: Props) {
 	const [open, setOpen] = useState(false);
 	const expandedRef = useRef<HTMLDivElement>(null);
 
@@ -59,6 +65,7 @@ export function ChartExpandButton({ exportSlug, title, description, renderChart 
 							<div className="flex items-center gap-1 shrink-0">
 								<ChartCopyButton captureRef={expandedRef} exportSlug={`${exportSlug}-expanded`} />
 								<ChartExportButton captureRef={expandedRef} exportSlug={`${exportSlug}-expanded`} />
+								{getCsvData && <ChartCsvButton exportSlug={exportSlug} getCsvData={getCsvData} />}
 							</div>
 						</div>
 					</DialogHeader>

--- a/src/features/instance/status/analytics/hooks/useAnalyticsRecords.ts
+++ b/src/features/instance/status/analytics/hooks/useAnalyticsRecords.ts
@@ -30,6 +30,12 @@ export interface UseAnalyticsRecordsResult {
 	fieldKeys: Set<string>;
 	/** Subset of `requiredFields` that did not appear on any row. */
 	missingFields: string[];
+	/** True while `data` is the previous window's rows held by
+	 *  `keepPreviousData` during an in-flight window change — the rows do
+	 *  NOT belong to the requested [startTime, endTime]. Consumers that
+	 *  pair `data` with the requested window (CSV export filenames,
+	 *  previous-vs-current deltas) must gate on this. */
+	isPlaceholderData: boolean;
 	refetch: () => void;
 }
 
@@ -132,6 +138,7 @@ export function useAnalyticsRecords({
 		isEmpty: data.length === 0,
 		fieldKeys,
 		missingFields,
+		isPlaceholderData: query.isPlaceholderData,
 		refetch: query.refetch,
 	};
 }

--- a/src/features/instance/status/analytics/lib/chartExport.ts
+++ b/src/features/instance/status/analytics/lib/chartExport.ts
@@ -43,14 +43,13 @@ export async function captureChartAsBlob(
  *  Shared by the PNG export and the CSV export so they can't drift. */
 export function triggerBlobDownload(blob: Blob, filename: string): void {
 	const url = URL.createObjectURL(blob);
-	try {
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = filename;
-		a.click();
-	} finally {
-		URL.revokeObjectURL(url);
-	}
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	a.click();
+	// Revoke on a later tick: some browsers (Firefox) start the download
+	// asynchronously, and a synchronous revoke can abort it.
+	window.setTimeout(() => URL.revokeObjectURL(url), 10_000);
 }
 
 export async function downloadChart(chartContainer: HTMLElement, filename: string): Promise<void> {

--- a/src/features/instance/status/analytics/lib/chartExport.ts
+++ b/src/features/instance/status/analytics/lib/chartExport.ts
@@ -39,8 +39,9 @@ export async function captureChartAsBlob(
 	return blob;
 }
 
-export async function downloadChart(chartContainer: HTMLElement, filename: string): Promise<void> {
-	const blob = await captureChartAsBlob(chartContainer);
+/** Trigger a browser download of `blob` as `filename` via a transient anchor.
+ *  Shared by the PNG export and the CSV export so they can't drift. */
+export function triggerBlobDownload(blob: Blob, filename: string): void {
 	const url = URL.createObjectURL(blob);
 	try {
 		const a = document.createElement('a');
@@ -50,6 +51,11 @@ export async function downloadChart(chartContainer: HTMLElement, filename: strin
 	} finally {
 		URL.revokeObjectURL(url);
 	}
+}
+
+export async function downloadChart(chartContainer: HTMLElement, filename: string): Promise<void> {
+	const blob = await captureChartAsBlob(chartContainer);
+	triggerBlobDownload(blob, filename);
 }
 
 /** Capture the chart and write it to the clipboard as a PNG ClipboardItem.
@@ -71,9 +77,17 @@ export async function copyChartToClipboard(chartContainer: HTMLElement): Promise
 	}
 }
 
+/** Slugify a metric/title for use in a download filename. */
+export function slugifyForFilename(prefix: string): string {
+	return prefix.replace(/[^a-z0-9-]+/gi, '-').replace(/(^-|-$)/g, '').toLowerCase();
+}
+
+/** ISO-8601 timestamp with filename-hostile characters (`:` `.`) dashed. */
+export function filenameTimestamp(ms: number): string {
+	return new Date(ms).toISOString().replace(/[:.]/g, '-');
+}
+
 /** Slugify a metric/title for use as a download filename. */
 export function makeExportFilename(prefix: string, range: { startTime: number; endTime: number }): string {
-	const safe = prefix.replace(/[^a-z0-9-]+/gi, '-').replace(/(^-|-$)/g, '').toLowerCase();
-	const stamp = new Date(range.endTime).toISOString().replace(/[:.]/g, '-');
-	return `${safe}-${stamp}.png`;
+	return `${slugifyForFilename(prefix)}-${filenameTimestamp(range.endTime)}.png`;
 }

--- a/src/features/instance/status/analytics/lib/csvExport.test.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import type { AnalyticsDataPoint, HeatmapData, SeriesData } from '../types/analytics';
+import { computeMetricCsvData, heatmapToCsv, makeCsvFilename, seriesToCsv } from './csvExport';
+
+function lines(csv: string): string[] {
+	// Trailing CRLF terminates the last record — strip it before splitting.
+	expect(csv.endsWith('\r\n')).toBe(true);
+	return csv.slice(0, -2).split('\r\n');
+}
+
+describe('seriesToCsv', () => {
+	it('emits an ISO-8601 timestamp column plus one column per series, in series order', () => {
+		const data: SeriesData = {
+			series: [
+				{ key: 'a', label: 'alpha', points: [{ x: 0, y: 1 }, { x: 60_000, y: 2 }] },
+				{ key: 'b', label: 'beta', points: [{ x: 0, y: 10 }, { x: 60_000, y: 20 }] },
+			],
+		};
+		expect(lines(seriesToCsv(data))).toEqual([
+			'timestamp,alpha,beta',
+			'1970-01-01T00:00:00.000Z,1,10',
+			'1970-01-01T00:01:00.000Z,2,20',
+		]);
+	});
+
+	it('unions x values across series and leaves empty cells for gaps and null samples', () => {
+		const data: SeriesData = {
+			series: [
+				// null y = explicit gap; missing x = no sample at that timestamp.
+				{ key: 'a', label: 'alpha', points: [{ x: 0, y: null }, { x: 120_000, y: 3 }] },
+				{ key: 'b', label: 'beta', points: [{ x: 60_000, y: 5 }] },
+			],
+		};
+		expect(lines(seriesToCsv(data))).toEqual([
+			'timestamp,alpha,beta',
+			'1970-01-01T00:00:00.000Z,,',
+			'1970-01-01T00:01:00.000Z,,5',
+			'1970-01-01T00:02:00.000Z,3,',
+		]);
+	});
+
+	it('escapes labels containing commas, quotes, and newlines per RFC 4180', () => {
+		const data: SeriesData = {
+			series: [
+				{ key: 'a', label: 'a,b', points: [{ x: 0, y: 1 }] },
+				{ key: 'b', label: 'say "hi"', points: [{ x: 0, y: 2 }] },
+				{ key: 'c', label: 'two\nlines', points: [{ x: 0, y: 3 }] },
+			],
+		};
+		expect(lines(seriesToCsv(data))[0]).toBe('timestamp,"a,b","say ""hi""","two\nlines"');
+	});
+
+	it('neutralizes formula-leading labels so spreadsheets import them as text', () => {
+		const data: SeriesData = {
+			series: [
+				{ key: 'a', label: '=SUM(A1:A9)', points: [{ x: 0, y: 1 }] },
+				{ key: 'b', label: '+p95', points: [{ x: 0, y: 2 }] },
+				{ key: 'c', label: '@cmd', points: [{ x: 0, y: 3 }] },
+				{ key: 'd', label: '-neg', points: [{ x: 0, y: -4 }] },
+			],
+		};
+		const out = lines(seriesToCsv(data));
+		expect(out[0]).toBe(`timestamp,'=SUM(A1:A9),'+p95,'@cmd,'-neg`);
+		// Numeric cells keep their sign — only string cells are neutralized.
+		expect(out[1]).toBe('1970-01-01T00:00:00.000Z,1,2,3,-4');
+	});
+
+	it('dedupes duplicate labels by appending the series key', () => {
+		const data: SeriesData = {
+			series: [
+				{ key: 'db1|n1', label: 'db1', points: [{ x: 0, y: 1 }] },
+				{ key: 'db1|n2', label: 'db1', points: [{ x: 0, y: 2 }] },
+			],
+		};
+		expect(lines(seriesToCsv(data))[0]).toBe('timestamp,db1 (db1|n1),db1 (db1|n2)');
+	});
+
+	it('includes the ceiling series as a trailing column when present', () => {
+		const data: SeriesData = {
+			series: [{ key: 'heap', label: 'heap', points: [{ x: 0, y: 1 }] }],
+			ceiling: { key: 'rss', label: 'rss', points: [{ x: 0, y: 8 }] },
+		};
+		expect(lines(seriesToCsv(data))).toEqual([
+			'timestamp,heap,rss',
+			'1970-01-01T00:00:00.000Z,1,8',
+		]);
+	});
+
+	it('returns only the header for empty series data', () => {
+		expect(lines(seriesToCsv({ series: [] }))).toEqual(['timestamp']);
+	});
+});
+
+describe('heatmapToCsv', () => {
+	it('emits row,col,value,count with empty cells for absent values/counts', () => {
+		const data: HeatmapData = {
+			rows: ['n1', 'n2'],
+			cols: ['n2'],
+			cells: [
+				{ row: 'n1', col: 'n2', value: 12.5, count: 40 },
+				{ row: 'n2', col: 'n2', value: null },
+			],
+			skippedRecordsCount: 0,
+		};
+		expect(lines(heatmapToCsv(data))).toEqual([
+			'row,col,value,count',
+			'n1,n2,12.5,40',
+			'n2,n2,,',
+		]);
+	});
+
+	it('escapes row/col labels per RFC 4180', () => {
+		const data: HeatmapData = {
+			rows: ['a,b'],
+			cols: ['c"d'],
+			cells: [{ row: 'a,b', col: 'c"d', value: 1, count: 2 }],
+			skippedRecordsCount: 0,
+		};
+		expect(lines(heatmapToCsv(data))[1]).toBe('"a,b","c""d",1,2');
+	});
+});
+
+describe('makeCsvFilename', () => {
+	it('produces <metric>-<start>-<end>.csv with a sanitized metric slug', () => {
+		const name = makeCsvFilename('CPU usage %', { startTime: 0, endTime: 60_000 });
+		expect(name).toBe('cpu-usage-1970-01-01T00-00-00-000Z-1970-01-01T00-01-00-000Z.csv');
+	});
+});
+
+describe('computeMetricCsvData', () => {
+	const window = { startTime: 0, endTime: 120_000 };
+
+	it('returns null for empty records and for unknown metrics', () => {
+		expect(computeMetricCsvData('cpu-usage', [], window, [])).toBeNull();
+		const rows: AnalyticsDataPoint[] = [{ time: 0, node: 'n1' }];
+		expect(computeMetricCsvData('no-such-metric', rows, window, ['n1'])).toBeNull();
+	});
+
+	it('runs the spec pipeline for a Renderer-backed groupBy metric (connections)', () => {
+		const rows: AnalyticsDataPoint[] = [
+			{ time: 60_000, node: 'n1', type: 'mqtt', connections: 5, period: 60_000, count: 1 },
+			{ time: 60_000, node: 'n1', type: 'ws', connections: 3, period: 60_000, count: 1 },
+		];
+		const out = computeMetricCsvData('connections', rows, window, ['n1']);
+		expect(out?.kind).toBe('series');
+		if (out?.kind !== 'series') { return; }
+		expect(out.data.series.map((s) => s.dim).sort()).toEqual(['mqtt', 'ws']);
+	});
+
+	it('preprocesses connection records so the pathMethod groupBy is not empty', () => {
+		const rows: AnalyticsDataPoint[] = [
+			{
+				time: 60_000,
+				node: 'n1',
+				path: 'mqtt',
+				method: 'connect',
+				ratio: 0.995,
+				total: 199,
+				count: 200,
+				period: 60_000,
+			},
+			{
+				time: 60_000,
+				node: 'n1',
+				path: 'mqtt',
+				method: 'disconnect',
+				ratio: 0.5,
+				total: 300,
+				count: 600,
+				period: 60_000,
+			},
+		];
+		const out = computeMetricCsvData('connection', rows, window, ['n1']);
+		expect(out?.kind).toBe('series');
+		if (out?.kind !== 'series') { return; }
+		expect(out.data.series.map((s) => s.dim).sort()).toEqual(['mqtt · connect', 'mqtt · disconnect']);
+	});
+
+	it('uses the derived recompute for derived metrics (request-rate)', () => {
+		const rows: AnalyticsDataPoint[] = [
+			{ time: 60_000, node: 'n1', path: '/dogs', count: 30, period: 60_000 },
+		];
+		const out = computeMetricCsvData('request-rate', rows, window, ['n1']);
+		expect(out?.kind).toBe('series');
+		if (out?.kind !== 'series') { return; }
+		expect(out.data.series).toHaveLength(1);
+		expect(out.data.series[0].label).toBe('/dogs');
+		expect(out.data.series[0].points).toEqual([{ x: 60_000, y: 0.5, count: 30 }]);
+	});
+
+	it('returns heatmap data for replication-latency', () => {
+		const rows: AnalyticsDataPoint[] = [
+			{ time: 60_000, node: 'n2', path: 'not-a-replication-path', count: 1 },
+		];
+		const out = computeMetricCsvData('replication-latency', rows, window, ['n1', 'n2']);
+		expect(out?.kind).toBe('heatmap');
+	});
+});

--- a/src/features/instance/status/analytics/lib/csvExport.test.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AnalyticsDataPoint, HeatmapData, SeriesData } from '../types/analytics';
-import { computeMetricCsvData, heatmapToCsv, makeCsvFilename, seriesToCsv } from './csvExport';
+import { chartCsv, computeMetricCsvData, heatmapToCsv, makeCsvFilename, seriesToCsv } from './csvExport';
 
 function lines(csv: string): string[] {
 	// Trailing CRLF terminates the last record — strip it before splitting.
@@ -118,6 +118,41 @@ describe('heatmapToCsv', () => {
 		};
 		expect(lines(heatmapToCsv(data))[1]).toBe('"a,b","c""d",1,2');
 	});
+
+	it('names the value column after the exported field when one is supplied', () => {
+		const data: HeatmapData = {
+			rows: ['n1'],
+			cols: ['n2'],
+			cells: [{ row: 'n1', col: 'n2', value: 3, count: 4 }],
+			skippedRecordsCount: 0,
+		};
+		expect(lines(heatmapToCsv(data, 'p95'))[0]).toBe('row,col,p95,count');
+	});
+
+	it('adds a confidence column mirroring the chart tiers, keeping suppressed values', () => {
+		// Tier boundaries mirror classifyCell in primitives/HeatmapMatrix.tsx:
+		// suppress when count < greyBelow, grey when greyBelow ≤ count <
+		// suppressBelow, absent when the cell has no value.
+		const data: HeatmapData = {
+			rows: ['n1', 'n2'],
+			cols: ['n3'],
+			cells: [
+				{ row: 'n1', col: 'n3', value: 12.5, count: 39 }, // below greyBelow
+				{ row: 'n2', col: 'n3', value: 8, count: 40 }, // grey band
+				{ row: 'n3', col: 'n3', value: 5, count: 100 }, // settled
+				{ row: 'n4', col: 'n3', value: null, count: 0 }, // no data
+			],
+			confidence: { greyBelow: 40, suppressBelow: 100 },
+			skippedRecordsCount: 0,
+		};
+		expect(lines(heatmapToCsv(data))).toEqual([
+			'row,col,value,count,confidence',
+			'n1,n3,12.5,39,suppress',
+			'n2,n3,8,40,grey',
+			'n3,n3,5,100,ok',
+			'n4,n3,,0,absent',
+		]);
+	});
 });
 
 describe('makeCsvFilename', () => {
@@ -194,5 +229,21 @@ describe('computeMetricCsvData', () => {
 		];
 		const out = computeMetricCsvData('replication-latency', rows, window, ['n1', 'n2']);
 		expect(out?.kind).toBe('heatmap');
+	});
+
+	it('serializes replication-latency with a p95 value column and confidence tiers', () => {
+		const rows: AnalyticsDataPoint[] = [
+			// count 20 < greyBelow (40) → the chart suppresses this cell; the
+			// CSV keeps the number and flags the row instead.
+			{ time: 60_000, node: 'n2', path: 'n1.db.dogs', p95: 12, count: 20 },
+		];
+		const out = computeMetricCsvData('replication-latency', rows, window, ['n1', 'n2']);
+		expect(out?.kind).toBe('heatmap');
+		if (out?.kind !== 'heatmap') { return; }
+		expect(out.valueColumn).toBe('p95');
+		expect(lines(chartCsv(out))).toEqual([
+			'row,col,p95,count,confidence',
+			'n1,n2,12,20,suppress',
+		]);
 	});
 });

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -1,12 +1,20 @@
 // CSV export for Status chart data — serializes the pipeline output shapes
-// (SeriesData / HeatmapData) that the chart primitives render, so the CSV a
-// user downloads carries the same numbers as the chart on screen. No network
-// calls: everything recomputes from the records the panel already fetched.
+// (SeriesData / HeatmapData) that the chart primitives render. Series CSVs
+// carry the same numbers as the chart on screen. The heatmap CSV is
+// self-describing where the renderer has UI-local state the exporter can't
+// see: the value column is named for the quantile actually exported (the
+// spec default, regardless of the on-screen quantile selector), and a
+// `confidence` column mirrors the chart's suppress/grey tiers — cells the
+// chart hides or dims keep their numeric value in the CSV, flagged so the
+// consumer can filter. No network calls: everything recomputes from the
+// records the panel already fetched.
 
+import { preprocessConnectionRecords } from '../pipeline/connection';
 import { derivedRegistry } from '../pipeline/derived/index';
 import { specRegistry } from '../pipeline/index';
 import { runPipeline } from '../pipeline/pipeline';
-import { aggregateReplicationMatrix } from '../pipeline/replication-latency';
+import { aggregateReplicationMatrix, type ReplicationQuantileField } from '../pipeline/replication-latency';
+import { wantsClusterLineFold, wantsDimensionLineSplit, wantsStackedAreaNodeRemap } from '../primitives/MetricRenderer';
 import type { AnalyticsDataPoint, HeatmapData, MetricSpec, Series, SeriesData, TimeRange } from '../types/analytics';
 import { filenameTimestamp, slugifyForFilename, triggerBlobDownload } from './chartExport';
 
@@ -14,7 +22,13 @@ import { filenameTimestamp, slugifyForFilename, triggerBlobDownload } from './ch
  *  shape its primitive renders. */
 export type ChartCsvData =
 	| { kind: 'series'; data: SeriesData }
-	| { kind: 'heatmap'; data: HeatmapData };
+	| {
+		kind: 'heatmap';
+		data: HeatmapData;
+		/** Header for the value column (e.g. the quantile the exporter chose,
+		 *  'p95'). Defaults to 'value'. */
+		valueColumn?: string;
+	};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // RFC-4180 serialization
@@ -82,19 +96,49 @@ export function seriesToCsv(data: SeriesData): string {
 	return [header, ...rows].join(CRLF) + CRLF;
 }
 
-/** Serialize HeatmapData to CSV as `row,col,value,count` — one line per
- *  cell, in the primitive's row-major cell order. Absent values/counts are
- *  empty cells. */
-export function heatmapToCsv(data: HeatmapData): string {
-	const header = ['row', 'col', 'value', 'count'].join(',');
-	const rows = data.cells.map((c) =>
-		[csvField(c.row), csvField(c.col), csvNumber(c.value), csvNumber(c.count)].join(',')
-	);
+/** Confidence tier for one heatmap cell. Mirrors classifyCell in
+ *  primitives/HeatmapMatrix.tsx exactly — including the inverted-sounding
+ *  boundaries: 'suppress' when count < greyBelow, 'grey' when
+ *  greyBelow ≤ count < suppressBelow, 'absent' when the cell has no value.
+ *  (Duplicated rather than imported: HeatmapMatrix.tsx is owned by an
+ *  in-flight PR — fold this into an import once that lands.) */
+function heatmapConfidenceTier(
+	value: number | null | undefined,
+	count: number | undefined,
+	greyBelow: number,
+	suppressBelow: number,
+): 'ok' | 'grey' | 'suppress' | 'absent' {
+	if (value === null || value === undefined) { return 'absent'; }
+	const n = count ?? 0;
+	if (n < greyBelow) { return 'suppress'; }
+	if (n < suppressBelow) { return 'grey'; }
+	return 'ok';
+}
+
+/** Serialize HeatmapData to CSV as `row,col,<valueColumn>,count` — one line
+ *  per cell, in the primitive's row-major cell order. Absent values/counts
+ *  are empty cells. When the data carries confidence thresholds, a trailing
+ *  `confidence` column reports the chart's tier for each cell ('ok' / 'grey'
+ *  / 'suppress' / 'absent'); suppressed and grey cells keep their numeric
+ *  value — the chart hides/dims them, the CSV flags them instead. */
+export function heatmapToCsv(data: HeatmapData, valueColumn = 'value'): string {
+	const confidence = data.confidence;
+	const headerCells = ['row', 'col', csvField(valueColumn), 'count'];
+	if (confidence) { headerCells.push('confidence'); }
+	const header = headerCells.join(',');
+	const rows = data.cells.map((c) => {
+		const cells = [csvField(c.row), csvField(c.col), csvNumber(c.value), csvNumber(c.count)];
+		if (confidence) {
+			// Missing thresholds default to 0, matching HeatmapMatrix.
+			cells.push(heatmapConfidenceTier(c.value, c.count, confidence.greyBelow ?? 0, confidence.suppressBelow ?? 0));
+		}
+		return cells.join(',');
+	});
 	return [header, ...rows].join(CRLF) + CRLF;
 }
 
 export function chartCsv(data: ChartCsvData): string {
-	return data.kind === 'heatmap' ? heatmapToCsv(data.data) : seriesToCsv(data.data);
+	return data.kind === 'heatmap' ? heatmapToCsv(data.data, data.valueColumn) : seriesToCsv(data.data);
 }
 
 /** `<metric>-<start>-<end>.csv`, metric slugified and timestamps ISO-8601
@@ -108,51 +152,17 @@ export function downloadCsv(csv: string, filename: string): void {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Metric → chart-data recompute for the CSV button. Mirrors MetricRenderer's
-// dispatch (primitives/MetricRenderer.tsx — keep the two in sync) minus the
-// renderer-internal UI state: metrics whose custom renderer offers chip
-// filters / quantile selectors export their spec's default, unfiltered view.
+// Metric → chart-data recompute for the CSV button. Dispatches through the
+// same predicates MetricRenderer does (imported from
+// primitives/MetricRenderer.tsx) minus the renderer-internal UI state:
+// metrics whose custom renderer offers chip filters / quantile selectors
+// export their spec's default, unfiltered view.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** The `connection` spec groups on a synthetic `pathMethod` field that only
- *  exists after ConnectionRenderer's preprocessing (pipeline/connection.tsx
- *  — keep in sync): without it every record misses the groupBy dimension and
- *  the CSV would be empty. Mirrors the renderer's compositing and its
- *  total===0/count>0 → null ratio gap. */
-function preprocessConnectionRecords(records: AnalyticsDataPoint[]): AnalyticsDataPoint[] {
-	const out: AnalyticsDataPoint[] = [];
-	for (const r of records) {
-		const { path, method, total, count } = r;
-		if (typeof path !== 'string' && typeof path !== 'number') { continue; }
-		if (typeof method !== 'string' && typeof method !== 'number') { continue; }
-		const nullGap = total === 0 && typeof count === 'number' && count > 0;
-		out.push({ ...r, pathMethod: `${path} · ${method}`, ratio: nullGap ? null : r.ratio });
-	}
-	return out;
-}
-
-/** See MetricRenderer.wantsStackedAreaNodeRemap. */
-function stackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): boolean {
-	return spec.primitive === 'stacked-area'
-		&& isPerNodeMode
-		&& spec.series.kind === 'groupBy'
-		&& spec.series.dimension !== 'node';
-}
-
-/** See MetricRenderer.wantsClusterLineFold. */
-function clusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean {
-	return spec.primitive === 'line'
-		&& !isPerNodeMode
-		&& spec.series.kind === 'groupBy'
-		&& spec.series.dimension === 'node';
-}
-
-/** See MetricRenderer.wantsDimensionLineSplit. */
-function dimensionLineSplit(spec: MetricSpec): boolean {
-	return spec.primitive === 'line'
-		&& spec.series.kind === 'groupBy'
-		&& spec.series.dimension !== 'node';
-}
+/** The quantile the heatmap CSV exports — the spec default. The renderer's
+ *  quantile selector is component-local state the exporter can't observe, so
+ *  the CSV always exports this field and names its value column after it. */
+const HEATMAP_CSV_QUANTILE: ReplicationQuantileField = 'p95';
 
 /** Recompute the chart data a panel renders, for CSV serialization.
  *  Returns null when the metric is unknown or there is nothing to export. */
@@ -176,8 +186,13 @@ export function computeMetricCsvData(
 
 	if (spec.primitive === 'heatmap') {
 		// The only heatmap metric is replication-latency; export its default
-		// (p95) matrix — the renderer's quantile selector state is internal.
-		return { kind: 'heatmap', data: aggregateReplicationMatrix(records, nodes) };
+		// quantile's matrix and name the value column after it so the CSV
+		// states what it contains even when the on-screen selector differs.
+		return {
+			kind: 'heatmap',
+			data: aggregateReplicationMatrix(records, nodes, HEATMAP_CSV_QUANTILE),
+			valueColumn: HEATMAP_CSV_QUANTILE,
+		};
 	}
 
 	if (entry.Renderer) {
@@ -185,7 +200,9 @@ export function computeMetricCsvData(
 		// memory, connection, …) layer chip/quantile UI over the spec's own
 		// pipeline. Export the spec's natural grouping — every dimension value,
 		// cluster-aggregated — which is the full dataset behind those views.
-		const rows = metric === 'connection' ? preprocessConnectionRecords(records) : records;
+		// `connection` groups on the synthetic pathMethod field, so it needs
+		// the renderer's own preprocessing first.
+		const rows = metric === 'connection' ? preprocessConnectionRecords(records).records : records;
 		return { kind: 'series', data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true }) };
 	}
 
@@ -212,18 +229,18 @@ export function computeMetricCsvData(
 		return { kind: 'series', data: { series } };
 	}
 
-	if (stackedAreaNodeRemap(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
+	if (wantsStackedAreaNodeRemap(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const remapped: MetricSpec = { ...spec, series: { ...spec.series, dimension: 'node' } };
 		return { kind: 'series', data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true }) };
 	}
-	if (clusterLineFold(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
+	if (wantsClusterLineFold(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const inner: MetricSpec = {
 			...spec,
 			series: { kind: 'field', fields: [{ ...spec.series.field, label: 'cluster' }] },
 		};
 		return { kind: 'series', data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true }) };
 	}
-	if (dimensionLineSplit(spec)) {
+	if (wantsDimensionLineSplit(spec)) {
 		return {
 			kind: 'series',
 			data: runPipeline(spec, records, timeRange, nodes, { perNode: false, snapToPeriod: true }),

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -40,8 +40,10 @@ export type ChartCsvData =
  *  spreadsheets import them as text instead of evaluating them as formulas
  *  (labels come from telemetry paths/identifiers — CSV-injection guard).
  *  Numeric cells go through csvNumber and keep their sign. */
-function csvField(value: string): string {
-	const neutralized = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+function csvField(value: string | number | null | undefined): string {
+	if (value === null || value === undefined) { return ''; }
+	const asString = String(value);
+	const neutralized = /^[=+\-@\t\r]/.test(asString) ? `'${asString}` : asString;
 	if (/[",\r\n]/.test(neutralized)) {
 		return `"${neutralized.replace(/"/g, '""')}"`;
 	}
@@ -148,7 +150,9 @@ export function makeCsvFilename(metric: string, range: TimeRange): string {
 }
 
 export function downloadCsv(csv: string, filename: string): void {
-	triggerBlobDownload(new Blob([csv], { type: 'text/csv;charset=utf-8' }), filename);
+	// UTF-8 BOM so Excel detects the encoding (the ' · ' connection-path
+	// separator and node names garble without it).
+	triggerBlobDownload(new Blob(['\uFEFF', csv], { type: 'text/csv;charset=utf-8' }), filename);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -1,0 +1,236 @@
+// CSV export for Status chart data — serializes the pipeline output shapes
+// (SeriesData / HeatmapData) that the chart primitives render, so the CSV a
+// user downloads carries the same numbers as the chart on screen. No network
+// calls: everything recomputes from the records the panel already fetched.
+
+import { derivedRegistry } from '../pipeline/derived/index';
+import { specRegistry } from '../pipeline/index';
+import { runPipeline } from '../pipeline/pipeline';
+import { aggregateReplicationMatrix } from '../pipeline/replication-latency';
+import type { AnalyticsDataPoint, HeatmapData, MetricSpec, Series, SeriesData, TimeRange } from '../types/analytics';
+import { filenameTimestamp, slugifyForFilename, triggerBlobDownload } from './chartExport';
+
+/** Discriminated union the CSV button consumes — a panel supplies whichever
+ *  shape its primitive renders. */
+export type ChartCsvData =
+	| { kind: 'series'; data: SeriesData }
+	| { kind: 'heatmap'; data: HeatmapData };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RFC-4180 serialization
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Quote a field per RFC 4180: wrap in double quotes when it contains a
+ *  comma, quote, or line break; double any embedded quotes. Cells starting
+ *  with `=`, `+`, `-`, `@`, tab, or CR are prefixed with an apostrophe so
+ *  spreadsheets import them as text instead of evaluating them as formulas
+ *  (labels come from telemetry paths/identifiers — CSV-injection guard).
+ *  Numeric cells go through csvNumber and keep their sign. */
+function csvField(value: string): string {
+	const neutralized = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+	if (/[",\r\n]/.test(neutralized)) {
+		return `"${neutralized.replace(/"/g, '""')}"`;
+	}
+	return neutralized;
+}
+
+function csvNumber(value: number | null | undefined): string {
+	return value === null || value === undefined ? '' : String(value);
+}
+
+const CRLF = '\r\n';
+
+/** Column headers for a series list — series labels, deduped by appending
+ *  the (unique) series key when two series share a label (e.g. the same
+ *  dimension value on two nodes). */
+function seriesHeaders(series: Series[]): string[] {
+	const labelCounts = new Map<string, number>();
+	for (const s of series) {
+		labelCounts.set(s.label, (labelCounts.get(s.label) ?? 0) + 1);
+	}
+	return series.map((
+		s,
+	) => ((labelCounts.get(s.label) ?? 0) > 1 && s.key !== s.label ? `${s.label} (${s.key})` : s.label));
+}
+
+/** Serialize SeriesData to CSV: an ISO-8601 `timestamp` column plus one
+ *  column per series (ceiling included when present). Rows are the sorted
+ *  union of every series' x values; a series without a sample (or with a
+ *  null gap) at a given timestamp yields an empty cell. */
+export function seriesToCsv(data: SeriesData): string {
+	const allSeries = data.ceiling ? [...data.series, data.ceiling] : [...data.series];
+	const header = ['timestamp', ...seriesHeaders(allSeries)].map(csvField).join(',');
+
+	const xs = new Set<number>();
+	const bySeries: Map<number, number | null>[] = allSeries.map((s) => {
+		const byX = new Map<number, number | null>();
+		for (const p of s.points) {
+			xs.add(p.x);
+			byX.set(p.x, p.y);
+		}
+		return byX;
+	});
+
+	const rows = [...xs].sort((a, b) => a - b).map((x) => {
+		const cells = [csvField(new Date(x).toISOString())];
+		for (const byX of bySeries) {
+			cells.push(csvNumber(byX.get(x)));
+		}
+		return cells.join(',');
+	});
+
+	return [header, ...rows].join(CRLF) + CRLF;
+}
+
+/** Serialize HeatmapData to CSV as `row,col,value,count` — one line per
+ *  cell, in the primitive's row-major cell order. Absent values/counts are
+ *  empty cells. */
+export function heatmapToCsv(data: HeatmapData): string {
+	const header = ['row', 'col', 'value', 'count'].join(',');
+	const rows = data.cells.map((c) =>
+		[csvField(c.row), csvField(c.col), csvNumber(c.value), csvNumber(c.count)].join(',')
+	);
+	return [header, ...rows].join(CRLF) + CRLF;
+}
+
+export function chartCsv(data: ChartCsvData): string {
+	return data.kind === 'heatmap' ? heatmapToCsv(data.data) : seriesToCsv(data.data);
+}
+
+/** `<metric>-<start>-<end>.csv`, metric slugified and timestamps ISO-8601
+ *  (with `:`/`.` dashed for filename safety). */
+export function makeCsvFilename(metric: string, range: TimeRange): string {
+	return `${slugifyForFilename(metric)}-${filenameTimestamp(range.startTime)}-${filenameTimestamp(range.endTime)}.csv`;
+}
+
+export function downloadCsv(csv: string, filename: string): void {
+	triggerBlobDownload(new Blob([csv], { type: 'text/csv;charset=utf-8' }), filename);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Metric → chart-data recompute for the CSV button. Mirrors MetricRenderer's
+// dispatch (primitives/MetricRenderer.tsx — keep the two in sync) minus the
+// renderer-internal UI state: metrics whose custom renderer offers chip
+// filters / quantile selectors export their spec's default, unfiltered view.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The `connection` spec groups on a synthetic `pathMethod` field that only
+ *  exists after ConnectionRenderer's preprocessing (pipeline/connection.tsx
+ *  — keep in sync): without it every record misses the groupBy dimension and
+ *  the CSV would be empty. Mirrors the renderer's compositing and its
+ *  total===0/count>0 → null ratio gap. */
+function preprocessConnectionRecords(records: AnalyticsDataPoint[]): AnalyticsDataPoint[] {
+	const out: AnalyticsDataPoint[] = [];
+	for (const r of records) {
+		const { path, method, total, count } = r;
+		if (typeof path !== 'string' && typeof path !== 'number') { continue; }
+		if (typeof method !== 'string' && typeof method !== 'number') { continue; }
+		const nullGap = total === 0 && typeof count === 'number' && count > 0;
+		out.push({ ...r, pathMethod: `${path} · ${method}`, ratio: nullGap ? null : r.ratio });
+	}
+	return out;
+}
+
+/** See MetricRenderer.wantsStackedAreaNodeRemap. */
+function stackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+	return spec.primitive === 'stacked-area'
+		&& isPerNodeMode
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension !== 'node';
+}
+
+/** See MetricRenderer.wantsClusterLineFold. */
+function clusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+	return spec.primitive === 'line'
+		&& !isPerNodeMode
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension === 'node';
+}
+
+/** See MetricRenderer.wantsDimensionLineSplit. */
+function dimensionLineSplit(spec: MetricSpec): boolean {
+	return spec.primitive === 'line'
+		&& spec.series.kind === 'groupBy'
+		&& spec.series.dimension !== 'node';
+}
+
+/** Recompute the chart data a panel renders, for CSV serialization.
+ *  Returns null when the metric is unknown or there is nothing to export. */
+export function computeMetricCsvData(
+	metric: string,
+	records: AnalyticsDataPoint[],
+	timeRange: TimeRange,
+	nodes: string[],
+	viewMode?: 'per-node' | 'aggregate',
+): ChartCsvData | null {
+	if (records.length === 0) { return null; }
+
+	const derived = derivedRegistry[metric];
+	if (derived) {
+		return { kind: 'series', data: derived.recompute(records, timeRange, nodes, viewMode) };
+	}
+
+	const entry = specRegistry[metric];
+	const spec = entry?.spec;
+	if (!spec) { return null; }
+
+	if (spec.primitive === 'heatmap') {
+		// The only heatmap metric is replication-latency; export its default
+		// (p95) matrix — the renderer's quantile selector state is internal.
+		return { kind: 'heatmap', data: aggregateReplicationMatrix(records, nodes) };
+	}
+
+	if (entry.Renderer) {
+		// Custom renderers (DimensionSelectorRenderer, TrafficByTypeRenderer,
+		// memory, connection, …) layer chip/quantile UI over the spec's own
+		// pipeline. Export the spec's natural grouping — every dimension value,
+		// cluster-aggregated — which is the full dataset behind those views.
+		const rows = metric === 'connection' ? preprocessConnectionRecords(records) : records;
+		return { kind: 'series', data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true }) };
+	}
+
+	const isPerNodeMode = (viewMode ?? 'per-node') === 'per-node';
+
+	if (spec.primitive === 'small-multiples') {
+		if (spec.series.kind !== 'field') { return null; }
+		const series: Series[] = [];
+		for (const field of spec.series.fields) {
+			const innerSpec: MetricSpec = {
+				...spec,
+				series: { kind: 'field', fields: [field] },
+				aggregator: {
+					temporal: field.aggregator?.temporal ?? spec.aggregator.temporal,
+					crossNode: field.aggregator?.crossNode ?? spec.aggregator.crossNode,
+				},
+			};
+			const out = runPipeline(innerSpec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true });
+			series.push(...out.series);
+			// Each panel's ceiling (if any) becomes a regular column — SeriesData
+			// has a single ceiling slot, which can't carry one per panel.
+			if (out.ceiling) { series.push(out.ceiling); }
+		}
+		return { kind: 'series', data: { series } };
+	}
+
+	if (stackedAreaNodeRemap(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
+		const remapped: MetricSpec = { ...spec, series: { ...spec.series, dimension: 'node' } };
+		return { kind: 'series', data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true }) };
+	}
+	if (clusterLineFold(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
+		const inner: MetricSpec = {
+			...spec,
+			series: { kind: 'field', fields: [{ ...spec.series.field, label: 'cluster' }] },
+		};
+		return { kind: 'series', data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true }) };
+	}
+	if (dimensionLineSplit(spec)) {
+		return {
+			kind: 'series',
+			data: runPipeline(spec, records, timeRange, nodes, { perNode: false, snapToPeriod: true }),
+		};
+	}
+	return {
+		kind: 'series',
+		data: runPipeline(spec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true }),
+	};
+}

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -67,7 +67,12 @@ interface Preprocessed {
 	dimParts: Map<string, Record<string, string>>;
 }
 
-function preprocess(records: AnalyticsDataPoint[]): Preprocessed {
+/** Composite the synthetic `pathMethod` groupBy field onto each record (and
+ *  apply the total===0/count>0 → null ratio gap). Exported so the CSV
+ *  exporter (lib/csvExport.ts) feeds the pipeline the exact records the
+ *  renderer does; CSV callers only need `.records` — `dimParts` is
+ *  chip-selector plumbing. */
+export function preprocessConnectionRecords(records: AnalyticsDataPoint[]): Preprocessed {
 	const out: AnalyticsDataPoint[] = [];
 	const dimParts = new Map<string, Record<string, string>>();
 	for (const r of records) {
@@ -92,7 +97,7 @@ export function ConnectionRenderer(
 	{ records, timeRange, nodes, viewMode = 'per-node', fillParent }: RendererProps,
 ) {
 	const perNode = viewMode === 'per-node';
-	const { records: processed, dimParts } = useMemo(() => preprocess(records), [records]);
+	const { records: processed, dimParts } = useMemo(() => preprocessConnectionRecords(records), [records]);
 
 	const fullData = useMemo<SeriesData>(
 		() => runPipeline(connectionSpec, processed, timeRange, nodes, { perNode, snapToPeriod: true }),

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -38,11 +38,12 @@ function renderPrimitive(
 
 // ─── Generic-dispatch predicates ─────────────────────────────────────────────
 // Named guards for the spec-dispatch branches below, so each condition reads
-// as intent instead of a wall of `&&`s.
+// as intent instead of a wall of `&&`s. Exported so the CSV exporter
+// (lib/csvExport.ts) dispatches through the same predicates.
 
 /** Stacked-area spec grouped on a non-node dimension while the user asked for
  *  per-node view — restack the same field by node instead. */
-function wantsStackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+export function wantsStackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): boolean {
 	return spec.primitive === 'stacked-area'
 		&& isPerNodeMode
 		&& spec.series.kind === 'groupBy'
@@ -51,7 +52,7 @@ function wantsStackedAreaNodeRemap(spec: MetricSpec, isPerNodeMode: boolean): bo
 
 /** Line spec grouped BY node while the user asked for the aggregate view —
  *  fold the nodes into a single cluster-wide line. */
-function wantsClusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean {
+export function wantsClusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean {
 	return spec.primitive === 'line'
 		&& !isPerNodeMode
 		&& spec.series.kind === 'groupBy'
@@ -67,7 +68,7 @@ function wantsClusterLineFold(spec: MetricSpec, isPerNodeMode: boolean): boolean
  *  then renders one legend chip per dimension value (colored via
  *  getNodeColor's deterministic hash). The crossNode aggregator on the spec
  *  folds nodes into the cluster-wide line per dimension. */
-function wantsDimensionLineSplit(spec: MetricSpec): boolean {
+export function wantsDimensionLineSplit(spec: MetricSpec): boolean {
 	return spec.primitive === 'line'
 		&& spec.series.kind === 'groupBy'
 		&& spec.series.dimension !== 'node';

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
+import { computeMetricCsvData } from '../lib/csvExport';
 import { wrapperMetrics } from '../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint } from '../types/analytics';
 import { PanelErrorBoundary } from './PanelErrorBoundary';
@@ -61,6 +62,7 @@ function ConnectionsPanelInner() {
 	const nodes = useMemo(() => collectNodes(merged), [merged]);
 
 	const canExport = !isLoading && !isError && !isEmpty;
+	const getCsvData = () => computeMetricCsvData('connections', merged, timeRange, nodes);
 	const renderChart = (opts: { fillParent: boolean } = { fillParent: false }) => (
 		<ConnectionsRenderer
 			records={merged}
@@ -83,6 +85,7 @@ function ConnectionsPanelInner() {
 			exportSlug="connections"
 			canExport={canExport}
 			renderChart={renderChart}
+			getCsvData={getCsvData}
 		>
 			<PanelStateOrChart
 				isLoading={isLoading}

--- a/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/ConnectionsPanel.tsx
@@ -61,7 +61,11 @@ function ConnectionsPanelInner() {
 	const isEmpty = merged.length === 0;
 	const nodes = useMemo(() => collectNodes(merged), [merged]);
 
-	const canExport = !isLoading && !isError && !isEmpty;
+	// Placeholder rows are the PREVIOUS window's data held on screen during a
+	// window change — exporting them would pair old rows with a filename (and
+	// PNG title) claiming the new window, so hide the export actions until
+	// both sources' requested-window rows arrive.
+	const canExport = !isLoading && !isError && !isEmpty && !mqtt.isPlaceholderData && !ws.isPlaceholderData;
 	const getCsvData = () => computeMetricCsvData('connections', merged, timeRange, nodes);
 	const renderChart = (opts: { fillParent: boolean } = { fillParent: false }) => (
 		<ConnectionsRenderer

--- a/src/features/instance/status/analytics/tabs/MetricPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/MetricPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import { useAnalyticsRecords } from '../hooks/useAnalyticsRecords';
+import { computeMetricCsvData } from '../lib/csvExport';
 import { getSpecRequiredFields } from '../lib/specRequiredFields';
 import { derivedRegistry } from '../pipeline/derived/index';
 import { specRegistry } from '../pipeline/index';
@@ -45,6 +46,8 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 	const nodes = useMemo(() => collectNodes(data), [data]);
 	const canExport = !isLoading && !isError && !isEmpty;
 
+	const getCsvData = () => computeMetricCsvData(metric, data, timeRange, nodes);
+
 	const renderChart = (opts: { fillParent: boolean } = { fillParent: false }) => (
 		<MetricRenderer
 			metric={metric}
@@ -62,6 +65,7 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 			exportSlug={metric}
 			canExport={canExport}
 			renderChart={renderChart}
+			getCsvData={getCsvData}
 		>
 			<PanelStateOrChart
 				isLoading={isLoading}

--- a/src/features/instance/status/analytics/tabs/MetricPanel.tsx
+++ b/src/features/instance/status/analytics/tabs/MetricPanel.tsx
@@ -30,7 +30,7 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 	const { timeRange, bucketMs, instanceParams } = useAnalyticsContext();
 	const sourceMetric = derivedRegistry[metric]?.sourceMetric ?? metric;
 	const requiredFields = getSpecRequiredFields(metric);
-	const { data, isLoading, isError, error, isEmpty, missingFields, refetch } = useAnalyticsRecords({
+	const { data, isLoading, isError, error, isEmpty, missingFields, isPlaceholderData, refetch } = useAnalyticsRecords({
 		metric: sourceMetric,
 		startTime: timeRange.startTime,
 		endTime: timeRange.endTime,
@@ -44,7 +44,11 @@ function MetricPanelInner({ metric, titleOverride }: Props) {
 	const title = titleOverride ?? specEntry?.spec?.title ?? derivedEntry?.title ?? metric;
 	const description = specEntry?.spec?.description ?? derivedEntry?.subtitle;
 	const nodes = useMemo(() => collectNodes(data), [data]);
-	const canExport = !isLoading && !isError && !isEmpty;
+	// Placeholder rows are the PREVIOUS window's data held on screen during a
+	// window change — exporting them would pair old rows with a filename (and
+	// PNG title) claiming the new window, so hide the export actions until the
+	// requested window's rows arrive.
+	const canExport = !isLoading && !isError && !isEmpty && !isPlaceholderData;
 
 	const getCsvData = () => computeMetricCsvData(metric, data, timeRange, nodes);
 

--- a/src/features/instance/status/analytics/tabs/PanelShell.tsx
+++ b/src/features/instance/status/analytics/tabs/PanelShell.tsx
@@ -3,8 +3,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { errorText } from '@/lib/errorText';
 import { type ReactNode, useRef } from 'react';
 import { ChartCopyButton } from '../components/ChartCopyButton';
+import { ChartCsvButton } from '../components/ChartCsvButton';
 import { ChartExpandButton } from '../components/ChartExpandButton';
 import { ChartExportButton } from '../components/ChartExportButton';
+import type { ChartCsvData } from '../lib/csvExport';
 
 interface PanelCardProps {
 	title: string;
@@ -21,6 +23,9 @@ interface PanelCardProps {
 	/** Chart render function, forwarded to ChartExpandButton so the dialog
 	 *  re-renders the chart at full size. */
 	renderChart: (opts: { fillParent: boolean }) => ReactNode;
+	/** Lazily produces the rendered data for the CSV download button. When
+	 *  omitted the CSV button is not rendered (panel has no tabular data). */
+	getCsvData?: () => ChartCsvData | null;
 	children: ReactNode;
 }
 
@@ -35,6 +40,7 @@ export function PanelCard({
 	exportSlug,
 	canExport,
 	renderChart,
+	getCsvData,
 	children,
 }: PanelCardProps) {
 	// Capture only the chart body, not the whole Card. Otherwise the exported
@@ -54,9 +60,11 @@ export function PanelCard({
 							title={title}
 							description={expandDescription}
 							renderChart={renderChart}
+							getCsvData={getCsvData}
 						/>
 						<ChartCopyButton captureRef={chartRef} exportSlug={exportSlug} />
 						<ChartExportButton captureRef={chartRef} exportSlug={exportSlug} />
+						{getCsvData && <ChartCsvButton exportSlug={exportSlug} getCsvData={getCsvData} />}
 					</div>
 				)}
 			</CardHeader>

--- a/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/ConnectionsPanel.test.tsx
@@ -31,6 +31,7 @@ function makeResult(overrides: Partial<HookResult> = {}): HookResult {
 		isEmpty: true,
 		fieldKeys: new Set(),
 		missingFields: [],
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 		...overrides,
 	};
@@ -88,6 +89,23 @@ describe('ConnectionsPanel', () => {
 			</AnalyticsTestWrapper>,
 		);
 		expect(screen.getByText(/No active sessions in the selected time range/)).toBeTruthy();
+	});
+
+	it('hides the export actions while either source serves placeholder rows', () => {
+		setHookResults({
+			'mqtt-connections': makeResult({ data: makeRows(), isEmpty: false }),
+			'ws-connections': makeResult({ isPlaceholderData: true }),
+		});
+		render(
+			<AnalyticsTestWrapper>
+				<ConnectionsPanel />
+			</AnalyticsTestWrapper>,
+		);
+		// The chart still renders, but the export row is gated off until both
+		// sources carry the requested window's rows.
+		expect(screen.getByText('Connections')).toBeTruthy();
+		expect(screen.queryByLabelText('Expand connections')).toBeNull();
+		expect(screen.queryByLabelText('Download connections as CSV')).toBeNull();
 	});
 
 	it('renders the merged chart when either source has data', () => {

--- a/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/MetricPanel.test.tsx
@@ -24,6 +24,7 @@ function setHookResult(overrides: Partial<ReturnType<typeof useAnalyticsRecords>
 		isEmpty: true,
 		fieldKeys: new Set(),
 		missingFields: [],
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 		...overrides,
 	});
@@ -82,6 +83,35 @@ describe('MetricPanel', () => {
 		);
 		// Card title from the registered cpu-usage spec
 		expect(container.textContent).toMatch(/CPU/i);
+	});
+
+	it('hides the export actions while placeholder (previous-window) rows are shown', () => {
+		// keepPreviousData keeps the old window's rows on screen (isLoading is
+		// false) during a window change — exporting them would label old rows
+		// with the new window's filename/title.
+		setHookResult({ data: makeRows(), isEmpty: false, isPlaceholderData: true });
+		const { container } = render(
+			<AnalyticsTestWrapper>
+				<MetricPanel metric="cpu-usage" />
+			</AnalyticsTestWrapper>,
+		);
+		// The chart still renders…
+		expect(container.textContent).toMatch(/CPU/i);
+		// …but none of the export actions do.
+		expect(screen.queryByLabelText('Download cpu-usage as CSV')).toBeNull();
+		expect(screen.queryByLabelText('Download cpu-usage as PNG')).toBeNull();
+		expect(screen.queryByLabelText('Copy cpu-usage chart to clipboard')).toBeNull();
+	});
+
+	it("shows the export actions once the requested window's rows have settled", () => {
+		setHookResult({ data: makeRows(), isEmpty: false, isPlaceholderData: false });
+		render(
+			<AnalyticsTestWrapper>
+				<MetricPanel metric="cpu-usage" />
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByLabelText('Download cpu-usage as CSV')).toBeTruthy();
+		expect(screen.getByLabelText('Download cpu-usage as PNG')).toBeTruthy();
 	});
 
 	it('uses the metric id as a fallback title when neither spec nor derived registry has it', () => {

--- a/src/features/instance/status/analytics/tabs/__tests__/PanelCard.csv.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/PanelCard.csv.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChartCsvData } from '../../lib/csvExport';
+import { PanelCard } from '../PanelShell';
+import { AnalyticsTestWrapper } from './testHelpers';
+
+afterEach(cleanup);
+
+const csvData: ChartCsvData = {
+	kind: 'series',
+	data: { series: [{ key: 'a', label: 'alpha', points: [{ x: 0, y: 1 }] }] },
+};
+
+function renderCard({ canExport, getCsvData }: { canExport: boolean; getCsvData?: () => ChartCsvData | null }) {
+	return render(
+		<AnalyticsTestWrapper>
+			<PanelCard
+				title="CPU"
+				description="desc"
+				exportSlug="cpu-usage"
+				canExport={canExport}
+				renderChart={() => <div data-testid="chart-body">chart</div>}
+				getCsvData={getCsvData}
+			>
+				<div data-testid="chart-body">chart</div>
+			</PanelCard>
+		</AnalyticsTestWrapper>,
+	);
+}
+
+describe('PanelCard CSV button', () => {
+	it('renders the CSV button in the same action row as the PNG copy/export buttons', () => {
+		renderCard({ canExport: true, getCsvData: () => csvData });
+		const csv = screen.getByLabelText(/Download cpu-usage as CSV/i);
+		const png = screen.getByLabelText(/Download cpu-usage as PNG/i);
+		const copy = screen.getByLabelText(/Copy cpu-usage chart to clipboard/i);
+		expect(csv.parentElement).toBe(png.parentElement);
+		expect(csv.parentElement).toBe(copy.parentElement);
+	});
+
+	it('hides the CSV button alongside the other export actions when there is nothing to export (loading/error/empty)', () => {
+		renderCard({ canExport: false, getCsvData: () => csvData });
+		expect(screen.queryByLabelText(/Download cpu-usage as CSV/i)).toBeNull();
+		expect(screen.queryByLabelText(/Download cpu-usage as PNG/i)).toBeNull();
+	});
+
+	it('omits the CSV button when the panel supplies no getCsvData', () => {
+		renderCard({ canExport: true });
+		expect(screen.queryByLabelText(/Download cpu-usage as CSV/i)).toBeNull();
+		// The PNG buttons still render — CSV gating is additive.
+		expect(screen.getByLabelText(/Download cpu-usage as PNG/i)).toBeTruthy();
+	});
+
+	it('offers the CSV download inside the expand dialog too', () => {
+		renderCard({ canExport: true, getCsvData: () => csvData });
+		fireEvent.click(screen.getByLabelText(/Expand cpu-usage/i));
+		// One in the (hidden-behind-dialog) header, one in the dialog.
+		expect(screen.getAllByLabelText(/Download cpu-usage as CSV/i)).toHaveLength(2);
+	});
+});

--- a/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/StorageTab.test.tsx
@@ -49,6 +49,7 @@ function setHookResult(rows: ReturnType<typeof makeTableSizeRows>) {
 		isEmpty: rows.length === 0,
 		fieldKeys: new Set(['size', 'database', 'table']),
 		missingFields: [],
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 	});
 }
@@ -63,6 +64,7 @@ describe('StorageTab', () => {
 			isEmpty: true,
 			fieldKeys: new Set(),
 			missingFields: [],
+			isPlaceholderData: false,
 			refetch: vi.fn(),
 		});
 		const { container } = render(

--- a/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
+++ b/src/features/instance/status/analytics/tabs/__tests__/tabs.smoke.test.tsx
@@ -29,6 +29,7 @@ function happyState() {
 		isEmpty: false,
 		fieldKeys: new Set(['count', 'mean', 'period', 'p50', 'p95', 'p99']),
 		missingFields: [],
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 	});
 }
@@ -42,6 +43,7 @@ function loadingState() {
 		isEmpty: true,
 		fieldKeys: new Set(),
 		missingFields: [],
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 	});
 }
@@ -55,6 +57,7 @@ function emptyMissingFieldsState(missing: string[]) {
 		isEmpty: true,
 		fieldKeys: new Set(),
 		missingFields: missing,
+		isPlaceholderData: false,
 		refetch: vi.fn(),
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #1461 — every Status analytics panel that offers PNG copy/export now also offers a CSV download of the rendered data, from both the panel header and the expand dialog. No new network calls: the CSV recomputes synchronously from the records the panel already fetched.

- **`lib/csvExport.ts`** — serializers plus the metric→data recompute:
  - `seriesToCsv`: ISO-8601 `timestamp` column + one RFC-4180-escaped column per series (ceiling included). Rows are the sorted union of every series' x values; gaps and `null` samples become empty cells. Duplicate labels are disambiguated with the series key. Formula-leading cells (`=`, `+`, `-`, `@`) are apostrophe-prefixed so spreadsheets import them as text (CSV-injection guard).
  - `heatmapToCsv`: one line per cell. The value column is named for the quantile actually exported (`p95`), and when the data carries confidence thresholds a trailing `confidence` column mirrors the chart's tiers (`ok`/`grey`/`suppress`/`absent`) — cells the chart hides or dims keep their numeric value in the CSV, flagged so consumers can filter.
  - `makeCsvFilename`: `<metric>-<start>-<end>.csv` (slugified metric, ISO timestamps).
  - `computeMetricCsvData`: dispatches through `MetricRenderer`'s own exported predicates (`wantsStackedAreaNodeRemap`/`wantsClusterLineFold`/`wantsDimensionLineSplit`) and `ConnectionRenderer`'s exported `preprocessConnectionRecords`, plus derived `recompute`, small-multiples per-field pipelines, and `aggregateReplicationMatrix` for the replication-latency heatmap — the exporter and renderer share one implementation and can't drift.
- **`components/ChartCsvButton.tsx`** — icon button styled like `ChartCopyButton`/`ChartExportButton`, with the same toast feedback.
- **Wiring** — `PanelCard` (shared by `MetricPanel` and `ConnectionsPanel`) renders the button in the existing action row and forwards it into `ChartExpandButton`'s dialog. Gated by the same `canExport` flag as the PNG buttons, so it hides in loading/error/empty states — and while a panel is showing `keepPreviousData` placeholder rows during a window change (`useAnalyticsRecords` now exposes `isPlaceholderData`), since those rows belong to the previous window and would contradict the export's filename/title.
- **`lib/chartExport.ts`** — extracted `triggerBlobDownload`/`slugifyForFilename`/`filenameTimestamp` so the PNG and CSV paths share one download/filename implementation.

## Surfaces covered (symmetry audit)

| Surface | PNG copy/export | CSV |
| --- | --- | --- |
| `PanelCard` header (all `MetricPanel` tabs: Health, Traffic, Requests, DB activity, Replication, Storage metric panels) | yes | yes |
| Expand dialog (via `PanelCard` → `ChartExpandButton`) | yes | yes |
| `ConnectionsPanel` (merged mqtt/ws records) | yes | yes |
| StorageTab table-size snapshot/trend cards | yes | deferred (see below) |

## Review focus

- RFC-4180 escaping and the formula-neutralization prefix in `csvField`.
- For metrics with custom renderers (chip filters, quantile selectors, per-node toggles), the CSV exports the spec's **default, unfiltered** dataset — every dimension value, cluster-aggregated (p95 for the replication heatmap) — not the chip-filtered view. The filter state lives inside primitive components owned by a sibling agent this batch; exporting the full dataset is arguably the more spreadsheet-useful shape anyway. Since review, the heatmap CSV states this contract explicitly (`p95` value column + `confidence` tiers).

## Post-review fixes (5a54a0b3)

1. **Stale-window export**: during an in-flight window change, `keepPreviousData` serves the previous window's rows with `isLoading=false`, so `canExport` stayed true and a click exported old rows under the new window's filename. `useAnalyticsRecords` now exposes `isPlaceholderData` and both panels fold it into `canExport`, hiding the whole export action row (CSV and PNG share the mismatch hazard) until the requested window settles.
2. **Self-describing heatmap CSV**: the exporter always exports the spec-default p95 while the renderer has a user-selected quantile, and it emitted confidence-suppressed cells as bare values the chart deliberately hides. The value column is now named `p95` and a `confidence` column mirrors the chart's `classifyCell` tiers, keeping the numeric values.
3. **Shared dispatch**: the `wants*` predicates are now exported from `MetricRenderer.tsx` and `preprocessConnectionRecords` from `pipeline/connection.tsx`; `csvExport.ts` imports them instead of carrying token-for-token copies with keep-in-sync comments. Existing csvExport tests pass unchanged, confirming equivalence.

## Deferred (parallel-batch file ownership)

- **StorageTab table-size snapshot/trend cards**: these bespoke cards have PNG copy/export but live in `tabs/StorageTab.tsx`, which is outside this agent's file allocation for the batch. Their data is also a custom derived shape (`TableSizeDerived`), not `SeriesData`/`HeatmapData`. Follow-up: build the two `ChartCsvData` adapters and pass `getCsvData` to their button rows.
- **Replication-latency drilldown dialog**: the heatmap agent is adding a drilldown dialog to `pipeline/replication-latency.tsx` in this same batch; per batch coordination, CSV was intentionally not wired into that new dialog. The heatmap CSV is available from the panel header and expand dialog.
- **Exact rendered-state parity for custom renderers**: reflecting chip/quantile/viewMode selections in the CSV requires threading state out of `primitives/*` (owned by the crosshair agent this batch).

## Cross-model reviews

- **Codex**: 2 findings, both fixed — `connection` metric CSV was empty (spec groups on the synthetic `pathMethod` field created by renderer preprocessing; now mirrored in `csvExport.ts`), and spreadsheet formula injection via telemetry-derived labels (now apostrophe-neutralized). Regression tests added for both.
- **Gemini**: flagged the custom-renderer default-view trade-off (documented above), and small-multiples dropping per-panel ceiling series (fixed — ceilings now export as regular columns). One finding dismissed as a false premise (it assumed a `setTimeout`-deferred `URL.revokeObjectURL` that doesn't exist in this code).

Comment generated by kAIle (Claude Fable 5)

