### PR TITLE
feat(clusters): hide container ops on self-hosted, gate Deployments on auth

### DIFF
--- a/src/features/cluster/useInstanceMenuItems.tsx
+++ b/src/features/cluster/useInstanceMenuItems.tsx
@@ -85,10 +85,11 @@ export function useInstanceMenuItems(
 
 	// Container lifecycle ops (stop/start/restart) — distinct from the proxied Harper "restart".
 	// Only offered from a settled RUNNING/STOPPED state; hidden mid-transition (the instances poll
-	// reveals the resting state and the actions reappear).
+	// reveals the resting state and the actions reappear). Self-hosted clusters have no managed
+	// container lifecycle (Harper doesn't control their runtime), so the group is hidden for them.
 	const isRunning = instance.status === 'RUNNING';
 	const isStopped = instance.status === 'STOPPED';
-	const hasContainerOps = canManage && (isRunning || isStopped);
+	const hasContainerOps = canManage && !isSelfManaged && (isRunning || isStopped);
 
 	const actions: EntityMenuItem[] = [
 		hasAuth && isDirectlyLoggedIn && {

--- a/src/features/clusters/components/ClusterCard.tsx
+++ b/src/features/clusters/components/ClusterCard.tsx
@@ -86,6 +86,9 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 		[cluster.status],
 	);
 	const isSelfManaged = clusterIsSelfManaged(cluster);
+	// Self-hosted clusters have no managed container lifecycle — Harper doesn't control their
+	// runtime — so the whole Container action group is hidden for them (matching ClusterStateMenu).
+	const showContainerActions = update && !isSelfManaged;
 	const isFabricConnect = authStore.checkForFabricConnect(cluster.id);
 	const isDirectConnect = !isFabricConnect && !!auth.user;
 	const isTerminated = useMemo(
@@ -233,7 +236,7 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 			icon: <ServerIcon className="text-orange-300" />,
 			label: 'Instances',
 		},
-		isActive && view && {
+		isActive && view && !!auth.user && {
 			key: 'deployments',
 			to: `${cluster.id}/config/deployments`,
 			disabled: signingOut,
@@ -241,39 +244,39 @@ export function ClusterCard({ cluster }: { cluster: Cluster }) {
 			label: 'Deployments',
 		},
 
-		update && (isClusterRunning || isClusterStopped || isClusterPartial)
+		showContainerActions && (isClusterRunning || isClusterStopped || isClusterPartial)
 		&& { type: 'separator' as const, key: 'container-separator' },
-		update && (isClusterRunning || isClusterStopped || isClusterPartial)
+		showContainerActions && (isClusterRunning || isClusterStopped || isClusterPartial)
 		&& { type: 'label' as const, key: 'container-label', className: 'text-gray-600 text-xs', label: 'Container' },
-		update && (isClusterStopped || isClusterPartial) && {
+		showContainerActions && (isClusterStopped || isClusterPartial) && {
 			key: 'container-start',
 			disabled: isClusterOpPending,
 			onClick: () => void runClusterOp('start', { safeMode: false, strategy: 'parallel' }),
 			icon: <PlayIcon />,
 			label: 'Start',
 		},
-		update && isClusterStopped && {
+		showContainerActions && isClusterStopped && {
 			key: 'container-start-safe',
 			disabled: isClusterOpPending,
 			onClick: () => setSafeModeAction('start'),
 			icon: <LifeBuoyIcon />,
 			label: 'Start in safe mode',
 		},
-		update && (isClusterRunning || isClusterPartial) && {
+		showContainerActions && (isClusterRunning || isClusterPartial) && {
 			key: 'container-restart',
 			disabled: isClusterOpPending,
 			onClick: () => setRestartDialogOpen(true),
 			icon: <RotateCwIcon />,
 			label: 'Restart',
 		},
-		update && isClusterRunning && {
+		showContainerActions && isClusterRunning && {
 			key: 'container-restart-safe',
 			disabled: isClusterOpPending,
 			onClick: () => setSafeModeAction('restart'),
 			icon: <LifeBuoyIcon />,
 			label: 'Restart in safe mode',
 		},
-		update && (isClusterRunning || isClusterPartial) && {
+		showContainerActions && (isClusterRunning || isClusterPartial) && {
 			key: 'container-stop',
 			variant: 'destructive' as const,
 			disabled: isClusterOpPending,


### PR DESCRIPTION
## What

Hides a few cluster features that don't apply to **self-hosted** clusters, plus gates the Deployments menu item on cluster authentication.

### 1. Container actions hidden on self-hosted clusters
Self-hosted clusters have no managed container lifecycle — Harper doesn't control their runtime — so the **Container** action group (Start, Start in safe mode, Restart, Restart in safe mode, Stop) is now hidden for them in:
- the cluster-card context menu / "…" dropdown (`ClusterCard`)
- the per-instance context menu / "…" dropdown (`useInstanceMenuItems`)

This matches the existing behavior of the cluster-overview **"Cluster actions"** dropdown (`ClusterStateMenu`), which already returns `null` for self-hosted clusters — so no change was needed there.

> Note: the request specifically named Restart / Restart in safe mode / Stop, but I hid the whole group (Start / Start in safe mode too) for consistency with `ClusterStateMenu`'s "self-hosted clusters have no container ops" rule. In practice self-hosted clusters are `RUNNING`, so only the three named ones were ever visible anyway.

### 2. "Deployments" gated on cluster authentication
The **Deployments** cluster-card menu item now only appears once you've authenticated with the cluster (`!!auth.user`, the same signal `ClusterHome` uses for its connected state) — previously it showed whenever you had view permission.

## Verification
- `tsc -b`, `oxlint`, `dprint`, and the full `vitest` suite (241 files / 1732 tests) all pass.
- Verified live against real cluster data (worktree dev server on :5173) with a managed cluster ("Anvils") and a self-hosted cluster ("Self"), neither authenticated:

| Menu | Container actions | Deployments |
|---|---|---|
| **Self** (self-hosted) cluster card | absent ✓ | absent (not authed) ✓ |
| **Self** instance menu | absent ✓ | — |
| **Anvils** (managed) cluster card — control | Restart / Restart in safe mode / Stop present ✓ | absent (not authed) ✓ |

The managed cluster confirms the container-ops change is correctly scoped to self-hosted; Deployments disappearing for both clusters (where it previously showed unconditionally) confirms the auth gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)