### PR TITLE
feat(users): make removing a user from an organization intuitive

### DIFF
--- a/src/features/organization/users/components/RemoveUserFromOrgButton.test.tsx
+++ b/src/features/organization/users/components/RemoveUserFromOrgButton.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { RemoveUserFromOrgButton } from '@/features/organization/users/components/RemoveUserFromOrgButton';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('RemoveUserFromOrgButton', () => {
+	it('removing another user: shows "Remove from organization" and confirms in place', () => {
+		const onConfirm = vi.fn();
+		render(<RemoveUserFromOrgButton isSelf={false} isPending={false} onConfirm={onConfirm} />);
+
+		const trigger = screen.getByRole('button', { name: /remove from organization/i });
+		expect(screen.queryByRole('button', { name: /^cancel$/i })).toBeNull();
+
+		// First click reveals the confirm step (with a warning) without firing the removal.
+		fireEvent.click(trigger);
+		expect(onConfirm).not.toHaveBeenCalled();
+		expect(screen.getByRole('button', { name: /confirm removal/i })).toBeTruthy();
+		expect(screen.getByRole('button', { name: /^cancel$/i })).toBeTruthy();
+		expect(screen.getByRole('alert').textContent).toMatch(/revokes their access/i);
+
+		// Second click confirms.
+		fireEvent.click(screen.getByRole('button', { name: /confirm removal/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it('removing yourself: uses gentler "leave" wording', () => {
+		const onConfirm = vi.fn();
+		render(<RemoveUserFromOrgButton isSelf={true} isPending={false} onConfirm={onConfirm} />);
+
+		fireEvent.click(screen.getByRole('button', { name: /leave organization/i }));
+		expect(screen.getByRole('button', { name: /confirm leave/i })).toBeTruthy();
+		expect(screen.getByRole('alert').textContent).toMatch(/you’ll lose access/i);
+		// The self flow never says "remove".
+		expect(screen.queryByRole('button', { name: /remove/i })).toBeNull();
+
+		fireEvent.click(screen.getByRole('button', { name: /confirm leave/i }));
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+
+	it('cancel returns to the idle state without confirming', () => {
+		const onConfirm = vi.fn();
+		render(<RemoveUserFromOrgButton isSelf={false} isPending={false} onConfirm={onConfirm} />);
+
+		fireEvent.click(screen.getByRole('button', { name: /remove from organization/i }));
+		fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+		expect(onConfirm).not.toHaveBeenCalled();
+		expect(screen.getByRole('button', { name: /remove from organization/i })).toBeTruthy();
+		expect(screen.queryByRole('button', { name: /confirm removal/i })).toBeNull();
+	});
+
+	it('while a removal is pending both buttons are disabled and show busy copy', () => {
+		const onConfirm = vi.fn();
+		const { rerender } = render(
+			<RemoveUserFromOrgButton isSelf={false} isPending={false} onConfirm={onConfirm} />,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /remove from organization/i }));
+		rerender(<RemoveUserFromOrgButton isSelf={false} isPending={true} onConfirm={onConfirm} />);
+
+		const confirm = screen.getByRole('button', { name: /removing/i });
+		const cancel = screen.getByRole('button', { name: /^cancel$/i });
+		expect(confirm.hasAttribute('disabled')).toBe(true);
+		expect(cancel.hasAttribute('disabled')).toBe(true);
+
+		fireEvent.click(confirm);
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/organization/users/components/RemoveUserFromOrgButton.tsx
+++ b/src/features/organization/users/components/RemoveUserFromOrgButton.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@/components/ui/button';
+import { LogOut, TriangleAlertIcon, UserMinus } from 'lucide-react';
+import { useState } from 'react';
+
+/**
+ * A user belongs to an org purely by having org roles, so "removing" them means dropping all
+ * of those roles at once. That's a destructive, non-obvious action (see issue #1505), so this
+ * button makes it explicit and requires a second, deliberate click to confirm — the same inline
+ * confirmation pattern used for deleting secrets (see `SecretModals`). Removing yourself is the
+ * same action with gentler "leave" wording.
+ *
+ * The confirm control is intentionally right-aligned, away from the idle button's left-aligned
+ * footprint, so a fast double-click can't land on "Confirm" and skip the confirmation step.
+ */
+export function RemoveUserFromOrgButton({
+	isSelf,
+	isPending,
+	onConfirm,
+}: {
+	isSelf: boolean;
+	isPending: boolean;
+	onConfirm: () => void;
+}) {
+	const [confirming, setConfirming] = useState(false);
+
+	const copy = isSelf
+		? {
+			idle: 'Leave organization',
+			confirm: 'Confirm leave',
+			busy: 'Leaving…',
+			warning:
+				'You’ll lose access to this organization and everything in it. You won’t be able to return unless another member invites you back.',
+		}
+		: {
+			idle: 'Remove from organization',
+			confirm: 'Confirm removal',
+			busy: 'Removing…',
+			warning:
+				'This revokes their access to this organization and everything in it. Their Harper account isn’t deleted, and they can be added back later.',
+		};
+	const Icon = isSelf ? LogOut : UserMinus;
+
+	if (!confirming) {
+		return (
+			<div className="flex justify-start">
+				<Button
+					type="button"
+					variant="destructiveOutline"
+					disabled={isPending}
+					onClick={() => setConfirming(true)}
+				>
+					<Icon /> {copy.idle}
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			<p
+				role="alert"
+				className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3"
+			>
+				<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
+				<span>{copy.warning}</span>
+			</p>
+			<div className="flex justify-end gap-2">
+				<Button
+					type="button"
+					variant="ghostOutline"
+					disabled={isPending}
+					onClick={() => setConfirming(false)}
+				>
+					Cancel
+				</Button>
+				<Button
+					type="button"
+					variant="destructive"
+					disabled={isPending}
+					onClick={onConfirm}
+					autoFocus
+				>
+					<Icon /> {isPending ? copy.busy : copy.confirm}
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/features/organization/users/components/RemoveUserFromOrgButton.tsx
+++ b/src/features/organization/users/components/RemoveUserFromOrgButton.tsx
@@ -73,12 +73,12 @@ export function RemoveUserFromOrgButton({
 				>
 					Cancel
 				</Button>
+				{/* Not autoFocused: focus on the destructive button would let a stray Enter or double-click confirm. */}
 				<Button
 					type="button"
 					variant="destructive"
 					disabled={isPending}
 					onClick={onConfirm}
-					autoFocus
 				>
 					<Icon /> {isPending ? copy.busy : copy.confirm}
 				</Button>

--- a/src/features/organization/users/index.tsx
+++ b/src/features/organization/users/index.tsx
@@ -7,6 +7,7 @@ import { getOrganizationRolesQueryOptions } from '@/features/organization/querie
 import { dataTableColumns } from '@/features/organization/users/constants/tableDefinition';
 import { AddUserModal } from '@/features/organization/users/modals/AddUserModal';
 import { EditUserModal } from '@/features/organization/users/modals/EditUserModal';
+import { isAdminRoleName } from '@/features/organization/users/orgUserRemovalPolicy';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
 import { SchemaUser } from '@/integrations/api/api.gen';
@@ -40,6 +41,20 @@ export function OrgConfigUsersIndex() {
 			}
 		}
 		return Object.values(users).sort(sortByEmail);
+	}, [organizationRoles]);
+
+	// Distinct members holding an admin role — used to keep the last admin from removing their own
+	// admin role or leaving (which would leave the org with no one able to manage it).
+	const orgAdminCount = useMemo(() => {
+		const adminUserIds = new Set<SchemaUser['id']>();
+		for (const organizationRole of organizationRoles) {
+			if (isAdminRoleName(organizationRole.roleName)) {
+				for (const user of organizationRole.users ?? []) {
+					adminUserIds.add(user.id);
+				}
+			}
+		}
+		return adminUserIds.size;
 	}, [organizationRoles]);
 
 	const selectedUser = useMemo(() => cloudUsers?.find((user) => user.id === orgUserId), [cloudUsers, orgUserId]);
@@ -139,6 +154,8 @@ export function OrgConfigUsersIndex() {
 							data={selectedUser}
 							isModalOpen={isEditModalOpen}
 							onUserUpdated={onUserUpdated}
+							orgUserCount={cloudUsers.length}
+							orgAdminCount={orgAdminCount}
 						/>
 					)}
 				</Suspense>

--- a/src/features/organization/users/modals/EditUserModal.tsx
+++ b/src/features/organization/users/modals/EditUserModal.tsx
@@ -59,7 +59,7 @@ export function EditUserModal({
 			roles.map((role) => removeUserFromRole({ userId: data.id, roleId: role.id })),
 		);
 		const failed = results.some(
-			(result) => result.status === 'rejected' && (result.reason as AxiosError)?.status !== 404,
+			(result) => result.status === 'rejected' && (result.reason as AxiosError)?.response?.status !== 404,
 		);
 		if (failed) {
 			toast.error(

--- a/src/features/organization/users/modals/EditUserModal.tsx
+++ b/src/features/organization/users/modals/EditUserModal.tsx
@@ -1,31 +1,83 @@
 import { Loading } from '@/components/Loading';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useRemoveUserFromOrganizationRole } from '@/features/organization/mutations/removeUserFromOrganizationRole';
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { OrgUserRoleCheckbox } from '@/features/organization/users/components/OrgUserRoleCheckbox';
+import { RemoveUserFromOrgButton } from '@/features/organization/users/components/RemoveUserFromOrgButton';
+import { getOrgUserRemovalPolicy, isAdminRoleName } from '@/features/organization/users/orgUserRemovalPolicy';
 import { useCloudAuth } from '@/hooks/useAuth';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { SchemaUser } from '@/integrations/api/api.gen';
 import { keyBy } from '@/lib/keyBy';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { Suspense, useMemo, useState } from 'react';
+import { AxiosError } from 'axios';
+import { TriangleAlertIcon } from 'lucide-react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 
 export function EditUserModal({
 	closeModal,
 	data,
 	isModalOpen,
 	onUserUpdated,
+	orgUserCount,
+	orgAdminCount,
 }: {
 	closeModal: () => void;
 	data: SchemaUser;
 	isModalOpen: boolean;
 	onUserUpdated: () => void;
+	orgUserCount: number;
+	orgAdminCount: number;
 }) {
 	const { organizationId }: { organizationId: string } = useParams({ strict: false });
 	const auth = useCloudAuth();
 	const { update, remove } = useOrganizationRolePermissions(organizationId);
 	const isSelf = auth.user?.email === data.email;
 	const [changesMade, setChangesMade] = useState<boolean>(false);
+
+	const { canRemoveRoles, showRemovalAction, blockedReason } = getOrgUserRemovalPolicy({
+		canDelete: remove,
+		isSelf,
+		orgUserCount,
+		adminCount: orgAdminCount,
+		isAdmin: (data.roles ?? []).some((role) => isAdminRoleName(role.roleName)),
+		roleCount: data.roles?.length ?? 0,
+	});
+
+	const { mutateAsync: removeUserFromRole } = useRemoveUserFromOrganizationRole();
+	const [isRemoving, setIsRemoving] = useState(false);
+
+	// Removing a user from the org means dropping every role they hold in it. We fire one removal
+	// per role; a role that's already gone (404) is treated as success so a partially-completed
+	// attempt can be retried cleanly.
+	const onRemoveFromOrg = useCallback(async () => {
+		const roles = data.roles ?? [];
+		setIsRemoving(true);
+		const results = await Promise.allSettled(
+			roles.map((role) => removeUserFromRole({ userId: data.id, roleId: role.id })),
+		);
+		const failed = results.some(
+			(result) => result.status === 'rejected' && (result.reason as AxiosError)?.status !== 404,
+		);
+		if (failed) {
+			toast.error(
+				isSelf
+					? 'Something went wrong leaving the organization. Please try again.'
+					: `Couldn’t remove ${data.email} from the organization. Please try again.`,
+			);
+		} else {
+			toast.success(
+				isSelf
+					? 'You’ve left the organization.'
+					: `${data.email} was removed from the organization.`,
+			);
+		}
+		// Refetch either way so the list reflects whatever actually changed, then close.
+		setIsRemoving(false);
+		onUserUpdated();
+	}, [data.roles, data.id, data.email, isSelf, removeUserFromRole, onUserUpdated]);
 
 	// TODO: Cancel invite
 	return (
@@ -37,7 +89,11 @@ export function EditUserModal({
 
 				{update && (
 					<DialogDescription>
-						To remove {isSelf ? 'your self' : 'this user'} from the organization, uncheck all of the boxes below.
+						Use the checkboxes to change which roles {isSelf ? 'you have' : 'this user has'}.
+						{showRemovalAction
+							&& (isSelf
+								? ' To leave the organization entirely, use the button below.'
+								: ' To remove this user from the organization entirely, use the button below.')}
 					</DialogDescription>
 				)}
 
@@ -47,10 +103,31 @@ export function EditUserModal({
 						data={data}
 						organizationId={organizationId}
 						update={update}
-						remove={remove}
+						canRemove={canRemoveRoles}
 						setChangesMade={setChangesMade}
 					/>
 				</Suspense>
+
+				{showRemovalAction && (
+					<div className="border-t border-border pt-4">
+						<RemoveUserFromOrgButton isSelf={isSelf} isPending={isRemoving} onConfirm={onRemoveFromOrg} />
+					</div>
+				)}
+
+				{blockedReason && (
+					<p className="flex items-start gap-2 text-sm text-muted-foreground border border-amber-500/50 rounded-md p-3">
+						<TriangleAlertIcon className="size-4 text-amber-500 shrink-0 mt-0.5" />
+						<span>
+							{blockedReason === 'sole-member'
+								? `You’re the only member of this organization, so you can’t remove your roles or leave — it would be `
+									+ `left with no one to manage it. If you no longer need this organization, terminate its clusters, then `
+									+ `delete the organization from the ⋯ menu on the Organizations page.`
+								: `You’re the only admin of this organization, so you can’t remove your roles or leave — it would be left `
+									+ `with no one who can manage its members, roles, or clusters. Give another member the admin role first, `
+									+ `then you can step back.`}
+						</span>
+					</p>
+				)}
 			</DialogContent>
 		</Dialog>
 	);
@@ -60,13 +137,13 @@ function EditUserRolesList({
 	data,
 	organizationId,
 	update,
-	remove,
+	canRemove,
 	setChangesMade,
 }: {
 	data: SchemaUser;
 	organizationId: string;
 	update: boolean;
-	remove: boolean;
+	canRemove: boolean;
 	setChangesMade: (value: boolean) => void;
 }) {
 	const { data: orgRoles } = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
@@ -78,7 +155,7 @@ function EditUserRolesList({
 				<OrgUserRoleCheckbox
 					key={orgRole.id}
 					readOnly={!update}
-					canRemove={remove}
+					canRemove={canRemove}
 					data={data}
 					orgRole={orgRole}
 					selectedRoles={selectedRoles}

--- a/src/features/organization/users/orgUserRemovalPolicy.test.ts
+++ b/src/features/organization/users/orgUserRemovalPolicy.test.ts
@@ -1,0 +1,86 @@
+import { getOrgUserRemovalPolicy, isAdminRoleName } from '@/features/organization/users/orgUserRemovalPolicy';
+import { describe, expect, it } from 'vitest';
+
+// Sensible defaults for a plain, unblocked case; each test overrides what it cares about.
+const base = { canDelete: true, isSelf: false, orgUserCount: 3, adminCount: 2, isAdmin: false, roleCount: 1 };
+
+describe('isAdminRoleName', () => {
+	it('matches "admin" case-insensitively and trims whitespace', () => {
+		expect(isAdminRoleName('admin')).toBe(true);
+		expect(isAdminRoleName('Admin')).toBe(true);
+		expect(isAdminRoleName('  ADMIN  ')).toBe(true);
+	});
+
+	it('does not match other role names', () => {
+		expect(isAdminRoleName('administrator')).toBe(false);
+		expect(isAdminRoleName('new_role')).toBe(false);
+		expect(isAdminRoleName('')).toBe(false);
+		expect(isAdminRoleName(undefined)).toBe(false);
+	});
+});
+
+describe('getOrgUserRemovalPolicy', () => {
+	it('lets an admin remove another user who holds roles', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: false }))
+			.toEqual({ canRemoveRoles: true, showRemovalAction: true, blockedReason: null });
+	});
+
+	it('lets you leave when other members and other admins remain', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: true, orgUserCount: 3, adminCount: 2 }))
+			.toEqual({ canRemoveRoles: true, showRemovalAction: true, blockedReason: null });
+	});
+
+	it('blocks the sole member with the sole-member notice', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: true, orgUserCount: 1, adminCount: 1 }))
+			.toEqual({ canRemoveRoles: false, showRemovalAction: false, blockedReason: 'sole-member' });
+	});
+
+	it('blocks the last admin even when other (non-admin) members remain', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: true, orgUserCount: 4, adminCount: 1 }))
+			.toEqual({ canRemoveRoles: false, showRemovalAction: false, blockedReason: 'last-admin' });
+	});
+
+	it('prefers the sole-member reason when you are both the only member and the only admin', () => {
+		expect(
+			getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: true, orgUserCount: 1, adminCount: 1 }).blockedReason,
+		)
+			.toBe('sole-member');
+	});
+
+	it('does not block a non-admin self when other members remain', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: false, orgUserCount: 3, adminCount: 2 }))
+			.toEqual({ canRemoveRoles: true, showRemovalAction: true, blockedReason: null });
+	});
+
+	it('does not block a self admin when another admin exists', () => {
+		expect(
+			getOrgUserRemovalPolicy({ ...base, isSelf: true, isAdmin: true, orgUserCount: 3, adminCount: 2 }).blockedReason,
+		)
+			.toBe(null);
+	});
+
+	it('never blocks when acting on another user, even in a one-member org', () => {
+		// A fabric admin cleaning up someone else's solo org is never the "leave yourself" case.
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: false, orgUserCount: 1, adminCount: 1 }))
+			.toEqual({ canRemoveRoles: true, showRemovalAction: true, blockedReason: null });
+	});
+
+	it('hides everything (no notice) when the actor lacks delete permission', () => {
+		expect(
+			getOrgUserRemovalPolicy({
+				...base,
+				canDelete: false,
+				isSelf: true,
+				orgUserCount: 1,
+				adminCount: 1,
+				isAdmin: true,
+			}),
+		)
+			.toEqual({ canRemoveRoles: false, showRemovalAction: false, blockedReason: null });
+	});
+
+	it('allows removal in principle but hides the action when the user holds no roles', () => {
+		expect(getOrgUserRemovalPolicy({ ...base, isSelf: false, roleCount: 0 }))
+			.toEqual({ canRemoveRoles: true, showRemovalAction: false, blockedReason: null });
+	});
+});

