### PR TITLE
fix(clusters): hide overlapping version tags in the version picker

### DIFF
--- a/src/features/clusters/queries/getHarperVersionsQuery.test.ts
+++ b/src/features/clusters/queries/getHarperVersionsQuery.test.ts
@@ -121,4 +121,16 @@ describe('getHarperVersionsOptions', () => {
 			],
 		});
 	});
+
+	it('surfaces (rather than swallows) a malformed response with no value array', async () => {
+		// The endpoint's OpenAPI description is broken, so the `as HarperVersionsResponse` cast is not
+		// schema-backed. If it ever returns a body without `value`, the queryFn throws — React Query's
+		// QueryCache.onError surfaces it and every consumer null-checks `harperVersions?.value`, so it
+		// fails safely rather than silently rendering an empty picker.
+		mockedGet.mockResolvedValue({ data: { name: 'Harper Versions', description: '' } });
+
+		const options = getHarperVersionsOptions();
+
+		await expect((options.queryFn as () => Promise<HarperVersionsResponse>)()).rejects.toThrow();
+	});
 });

--- a/src/features/clusters/queries/getHarperVersionsQuery.test.ts
+++ b/src/features/clusters/queries/getHarperVersionsQuery.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from 'vitest';
-import { dedupeHarperVersionsByTag, HarperVersion } from './getHarperVersionsQuery';
+import { apiClient } from '@/config/apiClient';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	dedupeHarperVersionsByTag,
+	getHarperVersionsOptions,
+	HarperVersion,
+	HarperVersionsResponse,
+} from './getHarperVersionsQuery';
+
+vi.mock('@/config/apiClient', () => ({
+	apiClient: {
+		get: vi.fn(),
+	},
+}));
+
+const mockedGet = vi.mocked(apiClient.get);
+
+beforeEach(() => {
+	mockedGet.mockReset();
+});
 
 function tags(versions: HarperVersion[]) {
 	return versions.map(({ version, name }) => `${version} ${name}`);
@@ -10,6 +28,14 @@ describe('dedupeHarperVersionsByTag', () => {
 		const result = dedupeHarperVersionsByTag([
 			{ name: 'next', version: '5.1.21' },
 			{ name: 'stable', version: '5.1.21' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 stable']);
+	});
+
+	it('discards a less-preferred tag that arrives after a more-preferred one', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'stable', version: '5.1.21' },
+			{ name: 'next', version: '5.1.21' },
 		]);
 		expect(tags(result)).toEqual(['5.1.21 stable']);
 	});
@@ -58,5 +84,41 @@ describe('dedupeHarperVersionsByTag', () => {
 
 	it('handles an empty list', () => {
 		expect(dedupeHarperVersionsByTag([])).toEqual([]);
+	});
+});
+
+describe('getHarperVersionsOptions', () => {
+	it('configures the query to hit the HarperVersions cache key without retrying', () => {
+		const options = getHarperVersionsOptions();
+		expect(options.queryKey).toEqual(['HarperVersions']);
+		expect(options.staleTime).toBe(60_000);
+		expect(options.retry).toBe(false);
+	});
+
+	it('fetches the versions and dedupes overlapping tags, keeping the rest of the response', async () => {
+		mockedGet.mockResolvedValue({
+			data: {
+				name: 'Harper Versions',
+				description: 'Available Harper versions',
+				value: [
+					{ name: 'next', version: '5.1.21' },
+					{ name: 'stable', version: '5.1.21' },
+					{ name: 'beta', version: '5.2.0' },
+				],
+			} satisfies HarperVersionsResponse,
+		});
+
+		const options = getHarperVersionsOptions();
+		const result = await (options.queryFn as () => Promise<HarperVersionsResponse>)();
+
+		expect(mockedGet).toHaveBeenCalledWith('/HarperVersions/');
+		expect(result).toEqual({
+			name: 'Harper Versions',
+			description: 'Available Harper versions',
+			value: [
+				{ name: 'stable', version: '5.1.21' },
+				{ name: 'beta', version: '5.2.0' },
+			],
+		});
 	});
 });

--- a/src/features/clusters/queries/getHarperVersionsQuery.test.ts
+++ b/src/features/clusters/queries/getHarperVersionsQuery.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeHarperVersionsByTag, HarperVersion } from './getHarperVersionsQuery';
+
+function tags(versions: HarperVersion[]) {
+	return versions.map(({ version, name }) => `${version} ${name}`);
+}
+
+describe('dedupeHarperVersionsByTag', () => {
+	it('keeps the most-preferred tag when a version appears more than once', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'next', version: '5.1.21' },
+			{ name: 'stable', version: '5.1.21' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 stable']);
+	});
+
+	it('applies the full preference order stable > next > beta > alpha', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'alpha', version: '6.0.0' },
+			{ name: 'beta', version: '6.0.0' },
+			{ name: 'next', version: '6.0.0' },
+		]);
+		expect(tags(result)).toEqual(['6.0.0 next']);
+	});
+
+	it('prefers any known tag over an unknown one', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'foobarbaz', version: '5.1.21' },
+			{ name: 'alpha', version: '5.1.21' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 alpha']);
+	});
+
+	it('keeps a single unknown tag when there is nothing better', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'foobarbaz', version: '5.1.21' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 foobarbaz']);
+	});
+
+	it('keeps distinct versions untouched and preserves their order', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'stable', version: '5.1.21' },
+			{ name: 'next', version: '5.2.0' },
+			{ name: 'beta', version: '6.0.0' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 stable', '5.2.0 next', '6.0.0 beta']);
+	});
+
+	it('keeps each version at the position of its first appearance', () => {
+		const result = dedupeHarperVersionsByTag([
+			{ name: 'next', version: '5.1.21' },
+			{ name: 'stable', version: '5.2.0' },
+			{ name: 'stable', version: '5.1.21' },
+		]);
+		expect(tags(result)).toEqual(['5.1.21 stable', '5.2.0 stable']);
+	});
+
+	it('handles an empty list', () => {
+		expect(dedupeHarperVersionsByTag([])).toEqual([]);
+	});
+});

