### PR TITLE
fix(status): crosshair-sync polish — shared tooltip, hovered-only box, aligned buckets

### DIFF
--- a/src/features/instance/status/analytics/__tests__/charts/node-legend.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/charts/node-legend.test.tsx
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NodeLegend } from '../../charts/NodeLegend';
+
+describe('NodeLegend', () => {
+	afterEach(cleanup);
+
+	const nodes = ['node1.us.acme.com', 'node1.eu.acme.com', 'other.acme.com'];
+
+	it('shows collision-aware short names, not the full FQDN', () => {
+		render(<NodeLegend nodeIds={nodes} isActive={() => true} onClickNode={() => {}} />);
+		// node1.* collide on the first segment → keep one more segment.
+		expect(screen.getByText('node1.us')).toBeTruthy();
+		expect(screen.getByText('node1.eu')).toBeTruthy();
+		// unique first segment → shortened all the way.
+		expect(screen.getByText('other')).toBeTruthy();
+		expect(screen.queryByText('node1.us.acme.com')).toBe(null);
+	});
+
+	it('keeps the full FQDN on the button title for hover', () => {
+		render(<NodeLegend nodeIds={nodes} isActive={() => true} onClickNode={() => {}} />);
+		const btn = screen.getByText('other').closest('button');
+		expect(btn?.getAttribute('title')).toBe('other.acme.com');
+	});
+
+	it('disabled tab keeps its explanatory title instead of the FQDN', () => {
+		render(<NodeLegend nodeIds={nodes} isActive={() => true} onClickNode={() => {}} disabled />);
+		const btn = screen.getByText('other').closest('button');
+		expect(btn?.getAttribute('title')).toBe("Per-node filter unavailable on this tab's panels");
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/nodeLabels.test.ts
+++ b/src/features/instance/status/analytics/__tests__/nodeLabels.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { shortenNodeLabel, shortNodeLabelMap } from '../lib/nodeLabels';
+
+describe('shortenNodeLabel', () => {
+	it('keeps the first FQDN segment', () => {
+		expect(shortenNodeLabel('xb6-us-west-1.prod.ibm.harperfabric.com')).toBe('xb6-us-west-1');
+	});
+
+	it('falls back to the full string without a dot', () => {
+		expect(shortenNodeLabel('localhost')).toBe('localhost');
+	});
+});
+
+describe('shortNodeLabelMap', () => {
+	it('shortens non-colliding nodes to their first segment (same as shortenNodeLabel)', () => {
+		const map = shortNodeLabelMap(['a.acme.com', 'b.acme.com']);
+		expect(map.get('a.acme.com')).toBe('a');
+		expect(map.get('b.acme.com')).toBe('b');
+	});
+
+	it('extends colliding labels with enough segments to disambiguate', () => {
+		const map = shortNodeLabelMap(['node1.us.acme.com', 'node1.eu.acme.com', 'node2.us.acme.com']);
+		expect(map.get('node1.us.acme.com')).toBe('node1.us');
+		expect(map.get('node1.eu.acme.com')).toBe('node1.eu');
+		// Unique first segment stays short.
+		expect(map.get('node2.us.acme.com')).toBe('node2');
+	});
+
+	it('keeps deep collisions extending until they split', () => {
+		const map = shortNodeLabelMap(['n.us.east.acme.com', 'n.us.west.acme.com']);
+		expect(map.get('n.us.east.acme.com')).toBe('n.us.east');
+		expect(map.get('n.us.west.acme.com')).toBe('n.us.west');
+	});
+
+	it('falls back to the full name when a node exhausts its segments', () => {
+		const map = shortNodeLabelMap(['web', 'web.acme.com']);
+		expect(map.get('web')).toBe('web');
+		expect(map.get('web.acme.com')).toBe('web.acme');
+	});
+
+	it('dedupes repeated inputs and handles empties', () => {
+		const map = shortNodeLabelMap(['a.acme.com', 'a.acme.com']);
+		expect(map.size).toBe(1);
+		expect(shortNodeLabelMap([]).size).toBe(0);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
@@ -84,6 +84,24 @@ describe('ChartTooltip (shared cartesian chart tooltip)', () => {
 		expect(screen.getByText('node1.eu')).toBeTruthy();
 	});
 
+	it('does not over-shorten when one FQDN sits inside another node short label', () => {
+		// Short labels: acme.com→acme, x.acme.com.foo.net→x.acme.com.foo,
+		// x.acme.com.bar.net→x.acme.com.bar. `acme.com` is a substring of the
+		// `x.acme.com.foo` short label; a bare substring-replace would rewrite
+		// it to `x.acme.foo`. Boundary-anchored replacement leaves it intact.
+		const nodes = ['acme.com', 'x.acme.com.foo.net', 'x.acme.com.bar.net'];
+		const payload = [
+			{ dataKey: 'y', name: 'acme.com', value: 1, color: '#f00' },
+			{ dataKey: 'y', name: 'x.acme.com.foo.net', value: 2, color: '#0f0' },
+		];
+		render(
+			<ChartTooltip active payload={payload} label={1700000000000} formatter="count" nodeNames={nodes} />,
+		);
+		expect(screen.getByText('acme')).toBeTruthy();
+		expect(screen.getByText('x.acme.com.foo')).toBeTruthy();
+		expect(screen.queryByText('x.acme.foo')).toBe(null);
+	});
+
 	it('renders a Total row summing the payload when showTotal is set', () => {
 		const payload = [
 			{ dataKey: 'a', name: 'A', value: 20, color: '#f00' },

--- a/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChartTooltip } from '../../primitives/ChartTooltip';
+
+describe('ChartTooltip (shared cartesian chart tooltip)', () => {
+	afterEach(() => cleanup());
+
+	it('returns null when inactive', () => {
+		const { container } = render(<ChartTooltip active={false} />);
+		expect(container.firstChild).toBe(null);
+	});
+
+	it('returns null for an empty payload', () => {
+		const { container } = render(<ChartTooltip active payload={[]} label={1700000000000} />);
+		expect(container.firstChild).toBe(null);
+	});
+
+	it('formats the time header via formatTooltipTime', () => {
+		const payload = [{ dataKey: 'a', name: 'A', value: 1, color: '#f00' }];
+		const { container } = render(<ChartTooltip active payload={payload} label={1700000000000} formatter="count" />);
+		// Nov 14 2023 in every locale's short-month rendering carries the year.
+		expect(container.textContent ?? '').toMatch(/2023/);
+	});
+
+	it('formats values with the default formatter/unit', () => {
+		const payload = [{ dataKey: 'a', name: 'A', value: 1500, color: '#f00' }];
+		render(<ChartTooltip active payload={payload} label={1700000000000} formatter="bytes-si" unitSuffix="/s" />);
+		expect(screen.getByText(/1\.5 KB\/s/)).toBeTruthy();
+	});
+
+	it('resolveEntryFormat overrides the default per entry (dual-axis charts)', () => {
+		const payload = [
+			{ dataKey: 'y', name: 'util', value: 0.5, color: '#f00' },
+			{ dataKey: 'y', name: 'lag', value: 12, color: '#0f0' },
+		];
+		render(
+			<ChartTooltip
+				active
+				payload={payload}
+				label={1700000000000}
+				resolveEntryFormat={(entry) => entry.name === 'util' ? { formatter: 'percent' } : { formatter: 'ms' }}
+			/>,
+		);
+		expect(screen.getByText(/50\.0%/)).toBeTruthy();
+		expect(screen.getByText(/12\.0 ms/)).toBeTruthy();
+	});
+
+	it('renders — for a missing (null) value instead of a fake 0', () => {
+		const payload = [{ dataKey: 'a', name: 'A', value: null, color: '#f00' }];
+		render(<ChartTooltip active payload={payload} label={1700000000000} formatter="count" />);
+		expect(screen.getByText('—')).toBeTruthy();
+	});
+
+	it('shortens full node FQDNs in series names (display only)', () => {
+		const node = 'hpr-us-east1-b-1.anvils.acme-inc.stage.harperfabric.com';
+		const payload = [
+			{ dataKey: 'y', name: `cache hits — ${node}`, value: 5, color: '#f00' },
+			{ dataKey: 'y', name: node, value: 7, color: '#0f0' },
+		];
+		render(
+			<ChartTooltip active payload={payload} label={1700000000000} formatter="count" nodeNames={[node]} />,
+		);
+		expect(screen.getByText('cache hits — hpr-us-east1-b-1')).toBeTruthy();
+		expect(screen.getByText('hpr-us-east1-b-1')).toBeTruthy();
+		expect(screen.queryByText(new RegExp('anvils'))).toBe(null);
+	});
+
+	it('disambiguates nodes whose short labels collide', () => {
+		const nodes = ['node1.us.acme.com', 'node1.eu.acme.com'];
+		const payload = nodes.map((n, i) => ({ dataKey: 'y', name: n, value: i, color: '#f00' }));
+		render(
+			<ChartTooltip active payload={payload} label={1700000000000} formatter="count" nodeNames={nodes} />,
+		);
+		expect(screen.getByText('node1.us')).toBeTruthy();
+		expect(screen.getByText('node1.eu')).toBeTruthy();
+	});
+
+	it('renders a Total row summing the payload when showTotal is set', () => {
+		const payload = [
+			{ dataKey: 'a', name: 'A', value: 20, color: '#f00' },
+			{ dataKey: 'b', name: 'B', value: 15, color: '#0f0' },
+		];
+		render(<ChartTooltip active payload={payload} label={1700000000000} formatter="count" showTotal />);
+		expect(screen.getByText(/Total/)).toBeTruthy();
+		expect(screen.getByText(/35/)).toBeTruthy();
+	});
+
+	it('renders no Total row without showTotal (line charts)', () => {
+		const payload = [
+			{ dataKey: 'a', name: 'A', value: 20, color: '#f00' },
+			{ dataKey: 'b', name: 'B', value: 15, color: '#0f0' },
+		];
+		render(<ChartTooltip active payload={payload} label={1700000000000} formatter="count" />);
+		expect(screen.queryByText(/Total/)).toBe(null);
+	});
+
+	it('suppresses the Total row for single-series payloads', () => {
+		const payload = [{ dataKey: 'a', name: 'A', value: 42, color: '#f00' }];
+		render(<ChartTooltip active payload={payload} label={1700000000000} formatter="count" showTotal />);
+		expect(screen.queryByText(/Total/)).toBe(null);
+	});
+
+	it('uses raw count formatter for Total on count-si axis (preserve precision)', () => {
+		const payload = [
+			{ dataKey: 'a', name: 'A', value: 12345, color: '#f00' },
+			{ dataKey: 'b', name: 'B', value: 67890, color: '#0f0' },
+		];
+		render(
+			<ChartTooltip
+				active
+				payload={payload}
+				label={1700000000000}
+				formatter="count-si"
+				unitSuffix=" msg/s"
+				showTotal
+			/>,
+		);
+		// Total = 80235; rendered raw, not "80k".
+		expect(screen.getByText(/80235\s*msg\/s/)).toBeTruthy();
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/chart-tooltip.test.tsx
@@ -11,6 +11,14 @@ describe('ChartTooltip (shared cartesian chart tooltip)', () => {
 		expect(container.firstChild).toBe(null);
 	});
 
+	it('returns null when hidden, even while Recharts reports active (sync gating)', () => {
+		const payload = [{ dataKey: 'a', name: 'A', value: 1, color: '#f00' }];
+		const { container } = render(
+			<ChartTooltip active payload={payload} label={1700000000000} formatter="count" hidden />,
+		);
+		expect(container.firstChild).toBe(null);
+	});
+
 	it('returns null for an empty payload', () => {
 		const { container } = render(<ChartTooltip active payload={[]} label={1700000000000} />);
 		expect(container.firstChild).toBe(null);

--- a/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/stacked-area.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { StackedAreaChart, StackedAreaTooltip } from '../../primitives/StackedAreaChart';
+import { StackedAreaChart } from '../../primitives/StackedAreaChart';
 import type { SeriesData } from '../../types/analytics';
 
 const stacked: SeriesData = {
@@ -135,48 +135,5 @@ describe('StackedAreaChart Step 3.5 polish', () => {
 				.toBeTruthy();
 		});
 		document.documentElement.classList.remove('dark');
-	});
-});
-
-// TODO: the it.skip() cases below are Recharts visual-rendering assertions
-// that depend on real layout (computed width/height, stroke geometry, axis
-// tick text). Both jsdom and happy-dom fall short here even with the
-// getBoundingClientRect / ResizeObserver shim in __tests__/setup.ts. Math is
-// covered by the pipeline + aggregator suites; revisit these visual checks
-// with a Playwright smoke pass once studio adopts E2E.
-describe('StackedAreaTooltip', () => {
-	afterEach(() => cleanup());
-
-	it('renders Total row summing payload values', () => {
-		const payload = [
-			{ dataKey: 'a', name: 'A', value: 20, color: '#f00' },
-			{ dataKey: 'b', name: 'B', value: 15, color: '#0f0' },
-		];
-		render(<StackedAreaTooltip active payload={payload} label={1700000000000} formatter="count" />);
-		expect(screen.getByText(/Total/)).toBeTruthy();
-		expect(screen.getByText(/35/)).toBeTruthy();
-	});
-
-	it('suppresses Total row for single-series payload', () => {
-		const payload = [{ dataKey: 'a', name: 'A', value: 42, color: '#f00' }];
-		render(<StackedAreaTooltip active payload={payload} label={1700000000000} formatter="count" />);
-		expect(screen.queryByText(/Total/)).toBe(null);
-	});
-
-	it('uses raw count formatter for Total on count-si axis (preserve precision)', () => {
-		const payload = [
-			{ dataKey: 'a', name: 'A', value: 12345, color: '#f00' },
-			{ dataKey: 'b', name: 'B', value: 67890, color: '#0f0' },
-		];
-		render(
-			<StackedAreaTooltip active payload={payload} label={1700000000000} formatter="count-si" unitSuffix=" msg/s" />,
-		);
-		// Total = 80235; rendered raw not "80k".
-		expect(screen.getByText(/80235\s*msg\/s/)).toBeTruthy();
-	});
-
-	it('returns null when inactive', () => {
-		const { container } = render(<StackedAreaTooltip active={false} />);
-		expect(container.firstChild).toBe(null);
 	});
 });

--- a/src/features/instance/status/analytics/__tests__/primitives/tooltip-gating-props.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/tooltip-gating-props.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SeriesData } from '../../types/analytics';
+
+// StackedAreaChart and TableSizeTrend render an unconditional <Legend>, which
+// under the setup.ts getBoundingClientRect shim measures at full chart height
+// and leaves Recharts no plot area — real tooltip activation can't fire (see
+// tooltip-gating.test.tsx, which covers LineChart end-to-end via hideLegend).
+// So for these two, capture the props handed to the Recharts wrappers and
+// assert the gating contract: Tooltip has isAnimationActive={false} and its
+// content's `hidden` tracks the container hover state.
+const lineChartCalls: Record<string, unknown>[] = [];
+const areaChartCalls: Record<string, unknown>[] = [];
+
+vi.mock('recharts', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('recharts')>();
+	return {
+		...actual,
+		LineChart: (props: Record<string, unknown>) => {
+			lineChartCalls.push(props);
+			return null;
+		},
+		AreaChart: (props: Record<string, unknown>) => {
+			areaChartCalls.push(props);
+			return null;
+		},
+	};
+});
+
+const { Tooltip } = await import('recharts');
+const { StackedAreaChart } = await import('../../primitives/StackedAreaChart');
+const { TableSizeTrend } = await import('../../charts/TableSizeTrend');
+type TableSizeDerived = import('../../lib/tableSize').TableSizeDerived;
+
+function findTooltip(call: Record<string, unknown>): ReactElement<Record<string, unknown>> {
+	const children = Children.toArray(call.children as ReactNode);
+	const tooltip = children.find((c): c is ReactElement<Record<string, unknown>> =>
+		isValidElement(c) && c.type === Tooltip
+	);
+	expect(tooltip, 'chart renders a <Tooltip>').toBeTruthy();
+	return tooltip!;
+}
+
+function tooltipContentHidden(call: Record<string, unknown>): unknown {
+	const content = findTooltip(call).props.content as ReactElement<Record<string, unknown>>;
+	return content.props.hidden;
+}
+
+const data: SeriesData = {
+	series: [{ key: 's1', label: 'Series One', points: [{ x: 1, y: 10 }, { x: 2, y: 20 }] }],
+};
+
+const derived: TableSizeDerived = {
+	snapshot: { byNode: [], tableSet: ['db.t1'], hasOther: false, otherMembers: [] },
+	trend: () => [
+		{ time: 1_000, values: { n1: 100 } },
+		{ time: 2_000, values: { n1: 200 } },
+	],
+	defaultSelection: () => 'db.t1',
+	emptyCause: null,
+	signature: 'sig',
+};
+const trendProps = {
+	derived,
+	viewMode: 'per-node' as const,
+	selectedTable: 'db.t1',
+	onChipSelect: () => {},
+	manualSelection: true,
+	range: { startTime: 0, endTime: 60_000 },
+	clusterNodeIds: ['n1'],
+	rankBy: 'bytes' as const,
+	onRankChange: () => {},
+};
+
+describe('tooltip gating props (StackedAreaChart / TableSizeTrend)', () => {
+	beforeEach(() => {
+		lineChartCalls.length = 0;
+		areaChartCalls.length = 0;
+	});
+	afterEach(() => cleanup());
+
+	it('StackedAreaChart: Tooltip animation off; content hidden until the container is hovered', () => {
+		const { container } = render(<StackedAreaChart data={data} />);
+		expect(findTooltip(areaChartCalls.at(-1)!).props.isAnimationActive).toBe(false);
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(true);
+
+		const gate = container.querySelector('[role="img"]') as HTMLElement;
+		fireEvent.mouseOver(gate, { relatedTarget: document.body });
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(false);
+
+		fireEvent.mouseOut(gate, { relatedTarget: document.body });
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(true);
+	});
+
+	it('StackedAreaChart: touch and keyboard focus open the gate too (Recharts activates tooltips for both)', () => {
+		const { container } = render(<StackedAreaChart data={data} />);
+		const gate = container.querySelector('[role="img"]') as HTMLElement;
+
+		fireEvent.touchStart(gate);
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(false);
+		// Touch has no "leave" — the gate stays open until a close interaction.
+		fireEvent.focusIn(gate);
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(false);
+		fireEvent.focusOut(gate);
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(true);
+
+		fireEvent.focusIn(gate);
+		expect(tooltipContentHidden(areaChartCalls.at(-1)!)).toBe(false);
+	});
+
+	it('TableSizeTrend: Tooltip animation off; content hidden until the chart container is hovered', () => {
+		const { container } = render(<TableSizeTrend {...trendProps} />);
+		expect(findTooltip(lineChartCalls.at(-1)!).props.isAnimationActive).toBe(false);
+		expect(tooltipContentHidden(lineChartCalls.at(-1)!)).toBe(true);
+
+		const gate = container.querySelector('.recharts-responsive-container')!.parentElement as HTMLElement;
+		fireEvent.mouseOver(gate, { relatedTarget: document.body });
+		expect(tooltipContentHidden(lineChartCalls.at(-1)!)).toBe(false);
+
+		fireEvent.mouseOut(gate, { relatedTarget: document.body });
+		expect(tooltipContentHidden(lineChartCalls.at(-1)!)).toBe(true);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/tooltip-gating.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/tooltip-gating.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import type { InstanceClientIdConfig, InstanceTypeConfig } from '@/config/instanceClientConfig';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type AnalyticsContextValue, AnalyticsProvider } from '../../context/AnalyticsContext';
+import { LineChart } from '../../primitives/LineChart';
+import type { SeriesData } from '../../types/analytics';
+
+const data: SeriesData = {
+	series: [{
+		key: 's1',
+		label: 'Series One',
+		points: [{ x: 1_700_000_000_000, y: 10 }, { x: 1_700_000_060_000, y: 20 }],
+	}],
+};
+
+function makeContextValue(syncId?: string): AnalyticsContextValue {
+	return {
+		timeRange: { startTime: 1_700_000_000_000, endTime: 1_700_000_060_000 },
+		bucketMs: 60_000,
+		instanceParams: {
+			instanceClient: { post: async () => ({ data: [] }) } as never,
+			entityId: 'test-instance' as never,
+			entityType: 'instance',
+		} satisfies InstanceClientIdConfig & InstanceTypeConfig,
+		syncId,
+	};
+}
+
+/** Real-Recharts integration check for the per-chart tooltip gate: two charts
+ *  share a syncId; hovering one must render the tooltip box there only, while
+ *  the synced sibling keeps the crosshair cursor line.
+ *
+ *  hideLegend is required in this environment: the getBoundingClientRect shim
+ *  (setup.ts) reports 800×600 for every element, so a rendered <Legend> is
+ *  "measured" at full chart height and Recharts computes an empty plot area,
+ *  after which no pointer coordinate ever activates a tooltip. */
+describe('tooltip gating with two synced charts', () => {
+	afterEach(() => cleanup());
+
+	it('renders the tooltip box only on the hovered chart, cursor on the synced sibling', async () => {
+		render(
+			<AnalyticsProvider value={makeContextValue('test:health')}>
+				<div data-testid="chart-a">
+					<LineChart data={data} hideLegend />
+				</div>
+				<div data-testid="chart-b">
+					<LineChart data={data} hideLegend />
+				</div>
+			</AnalyticsProvider>,
+		);
+		const chartA = screen.getByTestId('chart-a');
+		const chartB = screen.getByTestId('chart-b');
+		await waitFor(() => {
+			expect(chartA.querySelector('.recharts-wrapper svg')).toBeTruthy();
+			expect(chartB.querySelector('.recharts-wrapper svg')).toBeTruthy();
+		});
+
+		// The hover gate lives on the chart's outer role=img container —
+		// mouseOver (which React maps to onMouseEnter) must target it, while
+		// Recharts activates the tooltip from mouseMove on its own wrapper.
+		const gateA = chartA.querySelector('[role="img"]') as HTMLElement;
+		fireEvent.mouseOver(gateA, { relatedTarget: document.body });
+		const surfaceA = chartA.querySelector('.recharts-wrapper') as HTMLElement;
+		fireEvent.mouseMove(surfaceA, { clientX: 400, clientY: 100 });
+
+		// Hovered chart: full tooltip box.
+		await waitFor(() => {
+			expect(chartA.querySelector('.recharts-tooltip-wrapper')?.textContent ?? '').toMatch(/Series One/);
+		});
+		// Synced sibling: NO tooltip box…
+		expect(chartB.querySelector('.recharts-tooltip-wrapper')?.textContent ?? '').toBe('');
+		// …but the synced crosshair cursor line still draws (Recharts renders
+		// the Tooltip `cursor` even when the content component returns null).
+		expect(chartB.querySelector('.recharts-tooltip-cursor')).toBeTruthy();
+
+		// Pointer leaves chart A: its tooltip box goes away too.
+		fireEvent.mouseOut(gateA, { relatedTarget: document.body });
+		await waitFor(() => {
+			expect(chartA.querySelector('.recharts-tooltip-wrapper')?.textContent ?? '').toBe('');
+		});
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/tableSize.test.ts
+++ b/src/features/instance/status/analytics/__tests__/tableSize.test.ts
@@ -17,7 +17,8 @@ import {
 	TOP_N,
 	toTableKey,
 } from '../lib/tableSize';
-import type { TableSizeRecord } from '../types/analytics';
+import { runPipeline } from '../pipeline/pipeline';
+import type { AnalyticsDataPoint, MetricSpec, TableSizeRecord } from '../types/analytics';
 
 function fixture(name: string): TableSizeRecord[] {
 	const path = join(import.meta.dirname, 'fixtures', 'table-size', `${name}.json`);
@@ -261,9 +262,12 @@ describe('computeTrendFactory', () => {
 		const normalized = normalizeRecords(fixture('node-drop'));
 		const trend = computeTrendFactory(normalized, range);
 		const points = trend('d.T');
-		// We expect buckets at 1700000000000, 1700000060000, 1700000120000, 1700000180000 (from n1 samples).
+		// Buckets are epoch-aligned (round to the nearest 60s multiple, like the
+		// pipeline's snapToPeriod), NOT anchored at range.startTime: the samples
+		// at 1700000000000 + n*60s sit 20s past the epoch lattice, so they snap
+		// down to 1699999980000 + n*60s.
 		expect(points.length >= 3).toBeTruthy();
-		const first = points.find((p) => p.time === 1_700_000_000_000)!;
+		const first = points.find((p) => p.time === 1_699_999_980_000)!;
 		expect(first).toBeTruthy();
 		expect(first.values.n1).toBe(100000);
 		expect(first.values.n2).toBe(200000);
@@ -283,9 +287,10 @@ describe('computeTrendFactory', () => {
 		const normalized = normalizeRecords(fixture('node-drop'));
 		const trend = computeTrendFactory(normalized, range);
 		const points = trend('d.T');
-		// n2 has its last sample at t=60_000_ms after start. No bucket past that should contain n2.
+		// n2's last sample (t=60s after start) lands in the epoch-aligned bucket
+		// 1699999980000 + 60s. No bucket past that should contain n2.
 		const n2PastLastSample = points
-			.filter((p) => p.time > 1_700_000_060_000)
+			.filter((p) => p.time > 1_700_000_040_000)
 			.some((p) => 'n2' in p.values);
 		expect(n2PastLastSample).toBe(false);
 	});
@@ -303,7 +308,66 @@ describe('computeTrendFactory', () => {
 		];
 		const trend = computeTrendFactory(normalizeRecords(raw), range);
 		const points = trend('d.t');
+		expect(points[0].time).toBe(1_699_999_980_000); // epoch-aligned bucket
 		expect(points[0].values.n1).toBe(200); // latest within bucket wins
+	});
+});
+
+describe('trend bucket grid alignment with the pipeline (#1514)', () => {
+	// Off-lattice window on purpose: the grid must come from the epoch, not
+	// from range.startTime.
+	const range = { startTime: 1_700_000_000_000, endTime: 1_700_000_300_000 }; // 5 min → bucketMs 60_000
+	const times = [1_700_000_010_000, 1_700_000_070_000, 1_700_000_155_000];
+
+	it('trend timestamps are epoch-aligned multiples of the bucket size', () => {
+		const raw: TableSizeRecord[] = times.map((id, i) => (
+			{ metric: 'table-size', database: 'd', table: 't', node: 'n1', id, size: 100 + i }
+		));
+		const trend = computeTrendFactory(normalizeRecords(raw), range);
+		for (const p of trend('d.t')) {
+			expect(p.time % 60_000).toBe(0);
+		}
+	});
+
+	it('two metrics bucket the same instants to identical timestamps (value-sync match)', () => {
+		// Metric A: the table-size trend grid.
+		const raw: TableSizeRecord[] = times.map((id, i) => (
+			{ metric: 'table-size', database: 'd', table: 't', node: 'n1', id, size: 100 + i }
+		));
+		const trendTimes = computeTrendFactory(normalizeRecords(raw), range)('d.t').map((p) => p.time);
+
+		// Metric B: a pipeline metric panel over the same instants, snapped to
+		// the same 60s period (MetricRenderer always enables snapToPeriod).
+		const spec: MetricSpec = {
+			title: 'test',
+			description: '',
+			tab: 'storage',
+			primaryDimension: 'node',
+			series: { kind: 'field', fields: [{ field: 'v', label: 'V' }] },
+			timestamp: 'time',
+			bucket: { source: 'period-field', fallbackMs: 60_000 },
+			aggregator: { temporal: 'mean', crossNode: 'mean' },
+			primitive: 'line',
+			yAxis: { unit: '', formatter: 'count' },
+		};
+		const records: AnalyticsDataPoint[] = times.map((time, i) => (
+			{ time, node: 'n1', v: i, period: 60_000 }
+		));
+		const out = runPipeline(spec, records, range, ['n1'], { snapToPeriod: true });
+		const panelTimes = out.series[0].points.map((p) => p.x);
+
+		expect(trendTimes).toEqual(panelTimes);
+	});
+
+	it('computeBucketMs rounds up to a multiple of alignMs so wide-window grids still coincide', () => {
+		const day = 24 * 60 * 60 * 1000;
+		// 24h window → base bucket 16 min, which is NOT on the 5-min panel grid.
+		expect(computeBucketMs(day)).toBe(960_000);
+		expect(computeBucketMs(day, 300_000)).toBe(1_200_000); // 20 min — multiple of 5 min
+		// Already-aligned and invalid alignments are no-ops.
+		expect(computeBucketMs(300_000, 60_000)).toBe(60_000);
+		expect(computeBucketMs(day, 0)).toBe(960_000);
+		expect(computeBucketMs(day, Number.NaN)).toBe(960_000);
 	});
 });
 

--- a/src/features/instance/status/analytics/charts/NodeLegend.tsx
+++ b/src/features/instance/status/analytics/charts/NodeLegend.tsx
@@ -1,4 +1,5 @@
 import { getNodeColor } from '../lib/nodeColors';
+import { shortNodeLabelMap } from '../lib/nodeLabels';
 
 interface NodeLegendProps {
 	nodeIds: string[];
@@ -10,6 +11,10 @@ interface NodeLegendProps {
 }
 
 export function NodeLegend({ nodeIds, isActive, onClickNode, disabled }: NodeLegendProps) {
+	// Show collision-aware short names (matching the chart series + tooltip),
+	// keeping the full FQDN on `title` for hover. Chips previously rendered the
+	// raw FQDN, so series read short while their own filter read long (#1515).
+	const shortLabels = shortNodeLabelMap(nodeIds);
 	return (
 		<div
 			role="group"
@@ -39,7 +44,7 @@ export function NodeLegend({ nodeIds, isActive, onClickNode, disabled }: NodeLeg
 						// remove the element from focus order entirely, so SR users
 						// couldn't discover what the legend means on this tab.
 						aria-disabled={disabled ? 'true' : undefined}
-						title={disabled ? "Per-node filter unavailable on this tab's panels" : undefined}
+						title={disabled ? "Per-node filter unavailable on this tab's panels" : node}
 						onClick={(e) => {
 							if (disabled) { return; }
 							onClickNode(node, e.ctrlKey || e.metaKey);
@@ -51,7 +56,7 @@ export function NodeLegend({ nodeIds, isActive, onClickNode, disabled }: NodeLeg
 							className="inline-block h-[3px] w-3 rounded"
 							style={{ backgroundColor: color }}
 						/>
-						<span>{node}</span>
+						<span>{shortLabels.get(node) ?? node}</span>
 					</button>
 				);
 			})}

--- a/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
@@ -7,7 +7,7 @@ import { getNodeColor } from '../lib/nodeColors';
 import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize';
 import { getChartColors } from '../lib/theme';
 import { formatAxisTick } from '../lib/time';
-import { ChartTooltip } from '../primitives/ChartTooltip';
+import { ChartTooltip, useTooltipGate } from '../primitives/ChartTooltip';
 import type { TimeRange, ViewMode } from '../types/analytics';
 import { NodeLegend } from './NodeLegend';
 import { TableSizeChipRow } from './TableSizeChipRow';
@@ -56,6 +56,9 @@ export function TableSizeTrend({
 	// StackedAreaChart primitives) — the trend shares the tab's x-domain.
 	// See useChartSyncProps for the dialog-scope rationale.
 	const syncProps = useChartSyncProps(!!fillParent);
+	// Tooltip box only on the chart under the pointer — synced siblings keep
+	// the cursor line but render no box (see useTooltipGate/ChartTooltip).
+	const { hovered, gateProps } = useTooltipGate();
 
 	const points = useMemo(
 		() => (selectedTable ? derived.trend(selectedTable) : []),
@@ -156,7 +159,7 @@ export function TableSizeTrend({
 				</div>
 			</div>
 
-			<div style={{ width: '100%', height: 300 }}>
+			<div style={{ width: '100%', height: 300 }} {...gateProps}>
 				<ResponsiveContainer width="100%" height="100%" minWidth={0}>
 					<LineChart data={chartData} {...syncProps}>
 						<CartesianGrid stroke={colors.gridColor} strokeDasharray="3 3" />
@@ -181,7 +184,12 @@ export function TableSizeTrend({
 							domain={viewMode === 'per-node' ? [1, 'auto'] : ['auto', 'auto']}
 							allowDataOverflow
 						/>
-						<Tooltip content={<ChartTooltip formatter="bytes-si" nodeNames={nodesWithData} />} />
+						<Tooltip
+							// No enter/move easing: with syncId every synced chart
+							// animates on each mouse-move, making the tab visibly jerk.
+							isAnimationActive={false}
+							content={<ChartTooltip hidden={!hovered} formatter="bytes-si" nodeNames={nodesWithData} />}
+						/>
 						{nodesWithData
 							.filter((n) => isActive(n))
 							.map((node) => (

--- a/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
+++ b/src/features/instance/status/analytics/charts/TableSizeTrend.tsx
@@ -6,8 +6,8 @@ import { useNodeSelection } from '../hooks/useNodeSelection';
 import { getNodeColor } from '../lib/nodeColors';
 import { computeGrowthAnnotation, type RankBy, type TableSizeDerived } from '../lib/tableSize';
 import { getChartColors } from '../lib/theme';
-import { formatAxisTick, formatTooltipTime } from '../lib/time';
-import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from '../primitives/tooltipStyle';
+import { formatAxisTick } from '../lib/time';
+import { ChartTooltip } from '../primitives/ChartTooltip';
 import type { TimeRange, ViewMode } from '../types/analytics';
 import { NodeLegend } from './NodeLegend';
 import { TableSizeChipRow } from './TableSizeChipRow';
@@ -181,13 +181,7 @@ export function TableSizeTrend({
 							domain={viewMode === 'per-node' ? [1, 'auto'] : ['auto', 'auto']}
 							allowDataOverflow
 						/>
-						<Tooltip
-							contentStyle={tooltipContentStyle}
-							labelStyle={tooltipLabelStyle}
-							itemStyle={tooltipItemStyle}
-							labelFormatter={(label) => formatTooltipTime(Number(label))}
-							formatter={(value) => formatBytes(Number(value))}
-						/>
+						<Tooltip content={<ChartTooltip formatter="bytes-si" nodeNames={nodesWithData} />} />
 						{nodesWithData
 							.filter((n) => isActive(n))
 							.map((node) => (

--- a/src/features/instance/status/analytics/lib/nodeLabels.ts
+++ b/src/features/instance/status/analytics/lib/nodeLabels.ts
@@ -5,3 +5,40 @@ export function shortenNodeLabel(node: string): string {
 	const dot = node.indexOf('.');
 	return dot === -1 ? node : node.slice(0, dot);
 }
+
+/** Collision-aware short labels for a set of node FQDNs (display-layer only —
+ *  callers must never write these back into series `label` fields, which CSV
+ *  export and legends elsewhere rely on).
+ *
+ *  Each node starts at its first segment (same as shortenNodeLabel); when two
+ *  distinct nodes share that segment (e.g. 'node1.us.acme.com' /
+ *  'node1.eu.acme.com'), the colliding group keeps one more segment
+ *  ('node1.us' / 'node1.eu') until the labels disambiguate, falling back to
+ *  the full name when a node's segments are exhausted. */
+export function shortNodeLabelMap(nodes: readonly string[]): Map<string, string> {
+	const labels = new Map<string, string>();
+	let pending = [...new Set(nodes)];
+	for (let depth = 1; pending.length > 0; depth++) {
+		const byPrefix = new Map<string, string[]>();
+		for (const node of pending) {
+			const prefix = node.split('.').slice(0, depth).join('.');
+			const group = byPrefix.get(prefix);
+			if (group) { group.push(node); }
+			else { byPrefix.set(prefix, [node]); }
+		}
+		pending = [];
+		for (const [prefix, group] of byPrefix) {
+			if (group.length === 1) {
+				labels.set(group[0], prefix);
+				continue;
+			}
+			for (const node of group) {
+				// A node whose whole name is the shared prefix can't extend
+				// further — keep it in full; the rest retry one segment deeper.
+				if (node.split('.').length <= depth) { labels.set(node, node); }
+				else { pending.push(node); }
+			}
+		}
+	}
+	return labels;
+}

--- a/src/features/instance/status/analytics/lib/tableSize.ts
+++ b/src/features/instance/status/analytics/lib/tableSize.ts
@@ -32,7 +32,10 @@ export interface Snapshot {
 }
 
 export interface TrendPoint {
-	time: number; // bucket start (ms)
+	/** Bucket timestamp (ms) — an epoch-aligned multiple of the bucket size,
+	 *  matching the pipeline's snapToPeriod grid so syncMethod="value"
+	 *  crosshair sync can match this chart's x values against the panels'. */
+	time: number;
 	values: Record<string, /* node */ number /* bytes */>;
 }
 
@@ -53,9 +56,19 @@ export const OTHER_KEY = '__other__';
 /** Threshold below which a table is considered empty/static and excluded from top-N. */
 const MEANINGFUL_SIZE_THRESHOLD = 4096;
 
-/** Compute bucket width (ms) for trend rendering. */
-export function computeBucketMs(windowMs: number): number {
-	return Math.max(60_000, Math.ceil(windowMs / 90));
+/** Compute bucket width (ms) for trend rendering.
+ *
+ *  `alignMs` (the tab's fetch bucket size, AnalyticsContext.bucketMs) rounds
+ *  the width up to a multiple of the metric panels' bucket grid: combined
+ *  with the epoch-aligned snapping in computeTrendFactory, every trend
+ *  timestamp then lands on a panel timestamp, so hovering the trend reliably
+ *  drives the synced crosshair on the other Storage-tab panels (#1514). */
+export function computeBucketMs(windowMs: number, alignMs?: number): number {
+	const base = Math.max(60_000, Math.ceil(windowMs / 90));
+	if (typeof alignMs === 'number' && Number.isFinite(alignMs) && alignMs > 0) {
+		return Math.ceil(base / alignMs) * alignMs;
+	}
+	return base;
 }
 
 /** Build a stable "database.table" key. */
@@ -195,41 +208,47 @@ export function computeSnapshot(
 export function computeTrendFactory(
 	normalized: NormalizedRecord[],
 	range: TimeRange,
+	alignMs?: number,
 ): (selectedTable: string) => TrendPoint[] {
-	const bucketMs = computeBucketMs(range.endTime - range.startTime);
+	const bucketMs = computeBucketMs(range.endTime - range.startTime, alignMs);
 
 	return function trend(selectedTable: string): TrendPoint[] {
 		// Collect the latest sample per (bucket, node) for the selected table.
 		const byBucket = new Map<number, Map<string, { size: number; time: number }>>();
-		// Track each node's last-sample time across the window to truncate trailing buckets.
-		const lastSampleTime = new Map<string, number>();
+		// Track each node's last populated bucket to truncate anything trailing it.
+		const lastBucketTime = new Map<string, number>();
 
 		for (const r of normalized) {
 			if (r.tableKey !== selectedTable) { continue; }
 			if (r.time < range.startTime || r.time > range.endTime) { continue; }
-			const bucketStart = range.startTime + Math.floor((r.time - range.startTime) / bucketMs) * bucketMs;
-			if (!byBucket.has(bucketStart)) { byBucket.set(bucketStart, new Map()); }
-			const nodeMap = byBucket.get(bucketStart)!;
+			// Epoch-aligned, round-to-nearest — the exact convention of the
+			// pipeline's snapToBucketTime. The old grid anchored buckets at
+			// range.startTime, which put trend timestamps on a lattice no other
+			// chart shared, so syncMethod="value" crosshairs never matched the
+			// Storage tab's metric panels (#1514).
+			const bucketTime = Math.round(r.time / bucketMs) * bucketMs;
+			if (!byBucket.has(bucketTime)) { byBucket.set(bucketTime, new Map()); }
+			const nodeMap = byBucket.get(bucketTime)!;
 			const prev = nodeMap.get(r.node);
 			if (!prev || r.time >= prev.time) {
 				nodeMap.set(r.node, { size: r.size, time: r.time });
 			}
-			const lastTime = lastSampleTime.get(r.node) ?? 0;
-			if (r.time > lastTime) { lastSampleTime.set(r.node, r.time); }
+			const lastBucket = lastBucketTime.get(r.node) ?? 0;
+			if (bucketTime > lastBucket) { lastBucketTime.set(r.node, bucketTime); }
 		}
 
 		const points: TrendPoint[] = [];
 		const sortedBuckets = [...byBucket.keys()].sort((a, b) => a - b);
-		for (const bucketStart of sortedBuckets) {
-			const nodeMap = byBucket.get(bucketStart)!;
+		for (const bucketTime of sortedBuckets) {
+			const nodeMap = byBucket.get(bucketTime)!;
 			const values: Record<string, number> = {};
 			for (const [node, { size }] of nodeMap) {
-				// Drop buckets that start after the node's last sample (truncate trailing).
-				const lastTime = lastSampleTime.get(node) ?? 0;
-				if (bucketStart > lastTime) { continue; }
+				// Drop buckets past the node's last populated bucket (truncate trailing).
+				const lastBucket = lastBucketTime.get(node) ?? 0;
+				if (bucketTime > lastBucket) { continue; }
 				values[node] = size;
 			}
-			if (Object.keys(values).length > 0) { points.push({ time: bucketStart, values }); }
+			if (Object.keys(values).length > 0) { points.push({ time: bucketTime, values }); }
 		}
 		return points;
 	};
@@ -307,12 +326,14 @@ export function computeEmptyCause(
 	return null;
 }
 
-/** Assemble a `TableSizeDerived` from raw records + current time range. */
-export function buildDerived(raw: TableSizeRecord[], range: TimeRange): TableSizeDerived {
+/** Assemble a `TableSizeDerived` from raw records + current time range.
+ *  `alignMs` — see computeBucketMs; StorageTab passes the tab's bucketMs so
+ *  the trend's bucket grid coincides with the metric panels'. */
+export function buildDerived(raw: TableSizeRecord[], range: TimeRange, alignMs?: number): TableSizeDerived {
 	const normalized = dedupRecords(normalizeRecords(raw));
 	const { tableSet, hasOther, otherMembers } = computeTableSet(normalized);
 	const byNode = computeSnapshot(normalized, tableSet, hasOther);
-	const trend = computeTrendFactory(normalized, range);
+	const trend = computeTrendFactory(normalized, range, alignMs);
 	const emptyCause = computeEmptyCause(raw.length, tableSet, hasOther);
 
 	// Content signature: window + a cheap digest of the raw input.

--- a/src/features/instance/status/analytics/lib/tableSize.ts
+++ b/src/features/instance/status/analytics/lib/tableSize.ts
@@ -215,8 +215,6 @@ export function computeTrendFactory(
 	return function trend(selectedTable: string): TrendPoint[] {
 		// Collect the latest sample per (bucket, node) for the selected table.
 		const byBucket = new Map<number, Map<string, { size: number; time: number }>>();
-		// Track each node's last populated bucket to truncate anything trailing it.
-		const lastBucketTime = new Map<string, number>();
 
 		for (const r of normalized) {
 			if (r.tableKey !== selectedTable) { continue; }
@@ -233,8 +231,6 @@ export function computeTrendFactory(
 			if (!prev || r.time >= prev.time) {
 				nodeMap.set(r.node, { size: r.size, time: r.time });
 			}
-			const lastBucket = lastBucketTime.get(r.node) ?? 0;
-			if (bucketTime > lastBucket) { lastBucketTime.set(r.node, bucketTime); }
 		}
 
 		const points: TrendPoint[] = [];
@@ -243,9 +239,6 @@ export function computeTrendFactory(
 			const nodeMap = byBucket.get(bucketTime)!;
 			const values: Record<string, number> = {};
 			for (const [node, { size }] of nodeMap) {
-				// Drop buckets past the node's last populated bucket (truncate trailing).
-				const lastBucket = lastBucketTime.get(node) ?? 0;
-				if (bucketTime > lastBucket) { continue; }
 				values[node] = size;
 			}
 			if (Object.keys(values).length > 0) { points.push({ time: bucketTime, values }); }

--- a/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
+++ b/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
@@ -1,0 +1,116 @@
+import { formatValue, type ValueFormatter } from '@/lib/formatValue';
+import { useMemo } from 'react';
+import { shortNodeLabelMap } from '../lib/nodeLabels';
+import { formatTooltipTime } from '../lib/time';
+import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle';
+
+/** The subset of Recharts' tooltip payload entry the shared content reads.
+ *  Kept structural (not Recharts' own type) so the component stays trivially
+ *  testable and independent of Recharts' generics. */
+export interface ChartTooltipEntry {
+	dataKey?: string | number;
+	name?: string | number;
+	value?: number | string | Array<number | string> | null;
+	color?: string;
+}
+
+export interface ChartTooltipEntryFormat {
+	formatter?: ValueFormatter;
+	unitSuffix?: string;
+}
+
+interface Props {
+	/** Injected by Recharts when passed as <Tooltip content={...}>. */
+	active?: boolean;
+	payload?: readonly ChartTooltipEntry[];
+	label?: number | string;
+	/** Default value format applied to every row. */
+	formatter?: ValueFormatter;
+	unitSuffix?: string;
+	/** Per-entry format override for dual-axis charts (LineChart resolves the
+	 *  entry's series to its left/right axis spec). Wins over
+	 *  `formatter`/`unitSuffix` when provided. */
+	resolveEntryFormat?: (entry: ChartTooltipEntry) => ChartTooltipEntryFormat;
+	/** Full node FQDNs present on the chart. Occurrences inside displayed
+	 *  series names are shortened (collision-aware, see shortNodeLabelMap).
+	 *  Display-layer only: the series `label` fields are untouched, so CSV
+	 *  exports and legends keep the full names. */
+	nodeNames?: readonly string[];
+	/** Append the stacked charts' summed Total row (ported from the old
+	 *  StackedAreaTooltip; hidden for single-entry payloads). */
+	showTotal?: boolean;
+}
+
+/** THE tooltip content for every synced cartesian chart on the Status tabs
+ *  (LineChart, StackedAreaChart, TableSizeTrend). One implementation so the
+ *  time header, node-name shortening, and value formatting can't drift
+ *  between chart types. */
+export function ChartTooltip(
+	{ active, payload, label, formatter, unitSuffix, resolveEntryFormat, nodeNames, showTotal }: Props,
+) {
+	const shortLabels = useMemo(() => {
+		const map = shortNodeLabelMap(nodeNames ?? []);
+		// Longest-first so a node name that contains another node's full name
+		// as a substring can't be half-replaced by the shorter match.
+		const fullNames = [...map.keys()].sort((a, b) => b.length - a.length);
+		return { map, fullNames };
+	}, [nodeNames]);
+
+	if (!active || !payload || payload.length === 0) { return null; }
+
+	const displayName = (raw: string): string => {
+		let out = raw;
+		for (const full of shortLabels.fullNames) {
+			const short = shortLabels.map.get(full)!;
+			if (short !== full && out.includes(full)) { out = out.split(full).join(short); }
+		}
+		return out;
+	};
+
+	const entryFormat = (entry: ChartTooltipEntry): ChartTooltipEntryFormat =>
+		resolveEntryFormat?.(entry) ?? { formatter, unitSuffix };
+
+	const numericValues = payload.map((p) => (typeof p.value === 'number' ? p.value : null));
+	const total = numericValues.reduce<number>((s, v) => s + (v ?? 0), 0);
+	// count-si rounds at tick level; use raw 'count' for the Total so the sum
+	// keeps its precision (ported from StackedAreaTooltip).
+	const totalFormatter: ValueFormatter | undefined = formatter === 'count-si' ? 'count' : formatter;
+
+	return (
+		<div style={tooltipContentStyle}>
+			<div style={tooltipLabelStyle}>
+				{label !== undefined ? formatTooltipTime(Number(label)) : ''}
+			</div>
+			{payload.map((p, i) => {
+				const fmt = entryFormat(p);
+				return (
+					<div
+						key={`${String(p.dataKey ?? '')}-${String(p.name ?? i)}`}
+						style={{ ...tooltipItemStyle, display: 'flex', justifyContent: 'space-between', gap: 12 }}
+					>
+						<span style={{ color: p.color }}>{displayName(String(p.name ?? p.dataKey ?? ''))}</span>
+						<span>{formatValue(numericValues[i], fmt.formatter, fmt.unitSuffix)}</span>
+					</div>
+				);
+			})}
+			{showTotal && payload.length > 1
+				? (
+					<div
+						style={{
+							display: 'flex',
+							justifyContent: 'space-between',
+							gap: 12,
+							marginTop: 4,
+							paddingTop: 4,
+							borderTop: '1px solid var(--border)',
+							fontWeight: 600,
+						}}
+					>
+						<span>Total</span>
+						<span>{formatValue(total, totalFormatter, unitSuffix)}</span>
+					</div>
+				)
+				: null}
+		</div>
+	);
+}

--- a/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
+++ b/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
@@ -88,6 +88,10 @@ export function useTooltipGate(): {
 	return { hovered, gateProps };
 }
 
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** THE tooltip content for every synced cartesian chart on the Status tabs
  *  (LineChart, StackedAreaChart, TableSizeTrend). One implementation so the
  *  time header, node-name shortening, and value formatting can't drift
@@ -95,22 +99,27 @@ export function useTooltipGate(): {
 export function ChartTooltip(
 	{ active, payload, label, formatter, unitSuffix, resolveEntryFormat, nodeNames, showTotal, hidden }: Props,
 ) {
-	const shortLabels = useMemo(() => {
+	const shortReplacers = useMemo(() => {
 		const map = shortNodeLabelMap(nodeNames ?? []);
-		// Longest-first so a node name that contains another node's full name
-		// as a substring can't be half-replaced by the shorter match.
-		const fullNames = [...map.keys()].sort((a, b) => b.length - a.length);
-		return { map, fullNames };
+		// Longest-first so a node name containing another node's FQDN as a
+		// substring is replaced first. Each match is anchored to hostname
+		// boundaries (`[\w.-]` on neither side), so a shorter FQDN can never
+		// match inside an already-shortened prefix — the substring-replace
+		// over-shortening a bare `.split().join()` was prone to.
+		return [...map.entries()]
+			.filter(([full, short]) => short !== full)
+			.sort((a, b) => b[0].length - a[0].length)
+			.map(([full, short]) => ({
+				re: new RegExp(`(?<![\\w.-])${escapeRegExp(full)}(?![\\w.-])`, 'g'),
+				short,
+			}));
 	}, [nodeNames]);
 
 	if (hidden || !active || !payload || payload.length === 0) { return null; }
 
 	const displayName = (raw: string): string => {
 		let out = raw;
-		for (const full of shortLabels.fullNames) {
-			const short = shortLabels.map.get(full)!;
-			if (short !== full && out.includes(full)) { out = out.split(full).join(short); }
-		}
+		for (const { re, short } of shortReplacers) { out = out.replace(re, short); }
 		return out;
 	};
 

--- a/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
+++ b/src/features/instance/status/analytics/primitives/ChartTooltip.tsx
@@ -1,5 +1,5 @@
 import { formatValue, type ValueFormatter } from '@/lib/formatValue';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { shortNodeLabelMap } from '../lib/nodeLabels';
 import { formatTooltipTime } from '../lib/time';
 import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle';
@@ -39,6 +39,53 @@ interface Props {
 	/** Append the stacked charts' summed Total row (ported from the old
 	 *  StackedAreaTooltip; hidden for single-entry payloads). */
 	showTotal?: boolean;
+	/** Render nothing even while Recharts reports `active` — set by charts in
+	 *  a crosshair-sync group that are NOT under the pointer (useTooltipGate).
+	 *  Recharts still draws the Tooltip `cursor` line when the content renders
+	 *  null, so non-hovered synced charts keep the crosshair without stacking
+	 *  a screenful of tooltip boxes. */
+	hidden?: boolean;
+}
+
+export interface TooltipGateProps {
+	onMouseEnter: () => void;
+	onMouseLeave: () => void;
+	onTouchStart: () => void;
+	onFocus: () => void;
+	onBlur: () => void;
+}
+
+/** Per-chart hover gate for synced tooltips: spread `gateProps` on the chart's
+ *  container and pass `hidden={!hovered}` to <ChartTooltip>. With Recharts'
+ *  syncId every synced chart activates its own full tooltip; this keeps the
+ *  box on the chart being interacted with while the others retain the synced
+ *  cursor.
+ *
+ *  Non-mouse input opens the gate too — Recharts activates tooltips from
+ *  touch events and (via its accessibility layer) from arrow keys on a
+ *  focused chart, so gating on mouse hover alone would blank tooltips for
+ *  those users entirely. Touch has no "leave", so the gate stays open until
+ *  the next mouse/focus interaction closes it — after tapping two synced
+ *  charts both may show a box, which simply matches pre-gate behavior. */
+export function useTooltipGate(): {
+	hovered: boolean;
+	gateProps: TooltipGateProps;
+} {
+	const [hovered, setHovered] = useState(false);
+	const gateProps = useMemo(() => {
+		const open = () => setHovered(true);
+		const close = () => setHovered(false);
+		return {
+			onMouseEnter: open,
+			onMouseLeave: close,
+			onTouchStart: open,
+			// React's onFocus/onBlur map to focusin/focusout, so focus moving
+			// anywhere inside the chart container keeps the gate open.
+			onFocus: open,
+			onBlur: close,
+		};
+	}, []);
+	return { hovered, gateProps };
 }
 
 /** THE tooltip content for every synced cartesian chart on the Status tabs
@@ -46,7 +93,7 @@ interface Props {
  *  time header, node-name shortening, and value formatting can't drift
  *  between chart types. */
 export function ChartTooltip(
-	{ active, payload, label, formatter, unitSuffix, resolveEntryFormat, nodeNames, showTotal }: Props,
+	{ active, payload, label, formatter, unitSuffix, resolveEntryFormat, nodeNames, showTotal, hidden }: Props,
 ) {
 	const shortLabels = useMemo(() => {
 		const map = shortNodeLabelMap(nodeNames ?? []);
@@ -56,7 +103,7 @@ export function ChartTooltip(
 		return { map, fullNames };
 	}, [nodeNames]);
 
-	if (!active || !payload || payload.length === 0) { return null; }
+	if (hidden || !active || !payload || payload.length === 0) { return null; }
 
 	const displayName = (raw: string): string => {
 		let out = raw;

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -13,9 +13,9 @@ import {
 import { useChartSyncProps } from '../context/AnalyticsContext';
 import { NODE_PALETTE } from '../lib/nodeColors';
 import { getChartColors } from '../lib/theme';
-import { formatAxisTick, formatTooltipTime } from '../lib/time';
+import { formatAxisTick } from '../lib/time';
 import type { AxisSpec, SeriesData, Threshold } from '../types/analytics';
-import { tooltipContentStyle, tooltipItemStyle, tooltipLabelStyle } from './tooltipStyle';
+import { ChartTooltip, type ChartTooltipEntry } from './ChartTooltip';
 
 interface Props {
 	data: SeriesData;
@@ -90,6 +90,10 @@ export function LineChart(
 
 	const chartColors = getChartColors();
 
+	// Full node FQDNs on this chart — the shared tooltip shortens them in
+	// displayed series names (display-layer only; `label` stays untouched).
+	const nodeNames = [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))];
+
 	return (
 		<div
 			role="img"
@@ -143,16 +147,17 @@ export function LineChart(
 							)
 							: null}
 						<Tooltip
-							labelFormatter={(label) => formatTooltipTime(Number(label))}
-							formatter={(val, name) => {
-								const nameStr = String(name);
-								const series = data.series.find((s) => s.label === nameStr || s.key === nameStr);
-								const axisSpec = series?.axis === 'right' ? rightAxis : leftAxis;
-								return [formatValue(Number(val), axisSpec?.formatter, axisSpec?.unit), nameStr];
-							}}
-							contentStyle={tooltipContentStyle}
-							labelStyle={tooltipLabelStyle}
-							itemStyle={tooltipItemStyle}
+							content={
+								<ChartTooltip
+									nodeNames={nodeNames}
+									resolveEntryFormat={(entry: ChartTooltipEntry) => {
+										const nameStr = String(entry.name ?? '');
+										const series = data.series.find((s) => s.label === nameStr || s.key === nameStr);
+										const axisSpec = series?.axis === 'right' ? rightAxis : leftAxis;
+										return { formatter: axisSpec?.formatter, unitSuffix: axisSpec?.unit };
+									}}
+								/>
+							}
 						/>
 						{!hideLegend && <Legend />}
 						{data.thresholds?.map((t: Threshold, i: number) => {

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -15,7 +15,7 @@ import { NODE_PALETTE } from '../lib/nodeColors';
 import { getChartColors } from '../lib/theme';
 import { formatAxisTick } from '../lib/time';
 import type { AxisSpec, SeriesData, Threshold } from '../types/analytics';
-import { ChartTooltip, type ChartTooltipEntry } from './ChartTooltip';
+import { ChartTooltip, type ChartTooltipEntry, useTooltipGate } from './ChartTooltip';
 
 interface Props {
 	data: SeriesData;
@@ -72,6 +72,9 @@ export function LineChart(
 	// dialog (ChartExpandButton), which gets its own sync scope — see
 	// useChartSyncProps for the full rationale.
 	const syncProps = useChartSyncProps(!!fillParent);
+	// Tooltip box only on the chart under the pointer — synced siblings keep
+	// the cursor line but render no box (see useTooltipGate/ChartTooltip).
+	const { hovered, gateProps } = useTooltipGate();
 
 	if (data.series.length === 0) {
 		return (
@@ -101,6 +104,7 @@ export function LineChart(
 			style={fillParent
 				? { width: '100%', height: '100%', minHeight: 0, flex: '1 1 auto', display: 'flex', flexDirection: 'column' }
 				: { width: '100%', height }}
+			{...gateProps}
 		>
 			{
 				/* Inner SVG is decorative once the outer role=img has the
@@ -147,8 +151,12 @@ export function LineChart(
 							)
 							: null}
 						<Tooltip
+							// No enter/move easing: with syncId every synced chart
+							// animates on each mouse-move, making the tab visibly jerk.
+							isAnimationActive={false}
 							content={
 								<ChartTooltip
+									hidden={!hovered}
 									nodeNames={nodeNames}
 									resolveEntryFormat={(entry: ChartTooltipEntry) => {
 										const nameStr = String(entry.name ?? '');

--- a/src/features/instance/status/analytics/primitives/LineChart.tsx
+++ b/src/features/instance/status/analytics/primitives/LineChart.tsx
@@ -1,4 +1,5 @@
 import { formatValue } from '@/lib/formatValue';
+import { useMemo } from 'react';
 import {
 	CartesianGrid,
 	Legend,
@@ -76,6 +77,17 @@ export function LineChart(
 	// the cursor line but render no box (see useTooltipGate/ChartTooltip).
 	const { hovered, gateProps } = useTooltipGate();
 
+	// Full node FQDNs on this chart — the shared tooltip shortens them in
+	// displayed series names (display-layer only; `label` stays untouched).
+	// Memoized: this chart re-renders on every hover tick (useTooltipGate), and
+	// a fresh array each render would re-run ChartTooltip's shortNodeLabelMap
+	// (keyed on this) on every mouse-move. Kept above the early return so the
+	// hook order stays stable when data is empty.
+	const nodeNames = useMemo(
+		() => [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))],
+		[data.series],
+	);
+
 	if (data.series.length === 0) {
 		return (
 			<div role="status" aria-live="polite" className="text-(--color-text-secondary) text-sm p-4">
@@ -92,10 +104,6 @@ export function LineChart(
 	const rightAxis = isDual ? yAxis.right : undefined;
 
 	const chartColors = getChartColors();
-
-	// Full node FQDNs on this chart — the shared tooltip shortens them in
-	// displayed series names (display-layer only; `label` stays untouched).
-	const nodeNames = [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))];
 
 	return (
 		<div

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -7,7 +7,7 @@ import { NODE_PALETTE } from '../lib/nodeColors';
 import { getChartColors } from '../lib/theme';
 import { formatAxisTick } from '../lib/time';
 import type { AxisSpec, SeriesData } from '../types/analytics';
-import { ChartTooltip } from './ChartTooltip';
+import { ChartTooltip, useTooltipGate } from './ChartTooltip';
 import { sortByMagnitude } from './sortByMagnitude';
 
 interface Props {
@@ -50,6 +50,9 @@ export function StackedAreaChart(
 	// `fillParent` caller) gets its own scope so it never drives the panels
 	// behind the overlay. See useChartSyncProps for the full rationale.
 	const syncProps = useChartSyncProps(!!fillParent);
+	// Tooltip box only on the chart under the pointer — synced siblings keep
+	// the cursor line but render no box (see useTooltipGate/ChartTooltip).
+	const { hovered, gateProps } = useTooltipGate();
 
 	if (data.series.length === 0) {
 		return (
@@ -113,6 +116,7 @@ export function StackedAreaChart(
 			style={fillParent
 				? { width: '100%', height: '100%', minHeight: 0, flex: '1 1 auto', display: 'flex', flexDirection: 'column' }
 				: { width: '100%', height }}
+			{...gateProps}
 		>
 			<div aria-hidden="true" style={{ width: '100%', height: '100%' }}>
 				<ResponsiveContainer width="100%" height="100%">
@@ -134,8 +138,12 @@ export function StackedAreaChart(
 							width={70}
 						/>
 						<Tooltip
+							// No enter/move easing: with syncId every synced chart
+							// animates on each mouse-move, making the tab visibly jerk.
+							isAnimationActive={false}
 							content={
 								<ChartTooltip
+									hidden={!hovered}
 									formatter={resolvedFormatter}
 									unitSuffix={resolvedUnit}
 									nodeNames={nodeNames}

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -5,10 +5,10 @@ import { Area, AreaChart, CartesianGrid, Legend, Line, ResponsiveContainer, Tool
 import { useChartSyncProps } from '../context/AnalyticsContext';
 import { NODE_PALETTE } from '../lib/nodeColors';
 import { getChartColors } from '../lib/theme';
-import { formatAxisTick, formatTooltipTime } from '../lib/time';
-import type { AxisFormatter, AxisSpec, SeriesData } from '../types/analytics';
+import { formatAxisTick } from '../lib/time';
+import type { AxisSpec, SeriesData } from '../types/analytics';
+import { ChartTooltip } from './ChartTooltip';
 import { sortByMagnitude } from './sortByMagnitude';
-import { tooltipContentStyle, tooltipLabelStyle } from './tooltipStyle';
 
 interface Props {
 	data: SeriesData;
@@ -37,59 +37,6 @@ function composeAriaLabel(data: SeriesData): string {
 	return `Stacked area chart with ${seriesNames.length} series: ${seriesNames.slice(0, 5).join(', ')}${
 		seriesNames.length > 5 ? '…' : ''
 	}`;
-}
-
-interface TooltipPayloadEntry {
-	dataKey: string;
-	name: string;
-	value: number | null;
-	color: string;
-}
-
-interface StackedAreaTooltipProps {
-	active?: boolean;
-	payload?: readonly TooltipPayloadEntry[];
-	label?: number;
-	formatter?: AxisFormatter;
-	unitSuffix?: string;
-}
-
-export function StackedAreaTooltip({ active, payload, label, formatter, unitSuffix }: StackedAreaTooltipProps) {
-	if (!active || !payload || payload.length === 0) { return null; }
-	const total = payload.reduce((s, p) => s + (typeof p.value === 'number' ? p.value : 0), 0);
-	// count-si rounds at tick level; use raw 'count' for tooltip total to preserve precision.
-	const totalFormatter: AxisFormatter | undefined = formatter === 'count-si' ? 'count' : formatter;
-	return (
-		<div style={tooltipContentStyle}>
-			<div style={tooltipLabelStyle}>
-				{label !== undefined ? formatTooltipTime(Number(label)) : ''}
-			</div>
-			{payload.map((p) => (
-				<div key={p.dataKey} style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
-					<span style={{ color: p.color }}>{p.name}</span>
-					<span>{formatValue(typeof p.value === 'number' ? p.value : 0, formatter, unitSuffix)}</span>
-				</div>
-			))}
-			{payload.length > 1
-				? (
-					<div
-						style={{
-							display: 'flex',
-							justifyContent: 'space-between',
-							gap: 12,
-							marginTop: 4,
-							paddingTop: 4,
-							borderTop: '1px solid var(--border)',
-							fontWeight: 600,
-						}}
-					>
-						<span>Total</span>
-						<span>{formatValue(total, totalFormatter, unitSuffix)}</span>
-					</div>
-				)
-				: null}
-		</div>
-	);
 }
 
 export function StackedAreaChart(
@@ -155,6 +102,10 @@ export function StackedAreaChart(
 	const resolvedUnit = yAxis?.unit;
 	const fillOpacity = theme === 'dark' ? 0.5 : 0.35;
 
+	// Full node FQDNs on this chart — the shared tooltip shortens them in
+	// displayed series names (display-layer only; `label` stays untouched).
+	const nodeNames = [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))];
+
 	return (
 		<div
 			role="img"
@@ -182,7 +133,16 @@ export function StackedAreaChart(
 							tick={{ fontSize: 11 }}
 							width={70}
 						/>
-						<Tooltip content={<StackedAreaTooltip formatter={resolvedFormatter} unitSuffix={resolvedUnit} />} />
+						<Tooltip
+							content={
+								<ChartTooltip
+									formatter={resolvedFormatter}
+									unitSuffix={resolvedUnit}
+									nodeNames={nodeNames}
+									showTotal
+								/>
+							}
+						/>
 						<Legend />
 						{sortedSeries.map((s, idx) => (
 							<Area

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -54,6 +54,17 @@ export function StackedAreaChart(
 	// the cursor line but render no box (see useTooltipGate/ChartTooltip).
 	const { hovered, gateProps } = useTooltipGate();
 
+	// Full node FQDNs on this chart — the shared tooltip shortens them in
+	// displayed series names (display-layer only; `label` stays untouched).
+	// Memoized: this chart re-renders on every hover tick (useTooltipGate), and
+	// a fresh array each render would re-run ChartTooltip's shortNodeLabelMap
+	// (keyed on this) on every mouse-move. Kept above the early return so the
+	// hook order stays stable when data is empty.
+	const nodeNames = useMemo(
+		() => [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))],
+		[data.series],
+	);
+
 	if (data.series.length === 0) {
 		return (
 			<div role="status" aria-live="polite" className="text-(--color-text-secondary) text-sm p-4">
@@ -104,10 +115,6 @@ export function StackedAreaChart(
 	const resolvedFormatter = yAxis?.formatter;
 	const resolvedUnit = yAxis?.unit;
 	const fillOpacity = theme === 'dark' ? 0.5 : 0.35;
-
-	// Full node FQDNs on this chart — the shared tooltip shortens them in
-	// displayed series names (display-layer only; `label` stays untouched).
-	const nodeNames = [...new Set(data.series.flatMap((s) => (s.node !== undefined ? [s.node] : [])))];
 
 	return (
 		<div

--- a/src/features/instance/status/analytics/tabs/StorageTab.tsx
+++ b/src/features/instance/status/analytics/tabs/StorageTab.tsx
@@ -67,7 +67,12 @@ function TableSizePanels() {
 		}
 		return cleaned;
 	}, [data]);
-	const derived = useMemo(() => buildDerived(raw, timeRange), [raw, timeRange.startTime, timeRange.endTime]);
+	// bucketMs aligns the trend's bucket grid with the metric panels' so the
+	// value-synced crosshair matches across the tab (see computeBucketMs).
+	const derived = useMemo(
+		() => buildDerived(raw, timeRange, bucketMs),
+		[raw, timeRange.startTime, timeRange.endTime, bucketMs],
+	);
 
 	// Backs TableSizeTrend's rank toggle — the trend chart renders bytes/%
 	// buttons and reports clicks via onRankChange (previously wired to a


### PR DESCRIPTION
Three follow-ups from @dawsontoth's review of #1507 (Status-tab crosshair sync), one commit per issue.

## Fixes #1515 — one shared tooltip, short node labels
There were three divergent tooltip implementations (LineChart's default `<Tooltip>` formatter, StackedAreaChart's bespoke `StackedAreaTooltip`, TableSizeTrend's default variant), and metric-panel tooltips echoed full node FQDNs. Now all three charts render one shared `primitives/ChartTooltip.tsx`:

- consistent `formatTooltipTime` header and `formatValue` values (per-entry axis resolution for dual-axis LineCharts),
- the stacked charts' **Total** row preserved behind a `showTotal` prop (including the count-si → count precision rule),
- node FQDNs in displayed series names shortened via a new collision-aware `shortNodeLabelMap` (`lib/nodeLabels.ts`): colliding first segments extend one FQDN segment at a time until unique (`node1.us` / `node1.eu`), falling back to the full name.

Display-layer only: pipeline series `label` fields are untouched, so CSV exports and legends keep full names. One deliberate display change: a `null` value in a stacked tooltip now renders `—` instead of the old fake `0`.

## Fixes #1513 — tooltip box only on the hovered chart, no animation jerk
- `isAnimationActive={false}` on the three chart `<Tooltip>`s kills the mouse-move easing that made every synced panel jerk.
- A per-chart hover gate (`useTooltipGate`, on the chart container) passes `hidden` to `ChartTooltip`, which renders `null` on synced charts not under the pointer. Recharts still draws the Tooltip `cursor` when content renders null, so the other panels keep the synced crosshair line — verified end-to-end with two real-Recharts synced charts (`tooltip-gating.test.tsx`: hovered chart shows the box, sibling shows cursor only).
- The gate also opens on `touchstart` and `focusin` (and closes on `focusout`): Recharts activates tooltips from touch events and, via its accessibility layer, from arrow keys on a focused chart — gating on mouse hover alone would have blanked tooltips for those users (caught by Codex review). Touch has no "leave", so after tapping two synced charts both may show a box — matches pre-gate behavior.

## Fixes #1514 — reliable value-sync via bucket alignment
`syncMethod="value"` only lights up when the hovered x exists exactly in the other chart's data. The table-size trend anchored its bucket grid at `range.startTime` — a lattice no other chart shared — so it "usually won't light up" (documented in #1507). Now:

- `computeTrendFactory` snaps records to the nearest epoch-aligned bucket multiple, the exact convention of the pipeline's `snapToBucketTime` (round-to-nearest, per its zigzag rationale), and truncates trailing buckets by last populated bucket rather than raw sample time (raw-time comparison would drop a final rounded-up bucket).
- `computeBucketMs` takes an optional `alignMs` and rounds the trend bucket up to a multiple of it; StorageTab passes the tab's fetch `bucketMs`, so wide windows stay on the panels' grid too (24h: 16 min → 20 min buckets on the 5-min lattice).
- Audited `charts/` and `lib/` for other `startTime`-anchored grids — the trend was the only one.
- New cross-metric test asserts the trend and a `snapToPeriod` pipeline panel bucket the same instants to identical timestamps; the tests that encoded the old anchoring were updated.

## Review focus
- **Tooltip gating approach**: content-returns-null relies on Recharts drawing the `cursor` independently of tooltip content (covered by the integration test, and browser-verified behavior in Recharts 3.9). If you know a case where cursor rendering is tied to content, shout.
- **Trend grid change**: bucket timestamps move (e.g. `1700000000000` → `1699999980000` for a 20s-off-lattice window) and the 24h/30d bucket width grows slightly when `alignMs` rounds up. Sanity-check the truncation change in `computeTrendFactory`.

## Deferred / notes
- `TableSizeSnapshot`'s bar tooltip keeps its bespoke "% of node total" formatter — category axis, not in the sync group; it already shares the `tooltipStyle` surface. Can migrate later if we want literal one-tooltip-everywhere.
- Metric-panel `<Legend>`s still show full FQDNs (issue #1515 explicitly allows this; chip-selector panels already shorten via `useNodeFilteredSeries`).
- Panel→trend hover still only matches where the trend has a point at that exact x (trend buckets are wider than panel buckets); trend→panel now always matches. Full bidirectional lighting would require equal bucket widths across all charts — out of scope here.

## Testing
`tsc -b`, `dprint`, `oxlint`, full `vitest run` (1582 passed / 11 skipped) green. Cross-model reviews pre-PR: Gemini found no issues; Codex flagged the touch/keyboard gating gap (fixed above), nothing else.

Comment generated by kAIle (Claude Fable 5)