--- a/src/features/organization/users/orgUserRemovalPolicy.ts
+++ b/src/features/organization/users/orgUserRemovalPolicy.ts
@@ -1,0 +1,61 @@
+/**
+ * Decides what an admin (or the user themselves) may do to an org membership in the Edit User
+ * modal. A user belongs to an org only by holding org roles, so removing their last role — or
+ * their admin role — is equivalent to removing them from the org.
+ *
+ * Two edge cases would orphan the organization when acting on yourself, so both block role
+ * removal / leaving and show a notice with the real way out:
+ *   - sole member: no one would be left in the org at all.
+ *   - last admin:  members would remain, but no one could manage them (or the clusters).
+ *
+ * "Admin" is matched by role name (see `isAdminRoleName`) — a deliberately simple heuristic that
+ * needs no per-role permission lookup. It can miss a custom-named admin role; the server remains
+ * the source of truth, this is just a guard rail.
+ */
+export interface OrgUserRemovalPolicy {
+	/** Whether individual role checkboxes may be unchecked (i.e. roles removed). */
+	canRemoveRoles: boolean;
+	/** Whether to show the explicit "Remove from organization" / "Leave organization" action. */
+	showRemovalAction: boolean;
+	/** Why removal is blocked for the acting user, if it is — drives which notice to show. */
+	blockedReason: 'sole-member' | 'last-admin' | null;
+}
+
+/** A role grants org administration if it is literally named "admin" (case-insensitive). */
+export function isAdminRoleName(roleName: string | undefined): boolean {
+	return roleName?.trim().toLowerCase() === 'admin';
+}
+
+export function getOrgUserRemovalPolicy({
+	canDelete,
+	isSelf,
+	orgUserCount,
+	adminCount,
+	isAdmin,
+	roleCount,
+}: {
+	/** The acting user has the org-role delete permission. */
+	canDelete: boolean;
+	/** The membership being edited is the acting user's own. */
+	isSelf: boolean;
+	/** Number of distinct members in the organization. */
+	orgUserCount: number;
+	/** Number of distinct members holding an admin role. */
+	adminCount: number;
+	/** The edited user holds an admin role. */
+	isAdmin: boolean;
+	/** Number of roles the edited user currently holds in the org. */
+	roleCount: number;
+}): OrgUserRemovalPolicy {
+	const isSoleMember = isSelf && orgUserCount <= 1;
+	const isLastAdmin = isSelf && isAdmin && adminCount <= 1;
+	// Sole-member takes priority: with no one else in the org, promoting another admin isn't an
+	// option, so we point them at deleting the org rather than at handing off admin.
+	const blockedReason = !canDelete ? null : isSoleMember ? 'sole-member' : isLastAdmin ? 'last-admin' : null;
+	const canRemoveRoles = canDelete && blockedReason === null;
+	return {
+		canRemoveRoles,
+		showRemovalAction: canRemoveRoles && roleCount > 0,
+		blockedReason,
+	};
+}


