### PR TITLE
feat(notifications): notification center (bell, banner, admin) [#1259]

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -190,9 +190,11 @@ function DesktopNav({ menuItems }: { menuItems: Array<MenuGroup | MenuItem> }) {
 								)
 								: <DesktopNavItem key={menuItem.text} menuItem={menuItem} />
 						)}
-						<NavigationMenuItem>
-							<NotificationBell />
-						</NavigationMenuItem>
+						{!isLocalStudio && (
+							<NavigationMenuItem>
+								<NotificationBell />
+							</NavigationMenuItem>
+						)}
 						<NavigationMenuItem>
 							<ThemeToggle />
 						</NavigationMenuItem>
@@ -248,7 +250,7 @@ function MobileNav({ menuItems }: { menuItems: Array<MenuGroup | MenuItem> }) {
 				</Link>
 				<Version />
 				<div className="flex items-center">
-					<NotificationBell />
+					{!isLocalStudio && <NotificationBell />}
 					<button
 						type="button"
 						className="shadow-xs text-muted-foreground dark:text-grey-400 hover:text-foreground dark:hover:text-white hover:bg-muted dark:hover:bg-black-dark"

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { DiscordLogo } from '@/components/DiscordLogo';
 import { MainLogo } from '@/components/MainLogo';
+import { NotificationBell } from '@/components/NotificationBell';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { NavigationMenu } from '@/components/ui/navigation/NavigationMenu';
 import { NavigationMenuItem } from '@/components/ui/navigation/NavigationMenuItem';
@@ -190,6 +191,9 @@ function DesktopNav({ menuItems }: { menuItems: Array<MenuGroup | MenuItem> }) {
 								: <DesktopNavItem key={menuItem.text} menuItem={menuItem} />
 						)}
 						<NavigationMenuItem>
+							<NotificationBell />
+						</NavigationMenuItem>
+						<NavigationMenuItem>
 							<ThemeToggle />
 						</NavigationMenuItem>
 					</NavigationMenuList>
