### PR TITLE
test: fail on render-phase update warnings; smoke-render every registry metric

### DIFF
--- a/src/features/instance/status/analytics/__tests__/registry-smoke.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/registry-smoke.test.tsx
@@ -13,6 +13,7 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { getSpecRequiredFields } from '../lib/specRequiredFields';
+import { derivedRegistry } from '../pipeline/derived/index';
 import { specRegistry } from '../pipeline/index';
 import { QUANTILE_FIELDS } from '../pipeline/quantileFields';
 import { MetricRenderer } from '../primitives/MetricRenderer';
@@ -42,10 +43,13 @@ const COMMON_NUMERIC_FIELDS = [
  *  cache hits) stay in-domain. */
 function syntheticRecords(metric: string): AnalyticsDataPoint[] {
 	const fields = getSpecRequiredFields(metric);
-	const spec = specRegistry[metric]?.spec;
+	// `spec` is required on SpecRegistryEntry (types/analytics.ts) and `metric`
+	// is always a specRegistry key here, so read it non-optionally — matches
+	// MUST_RENDER_CHART's `specRegistry[metric].spec` below.
+	const spec = specRegistry[metric].spec;
 	const dimensions = new Set<string>();
-	if (spec?.series.kind === 'groupBy') { dimensions.add(spec.series.dimension); }
-	for (const dim of [spec?.primaryDimension, spec?.subDimension].flat()) {
+	if (spec.series.kind === 'groupBy') { dimensions.add(spec.series.dimension); }
+	for (const dim of [spec.primaryDimension, spec.subDimension].flat()) {
 		if (dim) { dimensions.add(dim); }
 	}
 	dimensions.delete('node');
@@ -89,11 +93,80 @@ function syntheticRecords(metric: string): AnalyticsDataPoint[] {
  *  a newly registered line/stacked-area metric is automatically held to the
  *  chart tier (a hardcoded list would silently exempt new metrics).
  *  Non-cartesian primitives (heatmap, small-multiples) are dispatched to
- *  bespoke DOM and stay in the no-crash tier only. */
+ *  bespoke DOM and get their own dedicated real-render cases below. */
 const MUST_RENDER_CHART = Object.keys(specRegistry).filter((metric) => {
 	const primitive = specRegistry[metric].spec.primitive;
 	return primitive === 'line' || primitive === 'stacked-area';
 });
+
+/** Records for the derived-metric no-crash tier. Derived metrics recompute
+ *  from RAW source columns (their `recompute` bypasses runPipeline / the spec
+ *  aggregator — see pipeline/derived/index.ts), so getSpecRequiredFields
+ *  can't infer their inputs. This carries every raw column the five derived
+ *  recomputes read directly:
+ *    - request-rate  → path, count, period  (PerPathRateRenderer)
+ *    - error-rate    → path, count, total
+ *    - mqtt-traffic-{sent,received} → type, count, period  (runPipeline on the
+ *      inner bytes-{sent,received} spec via TrafficByTypeRenderer)
+ *    - transaction-log-growth → database, transactionLog (monotonic per node
+ *      so consecutive-sample deltas are positive), id/time
+ *  `count` is high so any confidence gate clears; `total` stays small so
+ *  error-rate's `1 − Σtotal/Σcount` stays in-domain. */
+const REQUEST_PATHS = ['GET /', 'POST /data'];
+const MQTT_TYPES = ['publish', 'subscribe'];
+
+function derivedSyntheticRecords(): AnalyticsDataPoint[] {
+	const records: AnalyticsDataPoint[] = [];
+	for (let bucket = 0; bucket < 6; bucket++) {
+		const time = T0 + bucket * 60_000;
+		for (const node of NODES) {
+			for (const path of REQUEST_PATHS) {
+				records.push({
+					time,
+					id: time,
+					period: 60_000,
+					node,
+					path,
+					type: MQTT_TYPES[bucket % MQTT_TYPES.length],
+					database: 'data',
+					// Cumulative counter — strictly increasing per (database, node)
+					// so transaction-log-growth's delta walk yields positive rates.
+					transactionLog: 1_000 * (bucket + 1),
+					count: 500,
+					total: 5,
+					p95: 10 + bucket,
+				});
+			}
+		}
+	}
+	return records;
+}
+
+/** Records that populate replication-latency's heatmap grid (dawson #1521).
+ *  `node` is the DESTINATION; the SOURCE is parsed from `path`
+ *  (`<source>.<db>.<table>` — see pathParser). Two sources × two destinations
+ *  gives a 2×2 matrix that clears both the ≥2-rows/≥2-cols and ≤12-cells gates
+ *  in ReplicationLatencyRenderer, so the real HeatmapMatrix draws instead of
+ *  the single-source line fallback. `count=500` clears the confidence gate. */
+function replicationHeatmapRecords(): AnalyticsDataPoint[] {
+	const records: AnalyticsDataPoint[] = [];
+	for (let bucket = 0; bucket < 3; bucket++) {
+		const time = T0 + bucket * 60_000;
+		for (const destination of NODES) {
+			for (const source of NODES) {
+				records.push({
+					time,
+					period: 60,
+					node: destination,
+					path: `${source}.data.tbl`,
+					p95: 10 + bucket,
+					count: 500,
+				});
+			}
+		}
+	}
+	return records;
+}
 
 describe('spec registry smoke — every registered metric renders without tripping the panel boundary', () => {
 	for (const metric of Object.keys(specRegistry)) {
@@ -126,8 +199,84 @@ describe('spec registry smoke — every registered metric renders without trippi
 					/>
 				</PanelErrorBoundary>,
 			);
-			expect(container.querySelector('.recharts-responsive-container, svg')).not.toBeNull();
+			// Assert the <svg> itself drew — NOT `.recharts-responsive-container`,
+			// which is the wrapper div always present once a ResponsiveContainer
+			// mounts (it's an ancestor of the svg, so the old
+			// `.recharts-responsive-container, svg` selector matched the wrapper
+			// first and never proved an svg existed). The analytics __tests__/setup.ts
+			// forces an 800×600 viewport, so recharts genuinely emits svg here.
+			expect(container.querySelector('svg')).not.toBeNull();
 			expect(container.textContent ?? '').not.toContain('No data in window');
 		});
 	}
+});
+
+// ─── Derived-metric no-crash tier (kriszyp #1 — verify-derived-…) ─────────────
+// MetricRenderer dispatches derivedRegistry[metric] at the TOP of its body,
+// before it ever consults specRegistry, so the specRegistry-keyed loops above
+// give the five derived metrics ZERO coverage. Iterate them here. Bar is
+// no-crash only: derived renderers differ (custom Renderers with chip/type UI,
+// per-path/per-database line series) and their populated-vs-empty shape isn't
+// uniform, so we assert only that none trips the panel boundary or the
+// render-failed fallback — the same guarantee the spec no-crash tier gives.
+describe('derived registry smoke — every derived metric renders without tripping the panel boundary', () => {
+	for (const metric of Object.keys(derivedRegistry)) {
+		it(`renders derived '${metric}'`, () => {
+			const { container } = render(
+				<PanelErrorBoundary metric={metric}>
+					<MetricRenderer
+						metric={metric}
+						records={derivedSyntheticRecords()}
+						window={WINDOW}
+						nodes={NODES}
+					/>
+				</PanelErrorBoundary>,
+			);
+			const text = container.textContent ?? '';
+			expect(text).not.toContain('is unavailable'); // PanelErrorBoundary tripped
+			expect(text).not.toContain('Render failed'); // MetricRenderer error fallback
+		});
+	}
+});
+
+// ─── Non-cartesian real-render tier (dawson #1521) ───────────────────────────
+// heatmap (replication-latency) and small-multiples (resource-usage) dispatch
+// to bespoke DOM, so the cartesian MUST_RENDER_CHART tier can't cover them.
+// Give each adequate synthetic data and assert it draws its real surface — not
+// its empty state — so a regression that silently drops to "No data in window"
+// is caught, not just a non-crash.
+describe('non-cartesian primitives render real DOM from populated records', () => {
+	it('replication-latency draws the heatmap grid (not the empty/line fallback)', () => {
+		const { container } = render(
+			<PanelErrorBoundary metric="replication-latency">
+				<MetricRenderer
+					metric="replication-latency"
+					records={replicationHeatmapRecords()}
+					window={WINDOW}
+					nodes={NODES}
+				/>
+			</PanelErrorBoundary>,
+		);
+		const grid = container.querySelector('[role="grid"]');
+		expect(grid).not.toBeNull();
+		// A real 2×2 matrix emits gridcells — the empty state renders none.
+		expect(grid?.querySelectorAll('[role="gridcell"]').length ?? 0).toBeGreaterThan(0);
+		expect(container.textContent ?? '').not.toContain('No data in window');
+	});
+
+	it('resource-usage draws multiple small-multiple sub-charts', () => {
+		const { container } = render(
+			<PanelErrorBoundary metric="resource-usage">
+				<MetricRenderer
+					metric="resource-usage"
+					records={syntheticRecords('resource-usage')}
+					window={WINDOW}
+					nodes={NODES}
+				/>
+			</PanelErrorBoundary>,
+		);
+		// One titled sub-panel + one svg per resource-usage field (4 fields).
+		expect(container.querySelectorAll('[data-testid="small-multiple-title"]').length).toBeGreaterThan(1);
+		expect(container.querySelectorAll('svg').length).toBeGreaterThan(1);
+	});
 });

--- a/src/features/instance/status/analytics/__tests__/registry-smoke.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/registry-smoke.test.tsx
@@ -1,0 +1,133 @@
+/** @vitest-environment jsdom */
+// Registry-wide panel smoke test — the unit-test form of the "do the metrics
+// panels actually load?" browser verification pass. Every specRegistry entry
+// renders through the same MetricRenderer dispatch MetricPanel uses, inside
+// the real PanelErrorBoundary, fed synthetic records shaped from the spec's
+// own required fields. Catches the "refactor broke a renderer nobody's test
+// imports" class (e.g. a registry retarget dropping a spec) without a browser.
+//
+// Assertion is two-tier: NO metric may trip the error boundary or the
+// render-failed fallback, and the well-known chart-backed metrics must
+// actually produce recharts SVG (guards against a vacuous pass where every
+// panel silently renders its empty state).
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { getSpecRequiredFields } from '../lib/specRequiredFields';
+import { specRegistry } from '../pipeline/index';
+import { QUANTILE_FIELDS } from '../pipeline/quantileFields';
+import { MetricRenderer } from '../primitives/MetricRenderer';
+import { PanelErrorBoundary } from '../tabs/PanelErrorBoundary';
+import type { AnalyticsDataPoint, TimeRange } from '../types/analytics';
+
+const T0 = 1_752_000_000_000;
+const NODES = ['node-a', 'node-b'];
+const WINDOW: TimeRange = { startTime: T0, endTime: T0 + 6 * 60_000 };
+
+/** Quantile columns are deliberately NOT in getSpecRequiredFields (they're
+ *  treated as picker alternates there — see its docstring), but p95 is the
+ *  default axis on the quantile-bearing specs, so records must carry them
+ *  for those charts to draw. `count`/`total` feed the count-weighted-mean
+ *  aggregators. */
+const COMMON_NUMERIC_FIELDS = [
+	...QUANTILE_FIELDS.map((quantile) => quantile.field),
+	'count',
+	'total',
+	'mean',
+];
+
+/** Six buckets × two nodes of records carrying every field the spec's
+ *  default view reads (per getSpecRequiredFields) plus the common quantile
+ *  and count columns, plus every dimension the spec groups or filters on.
+ *  Values are small positive numbers so ratio-style fields (success rates,
+ *  cache hits) stay in-domain. */
+function syntheticRecords(metric: string): AnalyticsDataPoint[] {
+	const fields = getSpecRequiredFields(metric);
+	const spec = specRegistry[metric]?.spec;
+	const dimensions = new Set<string>();
+	if (spec?.series.kind === 'groupBy') { dimensions.add(spec.series.dimension); }
+	for (const dim of [spec?.primaryDimension, spec?.subDimension].flat()) {
+		if (dim) { dimensions.add(dim); }
+	}
+	dimensions.delete('node');
+	const records: AnalyticsDataPoint[] = [];
+	for (let bucket = 0; bucket < 6; bucket++) {
+		for (const node of NODES) {
+			const record: AnalyticsDataPoint = {
+				time: T0 + bucket * 60_000,
+				period: 60,
+				node,
+			};
+			for (const field of [...fields, ...COMMON_NUMERIC_FIELDS]) {
+				record[field] = 1 + bucket;
+			}
+			// Big enough that Σcount per series clears every spec's
+			// confidence gate (duration et al. suppress below 100 samples);
+			// `total` stays small so error-ratio fields (1 − total/count)
+			// remain in-domain.
+			record.count = 500;
+			record.total = 5;
+			for (const dim of dimensions) {
+				record[dim] = bucket % 2 === 0 ? 'alpha' : 'beta';
+			}
+			// Re-stamp the structural columns last so a spec that lists
+			// time/period/node among its required fields can't corrupt the
+			// record's timestamp (which would silently eject it from WINDOW).
+			// `id` mirrors `time` for the specs with `timestamp: 'id'`
+			// (database-size, storage-volume).
+			record.time = T0 + bucket * 60_000;
+			record.id = record.time;
+			record.period = 60;
+			record.node = node;
+			records.push(record);
+		}
+	}
+	return records;
+}
+
+/** Metrics whose default view is a recharts cartesian chart — these must
+ *  emit SVG, not just avoid crashing. Derived from the spec's primitive so
+ *  a newly registered line/stacked-area metric is automatically held to the
+ *  chart tier (a hardcoded list would silently exempt new metrics).
+ *  Non-cartesian primitives (heatmap, small-multiples) are dispatched to
+ *  bespoke DOM and stay in the no-crash tier only. */
+const MUST_RENDER_CHART = Object.keys(specRegistry).filter((metric) => {
+	const primitive = specRegistry[metric].spec.primitive;
+	return primitive === 'line' || primitive === 'stacked-area';
+});
+
+describe('spec registry smoke — every registered metric renders without tripping the panel boundary', () => {
+	for (const metric of Object.keys(specRegistry)) {
+		it(`renders '${metric}'`, () => {
+			const { container } = render(
+				<PanelErrorBoundary metric={metric}>
+					<MetricRenderer
+						metric={metric}
+						records={syntheticRecords(metric)}
+						window={WINDOW}
+						nodes={NODES}
+					/>
+				</PanelErrorBoundary>,
+			);
+			const text = container.textContent ?? '';
+			expect(text).not.toContain('is unavailable'); // PanelErrorBoundary tripped
+			expect(text).not.toContain('Render failed'); // MetricRenderer error fallback
+		});
+	}
+
+	for (const metric of MUST_RENDER_CHART) {
+		it(`'${metric}' produces an actual chart from populated records`, () => {
+			const { container } = render(
+				<PanelErrorBoundary metric={metric}>
+					<MetricRenderer
+						metric={metric}
+						records={syntheticRecords(metric)}
+						window={WINDOW}
+						nodes={NODES}
+					/>
+				</PanelErrorBoundary>,
+			);
+			expect(container.querySelector('.recharts-responsive-container, svg')).not.toBeNull();
+			expect(container.textContent ?? '').not.toContain('No data in window');
+		});
+	}
+});

--- a/src/react-query/queryClient.test.ts
+++ b/src/react-query/queryClient.test.ts
@@ -23,7 +23,11 @@ describe('errorHandler', () => {
 	});
 
 	afterEach(() => {
-		consoleMock.mockReset();
+		// mockRestore (not mockReset) un-installs the spy so the global
+		// render-phase-update tripwire's console.error wrapper is back in place
+		// at teardown — mockReset leaves a swallowing no-op spy installed, which
+		// the tripwire self-check (failOnRenderPhaseUpdate #1520) flags.
+		consoleMock.mockRestore();
 	});
 
 	it('should display default error message when no specific error info is available', () => {

--- a/src/testSetup/failOnRenderPhaseUpdate.test.ts
+++ b/src/testSetup/failOnRenderPhaseUpdate.test.ts
@@ -1,0 +1,36 @@
+// Unit coverage for the render-phase-update tripwire's self-check (#1520): the
+// afterEach net-disabled detection must fire when a test replaces console.error
+// and leaves it replaced, and must stay quiet when the wrapper is intact.
+import { describe, expect, it } from 'vitest';
+import { detectDisabledNet, installTripwire } from './failOnRenderPhaseUpdate';
+
+describe('failOnRenderPhaseUpdate — tripwire net self-check', () => {
+	it('installTripwire installs a forwarding wrapper and captures the original', () => {
+		const before = console.error;
+		const { wrapper, original } = installTripwire();
+		try {
+			expect(original).toBe(before);
+			expect(console.error).toBe(wrapper);
+			expect(wrapper).not.toBe(before);
+		} finally {
+			// Put the setup's wrapper back so this test's own afterEach detection
+			// (which compares against that wrapper) does not flag a false disable.
+			console.error = before;
+		}
+	});
+
+	it('detectDisabledNet returns null while the installed wrapper is still in place', () => {
+		const wrapper = (() => {}) as typeof console.error;
+		expect(detectDisabledNet(wrapper, wrapper, 'some test')).toBeNull();
+	});
+
+	it('detectDisabledNet flags a warning when console.error was replaced and not restored', () => {
+		const wrapper = (() => {}) as typeof console.error;
+		const replacement = (() => {}) as typeof console.error; // e.g. a vi.spyOn mock
+		const message = detectDisabledNet(replacement, wrapper, 'a test that mocks console.error');
+
+		expect(message).not.toBeNull();
+		expect(message).toContain('DISABLED');
+		expect(message).toContain('a test that mocks console.error');
+	});
+});

--- a/src/testSetup/failOnRenderPhaseUpdate.ts
+++ b/src/testSetup/failOnRenderPhaseUpdate.ts
@@ -38,17 +38,25 @@ beforeEach(() => {
 	};
 });
 
-afterEach(() => {
-	if (interceptedError) {
-		console.error = interceptedError;
+afterEach((context) => {
+	const original = interceptedError;
+	if (original) {
+		console.error = original;
 		interceptedError = undefined;
 	}
 	if (offenders.length > 0) {
 		const details = offenders.join('\n  ');
 		offenders = [];
-		throw new Error(
+		const message =
 			`React render-phase update detected — a component setState'd (or notified a store subscriber) while another component was rendering. `
-				+ `Defer the notification (see useAnalyticsFreshness / notifyManager.batchCalls for the pattern):\n  ${details}`,
-		);
+			+ `Defer the notification (see useAnalyticsFreshness / notifyManager.batchCalls for the pattern):\n  ${details}`;
+		// If the test body already failed, don't throw from the hook — a hook
+		// error would shadow the primary assertion failure in the report. The
+		// offender detail still reaches the log; the test is red either way.
+		if (context.task.result?.state === 'fail') {
+			original?.(`[failOnRenderPhaseUpdate] ${message}`);
+			return;
+		}
+		throw new Error(message);
 	}
 });

--- a/src/testSetup/failOnRenderPhaseUpdate.ts
+++ b/src/testSetup/failOnRenderPhaseUpdate.ts
@@ -1,0 +1,54 @@
+// Global tripwire: fail any test during which React logs a render-phase
+// cross-component update ("Cannot update a component (`X`) while rendering a
+// different component (`Y`)"). This defect class ships silently — the suite
+// stays green while every affected render pollutes the browser console (and
+// Datadog RUM) in production. It has now bitten twice: the router-rebuild
+// Transitioner warning (see CLAUDE.md, Jul 2026) and the analytics freshness
+// watcher setState-ing from a QueryCache subscription (PR #1510) — both were
+// only caught by manually watching a real browser console.
+//
+// The match is deliberately narrow (this one React message), NOT a blanket
+// console.error ban: intentional error paths (PanelErrorBoundary's
+// `[panel:x] render failed`, the query-cache toast handler) log through
+// console.error legitimately.
+//
+// A test that MUST assert this warning fires (e.g. proving a repro against a
+// known-bad implementation) can capture console.error itself; replacing the
+// function inside the test body takes this interceptor out of the chain for
+// matching calls it swallows.
+import { afterEach, beforeEach } from 'vitest';
+
+const RENDER_PHASE_UPDATE = 'Cannot update a component';
+
+let offenders: string[] = [];
+let interceptedError: typeof console.error | undefined;
+
+beforeEach(() => {
+	offenders = [];
+	const original = console.error;
+	interceptedError = original;
+	console.error = (...args: unknown[]) => {
+		if (typeof args[0] === 'string' && args[0].includes(RENDER_PHASE_UPDATE)) {
+			// React logs printf-style: substitute %s args so the failure
+			// message names the actual components.
+			let i = 1;
+			offenders.push(args[0].replace(/%s/g, () => String(args[i++] ?? '%s')));
+		}
+		original.apply(console, args as Parameters<typeof console.error>);
+	};
+});
+
+afterEach(() => {
+	if (interceptedError) {
+		console.error = interceptedError;
+		interceptedError = undefined;
+	}
+	if (offenders.length > 0) {
+		const details = offenders.join('\n  ');
+		offenders = [];
+		throw new Error(
+			`React render-phase update detected — a component setState'd (or notified a store subscriber) while another component was rendering. `
+				+ `Defer the notification (see useAnalyticsFreshness / notifyManager.batchCalls for the pattern):\n  ${details}`,
+		);
+	}
+});

--- a/src/testSetup/failOnRenderPhaseUpdate.ts
+++ b/src/testSetup/failOnRenderPhaseUpdate.ts
@@ -16,18 +16,49 @@
 // known-bad implementation) can capture console.error itself; replacing the
 // function inside the test body takes this interceptor out of the chain for
 // matching calls it swallows.
+//
+// DEV-MODE DEPENDENCY: this tripwire only works because React emits the
+// "Cannot update a component while rendering a different component" warning
+// from its DEV build (via console.error). A production React build strips that
+// warning entirely, so if the test runtime is ever switched to a production
+// React bundle this net silently goes green — it stops catching anything
+// rather than failing loudly. Keep tests on the development build of React.
+//
+// TRIPWIRE-NET SELF-CHECK (#1520): a test that replaces console.error
+// (`vi.spyOn(console, 'error').mockImplementation(...)`) swaps this wrapper out
+// of the chain, so render-phase warnings emitted while that mock is installed
+// are never seen — the net is disabled for that test. Two such tests live in
+// the exact subsystems this guard protects (tabs/OverviewTab, router
+// preloadEvictionRepro). We can't retroactively see a warning a mock already
+// swallowed, but we CAN detect at teardown that the wrapper is no longer
+// installed (the test replaced console.error and didn't restore it). A hard
+// failure there would break the ~4 tests that legitimately mock console.error,
+// so the chosen severity is a loud `console.warn` (through the restored real
+// console.error) naming the test, plus a defensive restore so the leak doesn't
+// bleed into the next test. Warn, don't throw.
 import { afterEach, beforeEach } from 'vitest';
 
 const RENDER_PHASE_UPDATE = 'Cannot update a component';
 
-let offenders: string[] = [];
-let interceptedError: typeof console.error | undefined;
+interface TripwireState {
+	/** Render-phase-update messages captured during the current test. */
+	offenders: string[];
+	/** The wrapper we installed onto console.error in beforeEach — the identity
+	 *  we compare against in afterEach to tell whether the net is still armed. */
+	wrapper: typeof console.error;
+	/** The real console.error captured before wrapping, restored in afterEach. */
+	original: typeof console.error;
+}
 
-beforeEach(() => {
-	offenders = [];
+let state: TripwireState | undefined;
+
+/** Wrap console.error so render-phase-update warnings are captured while still
+ *  forwarding every call through to the real console.error. Returns the state
+ *  needed to inspect and unwind the interception. Exported for unit testing. */
+export function installTripwire(): TripwireState {
+	const offenders: string[] = [];
 	const original = console.error;
-	interceptedError = original;
-	console.error = (...args: unknown[]) => {
+	const wrapper: typeof console.error = (...args: unknown[]) => {
 		if (typeof args[0] === 'string' && args[0].includes(RENDER_PHASE_UPDATE)) {
 			// React logs printf-style: substitute %s args so the failure
 			// message names the actual components.
@@ -36,25 +67,59 @@ beforeEach(() => {
 		}
 		original.apply(console, args as Parameters<typeof console.error>);
 	};
+	console.error = wrapper;
+	return { offenders, wrapper, original };
+}
+
+/** Detect whether the tripwire net was disabled during a test: at teardown,
+ *  `current` (console.error as the test left it) should still be the `wrapper`
+ *  we installed. When it isn't, a test replaced console.error and never put our
+ *  wrapper back — any render-phase warning it logged went unseen. Returns the
+ *  warning to surface, or null when the net is still armed. Exported so the
+ *  detection is unit-testable without driving the global hooks. */
+export function detectDisabledNet(
+	current: typeof console.error,
+	wrapper: typeof console.error,
+	testName: string,
+): string | null {
+	if (current === wrapper) { return null; }
+	return `[failOnRenderPhaseUpdate] The render-phase-update tripwire was DISABLED during "${testName}" — `
+		+ `console.error was replaced (e.g. vi.spyOn(console, 'error').mockImplementation) and not restored to this `
+		+ `setup's wrapper, so any render-phase warning logged in that test went unseen. Restore with `
+		+ `mockRestore() / vi.restoreAllMocks() (not mockReset, which leaves the spy installed) to keep the net armed.`;
+}
+
+beforeEach(() => {
+	state = installTripwire();
 });
 
 afterEach((context) => {
-	const original = interceptedError;
-	if (original) {
-		console.error = original;
-		interceptedError = undefined;
+	const s = state;
+	state = undefined;
+	if (!s) { return; }
+
+	// Snapshot console.error as the test left it, then restore the real one
+	// unconditionally — even if a test leaked a mock, the next test starts clean.
+	const current = console.error;
+	console.error = s.original;
+
+	// Surface (but don't fail on) a test that left the tripwire net disabled.
+	const disabledMessage = detectDisabledNet(current, s.wrapper, context.task.name);
+	if (disabledMessage) {
+		console.warn(disabledMessage);
 	}
-	if (offenders.length > 0) {
-		const details = offenders.join('\n  ');
-		offenders = [];
+
+	if (s.offenders.length > 0) {
+		const details = s.offenders.join('\n  ');
 		const message =
 			`React render-phase update detected — a component setState'd (or notified a store subscriber) while another component was rendering. `
 			+ `Defer the notification (see useAnalyticsFreshness / notifyManager.batchCalls for the pattern):\n  ${details}`;
 		// If the test body already failed, don't throw from the hook — a hook
 		// error would shadow the primary assertion failure in the report. The
-		// offender detail still reaches the log; the test is red either way.
+		// offender detail still reaches the log (console.error was restored just
+		// above, so call it directly); the test is red either way.
 		if (context.task.result?.state === 'fail') {
-			original?.(`[failOnRenderPhaseUpdate] ${message}`);
+			console.error(`[failOnRenderPhaseUpdate] ${message}`);
 			return;
 		}
 		throw new Error(message);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 			'**/.claude/worktrees/**',
 		],
 		setupFiles: [
+			'./src/testSetup/failOnRenderPhaseUpdate.ts',
 			'./src/features/instance/status/analytics/__tests__/setup.ts',
 			'./src/lib/monaco/__tests__/setup.ts',
 		],


### PR DESCRIPTION
## Summary

Test-infrastructure only — turns the two most valuable findings from the recent runtime-verification (Playwright) passes into permanent suite guards:

1. **Render-phase update tripwire** (`src/testSetup/failOnRenderPhaseUpdate.ts`, registered globally): any test during which React logs `Cannot update a component while rendering a different component` now fails, with the actual component names substituted into the failure message. This defect class has shipped silently twice (the router-rebuild `Transitioner` warning, and the analytics freshness watcher just fixed in #1510) — the suite stayed green both times while production consoles/RUM filled with warnings. The match is deliberately narrow (that one React message, not a blanket console.error ban), so intentional error-logging paths (PanelErrorBoundary, the query-cache toast handler) are unaffected. **Zero offenders in the current suite** (220 files / 1529 tests run clean), so there's no ordering dependency on other open PRs.

2. **Registry-wide panel smoke test** (`registry-smoke.test.tsx`): every `specRegistry` metric renders through the real `MetricRenderer` dispatch inside the real `PanelErrorBoundary`, fed synthetic records derived from each spec's own required fields (plus quantile columns, confidence-gate-clearing counts, and `id`-mirrored timestamps). Two tiers: no metric may trip the boundary or the render-failed fallback, and every `line`/`stacked-area` metric — derived from `spec.primitive`, not a hardcoded list, so new metrics are automatically held to it — must emit an actual chart, not just its empty state. This is the unit-test form of "do the metrics panels actually load?", the class the recent shim-deletion sweep had to browser-verify.

## Where to focus

- The tripwire's failure mechanism is an `afterEach` throw. If a test both fails an assertion *and* trips the wire, vitest reports the hook failure — it can shadow the primary assertion in the output (both are real failures; you fix the same code). Accepted trade-off, flagging for awareness.
- The `offenders` accumulator is not safe under `test.concurrent`, which this repo doesn't use.
- The synthetic-record generator was validated in both directions during development: it initially rendered empty states for quantile specs (confidence gate) and `timestamp: 'id'` specs — the chart-tier assertions caught both, which is the behavior you want from it going forward.

Comment generated by kAIle (Claude Fable 5)
