### PR TITLE
fix(status): keep rotated heatmap column labels clear of the cell grid

### DIFF
--- a/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
@@ -70,6 +70,29 @@ describe('HeatmapMatrix primitive', () => {
 		expect(screen.getByRole('columnheader', { name: /dest-a/i })).toBeTruthy();
 	});
 
+	it('displays the short node name while keeping the full FQDN in a11y + title', () => {
+		const fqdnData = {
+			...data,
+			rows: ['src-1.us-west.acme.harperfabric.com'],
+			cols: ['dest-a.us-east.acme.harperfabric.com'],
+			cells: [{
+				row: 'src-1.us-west.acme.harperfabric.com',
+				col: 'dest-a.us-east.acme.harperfabric.com',
+				value: 5,
+				count: 200,
+			}],
+		};
+		render(<HeatmapMatrix data={fqdnData} />);
+		// Displayed label text (the <text> node's own value, not the nested
+		// <title>) is the first DNS segment…
+		const col = screen.getByRole('columnheader', { name: 'dest-a.us-east.acme.harperfabric.com' });
+		expect(col.querySelector('text')?.firstChild?.textContent).toBe('dest-a');
+		// …while the <title> and aria-label preserve the full FQDN.
+		expect(col.querySelector('title')?.textContent).toBe('dest-a.us-east.acme.harperfabric.com');
+		const row = screen.getByRole('rowheader', { name: 'src-1.us-west.acme.harperfabric.com' });
+		expect(row.querySelector('text')?.firstChild?.textContent).toBe('src-1');
+	});
+
 	it('renders a color-scale legend', () => {
 		render(<HeatmapMatrix data={data} />);
 		const legend = screen.getByRole('img', { name: /color scale|p95 latency/i });

--- a/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/heatmap-matrix.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { HeatmapMatrix } from '../../primitives/HeatmapMatrix';
+import { computeHeaderHeight, HeatmapMatrix } from '../../primitives/HeatmapMatrix';
 import type { HeatmapData } from '../../types/analytics';
 
 const data: HeatmapData = {
@@ -303,6 +303,83 @@ describe('HeatmapMatrix primitive', () => {
 			unmount();
 			render(<HeatmapMatrix data={data} />);
 			expect(screen.getByTestId('heatmap-desc').textContent ?? '').not.toMatch(/Enter or Space/);
+		});
+	});
+
+	// Regression #1518: the rotated destination (column) labels used to anchor
+	// only 8px above the grid and rotate −45°, sending each label's far end DOWN
+	// into the first cell row where the cells painted over it. The fix anchors the
+	// label's END glyph just above the grid and leans it UP-and-left (+45°), so the
+	// anchor baseline is the label's lowest point and it never enters the cells;
+	// the header is sized so the far (top) end is never clipped either.
+	describe('column-label geometry (#1518)', () => {
+		const firstCellY = () => {
+			const rect = screen.getAllByRole('gridcell')[0].querySelector('rect')!;
+			return Number(rect.getAttribute('y'));
+		};
+		const colHeaderTexts = () => screen.getAllByRole('columnheader').map((g) => g.querySelector('text')!);
+
+		it('anchors every column label above the first cell row (no overlap)', () => {
+			render(<HeatmapMatrix data={data} />);
+			const cellY = firstCellY();
+			for (const t of colHeaderTexts()) {
+				// The label's near-end baseline (its lowest point once rotated +45°)
+				// sits strictly above where the cells begin.
+				expect(Number(t.getAttribute('y'))).toBeLessThan(cellY);
+			}
+		});
+
+		it('rotates the labels UP-left (+45°), not the old down-left −45°', () => {
+			render(<HeatmapMatrix data={data} />);
+			for (const t of colHeaderTexts()) {
+				const transform = t.getAttribute('transform') ?? '';
+				expect(transform).toMatch(/rotate\(\s*45\s*,/);
+				expect(transform).not.toMatch(/rotate\(\s*-45/);
+			}
+		});
+
+		it('reserves header room that matches computeHeaderHeight, and the viewBox contains it', () => {
+			const { container } = render(<HeatmapMatrix data={data} />);
+			const svg = container.querySelector('svg[role="grid"]')!;
+			const cellSize = Number(svg.getAttribute('data-cell-size'));
+			// The first cell row starts exactly at the reserved header height.
+			expect(firstCellY()).toBe(computeHeaderHeight(data.cols, cellSize));
+			// viewBox is "0 0 W H"; H must be tall enough to contain the header
+			// plus at least the first cell row — nothing clipped top or bottom.
+			const [minX, minY, , vbHeight] = (svg.getAttribute('viewBox') ?? '').split(/\s+/).map(Number);
+			expect(minX).toBe(0);
+			expect(minY).toBe(0);
+			expect(vbHeight).toBeGreaterThan(firstCellY());
+		});
+	});
+
+	describe('computeHeaderHeight', () => {
+		it('floors short-label grids at the minimum header height (72)', () => {
+			expect(computeHeaderHeight(['a', 'bb', 'ccc'], 40)).toBe(72);
+			expect(computeHeaderHeight([], 80)).toBe(72);
+		});
+
+		it('grows to contain long labels rotated 45° so the far end is not clipped', () => {
+			const longCols = ['node-alpha.us-east-1.example.internal', 'n2.example.internal'];
+			const wide = computeHeaderHeight(longCols, 80); // wide cells → 20-char truncation
+			expect(wide).toBeGreaterThan(72);
+			// Must reserve at least the diagonal's vertical extent of a 20-char label
+			// (20 · 6.6 · sin45 ≈ 93px) so the up-left far end clears y=0.
+			expect(wide).toBeGreaterThanOrEqual(93);
+		});
+
+		it('is monotonic in the longest label length', () => {
+			const short = computeHeaderHeight(['abcdefghijklmnop'], 80);
+			const longer = computeHeaderHeight(['abcdefghijklmnopqrst'], 80);
+			expect(longer).toBeGreaterThanOrEqual(short);
+		});
+
+		it('caps growth via the per-cellSize truncation (narrow cells truncate to 8 chars)', () => {
+			const label = ['a-very-long-destination-label-that-exceeds-limits'];
+			// Narrow cells truncate to 8 chars, so the header stays at the floor.
+			expect(computeHeaderHeight(label, 40)).toBe(72);
+			// Wide cells truncate to 20 chars, so the header grows past the floor.
+			expect(computeHeaderHeight(label, 80)).toBeGreaterThan(72);
 		});
 	});
 

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -286,8 +286,10 @@ export function computeHeaderHeight(cols: string[], cellSize: number): number {
 		(m, c) => Math.max(m, Math.min(c.length, colTruncateLength(cellSize))),
 		0,
 	);
-	const rad = (COL_LABEL_ANGLE_DEG * Math.PI) / 180;
-	const vExtent = maxChars * COL_LABEL_CHAR_W * Math.sin(rad) + COL_LABEL_FONT_SIZE * Math.cos(rad);
+	// COL_LABEL_ANGLE_DEG is 45°, so sin θ = cos θ = √½ — factor it out of the
+	// per-render trig. If the label angle ever stops being 45°, restore the
+	// general `sin(rad)`/`cos(rad)` form.
+	const vExtent = (maxChars * COL_LABEL_CHAR_W + COL_LABEL_FONT_SIZE) * Math.SQRT1_2;
 	return Math.max(MIN_HEADER_HEIGHT, Math.ceil(vExtent) + HEADER_TOP_PAD + HEADER_BOTTOM_PAD);
 }
 

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -242,8 +242,53 @@ function HeatmapColorLegend({ stops, vmin, vmax, width, axis, approx, measureLab
 const MIN_CELL_SIZE = 40;
 const MAX_CELL_SIZE = 80;
 const CELL_GAP = 4;
-const HEADER_HEIGHT = 72; // reserved for rotated column headers
 const ROW_LABEL_WIDTH = 200;
+
+// ── Rotated column-header geometry ───────────────────────────────────────────
+// Destination labels are drawn diagonally above the grid. They anchor at their
+// END glyph (nearest the cell), sit just above the first cell row, and lean
+// UP-and-to-the-LEFT (rotate +45° with textAnchor="end"). Anchoring the near
+// end means the label's LOWEST point is the anchor baseline — independent of the
+// label's length — so no matter how long a label is it can never dip into the
+// cells; extra length only pushes the far (top) end higher. The header height is
+// sized from the longest rendered label so that far end is never clipped at the
+// top of the SVG. (Was rotate −45° anchored 8px above the grid, which sent the
+// far end DOWN into the first cell row and hid it behind the cells — #1518.)
+const COL_LABEL_FONT_SIZE = 11;
+const COL_LABEL_ANGLE_DEG = 45;
+// Approximate glyph advance at COL_LABEL_FONT_SIZE. Set on the generous side of a
+// mixed-case hostname's average so we over- rather than under-reserve vertical
+// room for the diagonal's top end. It's only an estimate (no DOM text
+// measurement, to keep computeHeaderHeight pure/deterministic), so a label of
+// unusually wide glyphs (all-caps, CJK) could still exceed it — but the near-end
+// anchoring means that only lifts the label's TOP, never its bottom into the
+// cells, and the SVG's `overflow: visible` renders any excess rather than
+// clipping it.
+const COL_LABEL_CHAR_W = 7.2;
+const HEADER_TOP_PAD = 8; // gap above the tallest label's top end
+const HEADER_BOTTOM_PAD = 6; // gap between the label's near end and the cells
+const MIN_HEADER_HEIGHT = 72; // floor, so short-label grids keep their proportions
+
+/** Chars a column label is truncated to before rendering — tighter for narrow
+ *  cells so long FQDNs don't crowd the diagonal. */
+function colTruncateLength(cellSize: number): number {
+	return cellSize < 56 ? 8 : 20;
+}
+
+/** Vertical space the rotated column headers need, sized to the longest label
+ *  that will actually render (post-truncation). The diagonal's vertical extent
+ *  is `width·sin θ + fontSize·cos θ`; we add top/bottom padding and floor it at
+ *  MIN_HEADER_HEIGHT. Kept pure (no DOM text measurement) so it's deterministic
+ *  in tests and SSR. */
+export function computeHeaderHeight(cols: string[], cellSize: number): number {
+	const maxChars = cols.reduce(
+		(m, c) => Math.max(m, Math.min(c.length, colTruncateLength(cellSize))),
+		0,
+	);
+	const rad = (COL_LABEL_ANGLE_DEG * Math.PI) / 180;
+	const vExtent = maxChars * COL_LABEL_CHAR_W * Math.sin(rad) + COL_LABEL_FONT_SIZE * Math.cos(rad);
+	return Math.max(MIN_HEADER_HEIGHT, Math.ceil(vExtent) + HEADER_TOP_PAD + HEADER_BOTTOM_PAD);
+}
 
 export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 	const titleId = useId();
@@ -321,8 +366,9 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 
 	const gridWidth = cols.length * cellSize + (cols.length - 1) * CELL_GAP;
 	const gridHeight = rows.length * cellSize + (rows.length - 1) * CELL_GAP;
+	const headerHeight = computeHeaderHeight(cols, cellSize);
 	const svgWidth = ROW_LABEL_WIDTH + gridWidth + 8;
-	const svgHeight = HEADER_HEIGHT + gridHeight + 8;
+	const svgHeight = headerHeight + gridHeight + 8;
 
 	// Roving tabindex state: [rowIdx, colIdx]. Clamped at render time so the
 	// active cell stays in range when rows/cols shrink after a data refresh
@@ -499,22 +545,26 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 							x={0}
 							y={0}
 							width={ROW_LABEL_WIDTH}
-							height={HEADER_HEIGHT}
+							height={headerHeight}
 							fill="transparent"
 							aria-hidden="true"
 						/>
 						{cols.map((col, ci) => {
 							const cx = ROW_LABEL_WIDTH + ci * (cellSize + CELL_GAP) + cellSize / 2;
-							const cy = HEADER_HEIGHT - 8;
-							const truncateLength = cellSize < 56 ? 8 : 20;
+							// Anchor the label's END glyph just above the first cell row and
+							// lean it up-and-left. The near-end baseline is the label's
+							// lowest point, so it can never reach into the cells regardless
+							// of length; see computeHeaderHeight.
+							const cy = headerHeight - HEADER_BOTTOM_PAD;
+							const truncateLength = colTruncateLength(cellSize);
 							return (
 								<g key={col} role="columnheader" aria-label={col}>
 									<text
 										x={cx}
 										y={cy}
-										fontSize={11}
+										fontSize={COL_LABEL_FONT_SIZE}
 										textAnchor="end"
-										transform={`rotate(-45, ${cx}, ${cy})`}
+										transform={`rotate(${COL_LABEL_ANGLE_DEG}, ${cx}, ${cy})`}
 										fill="currentColor"
 									>
 										{truncate(col, truncateLength)}
@@ -527,7 +577,7 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 
 					{/* Data rows */}
 					{rows.map((row, ri) => {
-						const y = HEADER_HEIGHT + ri * (cellSize + CELL_GAP);
+						const y = headerHeight + ri * (cellSize + CELL_GAP);
 						return (
 							<g key={row} role="row">
 								{/* Row header */}

--- a/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
+++ b/src/features/instance/status/analytics/primitives/HeatmapMatrix.tsx
@@ -2,6 +2,7 @@ import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { formatValue } from '@/lib/formatValue';
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { shortenNodeLabel } from '../lib/nodeLabels';
 import type { AxisSpec, HeatmapCell, HeatmapData } from '../types/analytics';
 import { warningBannerStyle } from './bannerStyle';
 import { computeCellSize } from './computeCellSize';
@@ -332,6 +333,13 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 	const rows = data.rows;
 	const cols = data.cols;
 
+	// Source/destination axis labels are node FQDNs; show the short node name
+	// (first DNS segment) instead of a blunt mid-string character truncation.
+	// The full FQDN stays on each label's <title> and aria-label. (#1515)
+	// TODO: once shortNodeLabelMap (collision-aware, added in #1522) lands on
+	// stage, swap to it so two sources sharing a first segment stay distinct.
+	const shortColLabels = useMemo(() => cols.map(shortenNodeLabel), [cols]);
+
 	// Responsive cell sizing: measure wrapper width, clamp to [MIN, MAX].
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const [cellSize, setCellSize] = useState<number>(MAX_CELL_SIZE);
@@ -366,7 +374,7 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 
 	const gridWidth = cols.length * cellSize + (cols.length - 1) * CELL_GAP;
 	const gridHeight = rows.length * cellSize + (rows.length - 1) * CELL_GAP;
-	const headerHeight = computeHeaderHeight(cols, cellSize);
+	const headerHeight = computeHeaderHeight(shortColLabels, cellSize);
 	const svgWidth = ROW_LABEL_WIDTH + gridWidth + 8;
 	const svgHeight = headerHeight + gridHeight + 8;
 
@@ -567,7 +575,7 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 										transform={`rotate(${COL_LABEL_ANGLE_DEG}, ${cx}, ${cy})`}
 										fill="currentColor"
 									>
-										{truncate(col, truncateLength)}
+										{truncate(shortenNodeLabel(col), truncateLength)}
 										<title>{col}</title>
 									</text>
 								</g>
@@ -589,7 +597,7 @@ export function HeatmapMatrix({ data, title, height, onCellSelect }: Props) {
 										textAnchor="end"
 										fill="currentColor"
 									>
-										{truncate(row, 24)}
+										{truncate(shortenNodeLabel(row), 24)}
 										<title>{row}</title>
 									</text>
 								</g>


### PR DESCRIPTION
## Symptom

In the replication-latency heatmap (`HeatmapMatrix`), the rotated destination (column) axis labels at the top were partly **hidden behind the first row of cells** — the lower end of each diagonal label disappeared under the cells. Pre-existing, surfaced by the interactive drilldown in #1508.

## Cause

The column labels anchored at `y = HEADER_HEIGHT - 8` (only 8px above the grid) and rendered with `textAnchor="end"` + `transform="rotate(-45, cx, cy)"`. The `-45` rotation sends the far end **down-and-left** — ~30-45px below the anchor for an 8-20 char label, i.e. inside the first cell row. And the header `<g role="row">` paints **before** the data rows, so the cells paint over the overlap.

## The geometry change

Make a label unable to enter the cell region, rather than masking with z-order:

- **Flip the rotation to `+45`** (still `textAnchor="end"`) so labels lean **up-and-left**, away from the grid. The anchored END glyph becomes the label's **lowest** point, so its lowest extent is fixed at the anchor baseline **regardless of label length** — extra length only lifts the far (top) end, never pushes it down into the cells.
- **Anchor that near end just above the first cell row** (`headerHeight - HEADER_BOTTOM_PAD`).
- **Replace the fixed `HEADER_HEIGHT = 72` constant with `computeHeaderHeight(cols, cellSize)`** — it sizes the header to the longest post-truncation label's diagonal vertical extent (`width·sinθ + fontSize·cosθ`), floored at 72px, so the up-left far end is never clipped at `y=0`. `svgHeight`/`viewBox` derive from it, so the taller header is always contained (no `height` prop is passed in production).

## Where to focus review

- The anchor math and rotation direction (`primitives/HeatmapMatrix.tsx`, the column-header `<text>` and `computeHeaderHeight`).
- `computeHeaderHeight` uses a per-character width estimate (`COL_LABEL_CHAR_W`) rather than DOM text measurement, to stay pure/deterministic (SSR + tests). A pathological all-caps/CJK label could still exceed the estimate, but because of the near-end anchoring that only lifts the label's **top** (never its bottom into the cells), and `overflow: visible` renders any excess rather than clipping. Char width was set to the generous side of a mixed-case hostname average.

## Tests

Extends the `HeatmapMatrix` suite with a column-label geometry block (labels anchored above the first cell row; `+45` not `-45`; first cell row starts exactly at `computeHeaderHeight`; viewBox contains the header) and unit tests for `computeHeaderHeight` (floor at 72, growth for long labels, monotonicity, per-`cellSize` truncation cap). Full suite green (1566 passed / 11 skipped); tsc / dprint / oxlint clean.

## Review adjudication

- **Codex** [P2]: the per-char width estimate can under-reserve for wide glyphs. Addressed — bumped the estimate and documented the bound + `overflow: visible` safety net (cell-overlap fix is width-independent).
- **Gemini**: no issues; validated the geometry, header sizing, edge cases (1 col / empty cols / long labels), and that the tests pin the invariant.

Fixes #1518

Comment generated by kAIle (Claude Fable 5)