### PR DESCRIPTION
Closes #1505.

## Problem
A user belongs to an organization only by virtue of holding org roles, so there was no obvious way to remove someone — you had to open the Edit User modal and *un-check every role box*, with a one-line hint as the only guidance. The issue reporter spent ~15 minutes clicking around before asking Slack AI. (Nothing actually said "delete", but the flow was undiscoverable.)

## What this does
- **Explicit action.** Adds a clear **Remove from organization** button to the Edit User modal (self: **Leave organization**). The role checkboxes remain for granular role changes.
- **No "delete" language.** We're revoking org access, not deleting the account — wording and toasts say "removed from the organization" / "you've left the organization".
- **Self vs. other wording**, keyed off the existing `isSelf` check (user-minus icon vs. log-out icon; "this user" vs. "you").
- **Inline two-step confirm** (following the `SecretModals` precedent). First click reveals a warning explaining the consequence plus a **Cancel / Confirm** pair. The confirm control is right-aligned — away from the initial button's footprint — so a fast double-click can't skip confirmation.
- **Guards against orphaning the org** (self only), with actionable guidance instead of a dead end:
  - **Sole member** → can't remove roles or leave; notice points to tearing down clusters and deleting the org.
  - **Last admin** (other members remain, but you're the only one who can manage them) → can't remove roles or leave; notice says to give another member the admin role first.
  - "Admin" is matched by role name (`admin`, case-insensitive) — a lightweight heuristic; the server remains the source of truth.
- **Extracts the rules** into a pure, unit-tested `getOrgUserRemovalPolicy()` so the "when can we remove" logic is easy to reason about and regression-proof.

## Removal mechanics
Removing a user fires one role-removal per role via `Promise.allSettled`; an already-gone role (404) is treated as success so a partial attempt can be retried cleanly. The list refetches afterward either way.

## Testing
- New unit tests: `orgUserRemovalPolicy.test.ts` (12 cases across the sole-member / last-admin / permission / role-count matrix) and `RemoveUserFromOrgButton.test.tsx` (wording per self/other, two-step confirm, cancel resets, disabled-while-pending).
- Full suite green: **227 files, 1575 passed** (11 skipped). `tsc` and oxlint clean.
- Verified in a local preview against real cluster data: sole-member notice + disabled checkbox; non-admin self in a healthy multi-admin org can leave; removing another user still works. (No real membership was changed — final confirm was never clicked.)

## Note for reviewers
Removal requires the org-role **delete** permission (same gate as un-checking a box today), so a view-only member can't self-leave — parity with current behavior. If we want members to always be able to leave, that's a small follow-up pending an API check. The **last-admin** *block* couldn't be reproduced in the local preview (no org with "only admin + other members" for the test account, and creating one means an access-control change) — it's covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1021" height="830" alt="can-leave-organization" src="https://github.com/user-attachments/assets/acc13298-ec7e-4f4b-b990-b3c3a8a9dd5c" />
<img width="1061" height="871" alt="cant-remove-last-admin" src="https://github.com/user-attachments/assets/88db3cc5-6231-41a4-818d-0ec90e118b27" />
<img width="1044" height="874" alt="click-to-remove" src="https://github.com/user-attachments/assets/916a60e2-b5ed-4828-ac1a-56581bdc95b9" />
<img width="1049" height="791" alt="confirm-removal" src="https://github.com/user-attachments/assets/577b0fd3-131d-4b50-a6dd-93e83a915a97" />