@@ -243,14 +247,17 @@ function MobileNav({ menuItems }: { menuItems: Array<MenuGroup | MenuItem> }) {
 					<MainLogo />
 				</Link>
 				<Version />
-				<button
-					type="button"
-					className="shadow-xs text-muted-foreground dark:text-grey-400 hover:text-foreground dark:hover:text-white hover:bg-muted dark:hover:bg-black-dark"
-					onClick={toggleMenu}
-				>
-					<span className="sr-only">{isMenuOpen ? 'Close menu' : 'Open menu'}</span>
-					{isMenuOpen ? <X /> : <Menu />}
-				</button>
+				<div className="flex items-center">
+					<NotificationBell />
+					<button
+						type="button"
+						className="shadow-xs text-muted-foreground dark:text-grey-400 hover:text-foreground dark:hover:text-white hover:bg-muted dark:hover:bg-black-dark"
+						onClick={toggleMenu}
+					>
+						<span className="sr-only">{isMenuOpen ? 'Close menu' : 'Open menu'}</span>
+						{isMenuOpen ? <X /> : <Menu />}
+					</button>
+				</div>
 			</div>
 			<div
 				className={`${

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -20,7 +20,12 @@ export function NotificationBanner() {
 	if (unacked.length === 0) { return null; }
 
 	return (
-		<div className="fixed inset-x-0 bottom-0 z-50 flex flex-col shadow-[0_-2px_12px_rgba(0,0,0,0.12)]">
+		<div
+			role="region"
+			aria-label="System notifications"
+			aria-live="polite"
+			className="fixed inset-x-0 bottom-0 z-50 flex flex-col shadow-[0_-2px_12px_rgba(0,0,0,0.12)]"
+		>
 			{unacked.map((notification) => <BannerStrip key={notification.id} notification={notification} />)}
 		</div>
 	);

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -1,0 +1,52 @@
+import { ackNotification } from '@/features/notifications/acks';
+import { NotificationLink } from '@/features/notifications/components/NotificationLink';
+import { useUnackedActiveNotifications } from '@/features/notifications/hooks';
+import { getSeverityConfig } from '@/features/notifications/notificationHelpers';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { cn } from '@/lib/cn';
+import { XIcon } from 'lucide-react';
+
+/**
+ * Full-width banner for active, un-acknowledged notifications — the "hey, look at me" surface for
+ * system-wide notices (#1259). Dismissing a strip acknowledges it (localStorage), so it drops from
+ * the banner and the bell badge but stays visible in the notification center.
+ *
+ * Anchored to the bottom of the viewport: Studio's chrome hardcodes the top band (fixed header at
+ * top-0, sub-nav bars at top-20, page content at mt-32), so a top banner would require offsetting
+ * every page. A bottom bar is robust on every route and never hides the primary navigation.
+ */
+export function NotificationBanner() {
+	const unacked = useUnackedActiveNotifications();
+	if (unacked.length === 0) { return null; }
+
+	return (
+		<div className="fixed inset-x-0 bottom-0 z-50 flex flex-col shadow-[0_-2px_12px_rgba(0,0,0,0.12)]">
+			{unacked.map((notification) => <BannerStrip key={notification.id} notification={notification} />)}
+		</div>
+	);
+}
+
+function BannerStrip({ notification }: { notification: SystemStatusNotification }) {
+	const { Icon, iconClass, bannerClass } = getSeverityConfig(notification.type);
+
+	return (
+		<div className={cn('flex items-start gap-3 border-t px-4 py-3 md:px-12', bannerClass)}>
+			<Icon className={cn('mt-0.5 size-5 shrink-0', iconClass)} />
+			<div className="min-w-0 flex-1 text-sm text-foreground">
+				<span className="break-words">{notification.message}</span>
+				<NotificationLink
+					url={notification.url}
+					className="ml-2 font-medium whitespace-nowrap underline underline-offset-2"
+				/>
+			</div>
+			<button
+				type="button"
+				aria-label="Dismiss notification"
+				onClick={() => ackNotification(notification.id)}
+				className="-my-1 shrink-0 rounded p-1.5 hover:bg-foreground/10"
+			>
+				<XIcon className="size-4" />
+			</button>
+		</div>
+	);
+}

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -1,7 +1,7 @@
 import { ackNotification } from '@/features/notifications/acks';
 import { NotificationLink } from '@/features/notifications/components/NotificationLink';
 import { useUnackedActiveNotifications } from '@/features/notifications/hooks';
-import { getSeverityConfig } from '@/features/notifications/notificationHelpers';
+import { getSeverity, getSeverityConfig } from '@/features/notifications/notificationHelpers';
 import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { cn } from '@/lib/cn';
 import { XIcon } from 'lucide-react';
@@ -19,11 +19,14 @@ export function NotificationBanner() {
 	const unacked = useUnackedActiveNotifications();
 	if (unacked.length === 0) { return null; }
 
+	// Interrupt the screen reader for a critical notice (outage), but stay polite for info/maintenance.
+	const hasCritical = unacked.some((notification) => getSeverity(notification.type) === 'critical');
+
 	return (
 		<div
 			role="region"
 			aria-label="System notifications"
-			aria-live="polite"
+			aria-live={hasCritical ? 'assertive' : 'polite'}
 			className="fixed inset-x-0 bottom-0 z-50 flex flex-col shadow-[0_-2px_12px_rgba(0,0,0,0.12)]"
 		>
 			{unacked.map((notification) => <BannerStrip key={notification.id} notification={notification} />)}

--- a/src/components/NotificationBell.test.tsx
+++ b/src/components/NotificationBell.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { NotificationBell } from '@/components/NotificationBell';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const active: SystemStatusNotification[] = [
+	{ id: 'sta-1', type: 'error', message: 'Maintenance tonight', url: 'https://status.harper.io' },
+	{ id: 'sta-2', type: 'info', message: 'New feature shipped' },
+];
+
+// Isolate the bell from data + routing; the underlying hooks/helpers are tested separately.
+vi.mock('@/features/notifications/hooks', () => ({
+	useActiveNotifications: () => active,
+	useUnackedActiveNotifications: () => active,
+	useNow: () => Date.UTC(2026, 6, 23, 12, 0, 0),
+}));
+
+vi.mock('@/features/notifications/acks', () => ({
+	useNotificationAcks: () => new Set<string>(),
+	ackNotification: vi.fn(),
+	unackNotification: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+	Link: ({ children, to }: { children?: ReactNode; to?: string }) => <a href={to}>{children}</a>,
+}));
+
+// Radix's menu relies on DOM APIs jsdom doesn't implement.
+beforeAll(() => {
+	Element.prototype.hasPointerCapture ??= () => false;
+	Element.prototype.setPointerCapture ??= () => undefined;
+	Element.prototype.releasePointerCapture ??= () => undefined;
+	Element.prototype.scrollIntoView ??= () => undefined;
+	if (typeof window.PointerEvent === 'undefined') {
+		window.PointerEvent = class extends MouseEvent {} as typeof PointerEvent;
+	}
+});
+
+afterEach(() => cleanup());
+
+describe('NotificationBell', () => {
+	it('shows the unread count on the bell', () => {
+		render(<NotificationBell />);
+		const trigger = screen.getByRole('button', { name: /notifications \(2 unread\)/i });
+		expect(trigger.textContent).toContain('2');
+	});
+
+	it('lists active notifications and a view-all link when opened', () => {
+		render(<NotificationBell />);
+		fireEvent.pointerDown(screen.getByRole('button', { name: /notifications/i }), { button: 0, ctrlKey: false });
+		expect(screen.getByText('Maintenance tonight')).toBeTruthy();
+		expect(screen.getByText('New feature shipped')).toBeTruthy();
+		expect(screen.getByText(/view all notifications/i)).toBeTruthy();
+	});
+});

--- a/src/components/NotificationBell.test.tsx
+++ b/src/components/NotificationBell.test.tsx
@@ -2,32 +2,62 @@
  * @vitest-environment jsdom
  */
 import { NotificationBell } from '@/components/NotificationBell';
-import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { queryClient } from '@/react-query/queryClient';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const active: SystemStatusNotification[] = [
-	{ id: 'sta-1', type: 'error', message: 'Maintenance tonight', url: 'https://status.harper.io' },
-	{ id: 'sta-2', type: 'info', message: 'New feature shipped' },
-];
+// Fixtures the mocked query serves. `vi.hoisted` so they exist when the hoisted vi.mock factory runs.
+const { NOTIFICATIONS } = vi.hoisted(() => {
+	const now = Date.now();
+	return {
+		NOTIFICATIONS: [
+			{
+				id: 'sta-critical',
+				type: 'error',
+				message: 'Investigating an outage',
+				url: 'https://status.harper.io',
+				startAt: null,
+				endAt: null,
+			},
+			{ id: 'sta-info', type: 'info', message: 'New feature shipped', startAt: null, endAt: null },
+			// Ended yesterday — the real active-window filter must exclude it.
+			{
+				id: 'sta-expired',
+				type: 'warning',
+				message: 'Old maintenance',
+				startAt: new Date(now - 2 * 86_400_000).toISOString(),
+				endAt: new Date(now - 86_400_000).toISOString(),
+			},
+		],
+	};
+});
 
-// Isolate the bell from data + routing; the underlying hooks/helpers are tested separately.
-vi.mock('@/features/notifications/hooks', () => ({
-	useActiveNotifications: () => active,
-	useUnackedActiveNotifications: () => active,
-	useNow: () => Date.UTC(2026, 6, 23, 12, 0, 0),
+// Mock ONLY the query (per review) — everything the bell actually computes (active-window filter,
+// unread count, acked-first + severity sort, ack store) runs for real against a seeded cache.
+vi.mock('@/features/notifications/queries', () => ({
+	systemStatusQueryKey: ['system-status'],
+	getSystemStatusQueryOptions: () => ({
+		queryKey: ['system-status'],
+		queryFn: () => Promise.resolve(NOTIFICATIONS),
+		initialData: NOTIFICATIONS,
+		staleTime: Infinity,
+	}),
 }));
 
-vi.mock('@/features/notifications/acks', () => ({
-	useNotificationAcks: () => new Set<string>(),
-	ackNotification: vi.fn(),
-	unackNotification: vi.fn(),
-}));
-
+// Only routing is stubbed (no RouterProvider in this unit test).
 vi.mock('@tanstack/react-router', () => ({
 	Link: ({ children, to }: { children?: ReactNode; to?: string }) => <a href={to}>{children}</a>,
 }));
+
+function renderBell() {
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<NotificationBell />
+		</QueryClientProvider>,
+	);
+}
 
 // Radix's menu relies on DOM APIs jsdom doesn't implement.
 beforeAll(() => {
@@ -40,20 +70,48 @@ beforeAll(() => {
 	}
 });
 
-afterEach(() => cleanup());
+beforeEach(() => {
+	localStorage.clear();
+	queryClient.clear();
+});
+afterEach(() => {
+	cleanup();
+	queryClient.clear();
+	localStorage.clear();
+});
+
+function openMenu() {
+	fireEvent.pointerDown(screen.getByRole('button', { name: /notifications/i }), { button: 0, ctrlKey: false });
+}
 
 describe('NotificationBell', () => {
-	it('shows the unread count on the bell', () => {
-		render(<NotificationBell />);
-		const trigger = screen.getByRole('button', { name: /notifications \(2 unread\)/i });
-		expect(trigger.textContent).toContain('2');
+	it('counts only active, un-acked notifications (excludes the expired one)', () => {
+		renderBell();
+		// 3 fixtures, but the expired notice is filtered out by the real active-window check → 2 unread.
+		expect(screen.getByRole('button', { name: /notifications \(2 unread\)/i })).toBeTruthy();
 	});
 
-	it('lists active notifications and a view-all link when opened', () => {
-		render(<NotificationBell />);
-		fireEvent.pointerDown(screen.getByRole('button', { name: /notifications/i }), { button: 0, ctrlKey: false });
-		expect(screen.getByText('Maintenance tonight')).toBeTruthy();
+	it('drops an acknowledged notification from the unread count', () => {
+		localStorage.setItem('AckedNotificationIds', JSON.stringify(['sta-info']));
+		renderBell();
+		expect(screen.getByRole('button', { name: /notifications \(1 unread\)/i })).toBeTruthy();
+	});
+
+	it('lists active notices, excludes expired, and orders un-acked before acked', () => {
+		// Ack the critical one so the acked-first branch beats severity ordering.
+		localStorage.setItem('AckedNotificationIds', JSON.stringify(['sta-critical']));
+		renderBell();
+		openMenu();
+
+		expect(screen.getByText('Investigating an outage')).toBeTruthy();
 		expect(screen.getByText('New feature shipped')).toBeTruthy();
+		expect(screen.queryByText('Old maintenance')).toBeNull();
 		expect(screen.getByText(/view all notifications/i)).toBeTruthy();
+
+		const rows = screen.getAllByRole('listitem').map((li) => li.textContent ?? '');
+		const infoIdx = rows.findIndex((t) => t.includes('New feature shipped'));
+		const criticalIdx = rows.findIndex((t) => t.includes('Investigating an outage'));
+		// Un-acked info sorts ahead of the acked critical, even though critical is more severe.
+		expect(infoIdx).toBeLessThan(criticalIdx);
 	});
 });

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,0 +1,137 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
+import { ScrollArea } from '@/components/ui/scrollArea';
+import { ackNotification, unackNotification, useNotificationAcks } from '@/features/notifications/acks';
+import { NotificationLink } from '@/features/notifications/components/NotificationLink';
+import { useActiveNotifications, useNow, useUnackedActiveNotifications } from '@/features/notifications/hooks';
+import {
+	BellIcon,
+	getSeverityConfig,
+	getWindowStatus,
+	type Severity,
+} from '@/features/notifications/notificationHelpers';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { cn } from '@/lib/cn';
+import { Link } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
+
+const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, warning: 1, info: 2 };
+
+export function NotificationBell() {
+	const [open, setOpen] = useState(false);
+	const active = useActiveNotifications();
+	const unacked = useUnackedActiveNotifications();
+	const acks = useNotificationAcks();
+	const now = useNow();
+
+	const count = unacked.length;
+
+	// Unacknowledged first, then by severity (most serious first).
+	const ordered = useMemo(() => {
+		return [...active].sort((a, b) => {
+			const ackedA = acks.has(a.id) ? 1 : 0;
+			const ackedB = acks.has(b.id) ? 1 : 0;
+			if (ackedA !== ackedB) { return ackedA - ackedB; }
+			return SEVERITY_ORDER[getSeverityConfig(a.type).severity] - SEVERITY_ORDER[getSeverityConfig(b.type).severity];
+		});
+	}, [active, acks]);
+
+	return (
+		<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="relative"
+					aria-label={count > 0 ? `Notifications (${count} unread)` : 'Notifications'}
+				>
+					<BellIcon />
+					{count > 0 && (
+						<Badge
+							variant="destructive"
+							className="absolute -top-1 -right-1 h-4 min-w-4 justify-center rounded-full px-1 text-[10px] leading-none"
+						>
+							{count > 9 ? '9+' : count}
+						</Badge>
+					)}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-96 p-0">
+				<div className="flex items-center justify-between px-4 py-3">
+					<span className="text-sm font-semibold">Notifications</span>
+					{count > 0 && <span className="text-xs text-muted-foreground">{count} unread</span>}
+				</div>
+				<div className="border-t border-border" />
+				{ordered.length === 0
+					? (
+						<div className="px-4 py-8 text-center text-sm text-muted-foreground">
+							You're all caught up.
+						</div>
+					)
+					: (
+						<ScrollArea className="max-h-96">
+							<ul className="divide-y divide-border">
+								{ordered.map((notification) => (
+									<NotificationRow
+										key={notification.id}
+										notification={notification}
+										acked={acks.has(notification.id)}
+										nowMs={now}
+										onNavigate={() => setOpen(false)}
+									/>
+								))}
+							</ul>
+						</ScrollArea>
+					)}
+				<div className="border-t border-border" />
+				<Link
+					to="/notifications"
+					onClick={() => setOpen(false)}
+					className="block px-4 py-3 text-center text-sm font-medium text-primary hover:underline dark:text-white"
+				>
+					View all notifications
+				</Link>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+function NotificationRow({
+	notification,
+	acked,
+	nowMs,
+	onNavigate,
+}: {
+	notification: SystemStatusNotification;
+	acked: boolean;
+	nowMs: number;
+	onNavigate: () => void;
+}) {
+	const { Icon, iconClass } = getSeverityConfig(notification.type);
+	const window = getWindowStatus(notification, nowMs);
+
+	return (
+		<li className={cn('flex gap-3 px-4 py-3', acked && 'opacity-55')}>
+			<Icon className={cn('mt-0.5 size-4 shrink-0', iconClass)} />
+			<div className="min-w-0 flex-1">
+				<p className="text-sm text-foreground break-words">{notification.message}</p>
+				<p className="mt-1 text-xs text-muted-foreground">{window.label}</p>
+				<div className="mt-1 flex items-center gap-3 text-xs">
+					<NotificationLink
+						url={notification.url}
+						onNavigate={onNavigate}
+						className="font-medium text-primary hover:underline dark:text-white"
+					/>
+					<button
+						type="button"
+						className="text-muted-foreground hover:text-foreground"
+						onClick={() => (acked ? unackNotification(notification.id) : ackNotification(notification.id))}
+					>
+						{acked ? 'Undo' : 'Ignore'}
+					</button>
+				</div>
+			</div>
+		</li>
+	);
+}

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -9,14 +9,12 @@ import {
 	BellIcon,
 	getSeverityConfig,
 	getWindowStatus,
-	type Severity,
+	SEVERITY_ORDER,
 } from '@/features/notifications/notificationHelpers';
 import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { cn } from '@/lib/cn';
 import { Link } from '@tanstack/react-router';
 import { useMemo, useState } from 'react';
-
-const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, warning: 1, info: 2 };
 
 export function NotificationBell() {
 	const [open, setOpen] = useState(false);

--- a/src/components/StudioCloud.tsx
+++ b/src/components/StudioCloud.tsx
@@ -1,3 +1,5 @@
+import { NotificationBanner } from '@/components/NotificationBanner';
+import { NotificationsSubscriptionManager } from '@/features/notifications/NotificationsSubscriptionManager';
 import { useOnRouteLoadTracker } from '@/integrations/datadog/datadog';
 import { HeadContent, Outlet } from '@tanstack/react-router';
 
@@ -6,7 +8,16 @@ export function StudioCloud() {
 	return (
 		<>
 			<HeadContent />
+			{
+				/*
+				 * Mounted at the cloud root (not the authed Dashboard) so global notices — maintenance,
+				 * outages — reach signed-out users on the sign-in page too. SystemStatus read is public, and
+				 * the WebSocket subscription connects anonymously. Cloud only: StudioLocal has no central-manager.
+				 */
+			}
+			<NotificationsSubscriptionManager />
 			<Outlet />
+			<NotificationBanner />
 		</>
 	);
 }

--- a/src/features/admin/components/AdminShell.tsx
+++ b/src/features/admin/components/AdminShell.tsx
@@ -1,7 +1,7 @@
 import { SubNavItem, SubNavRail } from '@/components/SubNavRail';
 import { isFabricAdmin, useCloudAuth } from '@/hooks/useAuth';
 import { Navigate, Outlet } from '@tanstack/react-router';
-import { KeyRoundIcon } from 'lucide-react';
+import { BellIcon, KeyRoundIcon } from 'lucide-react';
 
 /**
  * Shell for the Admin section: a responsive sub-nav rail (so future admin
@@ -11,6 +11,7 @@ import { KeyRoundIcon } from 'lucide-react';
  */
 const items: SubNavItem[] = [
 	{ to: '/admin', label: 'API Token', icon: KeyRoundIcon, exact: true },
+	{ to: '/admin/notifications', label: 'Notifications', icon: BellIcon },
 ];
 
 export function AdminShell() {

--- a/src/features/admin/notifications/index.tsx
+++ b/src/features/admin/notifications/index.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/features/admin/notifications/mutations/useNotificationMutations';
 import { NotificationLink } from '@/features/notifications/components/NotificationLink';
 import { useNotifications } from '@/features/notifications/hooks';
-import { getSeverityConfig, toMs } from '@/features/notifications/notificationHelpers';
+import { getSeverityConfig, parseNotificationLink, toMs } from '@/features/notifications/notificationHelpers';
 import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { ColumnDef } from '@tanstack/react-table';
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
@@ -241,11 +241,18 @@ function NotificationFormDialog({
 			setError('End time must be after start time.');
 			return;
 		}
+		// Validate the link with the same parser the UI renders with, so the form can't save a URL the
+		// notification would then silently drop (an unsafe scheme, or a typo'd `htp://…`).
+		const trimmedUrl = url.trim();
+		if (trimmedUrl && !parseNotificationLink(trimmedUrl)) {
+			setError('Link must be an http(s) URL, a mailto: address, or a path starting with “/”.');
+			return;
+		}
 
 		const draft: NotificationDraft = {
 			type,
 			message: trimmedMessage,
-			url: url.trim() || null,
+			url: trimmedUrl || null,
 			startAt: start,
 			endAt: end,
 		};

--- a/src/features/admin/notifications/index.tsx
+++ b/src/features/admin/notifications/index.tsx
@@ -1,0 +1,344 @@
+import { DataTable } from '@/components/DataTable';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alertDialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import {
+	NotificationDraft,
+	useCreateNotificationMutation,
+	useDeleteNotificationMutation,
+	useUpdateNotificationMutation,
+} from '@/features/admin/notifications/mutations/useNotificationMutations';
+import { NotificationLink } from '@/features/notifications/components/NotificationLink';
+import { useNotifications } from '@/features/notifications/hooks';
+import { getSeverityConfig, toMs } from '@/features/notifications/notificationHelpers';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { ColumnDef } from '@tanstack/react-table';
+import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const TYPE_OPTIONS = [
+	{ value: 'error', label: 'Error / Outage' },
+	{ value: 'warning', label: 'Warning' },
+	{ value: 'maintenance', label: 'Maintenance' },
+	{ value: 'info', label: 'Info' },
+];
+
+/** A stored timestamp → the `YYYY-MM-DDTHH:mm` local value a `datetime-local` input expects. */
+function toInputValue(value: string | number | null | undefined): string {
+	const ms = toMs(value);
+	if (ms === null) { return ''; }
+	const date = new Date(ms);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${
+		pad(date.getMinutes())
+	}`;
+}
+
+/** A `datetime-local` value (local time) → a UTC ISO string, or null when empty. */
+function fromInputValue(value: string): string | null {
+	if (!value) { return null; }
+	const ms = Date.parse(value);
+	return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+}
+
+function formatWindow(notification: SystemStatusNotification): string {
+	const start = toMs(notification.startAt);
+	const end = toMs(notification.endAt);
+	if (start === null && end === null) { return 'Always'; }
+	const fmt = (ms: number | null) => (ms === null ? '—' : new Date(ms).toLocaleString());
+	return `${fmt(start)} → ${fmt(end)}`;
+}
+
+export function NotificationsAdminIndex() {
+	const { data, isLoading } = useNotifications();
+	const [formOpen, setFormOpen] = useState(false);
+	const [editing, setEditing] = useState<SystemStatusNotification | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<SystemStatusNotification | null>(null);
+	const deleteMutation = useDeleteNotificationMutation();
+
+	const openCreate = useCallback(() => {
+		setEditing(null);
+		setFormOpen(true);
+	}, []);
+	const openEdit = useCallback((notification: SystemStatusNotification) => {
+		setEditing(notification);
+		setFormOpen(true);
+	}, []);
+
+	const columns = useMemo<ColumnDef<SystemStatusNotification>[]>(
+		() => buildColumns({ openEdit, onDelete: setDeleteTarget }),
+		[openEdit],
+	);
+
+	return (
+		<div className="max-w-5xl">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="text-2xl font-light">Notifications</h1>
+					<p className="mt-2 text-sm text-muted-foreground">
+						System-wide notices shown to all users in the notification center. Times are stored in UTC.
+					</p>
+				</div>
+				<Button variant="submit" onClick={openCreate} className="shrink-0">
+					<PlusIcon />
+					New notification
+				</Button>
+			</div>
+
+			<div className="mt-6">
+				{isLoading ? <Skeleton className="h-40 w-full" /> : <DataTable columns={columns} data={data ?? []} />}
+			</div>
+
+			<NotificationFormDialog open={formOpen} onOpenChange={setFormOpen} editing={editing} />
+
+			<AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete notification?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This removes it for everyone immediately. This can't be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							disabled={deleteMutation.isPending}
+							onClick={(event) => {
+								event.preventDefault();
+								if (!deleteTarget) { return; }
+								deleteMutation.mutate(deleteTarget.id, { onSuccess: () => setDeleteTarget(null) });
+							}}
+						>
+							{deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}
+
+function buildColumns(
+	{ openEdit, onDelete }: {
+		openEdit: (notification: SystemStatusNotification) => void;
+		onDelete: (notification: SystemStatusNotification) => void;
+	},
+): ColumnDef<SystemStatusNotification>[] {
+	return [
+		{
+			header: 'Type',
+			accessorKey: 'type',
+			size: 12,
+			cell: ({ row }) => {
+				const { label, badgeVariant } = getSeverityConfig(row.original.type);
+				return <Badge variant={badgeVariant}>{row.original.type || label}</Badge>;
+			},
+		},
+		{
+			header: 'Message',
+			accessorKey: 'message',
+			size: 40,
+			cell: ({ row }) => <span className="line-clamp-2 break-words">{row.original.message}</span>,
+		},
+		{
+			header: 'Active window (local)',
+			size: 28,
+			cell: ({ row }) => <span className="text-sm text-muted-foreground">{formatWindow(row.original)}</span>,
+		},
+		{
+			header: 'Link',
+			size: 8,
+			cell: ({ row }) =>
+				row.original.url
+					? <NotificationLink url={row.original.url} className="text-sm text-primary hover:underline dark:text-white" />
+					: <span className="text-muted-foreground">—</span>,
+		},
+		{
+			header: '',
+			id: 'actions',
+			size: 12,
+			cell: ({ row }) => (
+				<div className="flex justify-end gap-1">
+					<Button variant="ghost" size="icon" aria-label="Edit" onClick={() => openEdit(row.original)}>
+						<PencilIcon />
+					</Button>
+					<Button
+						variant="destructiveGhost"
+						size="icon"
+						aria-label="Delete"
+						onClick={() => onDelete(row.original)}
+					>
+						<Trash2Icon />
+					</Button>
+				</div>
+			),
+		},
+	];
+}
+
+function NotificationFormDialog({
+	open,
+	onOpenChange,
+	editing,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	editing: SystemStatusNotification | null;
+}) {
+	const createMutation = useCreateNotificationMutation();
+	const updateMutation = useUpdateNotificationMutation();
+	const isPending = createMutation.isPending || updateMutation.isPending;
+
+	const [type, setType] = useState('error');
+	const [message, setMessage] = useState('');
+	const [url, setUrl] = useState('');
+	const [startAt, setStartAt] = useState('');
+	const [endAt, setEndAt] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	// Reset the form to the edited row (or blanks for create) each time the dialog opens.
+	useEffect(() => {
+		if (!open) { return; }
+		setType(editing?.type ?? 'error');
+		setMessage(editing?.message ?? '');
+		setUrl(editing?.url ?? '');
+		setStartAt(toInputValue(editing?.startAt));
+		setEndAt(toInputValue(editing?.endAt));
+		setError(null);
+	}, [open, editing]);
+
+	const submit = () => {
+		const trimmedMessage = message.trim();
+		if (!trimmedMessage) {
+			setError('Message is required.');
+			return;
+		}
+		const start = fromInputValue(startAt);
+		const end = fromInputValue(endAt);
+		if (start && end && Date.parse(end) <= Date.parse(start)) {
+			setError('End time must be after start time.');
+			return;
+		}
+
+		const draft: NotificationDraft = {
+			type,
+			message: trimmedMessage,
+			url: url.trim() || null,
+			startAt: start,
+			endAt: end,
+		};
+		const onSuccess = () => onOpenChange(false);
+		if (editing) {
+			updateMutation.mutate({ id: editing.id, draft }, { onSuccess });
+		} else {
+			createMutation.mutate(draft, { onSuccess });
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{editing ? 'Edit notification' : 'New notification'}</DialogTitle>
+					<DialogDescription>
+						Shown to all users. Leave start/end empty for an open-ended window.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="notification-type">Type</Label>
+						<Select value={type} onValueChange={setType}>
+							<SelectTrigger id="notification-type" className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{TYPE_OPTIONS.map((option) => (
+									<SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="notification-message">Message</Label>
+						<Textarea
+							id="notification-message"
+							rows={3}
+							value={message}
+							onChange={(event) => setMessage(event.target.value)}
+							placeholder="The Fabric control plane will be undergoing maintenance…"
+						/>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<Label htmlFor="notification-url">Link (optional)</Label>
+						<Input
+							id="notification-url"
+							value={url}
+							onChange={(event) => setUrl(event.target.value)}
+							placeholder="https://status.harper.io  or  /organizations"
+						/>
+						<p className="text-xs text-muted-foreground">
+							An absolute URL opens in a new tab; a path like <code>/organizations</code> links inside Studio.
+						</p>
+					</div>
+
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="notification-start">Start (local time)</Label>
+							<Input
+								id="notification-start"
+								type="datetime-local"
+								value={startAt}
+								onChange={(event) => setStartAt(event.target.value)}
+							/>
+						</div>
+						<div className="flex flex-col gap-2">
+							<Label htmlFor="notification-end">End (local time)</Label>
+							<Input
+								id="notification-end"
+								type="datetime-local"
+								value={endAt}
+								onChange={(event) => setEndAt(event.target.value)}
+							/>
+						</div>
+					</div>
+
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+
+				<DialogFooter>
+					<Button variant="ghostOutline" onClick={() => onOpenChange(false)} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button variant="submit" onClick={submit} disabled={isPending}>
+						{isPending ? 'Saving…' : editing ? 'Save changes' : 'Create'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/features/admin/notifications/mutations/useNotificationMutations.ts
+++ b/src/features/admin/notifications/mutations/useNotificationMutations.ts
@@ -1,0 +1,50 @@
+import { apiClient } from '@/config/apiClient';
+import { systemStatusQueryKey } from '@/features/notifications/queries';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Admin CRUD over the central-manager `SystemStatus` table. The resource already gates writes to
+ * fabric admins (isFabricAdmin) server-side, so these just need the fabric-admin session. The
+ * SystemStatus paths aren't in the generated OpenAPI types yet, so URLs are cast (as elsewhere).
+ * The global MutationCache.onError surfaces failures as a toast; each write refetches the list.
+ */
+export interface NotificationDraft {
+	type: string;
+	message: string;
+	url?: string | null;
+	/** UTC ISO string, or null for an open bound. */
+	startAt?: string | null;
+	endAt?: string | null;
+}
+
+export function useCreateNotificationMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (draft: NotificationDraft) => {
+			const { data } = await apiClient.post('/SystemStatus/' as '/Cluster/', draft);
+			return data as unknown as SystemStatusNotification;
+		},
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: systemStatusQueryKey }),
+	});
+}
+
+export function useUpdateNotificationMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({ id, draft }: { id: string; draft: NotificationDraft }) => {
+			await apiClient.patch(`/SystemStatus/${id}` as '/Cluster/{id}', draft);
+		},
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: systemStatusQueryKey }),
+	});
+}
+
+export function useDeleteNotificationMutation() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async (id: string) => {
+			await apiClient.delete(`/SystemStatus/${id}` as '/Cluster/{id}');
+		},
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: systemStatusQueryKey }),
+	});
+}

--- a/src/features/admin/routes.ts
+++ b/src/features/admin/routes.ts
@@ -15,5 +15,12 @@ const apiTokenRoute = createRoute({
 	component: lazyRouteComponent(async () => import('@/features/admin/apiToken/index'), 'ApiTokenIndex'),
 });
 
+const notificationsAdminRoute = createRoute({
+	getParentRoute: () => adminLayoutRoute,
+	path: '/notifications',
+	head: () => ({ meta: [{ title: 'Notifications — Harper Fabric' }] }),
+	component: lazyRouteComponent(async () => import('@/features/admin/notifications/index'), 'NotificationsAdminIndex'),
+});
+
 // Parent: adminLayoutRoute (keep in lockstep with rootRouteTree's addChildren).
-export const adminRoutes = [apiTokenRoute];
+export const adminRoutes = [apiTokenRoute, notificationsAdminRoute];

--- a/src/features/layouts/Dashboard.tsx
+++ b/src/features/layouts/Dashboard.tsx
@@ -1,7 +1,5 @@
 import { Loading } from '@/components/Loading';
 import { Navbar } from '@/components/Navbar';
-import { NotificationBanner } from '@/components/NotificationBanner';
-import { NotificationsSubscriptionManager } from '@/features/notifications/NotificationsSubscriptionManager';
 import { useOverallAuth } from '@/hooks/useAuth';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
@@ -24,14 +22,12 @@ export function Dashboard() {
 
 	return (
 		<>
-			<NotificationsSubscriptionManager />
 			<header className="fixed top-0 z-40 w-full h-20 p-4 bg-gradient-to-r from-violet-100 to-white border-b border-violet-200 dark:from-purple-950 dark:to-zinc-900 dark:border-purple-950 md:px-12">
 				<Navbar />
 			</header>
 			<main>
 				<Outlet />
 			</main>
-			<NotificationBanner />
 		</>
 	);
 }

--- a/src/features/layouts/Dashboard.tsx
+++ b/src/features/layouts/Dashboard.tsx
@@ -1,5 +1,7 @@
 import { Loading } from '@/components/Loading';
 import { Navbar } from '@/components/Navbar';
+import { NotificationBanner } from '@/components/NotificationBanner';
+import { NotificationsSubscriptionManager } from '@/features/notifications/NotificationsSubscriptionManager';
 import { useOverallAuth } from '@/hooks/useAuth';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
@@ -22,12 +24,14 @@ export function Dashboard() {
 
 	return (
 		<>
+			<NotificationsSubscriptionManager />
 			<header className="fixed top-0 z-40 w-full h-20 p-4 bg-gradient-to-r from-violet-100 to-white border-b border-violet-200 dark:from-purple-950 dark:to-zinc-900 dark:border-purple-950 md:px-12">
 				<Navbar />
 			</header>
 			<main>
 				<Outlet />
 			</main>
+			<NotificationBanner />
 		</>
 	);
 }

--- a/src/features/notifications/NotificationsSubscriptionManager.test.tsx
+++ b/src/features/notifications/NotificationsSubscriptionManager.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { NotificationsSubscriptionManager } from '@/features/notifications/NotificationsSubscriptionManager';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Drives the subscription's reconnect logic with fake timers and a stub WebSocket, locking in the
+ * failure modes this file has produced: a permanent silent give-up, and a reconnect storm from any path
+ * that unwinds the backoff (post-handshake close, or a burst of `online` events).
+ */
+
+/** Minimal stand-in for the browser WebSocket: records instances and lets the test drive the events. */
+class StubWebSocket {
+	static instances: StubWebSocket[] = [];
+	onopen: (() => void) | null = null;
+	onmessage: ((event: unknown) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	private closed = false;
+
+	constructor(public url: string) {
+		StubWebSocket.instances.push(this);
+	}
+
+	/** The component (and its cleanup) calls this; a real socket then fires `close`. */
+	close() {
+		this.fireClose();
+	}
+
+	/** Server accepted the upgrade. */
+	acceptUpgrade() {
+		this.onopen?.();
+	}
+
+	/** Server hung up (or the network dropped). */
+	hangUp() {
+		this.fireClose();
+	}
+
+	// A real socket fires `close` at most once, so repeated closes must not schedule extra reconnects.
+	private fireClose() {
+		if (this.closed) { return; }
+		this.closed = true;
+		this.onclose?.();
+	}
+}
+
+const socketCount = () => StubWebSocket.instances.length;
+const newestSocket = () => StubWebSocket.instances[StubWebSocket.instances.length - 1];
+
+beforeEach(() => {
+	StubWebSocket.instances = [];
+	vi.stubEnv('VITE_CENTRAL_MANAGER_API_URL', 'https://cm.test.invalid');
+	vi.stubGlobal('WebSocket', StubWebSocket);
+	// Keeps the give-up test quiet — the component warns once when it reaches the backoff ceiling.
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+describe('NotificationsSubscriptionManager', () => {
+	it('opens one subscription to the SystemStatus WebSocket endpoint', () => {
+		render(<NotificationsSubscriptionManager />);
+		expect(socketCount()).toBe(1);
+		// http(s) base is rewritten to the ws(s) scheme.
+		expect(newestSocket().url).toBe('wss://cm.test.invalid/SystemStatus');
+	});
+
+	it('keeps retrying after many consecutive failures instead of giving up permanently', () => {
+		render(<NotificationsSubscriptionManager />);
+
+		// Six failed attempts, each waited out at (or under) the 30s ceiling.
+		for (let i = 0; i < 6; i++) {
+			newestSocket().hangUp();
+			vi.advanceTimersByTime(30_000);
+		}
+
+		// A 7th socket exists: the retry loop is bounded in *delay*, not in attempts.
+		expect(socketCount()).toBe(7);
+	});
+
+	it('escalates the delay when the server accepts the upgrade then closes it', () => {
+		render(<NotificationsSubscriptionManager />);
+
+		// Accept-then-close, well short of a healthy session → first retry after 2s.
+		newestSocket().acceptUpgrade();
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(1999);
+		expect(socketCount()).toBe(1);
+		vi.advanceTimersByTime(1);
+		expect(socketCount()).toBe(2);
+
+		// Same again: the delay must grow to 4s rather than stay pinned at 2s.
+		newestSocket().acceptUpgrade();
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(2000);
+		expect(socketCount()).toBe(2);
+		vi.advanceTimersByTime(2000);
+		expect(socketCount()).toBe(3);
+	});
+
+	it('resets the backoff only after the socket stays open for a healthy session', () => {
+		render(<NotificationsSubscriptionManager />);
+
+		// Escalate to a 4s delay.
+		newestSocket().acceptUpgrade();
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(2000);
+		expect(socketCount()).toBe(2);
+
+		// This one stays open past the healthy-session threshold, so the backoff resets…
+		newestSocket().acceptUpgrade();
+		vi.advanceTimersByTime(10_000);
+
+		// …and the next failure starts again from 2s, not 4s.
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(1999);
+		expect(socketCount()).toBe(2);
+		vi.advanceTimersByTime(1);
+		expect(socketCount()).toBe(3);
+	});
+
+	it('collapses a burst of online events into a single reconnect', () => {
+		render(<NotificationsSubscriptionManager />);
+
+		// Two failures → a 4s wait is pending and no socket is live.
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(2000);
+		newestSocket().hangUp();
+		expect(socketCount()).toBe(2);
+
+		// Past the online floor but before the retry fires. Each event is followed by a failure — that's
+		// what frees the "already connected" guard, so without the time floor every one of them would
+		// start a socket at the same millisecond.
+		vi.advanceTimersByTime(2500);
+		for (let i = 0; i < 5; i++) {
+			window.dispatchEvent(new Event('online'));
+			newestSocket().hangUp();
+		}
+
+		// One reconnect, not five.
+		expect(socketCount()).toBe(3);
+	});
+
+	it('online skips the remaining wait without unwinding the escalation', () => {
+		render(<NotificationsSubscriptionManager />);
+
+		// Reach a 4s delay (failures = 2).
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(2000);
+		newestSocket().hangUp();
+		expect(socketCount()).toBe(2);
+
+		// `online` reconnects early…
+		vi.advanceTimersByTime(2500);
+		window.dispatchEvent(new Event('online'));
+		expect(socketCount()).toBe(3);
+
+		// …but the next failure waits 8s (failures kept climbing), not 2s as it would after a reset.
+		newestSocket().hangUp();
+		vi.advanceTimersByTime(4000);
+		expect(socketCount()).toBe(3);
+		vi.advanceTimersByTime(4000);
+		expect(socketCount()).toBe(4);
+	});
+
+	it('survives a WebSocket constructor that throws, and retries on a backoff', () => {
+		// A malformed base URL makes the real constructor throw synchronously — that must not escape the
+		// effect (this runs on the sign-in page for anonymous users).
+		let attempts = 0;
+		vi.stubGlobal(
+			'WebSocket',
+			class {
+				constructor() {
+					attempts += 1;
+					throw new SyntaxError('bad url');
+				}
+			},
+		);
+
+		expect(() => render(<NotificationsSubscriptionManager />)).not.toThrow();
+		expect(attempts).toBe(1);
+
+		// Still retries rather than wedging on the first throw.
+		vi.advanceTimersByTime(2000);
+		expect(attempts).toBe(2);
+	});
+
+	it('does not subscribe when the central-manager URL is unset', () => {
+		vi.stubEnv('VITE_CENTRAL_MANAGER_API_URL', '');
+		render(<NotificationsSubscriptionManager />);
+		expect(socketCount()).toBe(0);
+	});
+
+	it('stops reconnecting once unmounted', () => {
+		const { unmount } = render(<NotificationsSubscriptionManager />);
+		unmount();
+
+		// The teardown closes the socket; that close must not schedule another attempt.
+		vi.advanceTimersByTime(120_000);
+		window.dispatchEvent(new Event('online'));
+		expect(socketCount()).toBe(1);
+	});
+});

--- a/src/features/notifications/NotificationsSubscriptionManager.tsx
+++ b/src/features/notifications/NotificationsSubscriptionManager.tsx
@@ -2,16 +2,27 @@ import { systemStatusQueryKey } from '@/features/notifications/queries';
 import { queryClient } from '@/react-query/queryClient';
 import { useEffect } from 'react';
 
+// A connection has to *stay open* this long before we trust it and reset the backoff. Resetting on
+// the bare handshake instead would let a server that accepts-then-closes the upgrade (post-handshake
+// auth rejection, a CM restart loop, an edge dropping non-conforming upgrades) reconnect-storm forever.
+const HEALTHY_SESSION_MS = 10_000;
+const MAX_BACKOFF_MS = 30_000;
+
 /**
  * Subscribes to central-manager's `SystemStatus` table over Harper's automatic WebSocket endpoint and
  * refetches the notifications query on any change — "subscriptions, not polling" (#1259).
  *
  * WebSocket rather than SSE, on purpose: probing stage showed the edge buffers `text/event-stream`
  * (an SSE GET yields 0 bytes until the connection closes), whereas the WebSocket upgrade passes
- * straight through (HTTP 101) to Harper's table subscription — anonymously, matching the table's
- * public read. On any message we invalidate rather than merge deltas (the list is tiny; a refetch is
- * always correct). WebSockets don't auto-reconnect, so we back off on close and give up after a few
- * tries, leaning on the query's `refetchInterval` backstop. Mounted once from the signed-in Dashboard.
+ * straight through (HTTP 101) to Harper's table subscription. It connects **anonymously by design** —
+ * SystemStatus is public-read broadcast content, so the banner reaches signed-out users on the sign-in
+ * page too. (Note: CM's #483 anonymous-subscribe guard is scoped to `loadAsInstance = false` resources,
+ * which SystemStatus is not, so this permissiveness is by omission — intentional here, not a leak.)
+ *
+ * Resilience: we cap the *backoff* (not the number of attempts) and keep retrying, so a transient
+ * network blip can't strand the tab on the 60s poll backstop for the rest of the session. `failures`
+ * only resets after a healthy session (see above), and we reconnect immediately when the browser fires
+ * `online`. Mounted once from the cloud root (StudioCloud), which never unmounts.
  */
 export function NotificationsSubscriptionManager() {
 	useEffect(() => {
@@ -24,33 +35,76 @@ export function NotificationsSubscriptionManager() {
 		let cancelled = false;
 		let failures = 0;
 		let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+		let healthyTimer: ReturnType<typeof setTimeout> | undefined;
 
-		const connect = () => {
+		const clearHealthyTimer = () => {
+			if (healthyTimer) {
+				clearTimeout(healthyTimer);
+				healthyTimer = undefined;
+			}
+		};
+
+		const scheduleReconnect = () => {
 			if (cancelled) { return; }
-			socket = new WebSocket(url);
-			socket.onopen = () => {
-				failures = 0;
+			failures += 1;
+			// Cap the delay, never the attempt count. Warn once when we hit the ceiling so a persistently
+			// dead feed is greppable in a RUM session (the poll backstop still keeps data fresh meanwhile).
+			const delay = Math.min(1000 * 2 ** failures, MAX_BACKOFF_MS);
+			if (delay === MAX_BACKOFF_MS && (1000 * 2 ** (failures - 1)) < MAX_BACKOFF_MS) {
+				console.warn(
+					'[notifications] SystemStatus subscription unstable; retrying at 30s (data still polls every 60s)',
+				);
+			}
+			reconnectTimer = setTimeout(connect, delay);
+		};
+
+		function connect() {
+			if (cancelled) { return; }
+			let sock: WebSocket;
+			try {
+				sock = new WebSocket(url);
+			} catch (err) {
+				// Malformed URL (e.g. a relative VITE_CENTRAL_MANAGER_API_URL in some future deploy config)
+				// throws synchronously — treat it as a failed attempt rather than crashing the effect.
+				console.warn('[notifications] could not open SystemStatus WebSocket', err);
+				scheduleReconnect();
+				return;
+			}
+			socket = sock;
+			sock.onopen = () => {
+				clearHealthyTimer();
+				healthyTimer = setTimeout(() => {
+					failures = 0;
+				}, HEALTHY_SESSION_MS);
 			};
 			// Any table change arrives as a message; refetch the canonical list.
-			socket.onmessage = () => {
+			sock.onmessage = () => {
 				void queryClient.invalidateQueries({ queryKey: systemStatusQueryKey });
 			};
-			socket.onerror = () => socket?.close();
-			socket.onclose = () => {
+			sock.onerror = () => sock.close();
+			sock.onclose = () => {
+				clearHealthyTimer();
 				socket = null;
-				if (cancelled) { return; }
-				failures += 1;
-				// Give up after a handful of failures; the refetchInterval backstop keeps data fresh.
-				if (failures > 5) { return; }
-				reconnectTimer = setTimeout(connect, Math.min(1000 * 2 ** failures, 30_000));
+				scheduleReconnect();
 			};
+		}
+
+		// Connectivity came back — reconnect now instead of waiting out the backoff.
+		const onOnline = () => {
+			if (cancelled || socket) { return; }
+			if (reconnectTimer) { clearTimeout(reconnectTimer); }
+			failures = 0;
+			connect();
 		};
+		window.addEventListener('online', onOnline);
 
 		connect();
 
 		return () => {
 			cancelled = true;
 			if (reconnectTimer) { clearTimeout(reconnectTimer); }
+			clearHealthyTimer();
+			window.removeEventListener('online', onOnline);
 			socket?.close();
 		};
 	}, []);

--- a/src/features/notifications/NotificationsSubscriptionManager.tsx
+++ b/src/features/notifications/NotificationsSubscriptionManager.tsx
@@ -7,6 +7,10 @@ import { useEffect } from 'react';
 // auth rejection, a CM restart loop, an edge dropping non-conforming upgrades) reconnect-storm forever.
 const HEALTHY_SESSION_MS = 10_000;
 const MAX_BACKOFF_MS = 30_000;
+// Floor between connect attempts triggered by `online`. Browsers fire that event on real interface
+// transitions, but captive-portal/VPN churn can emit a burst — without this, each one would start a
+// socket at the same instant and sidestep the backoff entirely.
+const ONLINE_REARM_MIN_MS = 2_000;
 
 /**
  * Subscribes to central-manager's `SystemStatus` table over Harper's automatic WebSocket endpoint and
@@ -21,8 +25,10 @@ const MAX_BACKOFF_MS = 30_000;
  *
  * Resilience: we cap the *backoff* (not the number of attempts) and keep retrying, so a transient
  * network blip can't strand the tab on the 60s poll backstop for the rest of the session. `failures`
- * only resets after a healthy session (see above), and we reconnect immediately when the browser fires
- * `online`. Mounted once from the cloud root (StudioCloud), which never unmounts.
+ * only resets after a healthy session (see above); an `online` event skips the remaining wait but keeps
+ * the escalation intact. Mounted once from the cloud root (StudioCloud), which never unmounts.
+ *
+ * Covered by NotificationsSubscriptionManager.test.tsx (fake timers + a stub WebSocket).
  */
 export function NotificationsSubscriptionManager() {
 	useEffect(() => {
@@ -36,6 +42,7 @@ export function NotificationsSubscriptionManager() {
 		let failures = 0;
 		let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 		let healthyTimer: ReturnType<typeof setTimeout> | undefined;
+		let lastAttemptAt = 0;
 
 		const clearHealthyTimer = () => {
 			if (healthyTimer) {
@@ -60,6 +67,7 @@ export function NotificationsSubscriptionManager() {
 
 		function connect() {
 			if (cancelled) { return; }
+			lastAttemptAt = Date.now();
 			let sock: WebSocket;
 			try {
 				sock = new WebSocket(url);
@@ -89,11 +97,14 @@ export function NotificationsSubscriptionManager() {
 			};
 		}
 
-		// Connectivity came back — reconnect now instead of waiting out the backoff.
+		// Connectivity came back — retry now instead of waiting out the remaining backoff. Deliberately
+		// does NOT reset `failures`: skipping ahead is fine, but a burst of `online` events must not
+		// unwind the escalation, or this becomes an unbounded-connect path of its own. The floor below
+		// collapses such a burst into a single attempt.
 		const onOnline = () => {
 			if (cancelled || socket) { return; }
+			if (Date.now() - lastAttemptAt < ONLINE_REARM_MIN_MS) { return; }
 			if (reconnectTimer) { clearTimeout(reconnectTimer); }
-			failures = 0;
 			connect();
 		};
 		window.addEventListener('online', onOnline);

--- a/src/features/notifications/NotificationsSubscriptionManager.tsx
+++ b/src/features/notifications/NotificationsSubscriptionManager.tsx
@@ -1,0 +1,59 @@
+import { systemStatusQueryKey } from '@/features/notifications/queries';
+import { queryClient } from '@/react-query/queryClient';
+import { useEffect } from 'react';
+
+/**
+ * Subscribes to central-manager's `SystemStatus` table over Harper's automatic WebSocket endpoint and
+ * refetches the notifications query on any change — "subscriptions, not polling" (#1259).
+ *
+ * WebSocket rather than SSE, on purpose: probing stage showed the edge buffers `text/event-stream`
+ * (an SSE GET yields 0 bytes until the connection closes), whereas the WebSocket upgrade passes
+ * straight through (HTTP 101) to Harper's table subscription — anonymously, matching the table's
+ * public read. On any message we invalidate rather than merge deltas (the list is tiny; a refetch is
+ * always correct). WebSockets don't auto-reconnect, so we back off on close and give up after a few
+ * tries, leaning on the query's `refetchInterval` backstop. Mounted once from the signed-in Dashboard.
+ */
+export function NotificationsSubscriptionManager() {
+	useEffect(() => {
+		const base = import.meta.env.VITE_CENTRAL_MANAGER_API_URL;
+		if (!base || typeof WebSocket === 'undefined') { return; }
+
+		// https://host → wss://host  (and http://host → ws://host for local dev).
+		const url = `${base.replace(/^http/, 'ws').replace(/\/$/, '')}/SystemStatus`;
+		let socket: WebSocket | null = null;
+		let cancelled = false;
+		let failures = 0;
+		let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+		const connect = () => {
+			if (cancelled) { return; }
+			socket = new WebSocket(url);
+			socket.onopen = () => {
+				failures = 0;
+			};
+			// Any table change arrives as a message; refetch the canonical list.
+			socket.onmessage = () => {
+				void queryClient.invalidateQueries({ queryKey: systemStatusQueryKey });
+			};
+			socket.onerror = () => socket?.close();
+			socket.onclose = () => {
+				socket = null;
+				if (cancelled) { return; }
+				failures += 1;
+				// Give up after a handful of failures; the refetchInterval backstop keeps data fresh.
+				if (failures > 5) { return; }
+				reconnectTimer = setTimeout(connect, Math.min(1000 * 2 ** failures, 30_000));
+			};
+		};
+
+		connect();
+
+		return () => {
+			cancelled = true;
+			if (reconnectTimer) { clearTimeout(reconnectTimer); }
+			socket?.close();
+		};
+	}, []);
+
+	return null;
+}

--- a/src/features/notifications/acks.test.ts
+++ b/src/features/notifications/acks.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ackNotification, unackNotification } from '@/features/notifications/acks';
+import { getLocalStorage } from '@/lib/storage/getLocalStorage';
+import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const read = () => getLocalStorage<string[]>(LocalStorageKeys.AckedNotificationIds, []);
+
+describe('notification acks', () => {
+	beforeEach(() => localStorage.clear());
+
+	it('adds an id and persists it to localStorage', () => {
+		ackNotification('sta-1');
+		expect(read()).toEqual(['sta-1']);
+	});
+
+	it('dedupes repeated acks of the same id', () => {
+		ackNotification('sta-1');
+		ackNotification('sta-1');
+		expect(read()).toEqual(['sta-1']);
+	});
+
+	it('removes an id on unack while leaving others intact', () => {
+		ackNotification('sta-1');
+		ackNotification('sta-2');
+		unackNotification('sta-1');
+		expect(read()).toEqual(['sta-2']);
+	});
+});

--- a/src/features/notifications/acks.ts
+++ b/src/features/notifications/acks.ts
@@ -1,0 +1,51 @@
+import { getLocalStorage } from '@/lib/storage/getLocalStorage';
+import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
+import { setLocalStorage } from '@/lib/storage/setLocalStorage';
+import { queryClient } from '@/react-query/queryClient';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+/**
+ * Client-side acknowledgement ("ignore") state for notifications, persisted to localStorage.
+ *
+ * We start with global notifications and no per-user backend scoping, so read/dismiss state lives on
+ * the device (issue #1259). It's kept in the query cache — rather than a plain `useLocalStorage` —
+ * so the bell, banner, and center all react to a change immediately (`useLocalStorage` explicitly does
+ * not sync across hook instances). This grows into a server-side per-user table later.
+ */
+export const notificationAcksQueryKey = ['notification-acks'] as const;
+
+function readAcks(): string[] {
+	return getLocalStorage<string[]>(LocalStorageKeys.AckedNotificationIds, []);
+}
+
+function writeAcks(ids: string[]): void {
+	setLocalStorage(LocalStorageKeys.AckedNotificationIds, ids);
+	queryClient.setQueryData(notificationAcksQueryKey, ids);
+}
+
+export function getNotificationAcksQueryOptions() {
+	return queryOptions({
+		queryKey: notificationAcksQueryKey,
+		queryFn: readAcks,
+		// Purely client-side state; never goes stale or gets garbage collected out from under us.
+		staleTime: Infinity,
+		gcTime: Infinity,
+		// Hydrate synchronously from localStorage so the first render already reflects prior acks.
+		initialData: readAcks,
+	});
+}
+
+export function ackNotification(id: string): void {
+	writeAcks(Array.from(new Set([...readAcks(), id])));
+}
+
+export function unackNotification(id: string): void {
+	writeAcks(readAcks().filter((existing) => existing !== id));
+}
+
+/** Reactive set of acknowledged notification ids. */
+export function useNotificationAcks(): Set<string> {
+	const { data } = useQuery(getNotificationAcksQueryOptions());
+	return useMemo(() => new Set(data ?? []), [data]);
+}

--- a/src/features/notifications/acks.ts
+++ b/src/features/notifications/acks.ts
@@ -16,12 +16,23 @@ import { useMemo } from 'react';
 export const notificationAcksQueryKey = ['notification-acks'] as const;
 
 function readAcks(): string[] {
-	return getLocalStorage<string[]>(LocalStorageKeys.AckedNotificationIds, []);
+	// safeParse handles malformed JSON, but valid JSON of the wrong shape (e.g. `{}` from an unrelated
+	// writer) would flow through the cast and later throw "not iterable" in `[...]`/`new Set(...)`,
+	// taking down bell, banner, and center at once (all globally mounted). Validate the shape here.
+	const raw = getLocalStorage<unknown>(LocalStorageKeys.AckedNotificationIds, []);
+	return Array.isArray(raw) ? raw.filter((id): id is string => typeof id === 'string') : [];
 }
 
 function writeAcks(ids: string[]): void {
-	setLocalStorage(LocalStorageKeys.AckedNotificationIds, ids);
+	// Update the in-memory cache first so the UI reacts even if persistence fails; then persist. A full
+	// localStorage (Safari private mode has thrown on first write) degrades to "ack didn't survive
+	// reload" rather than throwing out of an onClick and leaving the notice stuck on screen.
 	queryClient.setQueryData(notificationAcksQueryKey, ids);
+	try {
+		setLocalStorage(LocalStorageKeys.AckedNotificationIds, ids);
+	} catch (err) {
+		console.warn('[notifications] could not persist acknowledgements', err);
+	}
 }
 
 export function getNotificationAcksQueryOptions() {

--- a/src/features/notifications/components/NotificationLink.tsx
+++ b/src/features/notifications/components/NotificationLink.tsx
@@ -1,0 +1,40 @@
+import { parseNotificationLink } from '@/features/notifications/notificationHelpers';
+import { Link } from '@tanstack/react-router';
+import { ExternalLinkIcon } from 'lucide-react';
+import { ReactNode } from 'react';
+
+/**
+ * Renders a notification's optional deep link. External URLs (any scheme) open in a new tab as a plain
+ * anchor; internal paths use the router `Link` so they resolve through the app's hash history. Renders
+ * nothing when there's no usable link.
+ */
+export function NotificationLink({
+	url,
+	className,
+	children,
+	onNavigate,
+}: {
+	url: string | null | undefined;
+	className?: string;
+	children?: ReactNode;
+	/** Called after an internal navigation, e.g. to close the containing dropdown. */
+	onNavigate?: () => void;
+}) {
+	const link = parseNotificationLink(url);
+	if (!link) { return null; }
+
+	if (link.kind === 'external') {
+		return (
+			<a href={link.href} target="_blank" rel="noreferrer noopener" className={className}>
+				{children ?? 'Learn more'}
+				<ExternalLinkIcon className="inline size-3 ml-1 align-[-1px]" />
+			</a>
+		);
+	}
+
+	return (
+		<Link to={link.href} className={className} onClick={onNavigate}>
+			{children ?? 'View details'}
+		</Link>
+	);
+}

--- a/src/features/notifications/hooks.ts
+++ b/src/features/notifications/hooks.ts
@@ -3,19 +3,36 @@ import { isActive } from '@/features/notifications/notificationHelpers';
 import { getSystemStatusQueryOptions } from '@/features/notifications/queries';
 import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 
-/**
- * A coarse clock that re-renders on an interval, so time-windowed "active" state flips as windows
- * open/close even when the underlying data hasn't changed.
- */
-export function useNow(intervalMs = 30_000): number {
-	const [now, setNow] = useState(() => Date.now());
-	useEffect(() => {
-		const timer = setInterval(() => setNow(Date.now()), intervalMs);
-		return () => clearInterval(timer);
-	}, [intervalMs]);
-	return now;
+// One shared 30s tick drives every "is this still active?" consumer (bell, banner, center) instead of
+// an interval per component. Active windows only need coarse granularity, so a single clock is plenty.
+const TICK_MS = 30_000;
+const nowListeners = new Set<() => void>();
+let nowValue = Date.now();
+let nowInterval: ReturnType<typeof setInterval> | null = null;
+
+function subscribeNow(listener: () => void): () => void {
+	nowListeners.add(listener);
+	if (!nowInterval) {
+		nowValue = Date.now(); // refresh on (re)start so the first subscriber isn't handed a stale value
+		nowInterval = setInterval(() => {
+			nowValue = Date.now();
+			nowListeners.forEach((l) => l());
+		}, TICK_MS);
+	}
+	return () => {
+		nowListeners.delete(listener);
+		if (nowListeners.size === 0 && nowInterval) {
+			clearInterval(nowInterval);
+			nowInterval = null;
+		}
+	};
+}
+
+/** A coarse, shared clock: re-renders subscribers every 30s so active windows flip as time passes. */
+export function useNow(): number {
+	return useSyncExternalStore(subscribeNow, () => nowValue, () => nowValue);
 }
 
 /** All notifications from the central-manager `SystemStatus` table. */

--- a/src/features/notifications/hooks.ts
+++ b/src/features/notifications/hooks.ts
@@ -1,0 +1,41 @@
+import { useNotificationAcks } from '@/features/notifications/acks';
+import { isActive } from '@/features/notifications/notificationHelpers';
+import { getSystemStatusQueryOptions } from '@/features/notifications/queries';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+
+/**
+ * A coarse clock that re-renders on an interval, so time-windowed "active" state flips as windows
+ * open/close even when the underlying data hasn't changed.
+ */
+export function useNow(intervalMs = 30_000): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const timer = setInterval(() => setNow(Date.now()), intervalMs);
+		return () => clearInterval(timer);
+	}, [intervalMs]);
+	return now;
+}
+
+/** All notifications from the central-manager `SystemStatus` table. */
+export function useNotifications() {
+	return useQuery(getSystemStatusQueryOptions());
+}
+
+/** Notifications whose active window currently contains "now". */
+export function useActiveNotifications(): SystemStatusNotification[] {
+	const { data } = useNotifications();
+	const now = useNow();
+	return useMemo(() => (data ?? []).filter((notification) => isActive(notification, now)), [data, now]);
+}
+
+/**
+ * Active notifications the user hasn't acknowledged — the source for the bell badge count and the
+ * banner ("hey, look at me" surfaces).
+ */
+export function useUnackedActiveNotifications(): SystemStatusNotification[] {
+	const active = useActiveNotifications();
+	const acks = useNotificationAcks();
+	return useMemo(() => active.filter((notification) => !acks.has(notification.id)), [active, acks]);
+}

--- a/src/features/notifications/index.tsx
+++ b/src/features/notifications/index.tsx
@@ -30,8 +30,11 @@ export function NotificationsCenter() {
 		const severityDelta = SEVERITY_ORDER[getSeverityConfig(a.type).severity]
 			- SEVERITY_ORDER[getSeverityConfig(b.type).severity];
 		if (severityDelta !== 0) { return severityDelta; }
-		// Most recently ending first within a group.
-		return (toMs(b.endAt) ?? Infinity) - (toMs(a.endAt) ?? Infinity);
+		// Most recently ending first within a group. Use MAX_SAFE_INTEGER (not Infinity) as the
+		// open-ended fallback so two never-ending notices compare as 0, not NaN (unstable sort).
+		const endA = toMs(a.endAt) ?? Number.MAX_SAFE_INTEGER;
+		const endB = toMs(b.endAt) ?? Number.MAX_SAFE_INTEGER;
+		return endB - endA;
 	});
 
 	return (

--- a/src/features/notifications/index.tsx
+++ b/src/features/notifications/index.tsx
@@ -1,0 +1,113 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ackNotification, unackNotification, useNotificationAcks } from '@/features/notifications/acks';
+import { NotificationLink } from '@/features/notifications/components/NotificationLink';
+import { useNotifications, useNow } from '@/features/notifications/hooks';
+import {
+	getSeverityConfig,
+	getWindowStatus,
+	type Severity,
+	toMs,
+	type WindowState,
+} from '@/features/notifications/notificationHelpers';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { cn } from '@/lib/cn';
+
+const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, warning: 1, info: 2 };
+const STATE_ORDER: Record<WindowState, number> = { active: 0, upcoming: 1, expired: 2 };
+
+export function NotificationsCenter() {
+	const { data, isLoading } = useNotifications();
+	const acks = useNotificationAcks();
+	const now = useNow();
+
+	const notifications = data ?? [];
+	const sorted = [...notifications].sort((a, b) => {
+		const stateA = STATE_ORDER[getWindowStatus(a, now).state];
+		const stateB = STATE_ORDER[getWindowStatus(b, now).state];
+		if (stateA !== stateB) { return stateA - stateB; }
+		const severityDelta = SEVERITY_ORDER[getSeverityConfig(a.type).severity]
+			- SEVERITY_ORDER[getSeverityConfig(b.type).severity];
+		if (severityDelta !== 0) { return severityDelta; }
+		// Most recently ending first within a group.
+		return (toMs(b.endAt) ?? Infinity) - (toMs(a.endAt) ?? Infinity);
+	});
+
+	return (
+		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
+			<div className="max-w-3xl">
+				<h1 className="text-2xl font-light">Notifications</h1>
+				<p className="mt-2 text-sm text-muted-foreground">
+					System-wide notices, including maintenance windows and downstream provider incidents.
+				</p>
+
+				<div className="mt-6 flex flex-col gap-3">
+					{isLoading
+						? <Skeleton className="h-24 w-full" />
+						: sorted.length === 0
+						? (
+							<p className="rounded-md border border-border bg-card p-8 text-center text-sm text-muted-foreground dark:bg-black-dark">
+								No notifications right now.
+							</p>
+						)
+						: sorted.map((notification) => (
+							<NotificationCard
+								key={notification.id}
+								notification={notification}
+								acked={acks.has(notification.id)}
+								nowMs={now}
+							/>
+						))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function NotificationCard({
+	notification,
+	acked,
+	nowMs,
+}: {
+	notification: SystemStatusNotification;
+	acked: boolean;
+	nowMs: number;
+}) {
+	const { Icon, iconClass, label, badgeVariant } = getSeverityConfig(notification.type);
+	const window = getWindowStatus(notification, nowMs);
+
+	return (
+		<div
+			className={cn(
+				'flex gap-3 rounded-md border border-border bg-card p-4 dark:bg-black-dark',
+				acked && 'opacity-60',
+				window.state === 'expired' && 'opacity-70',
+			)}
+		>
+			<Icon className={cn('mt-0.5 size-5 shrink-0', iconClass)} />
+			<div className="min-w-0 flex-1">
+				<div className="flex flex-wrap items-center gap-2">
+					<Badge variant={badgeVariant}>{label}</Badge>
+					{window.state !== 'active' && <Badge variant="outline" className="capitalize">{window.state}</Badge>}
+					<span className="text-xs text-muted-foreground">{window.label}</span>
+				</div>
+				<p className="mt-2 text-sm break-words text-foreground">{notification.message}</p>
+				<div className="mt-2 flex items-center gap-4 text-sm">
+					<NotificationLink
+						url={notification.url}
+						className="font-medium text-primary hover:underline dark:text-white"
+					/>
+				</div>
+			</div>
+			<Button
+				variant="ghost"
+				size="sm"
+				className="shrink-0 text-muted-foreground"
+				onClick={() => (acked ? unackNotification(notification.id) : ackNotification(notification.id))}
+			>
+				{acked ? 'Undo' : 'Ignore'}
+			</Button>
+		</div>
+	);
+}

--- a/src/features/notifications/index.tsx
+++ b/src/features/notifications/index.tsx
@@ -7,14 +7,14 @@ import { useNotifications, useNow } from '@/features/notifications/hooks';
 import {
 	getSeverityConfig,
 	getWindowStatus,
-	type Severity,
+	SEVERITY_ORDER,
 	toMs,
 	type WindowState,
 } from '@/features/notifications/notificationHelpers';
 import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { cn } from '@/lib/cn';
+import { useMemo } from 'react';
 
-const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, warning: 1, info: 2 };
 const STATE_ORDER: Record<WindowState, number> = { active: 0, upcoming: 1, expired: 2 };
 
 export function NotificationsCenter() {
@@ -22,20 +22,20 @@ export function NotificationsCenter() {
 	const acks = useNotificationAcks();
 	const now = useNow();
 
-	const notifications = data ?? [];
-	const sorted = [...notifications].sort((a, b) => {
-		const stateA = STATE_ORDER[getWindowStatus(a, now).state];
-		const stateB = STATE_ORDER[getWindowStatus(b, now).state];
-		if (stateA !== stateB) { return stateA - stateB; }
-		const severityDelta = SEVERITY_ORDER[getSeverityConfig(a.type).severity]
-			- SEVERITY_ORDER[getSeverityConfig(b.type).severity];
-		if (severityDelta !== 0) { return severityDelta; }
-		// Most recently ending first within a group. Use MAX_SAFE_INTEGER (not Infinity) as the
-		// open-ended fallback so two never-ending notices compare as 0, not NaN (unstable sort).
-		const endA = toMs(a.endAt) ?? Number.MAX_SAFE_INTEGER;
-		const endB = toMs(b.endAt) ?? Number.MAX_SAFE_INTEGER;
-		return endB - endA;
-	});
+	const sorted = useMemo(() =>
+		[...(data ?? [])].sort((a, b) => {
+			const stateA = STATE_ORDER[getWindowStatus(a, now).state];
+			const stateB = STATE_ORDER[getWindowStatus(b, now).state];
+			if (stateA !== stateB) { return stateA - stateB; }
+			const severityDelta = SEVERITY_ORDER[getSeverityConfig(a.type).severity]
+				- SEVERITY_ORDER[getSeverityConfig(b.type).severity];
+			if (severityDelta !== 0) { return severityDelta; }
+			// Most recently ending first within a group. Use MAX_SAFE_INTEGER (not Infinity) as the
+			// open-ended fallback so two never-ending notices compare as 0, not NaN (unstable sort).
+			const endA = toMs(a.endAt) ?? Number.MAX_SAFE_INTEGER;
+			const endB = toMs(b.endAt) ?? Number.MAX_SAFE_INTEGER;
+			return endB - endA;
+		}), [data, now]);
 
 	return (
 		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">

--- a/src/features/notifications/notificationHelpers.test.ts
+++ b/src/features/notifications/notificationHelpers.test.ts
@@ -1,0 +1,95 @@
+import {
+	getSeverity,
+	getWindowStatus,
+	isActive,
+	parseNotificationLink,
+	toMs,
+} from '@/features/notifications/notificationHelpers';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+
+function notification(overrides: Partial<SystemStatusNotification>): SystemStatusNotification {
+	return { id: 'sta-1', type: 'error', message: 'hi', ...overrides };
+}
+
+const NOW = Date.UTC(2026, 6, 23, 12, 0, 0); // 2026-07-23T12:00:00Z
+
+describe('toMs', () => {
+	it('passes through finite numbers and rejects non-finite', () => {
+		expect(toMs(1000)).toBe(1000);
+		expect(toMs(Number.NaN)).toBeNull();
+	});
+
+	it('parses ISO strings and epoch-ms strings', () => {
+		expect(toMs('2026-07-23T12:00:00.000Z')).toBe(NOW);
+		expect(toMs('1690113600000')).toBe(1690113600000);
+	});
+
+	it('treats null, undefined, empty, and garbage as null', () => {
+		expect(toMs(null)).toBeNull();
+		expect(toMs(undefined)).toBeNull();
+		expect(toMs('')).toBeNull();
+		expect(toMs('not a date')).toBeNull();
+	});
+});
+
+describe('isActive', () => {
+	it('is active with open bounds (no start, no end)', () => {
+		expect(isActive(notification({ startAt: null, endAt: null }), NOW)).toBe(true);
+	});
+
+	it('is inactive before the start', () => {
+		expect(isActive(notification({ startAt: NOW + 1000 }), NOW)).toBe(false);
+	});
+
+	it('is inactive after the end', () => {
+		expect(isActive(notification({ endAt: NOW - 1000 }), NOW)).toBe(false);
+	});
+
+	it('is active inside the window (inclusive bounds)', () => {
+		expect(isActive(notification({ startAt: NOW - 1000, endAt: NOW + 1000 }), NOW)).toBe(true);
+		expect(isActive(notification({ startAt: NOW, endAt: NOW }), NOW)).toBe(true);
+	});
+});
+
+describe('getWindowStatus', () => {
+	it('reports upcoming, active, and expired states', () => {
+		expect(getWindowStatus(notification({ startAt: NOW + 1000 }), NOW).state).toBe('upcoming');
+		expect(getWindowStatus(notification({ endAt: NOW - 1000 }), NOW).state).toBe('expired');
+		expect(getWindowStatus(notification({ startAt: null, endAt: null }), NOW).state).toBe('active');
+		expect(getWindowStatus(notification({ endAt: NOW + 1000 }), NOW).label).toContain('Active until');
+	});
+});
+
+describe('getSeverity', () => {
+	it('maps known types and defaults unknown types to serious (critical)', () => {
+		expect(getSeverity('error')).toBe('critical');
+		expect(getSeverity('OUTAGE')).toBe('critical');
+		expect(getSeverity('maintenance')).toBe('warning');
+		expect(getSeverity('info')).toBe('info');
+		expect(getSeverity('something-else')).toBe('critical');
+		expect(getSeverity('')).toBe('critical');
+		expect(getSeverity(null)).toBe('critical');
+	});
+});
+
+describe('parseNotificationLink', () => {
+	it('returns null for empty links', () => {
+		expect(parseNotificationLink(null)).toBeNull();
+		expect(parseNotificationLink('   ')).toBeNull();
+	});
+
+	it('classifies absolute URLs and other schemes as external', () => {
+		expect(parseNotificationLink('https://status.harper.io')).toEqual({
+			kind: 'external',
+			href: 'https://status.harper.io',
+		});
+		expect(parseNotificationLink('//cdn.example.com/x')?.kind).toBe('external');
+		expect(parseNotificationLink('mailto:ops@harper.io')?.kind).toBe('external');
+	});
+
+	it('classifies relative paths as internal and normalises the leading slash', () => {
+		expect(parseNotificationLink('/organizations')).toEqual({ kind: 'internal', href: '/organizations' });
+		expect(parseNotificationLink('organizations/abc')).toEqual({ kind: 'internal', href: '/organizations/abc' });
+	});
+});

--- a/src/features/notifications/notificationHelpers.test.ts
+++ b/src/features/notifications/notificationHelpers.test.ts
@@ -55,6 +55,12 @@ describe('isActive', () => {
 		expect(isActive(notification({ startAt: NOW - 1000, endAt: NOW + 1000 }), NOW)).toBe(true);
 		expect(isActive(notification({ startAt: NOW, endAt: NOW }), NOW)).toBe(true);
 	});
+
+	it('fails closed on an unparseable bound instead of treating it as open', () => {
+		// A bad endAt must NOT read as "never expires" — that would pin a stale notice on-screen forever.
+		expect(isActive(notification({ endAt: 'not-a-date' }), NOW)).toBe(false);
+		expect(isActive(notification({ startAt: 'garbage', endAt: null }), NOW)).toBe(false);
+	});
 });
 
 describe('getWindowStatus', () => {
@@ -63,6 +69,12 @@ describe('getWindowStatus', () => {
 		expect(getWindowStatus(notification({ endAt: NOW - 1000 }), NOW).state).toBe('expired');
 		expect(getWindowStatus(notification({ startAt: null, endAt: null }), NOW).state).toBe('active');
 		expect(getWindowStatus(notification({ endAt: NOW + 1000 }), NOW).label).toContain('Active until');
+	});
+
+	it('never labels an unreadable schedule as active', () => {
+		const status = getWindowStatus(notification({ endAt: 'not-a-date' }), NOW);
+		expect(status.state).toBe('expired');
+		expect(status.label).toBe('Schedule unavailable');
 	});
 });
 

--- a/src/features/notifications/notificationHelpers.test.ts
+++ b/src/features/notifications/notificationHelpers.test.ts
@@ -31,6 +31,11 @@ describe('toMs', () => {
 		expect(toMs('')).toBeNull();
 		expect(toMs('not a date')).toBeNull();
 	});
+
+	it('returns null for unexpected non-string/number types instead of throwing', () => {
+		expect(toMs(true as unknown as string)).toBeNull();
+		expect(toMs({} as unknown as string)).toBeNull();
+	});
 });
 
 describe('isActive', () => {
@@ -79,13 +84,21 @@ describe('parseNotificationLink', () => {
 		expect(parseNotificationLink('   ')).toBeNull();
 	});
 
-	it('classifies absolute URLs and other schemes as external', () => {
+	it('classifies safe-scheme and protocol-relative URLs as external', () => {
 		expect(parseNotificationLink('https://status.harper.io')).toEqual({
 			kind: 'external',
 			href: 'https://status.harper.io',
 		});
 		expect(parseNotificationLink('//cdn.example.com/x')?.kind).toBe('external');
 		expect(parseNotificationLink('mailto:ops@harper.io')?.kind).toBe('external');
+	});
+
+	it('rejects unsafe/unknown schemes (stored-XSS defense) rather than rendering them', () => {
+		expect(parseNotificationLink('javascript:alert(1)')).toBeNull();
+		expect(parseNotificationLink('JavaScript:alert(1)')).toBeNull();
+		expect(parseNotificationLink('data:text/html,<script>alert(1)</script>')).toBeNull();
+		expect(parseNotificationLink('vbscript:msgbox(1)')).toBeNull();
+		expect(parseNotificationLink('ftp://example.com/file')).toBeNull();
 	});
 
 	it('classifies relative paths as internal and normalises the leading slash', () => {

--- a/src/features/notifications/notificationHelpers.ts
+++ b/src/features/notifications/notificationHelpers.ts
@@ -64,30 +64,51 @@ export function getSeverityConfig(type: string | null | undefined): SeverityConf
 	return SEVERITY_CONFIG[getSeverity(type)];
 }
 
+/** Sort weight by severity, most serious first. Single source of truth shared by the bell and center. */
+export const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, warning: 1, info: 2 };
+
 export { BellIcon };
 
 /**
- * Harper's `Date` scalar can serialise as an ISO string or an epoch-ms number (and numeric strings
- * have been seen in the wild). Normalise any of those to epoch ms, or `null` when absent/unparseable.
+ * Result of parsing a Harper `Date` field: absent (null/empty), a valid instant, or present-but-
+ * unreadable. Distinguishing "absent" from "invalid" lets the active-window checks fail *closed* on a
+ * value we can't trust, rather than treating it as an open bound (which reads as "never expires").
  */
-export function toMs(value: string | number | null | undefined): number | null {
-	if (value === null || value === undefined) { return null; }
-	if (typeof value === 'number') { return Number.isFinite(value) ? value : null; }
+type ParsedInstant = { kind: 'absent' } | { kind: 'valid'; ms: number } | { kind: 'invalid' };
+
+function parseInstant(value: string | number | null | undefined): ParsedInstant {
+	if (value === null || value === undefined) { return { kind: 'absent' }; }
+	if (typeof value === 'number') { return Number.isFinite(value) ? { kind: 'valid', ms: value } : { kind: 'invalid' }; }
 	// Guard against unexpected API types (boolean/object) so `.trim()` can't throw.
-	if (typeof value !== 'string') { return null; }
+	if (typeof value !== 'string') { return { kind: 'invalid' }; }
 	const trimmed = value.trim();
-	if (!trimmed) { return null; }
-	if (/^\d+$/.test(trimmed)) { return Number(trimmed); }
+	if (!trimmed) { return { kind: 'absent' }; }
+	if (/^\d+$/.test(trimmed)) { return { kind: 'valid', ms: Number(trimmed) }; }
 	const parsed = Date.parse(trimmed);
-	return Number.isNaN(parsed) ? null : parsed;
+	return Number.isNaN(parsed) ? { kind: 'invalid' } : { kind: 'valid', ms: parsed };
 }
 
-/** A notification is active when `now` falls within its [startAt, endAt] window (open bounds allowed). */
+/**
+ * Harper's `Date` scalar can serialise as an ISO string or epoch-ms (or a numeric string). Normalise to
+ * epoch ms, or `null` when absent *or* unparseable. Active-window logic uses `parseInstant` directly so
+ * it can tell those apart; `toMs` is for display/sort callers that treat both as "no value".
+ */
+export function toMs(value: string | number | null | undefined): number | null {
+	const parsed = parseInstant(value);
+	return parsed.kind === 'valid' ? parsed.ms : null;
+}
+
+/**
+ * A notification is active when `now` falls within its [startAt, endAt] window (open bounds allowed).
+ * Fails **closed**: an unreadable bound makes the window untrustworthy, so we treat the notice as not
+ * active rather than as "no bound" — otherwise a bad `endAt` would pin a stale notice on-screen forever.
+ */
 export function isActive(notification: SystemStatusNotification, nowMs: number): boolean {
-	const start = toMs(notification.startAt);
-	const end = toMs(notification.endAt);
-	if (start !== null && nowMs < start) { return false; }
-	if (end !== null && nowMs > end) { return false; }
+	const start = parseInstant(notification.startAt);
+	const end = parseInstant(notification.endAt);
+	if (start.kind === 'invalid' || end.kind === 'invalid') { return false; }
+	if (start.kind === 'valid' && nowMs < start.ms) { return false; }
+	if (end.kind === 'valid' && nowMs > end.ms) { return false; }
 	return true;
 }
 
@@ -104,16 +125,20 @@ function formatAbsolute(ms: number): string {
 
 /** Human label describing where `now` sits relative to a notification's active window. */
 export function getWindowStatus(notification: SystemStatusNotification, nowMs: number): WindowStatus {
-	const start = toMs(notification.startAt);
-	const end = toMs(notification.endAt);
-	if (start !== null && nowMs < start) {
-		return { state: 'upcoming', label: `Starts ${formatAbsolute(start)}` };
+	const start = parseInstant(notification.startAt);
+	const end = parseInstant(notification.endAt);
+	// Mirror isActive's fail-closed stance: never advertise an unreadable schedule as "Active".
+	if (start.kind === 'invalid' || end.kind === 'invalid') {
+		return { state: 'expired', label: 'Schedule unavailable' };
 	}
-	if (end !== null && nowMs > end) {
-		return { state: 'expired', label: `Ended ${formatAbsolute(end)}` };
+	if (start.kind === 'valid' && nowMs < start.ms) {
+		return { state: 'upcoming', label: `Starts ${formatAbsolute(start.ms)}` };
 	}
-	if (end !== null) {
-		return { state: 'active', label: `Active until ${formatAbsolute(end)}` };
+	if (end.kind === 'valid' && nowMs > end.ms) {
+		return { state: 'expired', label: `Ended ${formatAbsolute(end.ms)}` };
+	}
+	if (end.kind === 'valid') {
+		return { state: 'active', label: `Active until ${formatAbsolute(end.ms)}` };
 	}
 	return { state: 'active', label: 'Active' };
 }

--- a/src/features/notifications/notificationHelpers.ts
+++ b/src/features/notifications/notificationHelpers.ts
@@ -73,6 +73,8 @@ export { BellIcon };
 export function toMs(value: string | number | null | undefined): number | null {
 	if (value === null || value === undefined) { return null; }
 	if (typeof value === 'number') { return Number.isFinite(value) ? value : null; }
+	// Guard against unexpected API types (boolean/object) so `.trim()` can't throw.
+	if (typeof value !== 'string') { return null; }
 	const trimmed = value.trim();
 	if (!trimmed) { return null; }
 	if (/^\d+$/.test(trimmed)) { return Number(trimmed); }
@@ -120,18 +122,26 @@ export type NotificationLink =
 	| { kind: 'external'; href: string }
 	| { kind: 'internal'; href: string };
 
+// Schemes we'll render in an href. Anything else with a scheme (javascript:, data:, vbscript:, …) is
+// rejected outright — an allowlist rather than a blocklist so unsafe schemes can't slip through as a
+// stored-XSS vector when a notification's URL is authored by an admin (or, later, an org/user).
+const SAFE_EXTERNAL_SCHEMES = new Set(['http', 'https', 'mailto']);
+
 /**
- * Classify a notification's optional deep link. An absolute URL (any scheme, or protocol-relative) is
- * external and opens in a new tab; anything else is treated as an internal router path.
+ * Classify a notification's optional deep link. A protocol-relative URL or one with a safe scheme is
+ * external (opens in a new tab); a scheme-less value is an internal router path; anything with an
+ * unsafe/unknown scheme yields no link.
  */
 export function parseNotificationLink(url: string | null | undefined): NotificationLink | null {
 	if (!url) { return null; }
 	const trimmed = url.trim();
 	if (!trimmed) { return null; }
-	// Protocol-relative (`//host`), or has an explicit scheme (`https:`, `mailto:`, …) → external.
-	if (trimmed.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
-		return { kind: 'external', href: trimmed };
+	// Protocol-relative (`//host`) resolves against https → external.
+	if (trimmed.startsWith('//')) { return { kind: 'external', href: trimmed }; }
+	const scheme = trimmed.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+	if (scheme) {
+		return SAFE_EXTERNAL_SCHEMES.has(scheme) ? { kind: 'external', href: trimmed } : null;
 	}
-	// Internal router path — normalise to a leading slash.
+	// No scheme → internal router path; normalise to a leading slash.
 	return { kind: 'internal', href: trimmed.startsWith('/') ? trimmed : `/${trimmed}` };
 }

--- a/src/features/notifications/notificationHelpers.ts
+++ b/src/features/notifications/notificationHelpers.ts
@@ -1,0 +1,137 @@
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { BellIcon, InfoIcon, type LucideIcon, OctagonAlertIcon, TriangleAlertIcon } from 'lucide-react';
+
+/**
+ * Notifications are backed by the central-manager `SystemStatus` table, whose `type` is a freeform
+ * string. We normalise it to one of three severities for styling. Per the #1259 decision we assume a
+ * *serious* severity by default, so an unrecognised `type` maps to `critical`.
+ */
+export type Severity = 'critical' | 'warning' | 'info';
+
+export interface SeverityConfig {
+	severity: Severity;
+	label: string;
+	Icon: LucideIcon;
+	/** Badge variant used for the per-notification severity chip. */
+	badgeVariant: 'destructive' | 'warning' | 'secondary';
+	/** Banner strip classes (light + dark). */
+	bannerClass: string;
+	/** Accent colour for the severity icon. */
+	iconClass: string;
+}
+
+export const SEVERITY_CONFIG: Record<Severity, SeverityConfig> = {
+	critical: {
+		severity: 'critical',
+		label: 'Critical',
+		Icon: OctagonAlertIcon,
+		badgeVariant: 'destructive',
+		bannerClass: 'bg-destructive/10 border-destructive/40 text-foreground',
+		iconClass: 'text-destructive',
+	},
+	warning: {
+		severity: 'warning',
+		label: 'Warning',
+		Icon: TriangleAlertIcon,
+		badgeVariant: 'warning',
+		bannerClass: 'bg-yellow/10 border-yellow/40 text-foreground',
+		iconClass: 'text-yellow',
+	},
+	info: {
+		severity: 'info',
+		label: 'Info',
+		Icon: InfoIcon,
+		badgeVariant: 'secondary',
+		bannerClass: 'bg-secondary/20 border-secondary/50 text-foreground',
+		iconClass: 'text-secondary-foreground',
+	},
+};
+
+const CRITICAL_TYPES = new Set(['critical', 'error', 'outage', 'incident', 'down', 'danger']);
+const WARNING_TYPES = new Set(['warning', 'warn', 'maintenance', 'degraded', 'notice']);
+const INFO_TYPES = new Set(['info', 'information', 'informational', 'success', 'ok']);
+
+/** Map a raw `SystemStatus.type` to a severity. Unknown types are treated as serious (`critical`). */
+export function getSeverity(type: string | null | undefined): Severity {
+	const normalised = (type ?? '').trim().toLowerCase();
+	if (WARNING_TYPES.has(normalised)) { return 'warning'; }
+	if (INFO_TYPES.has(normalised)) { return 'info'; }
+	if (CRITICAL_TYPES.has(normalised)) { return 'critical'; }
+	return 'critical';
+}
+
+export function getSeverityConfig(type: string | null | undefined): SeverityConfig {
+	return SEVERITY_CONFIG[getSeverity(type)];
+}
+
+export { BellIcon };
+
+/**
+ * Harper's `Date` scalar can serialise as an ISO string or an epoch-ms number (and numeric strings
+ * have been seen in the wild). Normalise any of those to epoch ms, or `null` when absent/unparseable.
+ */
+export function toMs(value: string | number | null | undefined): number | null {
+	if (value === null || value === undefined) { return null; }
+	if (typeof value === 'number') { return Number.isFinite(value) ? value : null; }
+	const trimmed = value.trim();
+	if (!trimmed) { return null; }
+	if (/^\d+$/.test(trimmed)) { return Number(trimmed); }
+	const parsed = Date.parse(trimmed);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** A notification is active when `now` falls within its [startAt, endAt] window (open bounds allowed). */
+export function isActive(notification: SystemStatusNotification, nowMs: number): boolean {
+	const start = toMs(notification.startAt);
+	const end = toMs(notification.endAt);
+	if (start !== null && nowMs < start) { return false; }
+	if (end !== null && nowMs > end) { return false; }
+	return true;
+}
+
+export type WindowState = 'active' | 'upcoming' | 'expired';
+
+export interface WindowStatus {
+	state: WindowState;
+	label: string;
+}
+
+function formatAbsolute(ms: number): string {
+	return new Date(ms).toLocaleString();
+}
+
+/** Human label describing where `now` sits relative to a notification's active window. */
+export function getWindowStatus(notification: SystemStatusNotification, nowMs: number): WindowStatus {
+	const start = toMs(notification.startAt);
+	const end = toMs(notification.endAt);
+	if (start !== null && nowMs < start) {
+		return { state: 'upcoming', label: `Starts ${formatAbsolute(start)}` };
+	}
+	if (end !== null && nowMs > end) {
+		return { state: 'expired', label: `Ended ${formatAbsolute(end)}` };
+	}
+	if (end !== null) {
+		return { state: 'active', label: `Active until ${formatAbsolute(end)}` };
+	}
+	return { state: 'active', label: 'Active' };
+}
+
+export type NotificationLink =
+	| { kind: 'external'; href: string }
+	| { kind: 'internal'; href: string };
+
+/**
+ * Classify a notification's optional deep link. An absolute URL (any scheme, or protocol-relative) is
+ * external and opens in a new tab; anything else is treated as an internal router path.
+ */
+export function parseNotificationLink(url: string | null | undefined): NotificationLink | null {
+	if (!url) { return null; }
+	const trimmed = url.trim();
+	if (!trimmed) { return null; }
+	// Protocol-relative (`//host`), or has an explicit scheme (`https:`, `mailto:`, …) → external.
+	if (trimmed.startsWith('//') || /^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+		return { kind: 'external', href: trimmed };
+	}
+	// Internal router path — normalise to a leading slash.
+	return { kind: 'internal', href: trimmed.startsWith('/') ? trimmed : `/${trimmed}` };
+}

--- a/src/features/notifications/queries.ts
+++ b/src/features/notifications/queries.ts
@@ -1,0 +1,23 @@
+import { apiClient } from '@/config/apiClient';
+import { SystemStatusNotification } from '@/integrations/api/api.patch';
+import { queryOptions } from '@tanstack/react-query';
+
+// The central-manager `SystemStatus` resource isn't in the generated OpenAPI types yet, so the URL is
+// cast (same approach as getCurrentUser / generateApiToken).
+export const systemStatusQueryKey = ['system-status'] as const;
+
+export async function fetchSystemStatus(): Promise<SystemStatusNotification[]> {
+	const { data } = await apiClient.get('/SystemStatus/' as '/Cluster/');
+	return (Array.isArray(data) ? data : []) as unknown as SystemStatusNotification[];
+}
+
+export function getSystemStatusQueryOptions() {
+	return queryOptions({
+		queryKey: systemStatusQueryKey,
+		queryFn: fetchSystemStatus,
+		// Live updates arrive over the WebSocket subscription (NotificationsSubscriptionManager); this
+		// long interval is only a backstop for when the socket is unavailable.
+		refetchInterval: 60_000,
+		staleTime: 30_000,
+	});
+}

--- a/src/features/notifications/routes.ts
+++ b/src/features/notifications/routes.ts
@@ -1,0 +1,12 @@
+import { dashboardLayout } from '@/router/dashboardRoute';
+import { createRoute, lazyRouteComponent } from '@tanstack/react-router';
+
+const notificationsRoute = createRoute({
+	getParentRoute: () => dashboardLayout,
+	path: 'notifications',
+	head: () => ({ meta: [{ title: 'Notifications — Harper Fabric' }] }),
+	component: lazyRouteComponent(async () => import('@/features/notifications/index'), 'NotificationsCenter'),
+});
+
+// Parent: dashboardLayout (keep in lockstep with rootRouteTree's addChildren).
+export const notificationsRoutes = [notificationsRoute];

--- a/src/integrations/api/api.patch.d.ts
+++ b/src/integrations/api/api.patch.d.ts
@@ -47,6 +47,24 @@ export interface ApiTokenResult {
 	expiresAt: string;
 }
 
+/**
+ * A row of the central-manager `SystemStatus` table — the backing store for the
+ * notification center (issue #1259). Not in the generated OpenAPI types yet, so
+ * declared here (see the note at the top of this file).
+ */
+export interface SystemStatusNotification {
+	id: string;
+	/** Freeform category, e.g. 'error' | 'warning' | 'maintenance' | 'info'. Treated as serious by default. */
+	type: string;
+	message: string;
+	/** Optional deep link: an absolute URL (external, new tab) or a relative path (internal route). */
+	url?: string | null;
+	/** Start of the active window (UTC). Null/absent = active from the beginning of time. Harper `Date` → ISO string or epoch ms. */
+	startAt?: string | number | null;
+	/** End of the active window (UTC). Null/absent = never expires. Harper `Date` → ISO string or epoch ms. */
+	endAt?: string | number | null;
+}
+
 export interface Organization extends SchemaOrganization {
 	type: ENTERPRISE | SELF_SERVICE | string | undefined;
 	settings?: {

--- a/src/lib/storage/localStorageKeys.ts
+++ b/src/lib/storage/localStorageKeys.ts
@@ -1,4 +1,5 @@
 export const enum LocalStorageKeys {
+	'AckedNotificationIds' = 'AckedNotificationIds',
 	'ApplicationChatPosition' = 'ApplicationChatPosition',
 	'ApplicationChatWidth' = 'ApplicationChatWidth',
 	'ApplicationsSidebarWidth' = 'ApplicationsSidebarWidth',

--- a/src/router/rootRouteTree.ts
+++ b/src/router/rootRouteTree.ts
@@ -5,6 +5,7 @@ import { clusterLayoutRoute } from '@/features/cluster/clusterLayoutRoute';
 import { clusterRoutes } from '@/features/cluster/routes';
 import { clusterEditRoutes, clustersLayoutRoute, clustersRoutes, newClusterRoute } from '@/features/clusters/routes';
 import { createInstanceRouteTree } from '@/features/instance/routes';
+import { notificationsRoutes } from '@/features/notifications/routes';
 import { orgLayoutRoute, orgRoutes } from '@/features/organization/routes';
 import { orgsLayoutRoute, orgsRoutes } from '@/features/organizations/routes';
 import { profileRoutes } from '@/features/profile/routes';
@@ -22,6 +23,7 @@ export const rootRouteTree = isLocalStudio
 		authRouteTree,
 		dashboardLayout.addChildren([
 			...profileRoutes,
+			...notificationsRoutes,
 			adminLayoutRoute.addChildren([...adminRoutes]),
 			orgsLayoutRoute.addChildren([
 				...orgsRoutes,


### PR DESCRIPTION
Closes #1259.

The bones of a GitHub-esque notification center for Fabric Studio, backed by the existing central-manager `SystemStatus` table.

## What's here
- **Bell + unread badge** in the navbar (desktop + mobile) with a preview dropdown — `NotificationBell.tsx`.
- **Notification center** at `/notifications` — full list grouped active / upcoming / expired — `features/notifications/index.tsx`.
- **Bottom banner** auto-showing active, un-acknowledged notices — `NotificationBanner.tsx`.
- **Admin management** at `/admin/notifications` (fabric-admin) — create / edit / delete via DataTable + dialog — `features/admin/notifications/`.
- **Live via subscription**, not polling — Harper's table WebSocket; a 60s poll only as a backstop — `NotificationsSubscriptionManager.tsx`.
- **Client-side (localStorage) acks**, time-windowed (UTC) active state, and optional internal (router) / external (new-tab) deep links.

## Notable decisions
- **WebSocket, not SSE.** Probing stage: `GET /SystemStatus/` with `Accept: text/event-stream` returns 0 bytes (the edge buffers `text/event-stream`, even for CM's own tables), while the WS upgrade to `wss://…/SystemStatus` returns HTTP 101 and connects anonymously (matches the table's public read). Still a true subscription; no polling.
- **No central-manager change needed.** `SystemStatus` already exposes public read, fabric-admin-gated writes, and a WebSocket subscription — so #1259's "blocked on CM" is unblocked by the existing table.
- **Banner is bottom-anchored.** Studio's chrome hardcodes the top band (fixed header `top-0`, sub-nav `top-20`, content `mt-32`) on every page, so a top banner would need a global offset refactor; a bottom bar is robust everywhere and never hides the nav. Easy to revisit.

## Scope / follow-ups
Starts **global**; org/user scoping is an additive next step (indexed columns + query filter, same center). Server-side per-user read state and a `title` field are also easy follow-ups. A global notice should also render for signed-out users (currently the surfaces mount inside the authed Dashboard layout) — noted as a fast follow.

## Testing
- 17 new unit tests (window/active filtering, deep-link classification, ack store, Radix bell dropdown); full suite green (1804 pass); `tsc`, `oxlint`, `dprint` clean.
- Verified end-to-end in the local preview against stage: bell badge, preview dropdown, bottom banner, center page, severity styling, internal + external deep links, and ack persistence — via synthetic client-side data (this session's account is `least_privileged`, so the admin CRUD + live WS push are being verified on `dev` with an admin account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
