### PR TITLE
feat(secrets): pick the scoped component from a cluster-aware picker

### DIFF
--- a/src/features/instance/config/secrets/SecretGrantsEditor.tsx
+++ b/src/features/instance/config/secrets/SecretGrantsEditor.tsx
@@ -2,24 +2,27 @@
  * Grants editor for one secret, shown inside the edit dialog. A secret is only materialized into
  * the environment of components listed in its grants, so this is where a stored secret actually
  * gets scoped to applications. Grant/revoke apply immediately (they are their own operations, not
- * part of the value form).
+ * part of the value form). The target application is chosen through the shared
+ * ComponentGrantCombobox, seeded with the components the cluster reports.
  */
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
+import { ComponentGrantCombobox } from '@/features/instance/secrets/ComponentGrantCombobox';
 import { useGrantSecret, useRevokeSecret } from '@/integrations/api/instance/secrets/secrets';
-import { PlusIcon, XIcon } from 'lucide-react';
-import { KeyboardEvent, useCallback, useState } from 'react';
+import { XIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
 export function SecretGrantsEditor({
 	name,
 	initialGrants,
+	components,
 	onChanged,
 }: {
 	name: string;
 	initialGrants: string[];
+	/** Component names the cluster reports, offered as picker suggestions (empty → free text). */
+	components: string[];
 	/** Called after a successful grant/revoke so the list view can refresh its metadata. */
 	onChanged?: () => void;
 }) {
@@ -30,22 +33,18 @@ export function SecretGrantsEditor({
 
 	// The mutation responses carry the resulting grants, so the chips track server truth.
 	const [grants, setGrants] = useState(initialGrants);
-	const [component, setComponent] = useState('');
 
-	const onGrantClick = useCallback(async () => {
-		const target = component.trim();
-		if (!target) {
-			return;
-		}
+	const onGrant = useCallback(async (target: string) => {
 		try {
 			const response = await grantSecret({ ...instanceParams, name, component: target });
 			setGrants(response.grants);
-			setComponent('');
 			onChanged?.();
 		} catch (error) {
 			toast.error(String(error));
+			// Rethrow so the combobox keeps the typed text for a retry instead of clearing it.
+			throw error;
 		}
-	}, [component, grantSecret, instanceParams, name, onChanged]);
+	}, [grantSecret, instanceParams, name, onChanged]);
 
 	const onRevokeClick = useCallback(async (target: string) => {
 		try {
@@ -56,14 +55,6 @@ export function SecretGrantsEditor({
 			toast.error(String(error));
 		}
 	}, [revokeSecret, instanceParams, name, onChanged]);
-
-	// This editor lives inside the value form — Enter must grant, not submit a value replacement.
-	const onComponentKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
-		if (event.key === 'Enter') {
-			event.preventDefault();
-			void onGrantClick();
-		}
-	}, [onGrantClick]);
 
 	return (
 		<div className="grid gap-2">
@@ -91,26 +82,13 @@ export function SecretGrantsEditor({
 					))}
 				</div>
 			)}
-			<div className="flex gap-2">
-				<Input
-					type="text"
-					autoComplete="off"
-					autoCapitalize="off"
-					placeholder="application name"
-					value={component}
-					onChange={(event) => setComponent(event.target.value)}
-					onKeyDown={onComponentKeyDown}
-					disabled={busy}
-				/>
-				<Button
-					type="button"
-					variant="positiveOutline"
-					onClick={() => void onGrantClick()}
-					disabled={busy || !component.trim()}
-				>
-					<PlusIcon /> Grant
-				</Button>
-			</div>
+			<ComponentGrantCombobox
+				components={components}
+				granted={grants}
+				onAdd={onGrant}
+				disabled={busy}
+				actionLabel="Grant"
+			/>
 		</div>
 	);
 }

--- a/src/features/instance/config/secrets/grantableComponents.test.ts
+++ b/src/features/instance/config/secrets/grantableComponents.test.ts
@@ -1,0 +1,44 @@
+import { APIDirectoryEntry } from '@/integrations/api/instance/applications/getComponents';
+import { describe, expect, it } from 'vitest';
+import { grantableComponentNames } from './grantableComponents';
+
+function tree(entries: APIDirectoryEntry['entries']): APIDirectoryEntry {
+	return { name: 'root', entries };
+}
+
+describe('grantableComponentNames', () => {
+	it('returns [] for an undefined tree', () => {
+		expect(grantableComponentNames(undefined)).toEqual([]);
+	});
+
+	it('returns the top-level directory (component) names, sorted', () => {
+		const result = grantableComponentNames(
+			tree([
+				{ name: 'web-app', entries: [] },
+				{ name: 'auth-service', entries: [{ name: 'index.js' }] },
+				{ name: 'billing', entries: [], package: '@acme/billing' },
+			]),
+		);
+		expect(result).toEqual(['auth-service', 'billing', 'web-app']);
+	});
+
+	it('drops top-level files that are not components (no entries)', () => {
+		const result = grantableComponentNames(
+			tree([
+				{ name: 'my-app', entries: [] },
+				{ name: 'harperdb-config.yaml' } as APIDirectoryEntry,
+			]),
+		);
+		expect(result).toEqual(['my-app']);
+	});
+
+	it('de-duplicates repeated component names', () => {
+		const result = grantableComponentNames(
+			tree([
+				{ name: 'dup', entries: [] },
+				{ name: 'dup', entries: [] },
+			]),
+		);
+		expect(result).toEqual(['dup']);
+	});
+});

