### PR TITLE
fix(browse): guard Delete Row against not-yet-loaded record (RUM: undefined[0] TypeError)

### DIFF
--- a/src/features/instance/databases/modals/EditTableRowModal.test.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { EditTableRowModal } from '@/features/instance/databases/modals/EditTableRowModal';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 // Monaco can't load in jsdom; stub the editor with a plain element that exposes the value it was
@@ -84,6 +84,20 @@ describe('EditTableRowModal', () => {
 		expect(screen.getByTestId('editor').getAttribute('data-readonly')).toBe('true');
 		expect(screen.queryByRole('button', { name: /Save Changes/i })).toBeNull();
 		expect(screen.queryByRole('button', { name: /Delete Row/i })).toBeNull();
+	});
+
+	it('does not throw when Delete Row is clicked before the record has loaded', () => {
+		// The parent passes `data={searchByIdData?.data}`, which is undefined while the
+		// record fetch is in flight — but the Delete Row button renders regardless. Clicking
+		// it then used to do an unguarded `data[0]` and throw an unhandled
+		// "Cannot read properties of undefined (reading '0')" (RUM, browse table view).
+		const onDeleteRecord = vi.fn();
+		renderModal({ data: undefined, onDeleteRecord });
+
+		const deleteButton = screen.getByRole('button', { name: /Delete Row/i });
+		expect(() => fireEvent.click(deleteButton)).not.toThrow();
+		// Nothing to delete without a loaded record, so the delete is a no-op.
+		expect(onDeleteRecord).not.toHaveBeenCalled();
 	});
 
 	it('lets a normal row be edited and deleted', () => {

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -37,7 +37,9 @@ export function EditTableRowModal({
 	/** Relationship/computed attribute names — read-only, so they are hidden from the editable JSON
 	 * (saving a record that assigns one fails, even with null). */
 	syntheticAttributes?: string[];
-	data: { __createdtime__?: number; __updatedtime__?: number; [record: string]: unknown }[];
+	/** Undefined while the record fetch is in flight (the parent passes `searchByIdData?.data`), so
+	 * every read must tolerate it — the editor renders a loading state and the write actions guard it. */
+	data?: { __createdtime__?: number; __updatedtime__?: number; [record: string]: unknown }[];
 	onSaveChanges: (data: Record<string, unknown>[]) => void;
 	onDeleteRecord: (data: unknown[]) => void;
 	isUpdateTableRecordsPending: boolean;
@@ -147,7 +149,7 @@ export function EditTableRowModal({
 								type="button"
 								autoFocus={false}
 								onClick={() => {
-									const primaryKeyValue = data[0]?.[primaryKey];
+									const primaryKeyValue = data?.[0]?.[primaryKey];
 									if (primaryKeyValue != null) {
 										onDeleteRecord([primaryKeyValue]);
 									}


### PR DESCRIPTION
## Summary

Fixes an **unhandled** `TypeError: Cannot read properties of undefined (reading '0')` surfaced in Datadog RUM on the table browse view (`/$organizationId/$clusterId/databases/$databaseName/$tableName/`), current deploy (commit `2ccba97c`).

## Root cause

The **Delete Row** button in `EditTableRowModal` reads the primary-key value with `data[0]?.[primaryKey]`. But `data` is `undefined` while the record fetch is in flight — the parent passes `data={searchByIdData?.data}` (see [`DatabaseTableView.tsx:616-618`](https://github.com/HarperFast/studio/blob/stage/src/features/instance/databases/components/DatabaseTableView.tsx#L616)), and the footer (containing Delete Row) renders regardless of whether `data` has loaded. The `?.` only guarded the `[primaryKey]` access, **not** the `[0]` — so clicking Delete before the record resolves does `undefined[0]` and throws.

The prop type declared `data` as a non-optional array, which hid the mismatch, even though the rest of the component already treats it as optional (`data?.map(...)`, `{data ? … : <Loading/>}`).

## Fix

- Make the prop type honest: `data?: …[]` (documents the loading state).
- Guard the read: `data?.[0]?.[primaryKey]`.
- Add a regression test that renders with `data={undefined}` and clicks **Delete Row**, asserting it neither throws nor calls `onDeleteRecord`. (Fails the vitest run — exit 1 — without the fix.)

## Datadog RUM findings

- **Error:** `TypeError: Cannot read properties of undefined (reading '0')` — `handling: unhandled`
- **View:** `/$organizationId/$clusterId/databases/$databaseName/$tableName/`
- **Frequency:** 2 events / 1 session / 1 user over the last 7d, all on commit `2ccba97c`
- **Frame:** `onClick @ index-*.js` (the Delete Row handler), confirmed against the deployed bundle

## Verification

`tsc -b`, `oxlint`, `dprint` clean; full suite green (1771 passed). The race (click Delete in the window before the record fetch resolves) isn't practically reproducible in the browser preview, so the unit test — which reproduces the exact `data=undefined` state — is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)