### PR TITLE
feat: Resend invite in user modal + verification flow for unverified login

### DIFF
--- a/src/features/auth/hooks/useCloudSignIn.test.tsx
+++ b/src/features/auth/hooks/useCloudSignIn.test.tsx
@@ -62,9 +62,28 @@ describe('useCloudSignIn — unverified email', () => {
 
 		await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/verifying?email=unverified%40example.com' }));
 		expect(apiClient.post).toHaveBeenCalledWith('/ResendVerificationEmail/', { email: EMAIL });
-		expect(toast.info).toHaveBeenCalled();
+		// The "we sent a link" toast only fires once the resend actually succeeds.
+		await waitFor(() => expect(toast.info).toHaveBeenCalled());
 		// The dead-end "Error" toast must NOT fire for this case.
 		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('still redirects (without claiming a link was sent) when the resend fails', async () => {
+		post.mockImplementation((url: string) => {
+			if (url === '/Login/') {
+				return Promise.reject(axiosError(403, { error: 'User has not verified email address' }));
+			}
+			// Resend fails (e.g. rate-limited) — the user must still reach /verifying, and we must
+			// NOT show a "we sent a link" toast that never happened.
+			return Promise.reject(axiosError(429, { error: 'Too many requests' }));
+		});
+
+		const { result } = renderHook(() => useCloudSignIn(), { wrapper: wrapper() });
+		act(() => result.current.submitForm({ email: EMAIL, password: 'correct-horse' }));
+
+		await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/verifying?email=unverified%40example.com' }));
+		await waitFor(() => expect(apiClient.post).toHaveBeenCalledWith('/ResendVerificationEmail/', { email: EMAIL }));
+		expect(toast.info).not.toHaveBeenCalled();
 	});
 
 	it('shows the standard error toast (no redirect, no resend) for invalid credentials', async () => {

--- a/src/features/auth/hooks/useCloudSignIn.test.tsx
+++ b/src/features/auth/hooks/useCloudSignIn.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { PropsWithChildren } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCloudSignIn } from './useCloudSignIn';
+
+// One shared apiClient mock backs both the login POST and the resend POST.
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock('@/config/apiClient', () => ({ apiClient: { post } }));
+
+// The hook only reaches for the router; give it inert doubles we can assert against.
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock('@tanstack/react-router', () => ({
+	useNavigate: () => navigate,
+	useRouter: () => ({ invalidate: vi.fn() }),
+	useSearch: () => ({}),
+}));
+
+vi.mock('sonner', () => ({
+	toast: { info: vi.fn(), error: vi.fn().mockReturnValue({ dismiss: vi.fn() }), dismiss: vi.fn() },
+}));
+
+// onSuccess-only integrations — never exercised by these error-path tests, mocked to keep imports inert.
+vi.mock('@/integrations/datadog/datadog', () => ({ loginSuccessDatadogAction: vi.fn() }));
+vi.mock('@/integrations/reo/reo', () => ({ reoClient: { identify: vi.fn() } }));
+
+import { apiClient } from '@/config/apiClient';
+import { toast } from 'sonner';
+
+const EMAIL = 'unverified@example.com';
+
+function axiosError(status: number, data: unknown): AxiosError {
+	return { isAxiosError: true, response: { status, data } } as AxiosError;
+}
+
+function wrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return ({ children }: PropsWithChildren) => <QueryClientProvider client={queryClient}>{children}
+	</QueryClientProvider>;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('useCloudSignIn — unverified email', () => {
+	it('resends verification, redirects to /verifying, and suppresses the generic error toast', async () => {
+		post.mockImplementation((url: string) => {
+			if (url === '/Login/') {
+				return Promise.reject(axiosError(403, { error: 'User has not verified email address' }));
+			}
+			if (url === '/ResendVerificationEmail/') { return Promise.resolve({ data: { email: EMAIL } }); }
+			return Promise.reject(new Error(`unexpected ${url}`));
+		});
+
+		const { result } = renderHook(() => useCloudSignIn(), { wrapper: wrapper() });
+		act(() => result.current.submitForm({ email: EMAIL, password: 'correct-horse' }));
+
+		await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: '/verifying?email=unverified%40example.com' }));
+		expect(apiClient.post).toHaveBeenCalledWith('/ResendVerificationEmail/', { email: EMAIL });
+		expect(toast.info).toHaveBeenCalled();
+		// The dead-end "Error" toast must NOT fire for this case.
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('shows the standard error toast (no redirect, no resend) for invalid credentials', async () => {
+		post.mockImplementation((url: string) =>
+			url === '/Login/'
+				? Promise.reject(axiosError(401, { error: 'Invalid email or password' }))
+				: Promise.reject(new Error(`unexpected ${url}`))
+		);
+
+		const { result } = renderHook(() => useCloudSignIn(), { wrapper: wrapper() });
+		act(() => result.current.submitForm({ email: EMAIL, password: 'wrong' }));
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(navigate).not.toHaveBeenCalled();
+		expect(apiClient.post).not.toHaveBeenCalledWith('/ResendVerificationEmail/', expect.anything());
+	});
+});

--- a/src/features/auth/hooks/useCloudSignIn.ts
+++ b/src/features/auth/hooks/useCloudSignIn.ts
@@ -50,10 +50,15 @@ export function useCloudSignIn() {
 			onError: (error) => {
 				if (isEmailNotVerifiedError(error)) {
 					// This rejection only happens after central-manager accepts the password, so the
-					// credentials are valid — resending a fresh link here can't be abused for spam.
-					resendEmailVerification({ email: formData.email });
-					toast.info('Verify your email to finish signing in', {
-						description: `We sent a new verification link to ${formData.email}.`,
+					// credentials are valid — resending a fresh link here can't be abused for spam. Only
+					// claim "we sent a link" once the resend actually succeeds; navigate regardless so an
+					// unverified user always lands on /verifying (which offers a manual resend) rather than
+					// dead-ending on the sign-in page.
+					resendEmailVerification({ email: formData.email }, {
+						onSuccess: () =>
+							toast.info('Verify your email to finish signing in', {
+								description: `We sent a new verification link to ${formData.email}.`,
+							}),
 					});
 					void navigate({ to: '/verifying?email=' + encodeURIComponent(formData.email) });
 					return;

--- a/src/features/auth/hooks/useCloudSignIn.ts
+++ b/src/features/auth/hooks/useCloudSignIn.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/config/apiClient';
+import { isEmailNotVerifiedError } from '@/features/auth/isEmailNotVerifiedError';
 import { currentUserQueryKey } from '@/features/auth/queries/getCurrentUser';
 import { authStore, OverallAppSignIn } from '@/features/auth/store/authStore';
 import { User } from '@/integrations/api/api.patch';
@@ -8,10 +9,13 @@ import { reoClient } from '@/integrations/reo/reo';
 import { parseCompanyFromEmail } from '@/lib/string/parseCompanyFromEmail';
 import { clearUtmParamsFromUrl } from '@/lib/urls/clearUtmParams';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
+import { errorHandler } from '@/react-query/queryClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useRouter, useSearch } from '@tanstack/react-router';
 import { useCallback } from 'react';
+import { toast } from 'sonner';
 import { z } from 'zod';
+import { useResendEmailVerification } from './useResendEmailVerification';
 
 export function useCloudSignIn() {
 	const navigate = useNavigate();
@@ -20,6 +24,7 @@ export function useCloudSignIn() {
 	const { redirect } = useSearch({ strict: false });
 
 	const { mutate: submitLoginData, isPending } = useLoginMutation();
+	const { mutate: resendEmailVerification } = useResendEmailVerification();
 
 	const submitForm = useCallback((formData: z.infer<typeof EmailSignInSchema>) => {
 		submitLoginData(formData, {
@@ -40,8 +45,24 @@ export function useCloudSignIn() {
 				void router.invalidate();
 				await navigate({ to: redirect?.startsWith('/') ? redirect : defaultCloudRoute });
 			},
+			// The login mutation opts out of the global error toast (meta.skipGlobalErrorToast) so we
+			// can special-case the unverified-email rejection instead of dead-ending on a red toast.
+			onError: (error) => {
+				if (isEmailNotVerifiedError(error)) {
+					// This rejection only happens after central-manager accepts the password, so the
+					// credentials are valid — resending a fresh link here can't be abused for spam.
+					resendEmailVerification({ email: formData.email });
+					toast.info('Verify your email to finish signing in', {
+						description: `We sent a new verification link to ${formData.email}.`,
+					});
+					void navigate({ to: '/verifying?email=' + encodeURIComponent(formData.email) });
+					return;
+				}
+				// Any other failure keeps the standard error toast.
+				errorHandler(error);
+			},
 		});
-	}, [navigate, queryClient, redirect, router, submitLoginData]);
+	}, [navigate, queryClient, redirect, resendEmailVerification, router, submitLoginData]);
 
 	return {
 		isPending,
@@ -52,6 +73,9 @@ export function useCloudSignIn() {
 function useLoginMutation() {
 	return useMutation<User, Error, z.infer<typeof EmailSignInSchema>>({
 		mutationFn: (loginData) => onLoginSubmit(loginData),
+		// submitForm renders the login-error UX itself (redirecting unverified users into the
+		// email-verification flow), so suppress the default global error toast for this mutation.
+		meta: { skipGlobalErrorToast: true },
 	});
 }
 

--- a/src/features/auth/isEmailNotVerifiedError.test.ts
+++ b/src/features/auth/isEmailNotVerifiedError.test.ts
@@ -1,0 +1,46 @@
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { isEmailNotVerifiedError } from './isEmailNotVerifiedError';
+
+// Shapes a rejection the way axios surfaces a central-manager error response.
+function axiosError(status: number, data: unknown): AxiosError {
+	return { isAxiosError: true, response: { status, data } } as AxiosError;
+}
+
+describe('isEmailNotVerifiedError', () => {
+	it('matches the 403 "User has not verified email address" rejection (data.error)', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, { error: 'User has not verified email address' }))).toBe(true);
+	});
+
+	it('matches when the message is under data.message', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, { message: 'User has not verified email address' }))).toBe(true);
+	});
+
+	it('matches when the body is a bare string', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, 'User has not verified email address'))).toBe(true);
+	});
+
+	it('matches a nested structured error object', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, { error: { message: 'User has not verified email address' } })))
+			.toBe(true);
+	});
+
+	it('does NOT match a 403 deactivated-account rejection (same status, different reason)', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, { error: 'User account deactivated' }))).toBe(false);
+	});
+
+	it('does NOT match a 401 invalid-credentials rejection', () => {
+		expect(isEmailNotVerifiedError(axiosError(401, { error: 'Invalid email or password' }))).toBe(false);
+	});
+
+	it('does NOT match a 409 conflict', () => {
+		expect(isEmailNotVerifiedError(axiosError(409, { error: 'Multiple user@example.com records found' }))).toBe(false);
+	});
+
+	it('is safe on non-axios / empty errors', () => {
+		expect(isEmailNotVerifiedError(new Error('Something went wrong'))).toBe(false);
+		expect(isEmailNotVerifiedError(undefined)).toBe(false);
+		expect(isEmailNotVerifiedError(null)).toBe(false);
+		expect(isEmailNotVerifiedError(axiosError(403, undefined))).toBe(false);
+	});
+});