--- a/src/features/clusters/queries/getHarperVersionsQuery.ts
+++ b/src/features/clusters/queries/getHarperVersionsQuery.ts
@@ -51,7 +51,7 @@ async function getHarperVersions() {
 	const response = data as HarperVersionsResponse;
 	return {
 		...response,
-		value: dedupeHarperVersionsByTag(response?.value ?? []),
+		value: dedupeHarperVersionsByTag(response.value),
 	} satisfies HarperVersionsResponse;
 }
 

--- a/src/features/clusters/queries/getHarperVersionsQuery.ts
+++ b/src/features/clusters/queries/getHarperVersionsQuery.ts
@@ -7,15 +7,52 @@ export interface HarperVersionsResponse {
 	value: HarperVersion[];
 }
 
-interface HarperVersion {
-	name: 'stable' | 'next' | 'current';
+export interface HarperVersion {
+	/**
+	 * Release tag for this version. `stable`, `next`, `beta`, and `alpha` come from the endpoint (which may
+	 * also return tags we don't know about yet, hence the plain `string`); `current` is synthesized
+	 * client-side for the version a cluster already runs.
+	 */
+	name: string;
 	version: string;
+}
+
+/**
+ * Known release tags, most-preferred first. When the endpoint returns the same version under more than one
+ * tag we keep the most-preferred; any unrecognized tag ranks below all of these.
+ */
+export const HARPER_VERSION_TAG_PREFERENCE = ['stable', 'next', 'beta', 'alpha'] as const;
+
+function tagRank(name: string): number {
+	const index = (HARPER_VERSION_TAG_PREFERENCE as readonly string[]).indexOf(name);
+	return index === -1 ? HARPER_VERSION_TAG_PREFERENCE.length : index;
+}
+
+/**
+ * Collapse versions that share the same version string down to a single entry, keeping the one with the
+ * most-preferred tag (stable > next > beta > alpha > anything else). The endpoint can return, e.g.,
+ * `5.1.21` tagged both `stable` and `next`; the picker should only offer `stable`.
+ */
+export function dedupeHarperVersionsByTag(versions: HarperVersion[]): HarperVersion[] {
+	const bestByVersion = new Map<string, HarperVersion>();
+	for (const version of versions) {
+		const existing = bestByVersion.get(version.version);
+		if (!existing || tagRank(version.name) < tagRank(existing.name)) {
+			// Map preserves first-insertion order, so replacing the value keeps the version's original position.
+			bestByVersion.set(version.version, version);
+		}
+	}
+	return [...bestByVersion.values()];
 }
 
 async function getHarperVersions() {
 	// TODO: OpenAPI from CM is erroring, so this new endpoint isn't described.
 	const { data } = await apiClient.get(`/HarperVersions/` as any);
-	return data as HarperVersionsResponse;
+	const response = data as HarperVersionsResponse;
+	return {
+		...response,
+		value: dedupeHarperVersionsByTag(response?.value ?? []),
+	} satisfies HarperVersionsResponse;
 }
 
 export function getHarperVersionsOptions() {


### PR DESCRIPTION
## What & why

Closes #1531.

The `HarperVersions` endpoint can return the same version under more than one release tag — e.g. `5.1.21` tagged both `stable` and `next`. The cluster version picker ([`ClusterVersion.tsx`](src/features/clusters/upsert/fields/ClusterVersion.tsx)) mapped the raw list straight through, so it offered the same version twice and, because it uses the version string as the React `key`, the duplicates also collided on their keys.

Per the issue, when two entries are identical but carry different tags we should surface only the most-preferred one.

## Change

Dedupe in [`getHarperVersionsQuery.ts`](src/features/clusters/queries/getHarperVersionsQuery.ts) itself, so **both** the create and edit flows are covered (the edit-only `useMemo` in `upsert/index.tsx` does its own version filtering but is skipped entirely when creating a new cluster).

- New pure helper `dedupeHarperVersionsByTag` collapses entries sharing a version string to a single entry.
- Tag preference, most- to least-preferred: **stable > next > beta > alpha**, and any of those beats an unrecognized tag (`HARPER_VERSION_TAG_PREFERENCE`).
- Kept entries retain their original position in the list (backed by `Map` insertion order).
- Widened the `HarperVersion.name` type from the incomplete `'stable' | 'next' | 'current'` union to `string`, reflecting that the endpoint also emits `beta`/`alpha` and potentially unknown tags.

## Testing

- New unit tests in `getHarperVersionsQuery.test.ts` cover the exact issue example (`5.1.21` stable+next → only stable), the full preference order, known-beats-unknown, a lone unknown tag, order preservation, and the empty case.
- Full suite green (1727 passed), plus `tsc -b`, `oxlint`, and `dprint`.

> Note: the live endpoint doesn't reliably emit overlapping tags on demand, so this was verified via the pure-function unit tests rather than the browser flow; the picker's rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)