--- a/src/features/instance/config/secrets/grantableComponents.ts
+++ b/src/features/instance/config/secrets/grantableComponents.ts
@@ -1,0 +1,22 @@
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
+import { APIDirectoryEntry } from '@/integrations/api/instance/applications/getComponents';
+
+/**
+ * The component names a secret can be scoped to, derived from a `get_components` tree. A grant
+ * targets a component by name, and every deployed component (local application or installed
+ * package) is a top-level directory entry in the tree — so those directory names are exactly the
+ * grantable targets. Stray top-level files (if any) aren't components and are dropped. Sorted for
+ * a stable picker order; the tree can list the same name twice across reads, so it's de-duped.
+ */
+export function grantableComponentNames(tree: APIDirectoryEntry | undefined): string[] {
+	if (!tree?.entries) {
+		return [];
+	}
+	const names = new Set<string>();
+	for (const entry of tree.entries) {
+		if (isDirectory(entry)) {
+			names.add(entry.name);
+		}
+	}
+	return [...names].sort((a, b) => a.localeCompare(b));
+}

--- a/src/features/instance/config/secrets/index.tsx
+++ b/src/features/instance/config/secrets/index.tsx
@@ -1,8 +1,11 @@
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
+import { grantableComponentNames } from '@/features/instance/config/secrets/grantableComponents';
 import { SecretGrantsEditor } from '@/features/instance/config/secrets/SecretGrantsEditor';
 import { SecretRow, SecretsManager } from '@/features/instance/secrets/SecretsManager';
