### PR TITLE
fix(auth): sign out and redirect on 401 from the CM API

### DIFF
--- a/src/features/auth/handlers/clearAuthStateLocally.ts
+++ b/src/features/auth/handlers/clearAuthStateLocally.ts
@@ -1,0 +1,23 @@
+import { authStore } from '@/features/auth/store/authStore';
+import { clearLocalStorage } from '@/lib/storage/clearLocalStorage';
+import { clearSessionStorage } from '@/lib/storage/clearSessionStorage';
+import { queryClient } from '@/react-query/queryClient';
+
+/**
+ * Full LOCAL sign-out for a session already known-dead (e.g. a 401 from CM):
+ * clears all in-memory auth connections/tokens/flags, persisted storage, and
+ * BOTH React Query caches — WITHOUT posting a logout to CM or instances (the
+ * session is gone, so a network logout would only fail).
+ *
+ * This closes the cross-user gap where, after A's session expired, A's stale
+ * in-memory entity connections / Fabric tokens / cached queries survived a
+ * same-tab re-login as B. Clears the MutationCache too (logoutOnSuccess clears
+ * only the QueryCache), so no credential lingers there either.
+ */
+export function clearAuthStateLocally(): void {
+	authStore.signOutAllLocally();
+	queryClient.getMutationCache().clear();
+	queryClient.getQueryCache().clear();
+	clearLocalStorage();
+	clearSessionStorage();
+}

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -421,6 +421,26 @@ class AuthStore {
 		this.updateConnectionIfChanged(id, false, null);
 	}
 
