### PR TITLE
feat(applications): banner when editor IntelliSense degrades

### DIFF
--- a/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.test.tsx
+++ b/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.test.tsx
@@ -13,11 +13,11 @@ describe('DegradedIntelliSenseBanner (HarperFast/studio#1504)', () => {
 		expect(screen.getByRole('status').getAttribute('aria-live')).toBe('polite');
 	});
 
-	it('explains the budget degradation in terms the user can act on', () => {
+	it('explains the budget degradation and its cause', () => {
 		render(<DegradedIntelliSenseBanner variant="budget" onDismiss={vi.fn()} />);
 		const text = screen.getByRole('status').textContent ?? '';
 		expect(text).toMatch(/cannot find module/i);
-		expect(text).toMatch(/reopening the tab/i);
+		expect(text).toMatch(/references more packages/i);
 	});
 
 	it('explains the oversized-file degradation', () => {

--- a/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.test.tsx
+++ b/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DegradedIntelliSenseBanner } from './DegradedIntelliSenseBanner';
+
+afterEach(cleanup);
+
+describe('DegradedIntelliSenseBanner (HarperFast/studio#1504)', () => {
+	it('announces politely rather than as an alert, so it is non-blocking', () => {
+		render(<DegradedIntelliSenseBanner variant="budget" onDismiss={vi.fn()} />);
+		expect(screen.getByRole('status').getAttribute('aria-live')).toBe('polite');
+	});
+
+	it('explains the budget degradation in terms the user can act on', () => {
+		render(<DegradedIntelliSenseBanner variant="budget" onDismiss={vi.fn()} />);
+		const text = screen.getByRole('status').textContent ?? '';
+		expect(text).toMatch(/cannot find module/i);
+		expect(text).toMatch(/reopening the tab/i);
+	});
+
+	it('explains the oversized-file degradation', () => {
+		render(<DegradedIntelliSenseBanner variant="oversized" onDismiss={vi.fn()} />);
+		expect(screen.getByRole('status').textContent ?? '').toMatch(/plain text/i);
+	});
+
+	it('invokes onDismiss when the dismiss control is clicked', () => {
+		const onDismiss = vi.fn();
+		render(<DegradedIntelliSenseBanner variant="oversized" onDismiss={onDismiss} />);
+		fireEvent.click(screen.getByRole('button', { name: /dismiss notice/i }));
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+});

--- a/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
+++ b/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
@@ -23,13 +23,15 @@ const MESSAGES: Record<IntelliSenseDegradation, string> = {
 	oversized: 'This file is large, so it’s shown as plain text without language features.',
 };
 
+export interface DegradedIntelliSenseBannerProps {
+	variant: IntelliSenseDegradation;
+	onDismiss: () => void;
+}
+
 export function DegradedIntelliSenseBanner({
 	variant,
 	onDismiss,
-}: {
-	variant: IntelliSenseDegradation;
-	onDismiss: () => void;
-}) {
+}: DegradedIntelliSenseBannerProps) {
 	const Icon = variant === 'oversized' ? InfoIcon : TriangleAlertIcon;
 	return (
 		<div

--- a/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
+++ b/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
@@ -19,7 +19,7 @@ export type IntelliSenseDegradation = 'budget' | 'oversized';
 
 const MESSAGES: Record<IntelliSenseDegradation, string> = {
 	budget:
-		'Type information is limited in this session to keep the editor responsive — some imported packages may show “cannot find module.” Reopening the tab resets this.',
+		'Type information is limited to keep the editor responsive — this application references more packages than the editor can load, so some imports may show “cannot find module.”',
 	oversized: 'This file is large, so it’s shown as plain text without language features.',
 };
 

--- a/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
+++ b/src/features/instance/applications/components/TextEditorView/DegradedIntelliSenseBanner.tsx
@@ -1,0 +1,54 @@
+/**
+ * A thin, dismissible notice shown above the code editor when the editor has
+ * silently degraded its language features to stay responsive
+ * (HarperFast/studio#1504). Two modes exist, both otherwise invisible:
+ *
+ *   - `budget`: the session-wide automatic type-acquisition budget is spent, so
+ *     further packages report a spurious "cannot find module"
+ *     (see `typeAcquisition.ts` / `ExtraLibBudget`).
+ *   - `oversized`: the open file is over `MAX_WORKER_MODEL_CHARS`, so it renders
+ *     as plaintext with no highlighting or IntelliSense.
+ *
+ * Non-blocking and dismissible (the caller owns the dismissed state so it can
+ * reset per file/mode); announced via `role="status"` / `aria-live="polite"`
+ * rather than a purely visual cue.
+ */
+import { InfoIcon, TriangleAlertIcon, XIcon } from 'lucide-react';
+
+export type IntelliSenseDegradation = 'budget' | 'oversized';
+
+const MESSAGES: Record<IntelliSenseDegradation, string> = {
+	budget:
+		'Type information is limited in this session to keep the editor responsive — some imported packages may show “cannot find module.” Reopening the tab resets this.',
+	oversized: 'This file is large, so it’s shown as plain text without language features.',
+};
+
+export function DegradedIntelliSenseBanner({
+	variant,
+	onDismiss,
+}: {
+	variant: IntelliSenseDegradation;
+	onDismiss: () => void;
+}) {
+	const Icon = variant === 'oversized' ? InfoIcon : TriangleAlertIcon;
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			// `mt-9` (36px) clears the `ContentActions` toolbar, which overlays the top
+			// of the editor pane — the same offset the other pane views (`mt-9`) use.
+			className="mt-9 flex items-start gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-2 text-sm text-foreground"
+		>
+			<Icon className="mt-0.5 size-4 shrink-0 text-amber-500" aria-hidden />
+			<span className="flex-1">{MESSAGES[variant]}</span>
+			<button
+				type="button"
+				onClick={onDismiss}
+				aria-label="Dismiss notice"
+				className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+			>
+				<XIcon className="size-4" aria-hidden />
+			</button>
+		</div>
+	);
+}

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -161,6 +161,17 @@ function getRunner(): Promise<(source: string) => Promise<void>> {
 }
 
 /**
+ * Whether this session's automatic type-acquisition budget is exhausted. Once
+ * true it stays true — the budget is never reclaimed — so further packages are
+ * no longer acquired and their imports report a spurious "cannot find module"
+ * until the tab is reopened. Surfaced (rather than only `console.warn`'d) so the
+ * editor can show a user-facing degradation notice (HarperFast/studio#1504).
+ */
+export function isTypeAcquisitionBudgetSpent(): boolean {
+	return extraLibBudget.isSpent;
+}
+
+/**
  * Acquire npm `@types` for every package imported across the given source files.
  * Best-effort and idempotent; safe to call on each project load.
  */

--- a/src/features/instance/applications/components/TextEditorView/index.tsx
+++ b/src/features/instance/applications/components/TextEditorView/index.tsx
@@ -14,6 +14,7 @@ import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { parseFileExtension } from '@/lib/string/parseFileExtension';
 import type { EditorProps, OnMount } from '@monaco-editor/react';
 import { useCallback, useEffect, useState } from 'react';
+import { DegradedIntelliSenseBanner, type IntelliSenseDegradation } from './DegradedIntelliSenseBanner';
 import { configureHarperLanguageSupport } from './harper-language';
 import './monaco-customizations.css';
 
@@ -64,7 +65,7 @@ export function TextEditorView() {
 	const instanceParams = useInstanceClientIdParams();
 	const { openedEntryContents, openedEntry, restrictPackageModification, isSavingFile, saveFile, rootEntries } =
 		useEditorView();
-	useApplicationTypeIntelligence(openedEntry, rootEntries);
+	const { typeAcquisitionBudgetExhausted } = useApplicationTypeIntelligence(openedEntry, rootEntries);
 	const {
 		content: updatedFileContent,
 		setContent,
@@ -78,6 +79,11 @@ export function TextEditorView() {
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
 	const [mounted, setMounted] = useState<Parameters<OnMount> | null>(null);
 	useCodeNavigation(mounted?.[0]);
+
+	// Which degradation notice the user has dismissed, keyed by `<path>:<variant>`
+	// so it re-shows for a different file or a different degradation, but stays
+	// dismissed while the same file/mode is open.
+	const [dismissedBanner, setDismissedBanner] = useState<string | null>(null);
 
 	const extension = parseFileExtension(openedEntry?.path);
 	const fileContent = updatedFileContent ?? openedEntryContents;
@@ -165,23 +171,52 @@ export function TextEditorView() {
 
 	const readOnly = isSavingFile || !!openedEntry.package || !canManageBrowseInstance;
 
+	// Surface either silent editor degradation as a dismissible notice. Oversized
+	// wins: the file is already plaintext, so the "cannot find module" wording
+	// wouldn't apply. The budget notice only fits a real (editable) script file,
+	// where a missing package's import would actually error.
+	const isScriptLanguage = language === 'javascript' || language === 'typescript';
+	const degradation: IntelliSenseDegradation | null = oversized
+		? 'oversized'
+		: (typeAcquisitionBudgetExhausted && isScriptLanguage && !openedEntry.package)
+		? 'budget'
+		: null;
+	const bannerKey = degradation ? `${openedEntry.path}:${degradation}` : null;
+	const showBanner = bannerKey !== null && dismissedBanner !== bannerKey;
+
 	return (
-		<Editor
-			className="w-full min-h-full h-80"
-			path={openedEntry.path}
-			language={language}
-			theme={monacoTheme}
-			value={fileContent}
-			keepCurrentModel
-			beforeMount={handleEditorWillMount}
-			onMount={handleEditorDidMount}
-			onChange={readOnly ? undefined : setUpdatedFileContent}
-			options={{
-				automaticLayout: true,
-				minimap: { enabled: false },
-				readOnly,
-				padding: { top: 48 },
-			}}
-		/>
+		// `h-full` (not `min-h-full`) gives this column a *definite* height, so the
+		// editor's `height:100%` resolves; the `flex-1 min-h-0` wrapper then hands
+		// Monaco a concrete, banner-adjusted height it can lay out against.
+		<div className="flex h-full w-full flex-col">
+			{showBanner && degradation && (
+				<DegradedIntelliSenseBanner
+					variant={degradation}
+					onDismiss={() => setDismissedBanner(bannerKey)}
+				/>
+			)}
+			<div className="min-h-0 flex-1">
+				<Editor
+					className="h-full w-full"
+					path={openedEntry.path}
+					language={language}
+					theme={monacoTheme}
+					value={fileContent}
+					keepCurrentModel
+					beforeMount={handleEditorWillMount}
+					onMount={handleEditorDidMount}
+					onChange={readOnly ? undefined : setUpdatedFileContent}
+					options={{
+						automaticLayout: true,
+						minimap: { enabled: false },
+						readOnly,
+						// When the banner sits above the editor it already clears the toolbar
+						// overlay, so the editor only needs a little breathing room; otherwise
+						// it reserves the toolbar's height itself.
+						padding: { top: showBanner ? 8 : 48 },
+					}}
+				/>
+			</div>
+		</div>
 	);
 }

--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -32,7 +32,10 @@
  * worker (HarperFast/studio#1407).
  */
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
-import { acquireApplicationTypes } from '@/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition';
+import {
+	acquireApplicationTypes,
+	isTypeAcquisitionBudgetSpent,
+} from '@/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition';
 import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
 import { FileEntry } from '@/features/instance/applications/context/fileEntry';
 import { isDirectory } from '@/features/instance/applications/context/isDirectory';
@@ -47,7 +50,16 @@ import { typescript } from '@/lib/monaco/languageServices';
 import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { useQueryClient } from '@tanstack/react-query';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+/** Degradation status the editor surfaces to the user (HarperFast/studio#1504). */
+export interface ApplicationTypeIntelligenceStatus {
+	/**
+	 * The session-wide `@types` budget is spent, so further packages are no longer
+	 * acquired and their imports report a spurious "cannot find module".
+	 */
+	typeAcquisitionBudgetExhausted: boolean;
+}
 
 /** Source files worth registering as models (everything the worker can parse). */
 const LOADABLE_SOURCE = /\.(tsx?|jsx?|mjs|cjs|mts|cts|json)$/i;
@@ -173,9 +185,17 @@ function projectUriPrefix(project: string | undefined): string | undefined {
 	return project === undefined ? undefined : monaco.Uri.parse(`file:///${project}/`).toString();
 }
 
-export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined, rootEntries: AnyEntry[]): void {
+export function useApplicationTypeIntelligence(
+	openedEntry: AnyEntry | undefined,
+	rootEntries: AnyEntry[],
+): ApplicationTypeIntelligenceStatus {
 	const instanceParams = useInstanceClientIdParams();
 	const queryClient = useQueryClient();
+
+	// The budget is module-level and monotonic, so seed from it: a file opened
+	// after a prior project already exhausted the budget shows the notice at once,
+	// without waiting for another (short-circuited) acquisition pass.
+	const [typeAcquisitionBudgetExhausted, setTypeAcquisitionBudgetExhausted] = useState(isTypeAcquisitionBudgetSpent);
 
 	// Only intelligence-load the user's own applications. Installed packages can
 	// be large dependency trees and are read-only.
@@ -309,7 +329,12 @@ export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined
 						&& file.content.length <= MAX_WORKER_MODEL_CHARS
 					)
 					.map(file => file.content);
-				void acquireApplicationTypes(scriptSources);
+				await acquireApplicationTypes(scriptSources);
+				// The pass may have just sealed the budget; surface the current state
+				// so the editor can show (or keep) the degradation notice.
+				if (!cancelled) {
+					setTypeAcquisitionBudgetExhausted(isTypeAcquisitionBudgetSpent());
+				}
 			})();
 		}
 
@@ -327,4 +352,6 @@ export function useApplicationTypeIntelligence(openedEntry: AnyEntry | undefined
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [project, context, filesKey]);
+
+	return { typeAcquisitionBudgetExhausted };
 }


### PR DESCRIPTION
## Summary

Closes #1504. When the Applications code editor silently degrades its language features to stay responsive, it now tells the user with a dismissible in-editor banner instead of only logging to the console. Follow-up to #1499/#1500 — that work added the safety bound and a developer-facing `console.warn`/`console.debug`; this is the user-facing half raised in review.

Two degradation modes are surfaced:

- **Type-acquisition budget exhausted** — once cumulative acquired `@types` reach `MAX_EXTRA_LIB_CHARS_TOTAL` and `ExtraLibBudget` seals, further packages aren't acquired and their imports report a spurious *"cannot find module"*.
- **Oversized file → plaintext** — a file over `MAX_WORKER_MODEL_CHARS` (512 KB) renders as `plaintext` with no highlighting or language features.

## What changed

- `typeAcquisition.ts`: new `isTypeAcquisitionBudgetSpent()` surfaces the sealed-budget signal (previously console-only).
- `useApplicationTypeIntelligence.ts`: now returns `{ typeAcquisitionBudgetExhausted }` — seeded from the module-level budget (so a session that already exhausted it shows the notice immediately) and refreshed after each acquisition pass.
- `DegradedIntelliSenseBanner.tsx` (new): a thin, dismissible notice with `role="status"` / `aria-live="polite"`.
- `TextEditorView/index.tsx`: computes the active degradation (oversized wins; budget notice only on editable JS/TS files) and renders the banner above the editor. Dismissal is keyed per `path:variant`, so it re-shows for a different file or degradation but stays dismissed for the current one.

## Design notes (matches the issue)

- Non-blocking, dismissible, and sits **flush below the toolbar** (`mt-9` = the 36px `ContentActions` overlay) so it never covers the first line of code.
- Subtle inline bar (amber), not a modal/toast — it reflects a persistent state.
- Announced via `role="status"` / `aria-live="polite"`.

Wrapping the editor in a flex column required giving that column a **definite** height (`h-full`, not `min-h-full`) plus a `flex-1 min-h-0` box — otherwise `@monaco-editor/react`'s `height:100%` can't resolve and Monaco collapses to a few pixels.

## Testing

- New unit test `DegradedIntelliSenseBanner.test.tsx` (copy, `aria-live="polite"`, dismiss callback); `workerLimits` tests still green.
- `tsc -b`, `oxlint`, `dprint` all clean.
- **Browser-verified** on `stage` data (Applications editor, real Monaco): with the banner forced on, it renders flush below the toolbar, the editor fills the pane (1043px), and the first line of code sits below the banner; dismissing removes it and the editor reflows to full height (1136px, `padding.top` restored to 48). With the trigger removed, no banner appears for a normal file — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