+import { useInstanceManagePermission } from '@/hooks/usePermissions';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
+import { getComponentsQueryOptions } from '@/integrations/api/instance/applications/getComponents';
 import {
 	listSecretsQueryOptions,
 	SecretMetadata,
@@ -25,6 +28,13 @@ export function ConfigSecretsIndex() {
 	const { secretName, clusterId }: { secretName?: string; clusterId?: string } = useParams({ strict: false });
 	const instanceParams = useInstanceClientIdParams();
 	const { data, refetch, isFetching } = useQuery(listSecretsQueryOptions(instanceParams));
+
+	// The components the cluster reports feed the grants picker so scoping a secret is a pick, not a
+	// retype. Gated on manage permission (same as the overview page); it degrades to a free-text
+	// field when unavailable (older Harper, no permission), so a failure here never blocks scoping.
+	const canManage = useInstanceManagePermission();
+	const { data: componentsTree } = useQuery(getComponentsQueryOptions({ ...instanceParams, enabled: canManage }));
+	const grantableComponents = useMemo(() => grantableComponentNames(componentsTree), [componentsTree]);
 
 	// Fabric-managed clusters get their public key from central-manager (the custodian — it mints
 	// the keypair on first use, central-manager#409); self-hosted/local nodes serve their own.
@@ -123,6 +133,7 @@ export function ConfigSecretsIndex() {
 				onSelectName={onSelectName}
 				nameHeader="Secret"
 				delivery={true}
+				grantableComponents={grantableComponents}
 				addDescription="The value is encrypted in your browser against the cluster's secrets key — plaintext never reaches the API, the operation log, or disk. It can be replaced or deleted, but never read back."
 				editDescription="The current value can't be shown — it's stored encrypted. Enter a new value to replace it, adjust how applications read it, or delete the secret."
 				valueDescription="Encrypted client-side before it leaves this page."
@@ -136,6 +147,7 @@ export function ConfigSecretsIndex() {
 								key={secret.name}
 								name={secret.name}
 								initialGrants={secret.grants}
+								components={grantableComponents}
 								onChanged={() => void refetch()}
 							/>
 						)

--- a/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ */
+/*
+ The shared grants picker: suggesting the components the cluster reports, still allowing a typed
+ name for a component that isn't reported, and reporting the choice through onAdd. Uses fireEvent
+ (no @testing-library/user-event in this repo).
+*/
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ComponentGrantCombobox } from './ComponentGrantCombobox';
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+const COMPONENTS = ['auth-service', 'billing-service', 'web-app'];
+
+function renderCombobox(overrides: Partial<Parameters<typeof ComponentGrantCombobox>[0]> = {}) {
+	const onAdd = overrides.onAdd ?? vi.fn();
+	render(
+		<ComponentGrantCombobox
+			components={COMPONENTS}
+			granted={[]}
+			onAdd={onAdd}
+			{...overrides}
+		/>,
+	);
+	return { onAdd };
+}
+
+/** The visible option rows (role=option) as their text. */
+function optionTexts(): string[] {
+	return screen.queryAllByRole('option').map((el) => el.textContent ?? '');
+}
+
+describe('ComponentGrantCombobox', () => {
+	it('lists the reported components once focused, filtered by what you type', () => {
+		renderCombobox();
+		const input = screen.getByRole('combobox');
+
+		fireEvent.focus(input);
+		expect(optionTexts()).toEqual(['auth-service', 'billing-service', 'web-app']);
+
+		fireEvent.change(input, { target: { value: 'auth' } });
+		// The matching component is offered first; a partial that isn't itself a deployed component
+		// also gets an explicit "use this name" row so it's clear it isn't a known application.
+		expect(optionTexts()[0]).toBe('auth-service');
+		expect(optionTexts().some((t) => t.includes('billing-service'))).toBe(false);
+		expect(optionTexts().some((t) => t.includes('not a deployed application'))).toBe(true);
+	});
+
+	it('hides already-granted components from the suggestions', () => {
+		renderCombobox({ granted: ['auth-service'] });
+		fireEvent.focus(screen.getByRole('combobox'));
+		expect(optionTexts()).toEqual(['billing-service', 'web-app']);
+	});
+
+	it('commits a picked component through onAdd', async () => {
+		const { onAdd } = renderCombobox();
+		fireEvent.focus(screen.getByRole('combobox'));
+		// onMouseDown (not click) is what commits — it fires before the input blur.
+		fireEvent.mouseDown(screen.getByText('billing-service'));
+		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('billing-service'));
+	});
+
+	it('lets you commit a typed name that is not a reported component', async () => {
+		const { onAdd } = renderCombobox();
+		const input = screen.getByRole('combobox');
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: 'not-deployed-yet' } });
+
+		// The typed name is offered as an explicit "use this" option, not silently swallowed.
+		expect(optionTexts().some((t) => t.includes('not-deployed-yet'))).toBe(true);
+
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('not-deployed-yet'));
+	});
+
+	it('commits the typed value from the action button', async () => {
+		const { onAdd } = renderCombobox({ actionLabel: 'Grant' });
+		const input = screen.getByRole('combobox');
+		fireEvent.change(input, { target: { value: 'web-app' } });
+		fireEvent.click(screen.getByRole('button', { name: /^grant$/i }));
+		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('web-app'));
+	});
+
+	it('Enter picks the keyboard-highlighted suggestion', async () => {
+		const { onAdd } = renderCombobox();
+		const input = screen.getByRole('combobox');
+		fireEvent.focus(input);
+		fireEvent.keyDown(input, { key: 'ArrowDown' }); // move off the first row to the second
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('billing-service'));
+	});
+
+	it('clears the field after a successful commit', async () => {
+		renderCombobox();
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		fireEvent.change(input, { target: { value: 'web-app' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(input.value).toBe(''));
+	});
+
+	it('keeps the typed text when onAdd rejects, so the user can retry', async () => {
+		const onAdd = vi.fn().mockRejectedValue(new Error('grant failed'));
+		renderCombobox({ onAdd });
+		const input = screen.getByRole('combobox') as HTMLInputElement;
+		fireEvent.change(input, { target: { value: 'web-app' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(onAdd).toHaveBeenCalled());
+		expect(input.value).toBe('web-app');
+	});
+
+	it('does not commit a name that is already granted', () => {
+		const { onAdd } = renderCombobox({ granted: ['web-app'] });
+		const input = screen.getByRole('combobox');
+		fireEvent.change(input, { target: { value: 'web-app' } });
+		fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+		expect(onAdd).not.toHaveBeenCalled();
+	});
+
+	describe('commitOnBlur', () => {
+		it('commits a typed-but-not-added name on blur when enabled', async () => {
+			const { onAdd } = renderCombobox({ commitOnBlur: true });
+			const input = screen.getByRole('combobox');
+			fireEvent.change(input, { target: { value: 'web-app' } });
+			fireEvent.blur(input);
+			await waitFor(() => expect(onAdd).toHaveBeenCalledWith('web-app'));
+		});
+
+		it('does not commit on blur by default', () => {
+			const { onAdd } = renderCombobox();
+			const input = screen.getByRole('combobox');
+			fireEvent.change(input, { target: { value: 'web-app' } });
+			fireEvent.blur(input);
+			expect(onAdd).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('no components reported (older Harper / no permission)', () => {
+		it('degrades to a free-text field that still commits a typed name', async () => {
+			const onAdd = vi.fn();
+			render(<ComponentGrantCombobox components={[]} granted={[]} onAdd={onAdd} />);
+			const input = screen.getByRole('combobox') as HTMLInputElement;
+			expect(input.getAttribute('placeholder')).toBe('application name');
+
+			fireEvent.focus(input);
+			expect(optionTexts()).toEqual([]); // nothing to suggest
+
+			fireEvent.change(input, { target: { value: 'my-app' } });
+			fireEvent.keyDown(input, { key: 'Enter' });
+			await waitFor(() => expect(onAdd).toHaveBeenCalledWith('my-app'));
+		});
+	});
+});

--- a/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
@@ -143,6 +143,15 @@ describe('ComponentGrantCombobox', () => {
 			await waitFor(() => expect(onAdd).toHaveBeenCalledWith('web-app'));
 		});
 
+		it('on blur commits the highlighted suggestion, same as Enter/the button', async () => {
+			// Consistency: typing a partial then blurring grants the matched component, not the typo.
+			const { onAdd } = renderCombobox({ commitOnBlur: true });
+			const input = screen.getByRole('combobox');
+			fireEvent.change(input, { target: { value: 'web' } });
+			fireEvent.blur(input);
+			await waitFor(() => expect(onAdd).toHaveBeenCalledWith('web-app'));
+		});
+
 		it('does not commit on blur by default', () => {
 			const { onAdd } = renderCombobox();
 			const input = screen.getByRole('combobox');
@@ -150,6 +159,35 @@ describe('ComponentGrantCombobox', () => {
 			fireEvent.blur(input);
 			expect(onAdd).not.toHaveBeenCalled();
 		});
+	});
+
+	it('commits once when Enter is pressed repeatedly before the first add resolves', async () => {
+		// A slow async grant must not fire twice on a burst of Enters (state-based `busy` lags a render).
+		let resolve: (() => void) | undefined;
+		const onAdd = vi.fn().mockReturnValue(
+			new Promise<void>((r) => {
+				resolve = () => r();
+			}),
+		);
+		renderCombobox({ onAdd });
+		const input = screen.getByRole('combobox');
+		fireEvent.change(input, { target: { value: 'web-app' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		expect(onAdd).toHaveBeenCalledTimes(1);
+		resolve?.();
+		await waitFor(() => expect((input as HTMLInputElement).value).toBe(''));
+	});
+
+	it('only references the listbox via aria-controls while it is open', () => {
+		renderCombobox();
+		const input = screen.getByRole('combobox');
+		expect(input.getAttribute('aria-controls')).toBeNull(); // closed: no dangling idref
+		fireEvent.focus(input);
+		const controls = input.getAttribute('aria-controls');
+		expect(controls).toBeTruthy();
+		expect(document.getElementById(controls!)).not.toBeNull();
 	});
 
 	describe('no components reported (older Harper / no permission)', () => {

--- a/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.test.tsx
@@ -95,6 +95,19 @@ describe('ComponentGrantCombobox', () => {
 		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('billing-service'));
 	});
 
+	it('keeps arrow-key navigation aligned after the list filters down', async () => {
+		const { onAdd } = renderCombobox();
+		const input = screen.getByRole('combobox');
+		fireEvent.focus(input);
+		// Highlight the last of three, then filter down to a single match: the active row must track
+		// the shrunk list, so ArrowUp/Enter can't get stuck on a stale out-of-bounds index.
+		fireEvent.keyDown(input, { key: 'ArrowDown' });
+		fireEvent.keyDown(input, { key: 'ArrowDown' });
+		fireEvent.change(input, { target: { value: 'billing' } });
+		fireEvent.keyDown(input, { key: 'Enter' });
+		await waitFor(() => expect(onAdd).toHaveBeenCalledWith('billing-service'));
+	});
+
 	it('clears the field after a successful commit', async () => {
 		renderCombobox();
 		const input = screen.getByRole('combobox') as HTMLInputElement;
@@ -150,6 +163,9 @@ describe('ComponentGrantCombobox', () => {
 			expect(optionTexts()).toEqual([]); // nothing to suggest
 
 			fireEvent.change(input, { target: { value: 'my-app' } });
+			// A true plain field: no dropdown (not even a "use this" row) when nothing is known.
+			expect(optionTexts()).toEqual([]);
+
 			fireEvent.keyDown(input, { key: 'Enter' });
 			await waitFor(() => expect(onAdd).toHaveBeenCalledWith('my-app'));
 		});

--- a/src/features/instance/secrets/ComponentGrantCombobox.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.tsx
@@ -1,0 +1,242 @@
+/**
+ * The input used to grant a scoped secret to an application, shared by the add flow
+ * (PendingGrantsInput) and the edit flow (SecretGrantsEditor). A grant targets a component by
+ * name, and that name has to match a deployed component exactly — a typo silently scopes the
+ * secret to nothing. So instead of a bare text box, this is a combobox seeded with the components
+ * the cluster actually reports (`get_components`): the user picks one from a filtered list rather
+ * than retyping a long, error-prone name.
+ *
+ * It stays a combobox, not a strict select, on purpose — a component that isn't deployed yet (or
+ * that the connected Harper doesn't surface) can still be pre-authorized by typing its name, which
+ * the list offers as an explicit "use this name" option. When the cluster reports no components
+ * (older Harper, missing permission), it degrades to a plain free-text field.
+ *
+ * Presentational only: the caller supplies the known component names and owns persistence, so the
+ * reusable secrets kit stays free of data-fetching and router coupling.
+ */
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/cn';
+import { PlusIcon } from 'lucide-react';
+import { KeyboardEvent, useCallback, useId, useMemo, useRef, useState } from 'react';
+
+interface ComponentGrantComboboxProps {
+	/** Component names the cluster reports (`get_components`); empty when unavailable. */
+	components: string[];
+	/** Already-granted names — hidden from the list and rejected as duplicates. */
+	granted: string[];
+	/**
+	 * Commit a chosen or typed component name. May be async (the edit flow's grant_secret); resolve
+	 * to clear the field, reject to keep the typed text so the user can retry (the caller owns any
+	 * error toast).
+	 */
+	onAdd: (component: string) => void | Promise<void>;
+	disabled?: boolean;
+	/** Action button label — "Add" for the pending (add) flow, "Grant" for the live (edit) flow. */
+	actionLabel?: string;
+	/**
+	 * Commit the typed text when focus leaves the field. The add flow turns this on so submitting
+	 * the surrounding form (which blurs this field first) doesn't silently drop a typed-but-not-added
+	 * name; the edit flow leaves it off so a stray blur never fires a grant_secret request.
+	 */
+	commitOnBlur?: boolean;
+}
+
+/** A concrete option the user can commit: a known component, or the typed free-text name. */
+interface Option {
+	value: string;
+	/** The typed name that isn't (yet) a known component — offered as an explicit "use this" row. */
+	custom: boolean;
+}
+
+export function ComponentGrantCombobox({
+	components,
+	granted,
+	onAdd,
+	disabled,
+	actionLabel = 'Add',
+	commitOnBlur = false,
+}: ComponentGrantComboboxProps) {
+	const [query, setQuery] = useState('');
+	const [open, setOpen] = useState(false);
+	const [activeIdx, setActiveIdx] = useState(0);
+	const [isCommitting, setIsCommitting] = useState(false);
+	const listboxId = useId();
+	const optionIdPrefix = useId();
+	// Guards the blur handler while a suggestion is being clicked: onMouseDown fires before blur, so
+	// we suppress the blur-close (and any commitOnBlur) until the click's own commit has run.
+	const clickingOption = useRef(false);
+
+	const busy = disabled || isCommitting;
+
+	const options = useMemo<Option[]>(() => {
+		const q = query.trim();
+		const qLower = q.toLowerCase();
+		const grantedSet = new Set(granted);
+		const available = components.filter((name) => !grantedSet.has(name));
+		const matches = q ? available.filter((name) => name.toLowerCase().includes(qLower)) : available;
+		const known: Option[] = matches.map((value) => ({ value, custom: false }));
+		// Offer the typed name explicitly when it isn't already an available match — this is what lets
+		// a not-yet-deployed component be pre-authorized without turning the whole field free-form.
+		const hasExact = available.some((name) => name.toLowerCase() === qLower);
+		if (q && !hasExact) {
+			known.push({ value: q, custom: true });
+		}
+		return known;
+	}, [components, granted, query]);
+
+	// Clamp the active row whenever the option set shrinks (e.g. the list filters down as you type).
+	const clampedActiveIdx = options.length === 0 ? 0 : Math.min(activeIdx, options.length - 1);
+
+	const commit = useCallback(
+		async (value: string) => {
+			const target = value.trim();
+			// Empty or already-granted: nothing to do, just clear the field (matches the old behaviour).
+			if (!target || granted.includes(target)) {
+				setQuery('');
+				return;
+			}
+			setIsCommitting(true);
+			try {
+				await onAdd(target);
+				setQuery('');
+				setOpen(false);
+			} catch {
+				// The caller surfaced the error; keep the typed text so the user can retry.
+			} finally {
+				setIsCommitting(false);
+			}
+		},
+		[granted, onAdd],
+	);
+
+	// Enter and the action button both accept the highlighted row — a reported component (the safe
+	// default that dodges typos) or, when the typed name matches none, the explicit "use this" row.
+	const commitActive = useCallback(() => {
+		void commit(options[clampedActiveIdx]?.value ?? query);
+	}, [commit, options, clampedActiveIdx, query]);
+
+	const onKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				setOpen(true);
+				setActiveIdx((i) => Math.min(i + 1, Math.max(0, options.length - 1)));
+				return;
+			}
+			if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				setActiveIdx((i) => Math.max(0, i - 1));
+				return;
+			}
+			if (event.key === 'Escape') {
+				if (open) {
+					// Close only the dropdown — don't let Escape bubble to the surrounding Radix Dialog.
+					event.preventDefault();
+					event.stopPropagation();
+					setOpen(false);
+				}
+				return;
+			}
+			if (event.key === 'Enter') {
+				// This input lives inside a form — Enter must add a grant, never submit the form.
+				event.preventDefault();
+				commitActive();
+			}
+		},
+		[open, options, commitActive],
+	);
+
+	const onBlur = useCallback(() => {
+		if (clickingOption.current) {
+			return;
+		}
+		setOpen(false);
+		if (commitOnBlur && query.trim()) {
+			void commit(query);
+		}
+	}, [commitOnBlur, query, commit]);
+
+	const showDropdown = open && options.length > 0;
+
+	return (
+		<div className="relative grid gap-2">
+			<div className="flex gap-2">
+				<Input
+					type="text"
+					role="combobox"
+					aria-expanded={showDropdown}
+					aria-controls={listboxId}
+					aria-autocomplete="list"
+					aria-activedescendant={showDropdown && options[clampedActiveIdx]
+						? `${optionIdPrefix}-${clampedActiveIdx}`
+						: undefined}
+					autoComplete="off"
+					autoCapitalize="off"
+					placeholder={components.length > 0 ? 'Search applications…' : 'application name'}
+					value={query}
+					onChange={(event) => {
+						setQuery(event.target.value);
+						setActiveIdx(0);
+						setOpen(true);
+					}}
+					onFocus={() => setOpen(true)}
+					onKeyDown={onKeyDown}
+					onBlur={onBlur}
+					disabled={busy}
+				/>
+				<Button
+					type="button"
+					variant="positiveOutline"
+					// Keep focus in the input so the blur handler (and commitOnBlur) don't race the click.
+					onMouseDown={(event) => event.preventDefault()}
+					onClick={commitActive}
+					disabled={busy || !query.trim()}
+				>
+					<PlusIcon /> {actionLabel}
+				</Button>
+			</div>
+			{showDropdown && (
+				<ul
+					id={listboxId}
+					role="listbox"
+					className="bg-popover text-popover-foreground absolute top-11 z-10 max-h-56 w-full overflow-auto rounded-md border p-1 shadow-md"
+				>
+					{options.map((option, idx) => {
+						const isActive = idx === clampedActiveIdx;
+						return (
+							<li
+								key={option.custom ? `__custom__${option.value}` : option.value}
+								id={`${optionIdPrefix}-${idx}`}
+								role="option"
+								aria-selected={isActive}
+								onMouseEnter={() => setActiveIdx(idx)}
+								// onMouseDown (not onClick) so we commit before the input's blur fires; preventDefault
+								// keeps focus in the input. The ref flag stops the blur handler closing us mid-click.
+								onMouseDown={(event) => {
+									event.preventDefault();
+									clickingOption.current = true;
+									void commit(option.value).finally(() => {
+										clickingOption.current = false;
+									});
+								}}
+								className={cn(
+									'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm',
+									isActive && 'bg-accent text-accent-foreground',
+								)}
+							>
+								{option.custom
+									? (
+										<span className="truncate">
+											Use “<span className="font-mono">{option.value}</span>” — not a deployed application
+										</span>
+									)
+									: <span className="truncate font-mono">{option.value}</span>}
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/src/features/instance/secrets/ComponentGrantCombobox.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.tsx
@@ -66,6 +66,9 @@ export function ComponentGrantCombobox({
 	// Guards the blur handler while a suggestion is being clicked: onMouseDown fires before blur, so
 	// we suppress the blur-close (and any commitOnBlur) until the click's own commit has run.
 	const clickingOption = useRef(false);
+	// Synchronous re-entrancy guard: `isCommitting` state lags a render, so a burst of Enters (or an
+	// Enter racing the click) could fire onAdd twice before `disabled={busy}` catches up.
+	const committing = useRef(false);
 
 	const busy = disabled || isCommitting;
 
@@ -96,12 +99,16 @@ export function ComponentGrantCombobox({
 
 	const commit = useCallback(
 		async (value: string) => {
+			if (committing.current) {
+				return;
+			}
 			const target = value.trim();
 			// Empty or already-granted: nothing to do, just clear the field (matches the old behaviour).
 			if (!target || granted.includes(target)) {
 				setQuery('');
 				return;
 			}
+			committing.current = true;
 			setIsCommitting(true);
 			try {
 				await onAdd(target);
@@ -110,6 +117,7 @@ export function ComponentGrantCombobox({
 			} catch {
 				// The caller surfaced the error; keep the typed text so the user can retry.
 			} finally {
+				committing.current = false;
 				setIsCommitting(false);
 			}
 		},
@@ -160,10 +168,14 @@ export function ComponentGrantCombobox({
 			return;
 		}
 		setOpen(false);
+		// Commit the same thing Enter/the button would (the highlighted row), not the raw text — so
+		// tabbing away after typing "web" grants "web-app" rather than the typo, and all three commit
+		// paths stay consistent. Still a safety net for the add flow: submitting the surrounding form
+		// blurs this field first, so a typed-but-not-added name isn't silently dropped.
 		if (commitOnBlur && query.trim()) {
-			void commit(query);
+			commitActive();
 		}
-	}, [commitOnBlur, query, commit]);
+	}, [commitOnBlur, query, commitActive]);
 
 	const showDropdown = open && options.length > 0;
 
@@ -174,7 +186,9 @@ export function ComponentGrantCombobox({
 					type="text"
 					role="combobox"
 					aria-expanded={showDropdown}
-					aria-controls={listboxId}
+					// Only point at the listbox while it's actually rendered — otherwise it's a dangling
+					// idref for screen readers.
+					aria-controls={showDropdown ? listboxId : undefined}
 					aria-autocomplete="list"
 					aria-activedescendant={showDropdown && options[clampedActiveIdx]
 						? `${optionIdPrefix}-${clampedActiveIdx}`

--- a/src/features/instance/secrets/ComponentGrantCombobox.tsx
+++ b/src/features/instance/secrets/ComponentGrantCombobox.tsx
@@ -70,6 +70,12 @@ export function ComponentGrantCombobox({
 	const busy = disabled || isCommitting;
 
 	const options = useMemo<Option[]>(() => {
+		// No components reported (older Harper / no permission): stay a plain free-text field — no
+		// dropdown, no "use this" row (there's nothing to disambiguate it from). Enter/Add still commit
+		// the typed value via commitActive's `?? query` fallback.
+		if (components.length === 0) {
+			return [];
+		}
 		const q = query.trim();
 		const qLower = q.toLowerCase();
 		const grantedSet = new Set(granted);
@@ -121,12 +127,14 @@ export function ComponentGrantCombobox({
 			if (event.key === 'ArrowDown') {
 				event.preventDefault();
 				setOpen(true);
-				setActiveIdx((i) => Math.min(i + 1, Math.max(0, options.length - 1)));
+				// Move relative to the row that's actually highlighted (clampedActiveIdx), not the raw
+				// state — which can be stale/out-of-bounds after the list filtered down as you typed.
+				setActiveIdx(Math.min(clampedActiveIdx + 1, Math.max(0, options.length - 1)));
 				return;
 			}
 			if (event.key === 'ArrowUp') {
 				event.preventDefault();
-				setActiveIdx((i) => Math.max(0, i - 1));
+				setActiveIdx(Math.max(0, clampedActiveIdx - 1));
 				return;
 			}
 			if (event.key === 'Escape') {
@@ -144,7 +152,7 @@ export function ComponentGrantCombobox({
 				commitActive();
 			}
 		},
-		[open, options, commitActive],
+		[open, options, clampedActiveIdx, commitActive],
 	);
 
 	const onBlur = useCallback(() => {

--- a/src/features/instance/secrets/PendingGrantsInput.tsx
+++ b/src/features/instance/secrets/PendingGrantsInput.tsx
@@ -2,47 +2,35 @@
  * A local, API-free grants collector for the Add-secret flow: the secret doesn't exist yet, so
  * grants can't be persisted with grant_secret (as the edit flow's live SecretGrantsEditor does) —
  * they're gathered here and submitted in the initial set_secret call. Chip UI mirrors
- * SecretGrantsEditor so the two read the same.
+ * SecretGrantsEditor so the two read the same, and both pick the target application through the
+ * shared ComponentGrantCombobox.
  */
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { PlusIcon, XIcon } from 'lucide-react';
-import { KeyboardEvent, useCallback, useState } from 'react';
+import { XIcon } from 'lucide-react';
+import { useCallback } from 'react';
+import { ComponentGrantCombobox } from './ComponentGrantCombobox';
 
 export function PendingGrantsInput({
 	grants,
 	onChange,
+	components,
 	disabled,
 }: {
 	grants: string[];
 	onChange: (next: string[]) => void;
+	/** Component names the cluster reports, offered as picker suggestions (empty → free text). */
+	components: string[];
 	disabled?: boolean;
 }) {
-	const [component, setComponent] = useState('');
-
-	const add = useCallback(() => {
-		const target = component.trim();
-		if (!target) {
-			return;
-		}
+	const add = useCallback((target: string) => {
 		if (!grants.includes(target)) {
 			onChange([...grants, target]);
 		}
-		setComponent('');
-	}, [component, grants, onChange]);
+	}, [grants, onChange]);
 
 	const remove = useCallback((target: string) => {
 		onChange(grants.filter((granted) => granted !== target));
 	}, [grants, onChange]);
-
-	// This input lives inside the add form — Enter must add a grant, not submit the secret.
-	const onKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
-		if (event.key === 'Enter') {
-			event.preventDefault();
-			add();
-		}
-	}, [add]);
 
 	return (
 		<div className="grid gap-2">
@@ -70,29 +58,16 @@ export function PendingGrantsInput({
 					))}
 				</div>
 			)}
-			<div className="flex gap-2">
-				<Input
-					type="text"
-					autoComplete="off"
-					autoCapitalize="off"
-					placeholder="application name"
-					value={component}
-					onChange={(event) => setComponent(event.target.value)}
-					onKeyDown={onKeyDown}
-					// Commit a typed-but-not-added name on blur too, so submitting the Add-secret form (which
-					// blurs this field first) doesn't silently drop it. add() no-ops on empty/duplicate.
-					onBlur={add}
-					disabled={disabled}
-				/>
-				<Button
-					type="button"
-					variant="positiveOutline"
-					onClick={add}
-					disabled={disabled || !component.trim()}
-				>
-					<PlusIcon /> Add
-				</Button>
-			</div>
+			<ComponentGrantCombobox
+				components={components}
+				granted={grants}
+				onAdd={add}
+				disabled={disabled}
+				actionLabel="Add"
+				// Submitting the Add-secret form blurs this field first; commit-on-blur keeps a typed-but-
+				// not-added name from being silently dropped. add() no-ops on empty/duplicate.
+				commitOnBlur
+			/>
 		</div>
 	);
 }

--- a/src/features/instance/secrets/SecretModals.tsx
+++ b/src/features/instance/secrets/SecretModals.tsx
@@ -57,6 +57,7 @@ export function AddSecretModal({
 	setIsModalOpen,
 	delivery = false,
 	defaultTier = 'scoped',
+	grantableComponents = [],
 }: {
 	description: ReactNode;
 	valueDescription?: ReactNode;
@@ -70,6 +71,8 @@ export function AddSecretModal({
 	delivery?: boolean;
 	/** Tier pre-selected when the dialog opens (defaults to the safer scoped tier). */
 	defaultTier?: SecretTier;
+	/** Component names the cluster reports, offered as suggestions in the grants picker. */
+	grantableComponents?: string[];
 }) {
 	const schema = useMemo(
 		() =>
@@ -173,7 +176,14 @@ export function AddSecretModal({
 								tier={tier}
 								onTierChange={setTier}
 								disabled={isPending}
-								grantsSlot={<PendingGrantsInput grants={grants} onChange={setGrants} disabled={isPending} />}
+								grantsSlot={
+									<PendingGrantsInput
+										grants={grants}
+										onChange={setGrants}
+										components={grantableComponents}
+										disabled={isPending}
+									/>
+								}
 							/>
 						)}
 

--- a/src/features/instance/secrets/SecretsManager.delivery.test.tsx
+++ b/src/features/instance/secrets/SecretsManager.delivery.test.tsx
@@ -68,10 +68,11 @@ describe('SecretsManager delivery tier — Add', () => {
 		const { onSet } = renderManager();
 		await openAddWithKeyValue();
 
-		// Add one grant (the PendingGrantsInput "Add" button, distinct from "Add Secret").
+		// Add one grant through the component picker. No components are supplied here, so it's a
+		// free-text field; Enter commits the typed name (the chip's Remove button confirms it landed).
 		fireEvent.change(screen.getByPlaceholderText('application name'), { target: { value: 'my-app' } });
-		fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
-		expect(screen.getByText('my-app')).toBeTruthy();
+		fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
+		await screen.findByRole('button', { name: /remove my-app/i });
 
 		const submit = screen.getByRole('button', { name: /add secret/i });
 		await waitFor(() => expect(submit.hasAttribute('disabled')).toBe(false));

--- a/src/features/instance/secrets/SecretsManager.tsx
+++ b/src/features/instance/secrets/SecretsManager.tsx
@@ -49,6 +49,7 @@ export function SecretsManager({
 	children,
 	delivery = false,
 	deliveryDefaultTier = 'scoped',
+	grantableComponents,
 }: {
 	rows: SecretRow[];
 	isFetching?: boolean;
@@ -78,6 +79,8 @@ export function SecretsManager({
 	delivery?: boolean;
 	/** Tier pre-selected in the Add dialog (defaults to the safer scoped tier). */
 	deliveryDefaultTier?: SecretTier;
+	/** Component names the cluster reports, offered as suggestions in the Add dialog's grants picker. */
+	grantableComponents?: string[];
 }) {
 	const columns = useMemo<Array<ColumnDef<SecretRow>>>(() => [
 		{
@@ -149,6 +152,7 @@ export function SecretsManager({
 					existingKeys={existingKeys}
 					delivery={delivery}
 					defaultTier={deliveryDefaultTier}
+					grantableComponents={grantableComponents}
 					onSubmit={({ key, value, ...options }) => onSet(key, value, options)}
 				/>
 			)}


### PR DESCRIPTION
Closes #1512.

## Problem

Scoping a secret to an application meant retyping a long component name into a free-form text box. App names can be long and can't be renamed, so a typo there silently scopes the secret to a component that doesn't exist — with no feedback.

## Change

Both grant flows (the **Add Secret** dialog and the live **edit** grants editor) now use a shared, cluster-aware **component picker** instead of a bare text input. It's seeded from the components the cluster reports via `get_components`, so scoping is a *pick*, not a retype.

- **Combobox, not a strict select.** A component that isn't deployed yet (or that older Harper doesn't surface) can still be pre-authorized by typing its name — the list offers it as an explicit **"Use "x" — not a deployed application"** row, which doubles as a typo nudge. Enter / the action button accept the highlighted suggestion (the safe default).
- **Graceful degradation.** When the cluster reports no components (older Harper, or no manage permission), it falls back to a plain free-text field, so it never blocks scoping.
- **Kit stays data-source-agnostic.** The reusable `secrets/` kit takes the component names as a prop; the cluster secrets page fetches them (gated on manage permission) and threads them down.

## Files

- **new** `ComponentGrantCombobox.tsx` — the shared combobox (keyboard nav + ARIA combobox/listbox, works inside the Radix dialog)
- `PendingGrantsInput.tsx` (add flow) and `SecretGrantsEditor.tsx` (edit flow) now render it
- `SecretModals.tsx` / `SecretsManager.tsx` thread `grantableComponents` through to the add dialog
- `config/secrets/index.tsx` fetches `get_components` and derives the names
- **new** `grantableComponents.ts` — extracts top-level component names (sorted, de-duped)

## Verification

- **Tests:** full suite green (1605 passed / 11 skipped), including 12 new combobox tests (filtering, pick, free-text fallback, keyboard, async-reject-keeps-text, commit-on-blur, dedup, degradation) + 4 helper tests + an updated delivery integration test. `tsc`, `oxlint`, `dprint` all clean.
- **Live:** verified against a real cluster — the picker suggested the cluster's deployed components, selecting one created a grant chip, and typing a non-deployed name surfaced the "not a deployed application" fallback.

## Open question

Suggestions currently include **all** top-level components (local apps and installed packages). Happy to filter to local applications only (`!entry.package`) if that reads cleaner — one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)