+	/**
+	 * Local-only full sign-out: clears every in-memory connection, Fabric token,
+	 * and flag for ALL entities, plus the cloud slot — WITHOUT posting a logout to
+	 * CM or any instance. For a session already known-dead (e.g. a 401 from CM),
+	 * where the in-memory maps would otherwise survive until a page reload and a
+	 * same-tab re-login could inherit the prior user's connections/tokens/cache.
+	 * Distinct from signOutFromPotentiallyAuthenticatedInstances, which also posts
+	 * per-instance logouts.
+	 */
+	public signOutAllLocally(): void {
+		// Snapshot keys first — signOutLocally mutates the flags as it goes.
+		for (const id of Object.keys(this.potentiallyAuthenticated)) {
+			this.signOutLocally(id);
+		}
+		this.fabricConnectAuth.clear();
+		this.fabricConnectInFlight.clear();
+		this.operationTokenRefreshInFlight.clear();
+		this.setUserForEntity(OverallAppSignIn, null);
+	}
+
 	private calculateKeyFromEntity(entity: EntityTypes): AuthenticatedConnectionKey | undefined {
 		if (isLocalStudio || entity === OverallAppSignIn) {
 			return OverallAppSignIn;

--- a/src/features/auth/store/signOutAllLocally.test.ts
+++ b/src/features/auth/store/signOutAllLocally.test.ts
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+// jsdom: authStore touches localStorage at module load and throughout.
+import { beforeEach, describe, expect, it } from 'vitest';
+import { authStore, OverallAppSignIn } from './authStore';
+
+type SetArgs = Parameters<typeof authStore.setUserForIdAndKey>;
+
+describe('authStore.signOutAllLocally', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+
+	it('clears the cloud slot and every entity connection/flag locally, without a network logout', () => {
+		// Establish A's cloud session plus an authenticated instance with a Fabric flag.
+		authStore.setUserForIdAndKey(OverallAppSignIn, OverallAppSignIn, { id: 'usr_a' } as SetArgs[2]);
+		authStore.setUserForIdAndKey(
+			'inst_1' as SetArgs[0],
+			'https://inst-1' as SetArgs[1],
+			{ username: 'u' } as SetArgs[2],
+		);
+		authStore.flagForFabricConnect('inst_1' as SetArgs[0], true);
+
+		expect(authStore.getConnectionById(OverallAppSignIn).user).not.toBeNull();
+		expect(authStore.getConnectionById('inst_1' as SetArgs[0]).user).not.toBeNull();
+		expect(authStore.checkForFabricConnect('inst_1' as SetArgs[0])).toBe(true);
+
+		authStore.signOutAllLocally();
+
+		// Cross-user leak guard: nothing of A's survives in memory or storage.
+		expect(authStore.getConnectionById(OverallAppSignIn).user).toBeNull();
+		expect(authStore.getConnectionById('inst_1' as SetArgs[0]).user).toBeNull();
+		expect(authStore.checkForFabricConnect('inst_1' as SetArgs[0])).toBe(false);
+	});
+});

--- a/src/lib/installApiUnauthorizedRedirect.ts
+++ b/src/lib/installApiUnauthorizedRedirect.ts
@@ -2,14 +2,35 @@ import { apiClient } from '@/config/apiClient';
 import { authStore, OverallAppSignIn } from '@/features/auth/store/authStore';
 import { makeUnauthorizedResponseHandler } from '@/lib/unauthorizedResponseHandler';
 
+// The unauthenticated auth flows 401 for a bad credential or a stale
+// reset/verify token (CM's verifyToken), not for a lost session — a stale
+// email link opened in a second tab must not sign out a live session.
+const AUTH_FLOW_PATHS = [
+	'/Login/',
+	'/ForgotPassword/',
+	'/ResetPassword/',
+	'/VerifyEmail/',
+	'/ResendVerificationEmail/',
+];
+
+let installed = false;
+
 /**
  * Install the 401 -> clear-auth interceptor on the CM api client. Call once at
- * app startup, before React mounts. On a lost session the cached cloud user is
+ * app startup, before React mounts; re-installs (HMR) are no-ops so duplicate
+ * interceptors can't stack. On a lost session the cached cloud user is
  * cleared, which re-runs the route guards and redirects to /sign-in.
  */
 export function installApiUnauthorizedRedirect(): void {
+	if (installed) {
+		return;
+	}
+	installed = true;
 	apiClient.interceptors.response.use(
 		(response) => response,
-		makeUnauthorizedResponseHandler(() => authStore.setUserForEntity(OverallAppSignIn, null)),
+		makeUnauthorizedResponseHandler(
+			() => authStore.setUserForEntity(OverallAppSignIn, null),
+			(url) => AUTH_FLOW_PATHS.some((path) => url.startsWith(path)),
+		),
 	);
 }

--- a/src/lib/installApiUnauthorizedRedirect.ts
+++ b/src/lib/installApiUnauthorizedRedirect.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/config/apiClient';
+import { authStore, OverallAppSignIn } from '@/features/auth/store/authStore';
+import { makeUnauthorizedResponseHandler } from '@/lib/unauthorizedResponseHandler';
+
+/**
+ * Install the 401 -> clear-auth interceptor on the CM api client. Call once at
+ * app startup, before React mounts. On a lost session the cached cloud user is
+ * cleared, which re-runs the route guards and redirects to /sign-in.
+ */
+export function installApiUnauthorizedRedirect(): void {
+	apiClient.interceptors.response.use(
+		(response) => response,
+		makeUnauthorizedResponseHandler(() => authStore.setUserForEntity(OverallAppSignIn, null)),
+	);
+}

--- a/src/lib/installApiUnauthorizedRedirect.ts
+++ b/src/lib/installApiUnauthorizedRedirect.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/config/apiClient';
+import { clearAuthStateLocally } from '@/features/auth/handlers/clearAuthStateLocally';
 import { authStore, OverallAppSignIn } from '@/features/auth/store/authStore';
 import { makeUnauthorizedResponseHandler } from '@/lib/unauthorizedResponseHandler';
 
@@ -13,24 +14,46 @@ const AUTH_FLOW_PATHS = [
 	'/ResendVerificationEmail/',
 ];
 
+// Config key stamped by the request interceptor with the cloud identity at send
+// time, so the response handler can tell whether the session has changed since.
+const AUTH_STAMP = 'authUserAtSend';
+
+// The cloud user's stable id, or null when signed out. LocalUser has no id.
+function currentCloudUserId(): string | null {
+	const user = authStore.getConnectionById(OverallAppSignIn).user;
+	return user && 'id' in user ? user.id : null;
+}
+
 let installed = false;
 
 /**
  * Install the 401 -> clear-auth interceptor on the CM api client. Call once at
  * app startup, before React mounts; re-installs (HMR) are no-ops so duplicate
- * interceptors can't stack. On a lost session the cached cloud user is
- * cleared, which re-runs the route guards and redirects to /sign-in.
+ * interceptors can't stack. On a lost session the cached auth is fully cleared
+ * (locally), which re-runs the route guards and redirects to /sign-in.
  */
 export function installApiUnauthorizedRedirect(): void {
 	if (installed) {
 		return;
 	}
 	installed = true;
+
+	// Stamp each request with the cloud identity at send time (see AUTH_STAMP).
+	apiClient.interceptors.request.use((config) => {
+		(config as typeof config & { [AUTH_STAMP]?: string | null })[AUTH_STAMP] = currentCloudUserId();
+		return config;
+	});
+
 	apiClient.interceptors.response.use(
 		(response) => response,
 		makeUnauthorizedResponseHandler(
-			() => authStore.setUserForEntity(OverallAppSignIn, null),
+			clearAuthStateLocally,
 			(url) => AUTH_FLOW_PATHS.some((path) => url.startsWith(path)),
+			// Only clear if the identity hasn't changed since the request was sent —
+			// don't let a slow 401 from the old session clear a fresh re-login.
+			(config) =>
+				(config as (typeof config & { [AUTH_STAMP]?: string | null }) | undefined)?.[AUTH_STAMP]
+					=== currentCloudUserId(),
 		),
 	);
 }

--- a/src/lib/unauthorizedResponseHandler.test.ts
+++ b/src/lib/unauthorizedResponseHandler.test.ts
@@ -1,0 +1,29 @@
+import type { AxiosError } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+import { makeUnauthorizedResponseHandler } from './unauthorizedResponseHandler';
+
+const errorWithStatus = (status?: number) =>
+	({ response: status === undefined ? undefined : { status } }) as AxiosError;
+
+describe('makeUnauthorizedResponseHandler', () => {
+	it('clears auth on 401 and still rejects with the original error', async () => {
+		const clearAuth = vi.fn();
+		const error = errorWithStatus(401);
+		await expect(makeUnauthorizedResponseHandler(clearAuth)(error)).rejects.toBe(error);
+		expect(clearAuth).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not clear auth on 403 (a legitimate permission denial)', async () => {
+		const clearAuth = vi.fn();
+		const error = errorWithStatus(403);
+		await expect(makeUnauthorizedResponseHandler(clearAuth)(error)).rejects.toBe(error);
+		expect(clearAuth).not.toHaveBeenCalled();
+	});
+
+	it('does not clear auth on a network error with no response', async () => {
+		const clearAuth = vi.fn();
+		const error = errorWithStatus(undefined);
+		await expect(makeUnauthorizedResponseHandler(clearAuth)(error)).rejects.toBe(error);
+		expect(clearAuth).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/unauthorizedResponseHandler.test.ts
+++ b/src/lib/unauthorizedResponseHandler.test.ts
@@ -26,4 +26,14 @@ describe('makeUnauthorizedResponseHandler', () => {
 		await expect(makeUnauthorizedResponseHandler(clearAuth)(error)).rejects.toBe(error);
 		expect(clearAuth).not.toHaveBeenCalled();
 	});
+
+	it('passes through an undefined rejection reason without throwing', async () => {
+		// An upstream interceptor could reject with a non-AxiosError (even undefined);
+		// the handler must re-reject with it as-is, not with its own TypeError.
+		const clearAuth = vi.fn();
+		await expect(makeUnauthorizedResponseHandler(clearAuth)(undefined as unknown as AxiosError)).rejects.toBe(
+			undefined,
+		);
+		expect(clearAuth).not.toHaveBeenCalled();
+	});
 });

--- a/src/lib/unauthorizedResponseHandler.test.ts
+++ b/src/lib/unauthorizedResponseHandler.test.ts
@@ -2,8 +2,11 @@ import type { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 import { makeUnauthorizedResponseHandler } from './unauthorizedResponseHandler';
 
-const errorWithStatus = (status?: number) =>
-	({ response: status === undefined ? undefined : { status } }) as AxiosError;
+const errorWithStatus = (status?: number, url?: string) =>
+	({
+		response: status === undefined ? undefined : { status },
+		config: url === undefined ? undefined : { url },
+	}) as AxiosError;
 
 describe('makeUnauthorizedResponseHandler', () => {
 	it('clears auth on 401 and still rejects with the original error', async () => {
@@ -25,6 +28,32 @@ describe('makeUnauthorizedResponseHandler', () => {
 		const error = errorWithStatus(undefined);
 		await expect(makeUnauthorizedResponseHandler(clearAuth)(error)).rejects.toBe(error);
 		expect(clearAuth).not.toHaveBeenCalled();
+	});
+
+	it('does not clear auth on a 401 from an exempt URL (unauthenticated auth flows)', async () => {
+		// A stale reset/verify-email link opened in a second tab 401s with "bad
+		// token" — that must not sign out a live session.
+		const clearAuth = vi.fn();
+		const isExempt = (url: string) => url.startsWith('/ResetPassword/');
+		const error = errorWithStatus(401, '/ResetPassword/');
+		await expect(makeUnauthorizedResponseHandler(clearAuth, isExempt)(error)).rejects.toBe(error);
+		expect(clearAuth).not.toHaveBeenCalled();
+	});
+
+	it('clears auth on a 401 from a non-exempt URL', async () => {
+		const clearAuth = vi.fn();
+		const isExempt = (url: string) => url.startsWith('/ResetPassword/');
+		const error = errorWithStatus(401, '/Organization/');
+		await expect(makeUnauthorizedResponseHandler(clearAuth, isExempt)(error)).rejects.toBe(error);
+		expect(clearAuth).toHaveBeenCalledTimes(1);
+	});
+
+	it('treats a 401 with no request config as non-exempt (fail toward sign-out)', async () => {
+		const clearAuth = vi.fn();
+		const isExempt = (url: string) => url.startsWith('/ResetPassword/');
+		const error = errorWithStatus(401); // no config
+		await expect(makeUnauthorizedResponseHandler(clearAuth, isExempt)(error)).rejects.toBe(error);
+		expect(clearAuth).toHaveBeenCalledTimes(1);
 	});
 
 	it('passes through an undefined rejection reason without throwing', async () => {

--- a/src/lib/unauthorizedResponseHandler.test.ts
+++ b/src/lib/unauthorizedResponseHandler.test.ts
@@ -2,10 +2,10 @@ import type { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 import { makeUnauthorizedResponseHandler } from './unauthorizedResponseHandler';
 
-const errorWithStatus = (status?: number, url?: string) =>
+const errorWithStatus = (status?: number, url?: string, config?: Record<string, unknown>) =>
 	({
 		response: status === undefined ? undefined : { status },
-		config: url === undefined ? undefined : { url },
+		config: config ?? (url === undefined ? undefined : { url }),
 	}) as AxiosError;
 
 describe('makeUnauthorizedResponseHandler', () => {
@@ -54,6 +54,35 @@ describe('makeUnauthorizedResponseHandler', () => {
 		const error = errorWithStatus(401); // no config
 		await expect(makeUnauthorizedResponseHandler(clearAuth, isExempt)(error)).rejects.toBe(error);
 		expect(clearAuth).toHaveBeenCalledTimes(1);
+	});
+
+	describe('auth-generation guard (isStillCurrent)', () => {
+		// Simulates the identity stamp: the request carries the user it was sent
+		// under; the handler compares against whoever is current at response time.
+		const handlerFor = (currentUserId: () => string | null, clearAuth = vi.fn()) => ({
+			clearAuth,
+			handler: makeUnauthorizedResponseHandler(
+				clearAuth,
+				() => false,
+				(config) => (config as { authUserAtSend?: string | null } | undefined)?.authUserAtSend === currentUserId(),
+			),
+		});
+
+		it('clears when the identity is unchanged since the request was sent (normal expiry)', async () => {
+			const { clearAuth, handler } = handlerFor(() => 'userA');
+			const error = errorWithStatus(401, undefined, { url: '/Organization/', authUserAtSend: 'userA' });
+			await expect(handler(error)).rejects.toBe(error);
+			expect(clearAuth).toHaveBeenCalledTimes(1);
+		});
+
+		it('does NOT clear when a re-login changed the identity (slow 401 from the old session)', async () => {
+			// A expired → 401 handled → re-login as B. B's earlier in-flight request
+			// (sent as A) now 401s; current identity is B, so it must be ignored.
+			const { clearAuth, handler } = handlerFor(() => 'userB');
+			const staleError = errorWithStatus(401, undefined, { url: '/Organization/', authUserAtSend: 'userA' });
+			await expect(handler(staleError)).rejects.toBe(staleError);
+			expect(clearAuth).not.toHaveBeenCalled();
+		});
 	});
 
 	it('passes through an undefined rejection reason without throwing', async () => {

--- a/src/lib/unauthorizedResponseHandler.ts
+++ b/src/lib/unauthorizedResponseHandler.ts
@@ -1,0 +1,26 @@
+import type { AxiosError } from 'axios';
+
+/**
+ * Build an axios response-error handler that runs `clearAuth` on a 401.
+ *
+ * A 401 from the CM API means the cloud session is gone — expired, revoked, or
+ * (for fabric admins) past its configured max age. Clearing the cached auth lets
+ * the route guards re-run and redirect to /sign-in, instead of leaving the SPA
+ * on a stale user while every data call fails until a manual refresh.
+ *
+ * Only 401 (unauthenticated) is treated as a lost session. 403 is deliberately
+ * left alone: it is a legitimate "authenticated but not permitted" response and
+ * must not sign the user out.
+ *
+ * Kept free of app imports (auth store, api client) so it unit-tests in the
+ * default node env without pulling in browser-only globals.
+ */
+export function makeUnauthorizedResponseHandler(clearAuth: () => void) {
+	return (error: AxiosError): Promise<never> => {
+		if (error.response?.status === 401) {
+			clearAuth();
+		}
+		// Re-reject so individual callers still see (and can handle) the error.
+		return Promise.reject(error);
+	};
+}

--- a/src/lib/unauthorizedResponseHandler.ts
+++ b/src/lib/unauthorizedResponseHandler.ts
@@ -1,4 +1,4 @@
-import type { AxiosError } from 'axios';
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 /**
  * Build an axios response-error handler that runs `clearAuth` on a 401.
@@ -12,7 +12,10 @@ import type { AxiosError } from 'axios';
  * left alone: it is a legitimate "authenticated but not permitted" response and
  * must not sign the user out. `isExemptUrl` lets the installer skip endpoints
  * whose 401s mean "bad credentials/token" rather than a lost session (the
- * unauthenticated auth flows).
+ * unauthenticated auth flows). `isStillCurrent` guards the auth-generation race:
+ * a slow 401 from a request sent under the OLD session must not clear a session
+ * the user has since re-established (A expires → 401 → re-login as B → B's
+ * earlier in-flight request 401s and would otherwise sign B out).
  *
  * Kept free of app imports (auth store, api client) so it unit-tests in the
  * default node env without pulling in browser-only globals.
@@ -20,12 +23,17 @@ import type { AxiosError } from 'axios';
 export function makeUnauthorizedResponseHandler(
 	clearAuth: () => void,
 	isExemptUrl: (url: string) => boolean = () => false,
+	isStillCurrent: (config: InternalAxiosRequestConfig | undefined) => boolean = () => true,
 ) {
 	return (error: AxiosError): Promise<never> => {
 		// `error?.`: axios itself always rejects with an AxiosError, but an upstream
 		// interceptor added later could reject with anything (even undefined) — don't
 		// let this handler replace the rejection reason with its own TypeError.
-		if (error?.response?.status === 401 && !isExemptUrl(error.config?.url ?? '')) {
+		if (
+			error?.response?.status === 401
+			&& !isExemptUrl(error.config?.url ?? '')
+			&& isStillCurrent(error.config)
+		) {
 			clearAuth();
 		}
 		// Re-reject so individual callers still see (and can handle) the error.

--- a/src/lib/unauthorizedResponseHandler.ts
+++ b/src/lib/unauthorizedResponseHandler.ts
@@ -17,7 +17,10 @@ import type { AxiosError } from 'axios';
  */
 export function makeUnauthorizedResponseHandler(clearAuth: () => void) {
 	return (error: AxiosError): Promise<never> => {
-		if (error.response?.status === 401) {
+		// `error?.`: axios itself always rejects with an AxiosError, but an upstream
+		// interceptor added later could reject with anything (even undefined) — don't
+		// let this handler replace the rejection reason with its own TypeError.
+		if (error?.response?.status === 401) {
 			clearAuth();
 		}
 		// Re-reject so individual callers still see (and can handle) the error.

--- a/src/lib/unauthorizedResponseHandler.ts
+++ b/src/lib/unauthorizedResponseHandler.ts
@@ -10,17 +10,22 @@ import type { AxiosError } from 'axios';
  *
  * Only 401 (unauthenticated) is treated as a lost session. 403 is deliberately
  * left alone: it is a legitimate "authenticated but not permitted" response and
- * must not sign the user out.
+ * must not sign the user out. `isExemptUrl` lets the installer skip endpoints
+ * whose 401s mean "bad credentials/token" rather than a lost session (the
+ * unauthenticated auth flows).
  *
  * Kept free of app imports (auth store, api client) so it unit-tests in the
  * default node env without pulling in browser-only globals.
  */
-export function makeUnauthorizedResponseHandler(clearAuth: () => void) {
+export function makeUnauthorizedResponseHandler(
+	clearAuth: () => void,
+	isExemptUrl: (url: string) => boolean = () => false,
+) {
 	return (error: AxiosError): Promise<never> => {
 		// `error?.`: axios itself always rejects with an AxiosError, but an upstream
 		// interceptor added later could reject with anything (even undefined) — don't
 		// let this handler replace the rejection reason with its own TypeError.
-		if (error?.response?.status === 401) {
+		if (error?.response?.status === 401 && !isExemptUrl(error.config?.url ?? '')) {
 			clearAuth();
 		}
 		// Re-reject so individual callers still see (and can handle) the error.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { App } from '@/App';
+import { installApiUnauthorizedRedirect } from '@/lib/installApiUnauthorizedRedirect';
 import { installBrowserTranslationDomGuard } from '@/lib/installBrowserTranslationDomGuard';
 import { installStaleDeployReload } from '@/lib/installStaleDeployReload';
 import { addReactError } from '@datadog/browser-rum-react';
@@ -12,6 +13,9 @@ installBrowserTranslationDomGuard();
 // Reload once when a redeploy invalidates this tab's hashed chunks, instead of
 // leaving routes and Monaco language workers broken for the session (issue #1406).
 installStaleDeployReload();
+// Redirect to /sign-in when a CM call returns 401 (lost/expired session), instead
+// of leaving the SPA on a stale user while every data call fails.
+installApiUnauthorizedRedirect();
 
 createRoot(
 	document.getElementById('root')!,


### PR DESCRIPTION
> **Draft** — companion to the central-manager fabric-admin session work (`fabric-admin-auth-hardening`, adds a `FABRIC_ADMIN_SESSION_MAX_AGE_HOURS` cap). Keeping this in draft until that lands. Useful on its own, though — it fixes the client reaction to *any* lost session.

## Problem
The CM `apiClient` ([apiClient.ts](src/config/apiClient.ts)) has no response interceptor, and the dashboard guard ([dashboardRoute.ts](src/router/dashboardRoute.ts)) only redirects when the cached `authStore` user is already `null`. So when a cloud session is lost mid-use — normal cookie expiry, server-side revocation, or a fabric admin hitting the new max-age cap — the SPA keeps rendering off the **stale cached user** while every data call fails with `Not allowed` errors. The user isn't bounced to sign-in until they manually refresh (which re-runs `getCurrentUser`, gets 401, and empties the store).

Verified live on dev: after a fabric-admin session was invalidated server-side, the UI kept navigating (cached `authStore`) and only redirected on a hard refresh.

## Fix
Add a response interceptor on `apiClient`: on **401**, clear the cached cloud auth (`authStore.setUserForEntity(OverallAppSignIn, null)`). That triggers the existing `AppRouted` `router.invalidate()` effect → guards re-run → redirect to `/sign-in`. No imperative router access needed.

**Only 401** triggers it. A dead session yields 401 from `GET /User/current` (its `allowRead` returns false when there's no user). **403 is left alone** — it's a legitimate "authenticated but not permitted" response and must not log the user out.

## Where to look
- `src/lib/unauthorizedResponseHandler.ts` — the 401 detection, factored app-import-free so it unit-tests in node env (importing `authStore` pulls in `localStorage` at module load).
- `src/lib/installApiUnauthorizedRedirect.ts` — wires it to `apiClient` with the authStore-clearing callback.
- `src/main.tsx` — installed at startup alongside the other `install*` guards.

## Testing
- `vitest run src/lib/unauthorizedResponseHandler.test.ts` — 3 passing (401 clears + rejects; 403 doesn't; network error doesn't).
- Not yet covered: the full interceptor→guard→redirect path in a running app. Worth a manual check once merged with the CM cap (sign in, let the session expire, confirm auto-redirect without a manual refresh).

## Open question for reviewers
403s from a dead session (admin endpoints return `Not allowed`/403, not 401) won't trigger this. Keying on 401 only is the safe choice (avoids logging out on genuine permission denials), but it means a data call that only ever 403s won't itself force logout — the redirect comes from the next 401-returning call (e.g. `getCurrentUser` on focus/refetch). Flagging in case we want 403-on-`/User/current` handling too.

_Generated with the assistance of an LLM (Claude Opus 4.8)._