### PR TITLE
chore(renovate): group pre-1.0 dprint/oxfmt bumps with non-major deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,8 +40,7 @@
 			"groupName": "all non-major dependencies",
 			"groupSlug": "all-minor-patch",
 			"matchPackageNames": ["dprint", "oxfmt"],
-			"matchCurrentVersion": "< 1.0.0",
-			"matchUpdateTypes": ["minor", "patch"]
+			"matchCurrentVersion": "< 1.0.0"
 		}
 	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,14 @@
 				"patch"
 			],
 			"matchCurrentVersion": "!/^0/"
+		},
+		{
+			"description": "Treat pre-1.0 dprint/oxfmt (stable formatters) as non-major so bumps group with other deps; regroups normally once they reach 1.0.0+.",
+			"groupName": "all non-major dependencies",
+			"groupSlug": "all-minor-patch",
+			"matchPackageNames": ["dprint", "oxfmt"],
+			"matchCurrentVersion": "< 1.0.0",
+			"matchUpdateTypes": ["minor", "patch"]
 		}
 	]
 }


### PR DESCRIPTION
## What

Treat pre-1.0 `dprint`/`oxfmt` bumps as **non-major**, so they group into the existing "all non-major dependencies" PR instead of opening a separate PR every release.

## Why

Under caret semantics `^0.x` doesn't satisfy the next `0.y`, so Renovate splits every pre-1.0 bump of these formatters into its own PR. They're stable in practice and any breakage surfaces immediately in the formatter tooling — no need for individual review.

## How

Adds a `packageRules` entry mirroring the existing non-major group, scoped to `dprint`/`oxfmt` while `matchCurrentVersion: "< 1.0.0"` (matches this repo's group, which does not automerge). Once either reaches 1.0.0 the rule stops matching and they return to the normal major cadence automatically. Validated with `renovate-config-validator`.

Companion PRs applied to the other repos carrying these tools (schema-codegen #39, agent-tools #28, create-harper #122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)