### PR TITLE
fix(routing): guard cluster beforeLoad against missing app-level auth connection

### DIFF
--- a/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
+++ b/src/features/instance/checkClusterInstanceAuthenticationBeforeLoad.test.ts
@@ -98,4 +98,18 @@ describe('checkClusterInstanceAuthenticationBeforeLoad', () => {
 		).resolves.toBeUndefined();
 		expect(establishSpy).not.toHaveBeenCalled();
 	});
+
+	it('does not redirect or crash when the app-level connection is absent from the context', async () => {
+		// Regression for the RUM "Cannot read properties of undefined (reading 'user')" TypeError thrown
+		// from this beforeLoad: context.authentication has no OverallAppSignIn entry, so overallAuth is
+		// undefined. The guard must neither dereference overallAuth.user nor redirect from here — another
+		// guard owns that redirect, and stacking redirects in one navigation can corrupt router state.
+		// permissions.update is true to prove the manage path is skipped, not taken.
+		permissions = { update: true };
+
+		await expect(
+			checkClusterInstanceAuthenticationBeforeLoad({ context: { authentication: {} }, params: PARAMS }),
+		).resolves.toBeUndefined();
+		expect(establishSpy).not.toHaveBeenCalled();
+	});
 });

--- a/src/features/instance/instanceLayoutRoute.ts
+++ b/src/features/instance/instanceLayoutRoute.ts
@@ -73,9 +73,12 @@ export async function checkClusterInstanceAuthenticationBeforeLoad({
 		return;
 	}
 
-	// Wait for the app-level sign-in to resolve before deciding whether to redirect.
-	const overallAuth = context.authentication[OverallAppSignIn] as AuthenticatedCloudConnection;
-	if (overallAuth?.isLoading) {
+	// Wait for the app-level sign-in to resolve before deciding whether to redirect. If there's no
+	// app-level connection in the context at all, don't redirect from here — another guard owns that
+	// decision, and stacking redirects within one navigation can corrupt router state. Returning also
+	// avoids dereferencing `overallAuth.user` below (which threw "Cannot read properties of undefined").
+	const overallAuth = context.authentication[OverallAppSignIn] as AuthenticatedCloudConnection | undefined;
+	if (!overallAuth || overallAuth.isLoading) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fixes a handled React `TypeError: Cannot read properties of undefined (reading 'user')` surfaced in **Datadog RUM** (daily monitoring review, 2026-07-24). Not previously tracked by any open/closed issue.

`checkClusterInstanceAuthenticationBeforeLoad` (`src/features/instance/instanceLayoutRoute.ts`) reads `overallAuth.user` right after only **optional-chaining** the preceding check (`overallAuth?.isLoading`). When `context.authentication[OverallAppSignIn]` is absent — i.e. no resolved app-level sign-in in the router context — `overallAuth` is `undefined`, the `?.isLoading` guard falls through, and `overallAuth.user` throws.

RUM captured it as a handled React error (caught by an error boundary → `componentDidCatch`) on cluster-level routes, e.g. `/$organizationId/$clusterId/config`:

```
TypeError: Cannot read properties of undefined (reading 'user')
  at Object.[beforeLoad] ...
  at async (vendor-tanstack) ...
```

## Fix

Return early when there's no app-level connection in the context (`if (!overallAuth || overallAuth.isLoading) return`), rather than falling through to this hook's sign-in redirect. When the app-level sign-in hasn't resolved, **another guard owns the redirect decision** — issuing a second redirect from here within the same navigation can corrupt router state. The early return also avoids the unguarded `overallAuth.user` dereference that caused the crash.

## Test

Adds a regression test to `checkClusterInstanceAuthenticationBeforeLoad.test.ts` asserting that an absent `OverallAppSignIn` entry **neither redirects nor throws** (resolves undefined). Verified it reproduces the exact RUM `TypeError` on the pre-fix code and passes after. Full suite green (1788 passed), tsc/oxlint/dprint clean.

## Datadog context
- App: Studio (RUM `f590deee-4bac-49b4-a202-3b6963d9721d`)
- Handled TypeError, source `custom`, caught by React error boundary; 1 occurrence in the last 24h window (low frequency but a genuine code crash in a route guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)