--- a/src/features/auth/isEmailNotVerifiedError.ts
+++ b/src/features/auth/isEmailNotVerifiedError.ts
@@ -1,0 +1,27 @@
+import { errorText } from '@/lib/errorText';
+import { AxiosError } from 'axios';
+
+/**
+ * Detects the cloud-login rejection that means "this account exists and the password was
+ * correct, but the email address hasn't been verified yet".
+ *
+ * central-manager's `Login` resource checks verification *after* validating the password
+ * (so an attacker with a wrong password can't distinguish an unverified account from a bad
+ * one) and throws HTTP 403 with the message "User has not verified email address". A
+ * *deactivated* account also comes back as 403, so we additionally match the message — a
+ * bare status check would wrongly funnel deactivated users into the email-verification flow.
+ *
+ * Because this state is only reachable once the password has been accepted, callers can treat
+ * it as proof of valid credentials (e.g. safe to auto-resend a verification link).
+ */
+export function isEmailNotVerifiedError(error: unknown): boolean {
+	const axiosError = error as AxiosError<string | { error?: unknown; message?: unknown }>;
+	if (axiosError?.response?.status !== 403) {
+		return false;
+	}
+	const data = axiosError.response.data;
+	const message = typeof data === 'string'
+		? data
+		: errorText(data?.error) ?? errorText(data?.message) ?? '';
+	return /verif/i.test(message);
+}

