### PR TITLE
fix(ssh-keys): validate Add SSH Key form onChange

### DIFF
--- a/src/features/instance/config/sshKeys/modals/AddSSHKeyModal.tsx
+++ b/src/features/instance/config/sshKeys/modals/AddSSHKeyModal.tsx
@@ -36,6 +36,7 @@ export function AddSSHKeyModal({
 }) {
 	const form = useForm({
 		resolver: zodResolver(SSHKeySchema),
+		mode: 'onChange',
 		defaultValues: {
 			name: '',
 			key: '',


### PR DESCRIPTION
The form had no validation mode, so RHF defaulted to onSubmit — but the submit button is gated on formState.isValid, which onSubmit mode never computes. Validation could never run and the button stayed disabled. onChange matches the other forms (ClusterForm, log config) and surfaces field errors as the user types.