--- a/src/features/auth/isEmailNotVerifiedError.ts
+++ b/src/features/auth/isEmailNotVerifiedError.ts
@@ -1,5 +1,5 @@
 import { errorText } from '@/lib/errorText';
-import { AxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 
 /**
  * Detects the cloud-login rejection that means "this account exists and the password was
@@ -15,11 +15,10 @@ import { AxiosError } from 'axios';
  * it as proof of valid credentials (e.g. safe to auto-resend a verification link).
  */
 export function isEmailNotVerifiedError(error: unknown): boolean {
-	const axiosError = error as AxiosError<string | { error?: unknown; message?: unknown }>;
-	if (axiosError?.response?.status !== 403) {
+	if (!isAxiosError(error) || error.response?.status !== 403) {
 		return false;
 	}
-	const data = axiosError.response.data;
+	const data = error.response.data as string | { error?: unknown; message?: unknown } | undefined;
 	const message = typeof data === 'string'
 		? data
 		: errorText(data?.error) ?? errorText(data?.message) ?? '';

--- a/src/features/organization/users/modals/EditUserModal.tsx
+++ b/src/features/organization/users/modals/EditUserModal.tsx
@@ -4,6 +4,7 @@ import { useRemoveUserFromOrganizationRole } from '@/features/organization/mutat
 import { getOrganizationRolesQueryOptions } from '@/features/organization/queries/getOrganizationRoles';
 import { OrgUserRoleCheckbox } from '@/features/organization/users/components/OrgUserRoleCheckbox';
 import { RemoveUserFromOrgButton } from '@/features/organization/users/components/RemoveUserFromOrgButton';
+import { ResendInviteButton } from '@/features/organization/users/components/ResendInviteButton';
 import { getOrgUserRemovalPolicy, isAdminRoleName } from '@/features/organization/users/orgUserRemovalPolicy';
 import { useCloudAuth } from '@/hooks/useAuth';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
@@ -107,6 +108,13 @@ export function EditUserModal({
 						setChangesMade={setChangesMade}
 					/>
 				</Suspense>
+
+				{/* Pending users haven't accepted their invite yet — offer the same resend action as the users table row. */}
+				{data.status === 'PENDING' && (
+					<div className="border-t border-border pt-4">
+						<ResendInviteButton user={data} />
+					</div>
+				)}
 
 				{showRemovalAction && (
 					<div className="border-t border-border pt-4">

--- a/src/react-query/queryClient.test.ts
+++ b/src/react-query/queryClient.test.ts
@@ -119,6 +119,17 @@ describe('errorHandler', () => {
 		);
 	});
 
+	// A mutation can opt out of the global toast to render its own error UX (e.g. the cloud login
+	// flow redirects an unverified user instead of dead-ending on a red toast).
+	it('skips the global toast when the mutation sets meta.skipGlobalErrorToast', async () => {
+		const observer = new MutationObserver(queryClient, {
+			mutationFn: () => Promise.reject(new Error('handled elsewhere')),
+			meta: { skipGlobalErrorToast: true },
+		});
+		await expect(observer.mutate()).rejects.toThrow('handled elsewhere');
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
 	it('should display error message from generic error.message', () => {
 		// Create a generic error with message property
 		const genericError = {

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -50,6 +50,14 @@ export const queryClient = new QueryClient({
 		onError: errorHandler,
 	}),
 	mutationCache: new MutationCache({
-		onError: errorHandler,
+		// Every mutation error routes through the shared toast by default. A mutation can opt out
+		// — to render its own inline UI or redirect instead — with `meta: { skipGlobalErrorToast: true }`
+		// (e.g. the cloud login flow redirects an unverified user to the email-verification page).
+		onError: (error, _variables, _context, mutation) => {
+			if (mutation.meta?.skipGlobalErrorToast) {
+				return;
+			}
+			errorHandler(error);
+		},
 	}),
 });


### PR DESCRIPTION
## Summary

Two related account/user-management improvements.

### 1. "Resend invite" in the user detail modal
The org users table already offers a **Resend invite** action on `PENDING` rows. This surfaces the same action inside `EditUserModal`, so it's reachable after opening a pending user — not only from the row.

- Reuses the existing `ResendInviteButton` component, so permission gating (org-role `update`), the invite mutation, and toasts are identical to the row.
- Rendered only when the user's `status === 'PENDING'` (in a bordered section above "Remove from organization").

### 2. Route unverified users into the email-verification flow on login
An email/password login for an unverified account is rejected by central-manager with **403 "User has not verified email address"** — and, notably, this check runs *after* the password is validated, so reaching it proves the credentials are valid. The cloud login mutation had no `onError`, so it dead-ended on a generic red **"Error"** toast with no way to get a new verification link.

Now, when a login fails specifically because the email is unverified, the app:
- **detects** that rejection (403 **and** a message match, so a 403 *deactivated* account isn't mis-routed),
- **auto-resends** a fresh verification link (safe — the branch is only reachable with valid credentials, so it can't be abused for spam),
- shows a friendly informational toast, and
- **redirects** to the existing `/verifying` page.

All other login failures (wrong password → 401, deactivated → 403, etc.) keep the standard error toast.

Also adds a `meta.skipGlobalErrorToast` opt-out to the `MutationCache` so a mutation can render its own error UX instead of the shared toast.

## Testing
- New unit tests for the `isEmailNotVerifiedError` detector (403-unverified vs 403-deactivated vs 401 vs non-axios).
- New `useCloudSignIn` flow test: unverified → resend + redirect + suppressed error toast; invalid credentials → standard toast, no redirect/resend.
- New `queryClient` test: `meta.skipGlobalErrorToast` suppresses the global toast (and the existing "global toast fires by default" test still passes).
- Full suite green (`vitest run`: 1743 passed, 11 skipped), `tsc -b` clean, oxlint + dprint clean.

### Verified live against the stage backend
- **Point 1 (modal):** Resend invite appears for PENDING users, absent for ACTIVE users.
- **Point 2 (unverified login):** created a new account, left it unverified, then signed in with it again → correctly redirected to the **"Check your email"** screen with the email pre-filled (verification link auto-resent). Note: this path only manifests against stage/prod — a *local* backend auto-verifies signups (`isVerified || isLocal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)