### PR TITLE
fix(cluster): hold initial admin setup until every instance is running

### DIFF
--- a/src/features/auth/ClusterInstanceSignIn.tsx
+++ b/src/features/auth/ClusterInstanceSignIn.tsx
@@ -13,6 +13,7 @@ import { calculateCreateClusterDeepLink } from '@/config/deepLinks';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useClusterInstanceSignIn } from '@/features/auth/hooks/useClusterInstanceSignIn';
 import { authStore } from '@/features/auth/store/authStore';
+import { allClusterInstancesRunning } from '@/features/cluster/allInstancesRunning';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { SchemaHdbInstance } from '@/integrations/api/api.gen';
 import { UsernameSignInSchema } from '@/integrations/api/instance/auth/signInSchema';
@@ -104,11 +105,17 @@ export function ClusterInstanceSignIn() {
 		return <Navigate to="../instances" replace={true} />;
 	}
 
-	if (isActive && cluster?.resetPassword) {
-		return <Navigate to={`/${cluster.organizationId}/${cluster.id}/finish-setup`} replace={true} />;
-	}
-	if (!isActive && cluster?.resetPassword) {
-		return <Navigate to={`/${cluster.organizationId}/${cluster.id}/starting-up`} replace={true} />;
+	// Setup is only ready once the cluster is active AND every instance is running — on an initial
+	// deploy the cluster can report RUNNING while instances are still cloning (FinishSetup enforces
+	// the same gate).
+	if (cluster?.resetPassword) {
+		const readyForSetup = isActive && allClusterInstancesRunning(cluster);
+		return (
+			<Navigate
+				to={`/${cluster.organizationId}/${cluster.id}/${readyForSetup ? 'finish-setup' : 'starting-up'}`}
+				replace={true}
+			/>
+		);
 	}
 
 	return (

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -4,6 +4,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { activeClusterStatuses, deletedClusterStatuses } from '@/config/clusterStatuses';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
+import { allClusterInstancesRunning } from '@/features/cluster/allInstancesRunning';
 import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterStateMenu } from '@/features/clusters/components/ClusterStateMenu';
@@ -121,8 +122,12 @@ export function ClusterHome() {
 				</ClusterHomeShell>
 			);
 		}
-		const isActive = cluster.status && activeClusterStatuses.includes(cluster.status);
-		return <Navigate to={`${base}/${isActive ? 'finish-setup' : 'starting-up'}`} replace />;
+		// Hold setup on starting-up until the cluster is active AND every instance is running — on an
+		// initial deploy the cluster can report RUNNING while instances are still cloning, and the
+		// admin credentials must not be set until they have all settled (FinishSetup enforces this too).
+		const readyForSetup = cluster.status && activeClusterStatuses.includes(cluster.status)
+			&& allClusterInstancesRunning(cluster);
+		return <Navigate to={`${base}/${readyForSetup ? 'finish-setup' : 'starting-up'}`} replace />;
 	}
 
 	const isFabricConnect = authStore.checkForFabricConnect(cluster.id);

--- a/src/features/cluster/FinishSetup.tsx
+++ b/src/features/cluster/FinishSetup.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
+import { allClusterInstancesRunning } from './allInstancesRunning';
 import { getClusterInfoQueryOptions } from './queries/getClusterInfoQuery';
 
 export function FinishSetup() {
@@ -54,12 +55,17 @@ export function FinishSetup() {
 	}, [setFocus]);
 
 	const tempPassword = cluster?.instances?.find(i => i.tempPassword)?.tempPassword;
+	const instancesReady = allClusterInstancesRunning(cluster);
 
 	const { mutate: submitInstanceResetPassword, isPending } = useInstanceResetPasswordMutation();
 
 	const submitForm = useCallback(async (formData: z.infer<typeof AddUserFormSchema>) => {
 		if (!operationsUrl) {
 			toast.error('Cluster is not yet fully loaded, please wait a moment before trying to sign in.');
+			return;
+		}
+		if (!instancesReady) {
+			toast.error('Some instances are still starting up. You can create your admin user once they are all running.');
 			return;
 		}
 		submitInstanceResetPassword({
@@ -81,6 +87,7 @@ export function FinishSetup() {
 		cluster,
 		clusterId,
 		instanceClient,
+		instancesReady,
 		navigate,
 		operationsUrl,
 		redirect,
@@ -91,6 +98,12 @@ export function FinishSetup() {
 
 	if (cluster && !cluster.resetPassword) {
 		return <Navigate to="../sign-in" replace={true} />;
+	}
+
+	// On an initial deploy, hold the admin user creation until every instance is running — creating
+	// it while an instance is still cloning would leave that clone with the replaced credentials.
+	if (cluster && !instancesReady) {
+		return <Navigate to="../starting-up" replace={true} />;
 	}
 
 	return (

--- a/src/features/cluster/StartingUp.tsx
+++ b/src/features/cluster/StartingUp.tsx
@@ -12,6 +12,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useParams, useRouter } from '@tanstack/react-router';
 import { CloudAlertIcon } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
+import { allClusterInstancesRunning } from './allInstancesRunning';
 import { getClusterInfoQueryOptions } from './queries/getClusterInfoQuery';
 
 export function StartingUp() {
@@ -23,9 +24,12 @@ export function StartingUp() {
 
 	const status = cluster?.status;
 
+	// "Ready" means the cluster is active AND every instance is running — on an initial deploy the
+	// cluster can report RUNNING while instances are still cloning, and the admin user must not be
+	// created until they have all settled (see FinishSetup, which enforces the same gate).
 	const clusterIsActive = useMemo(() => {
-		return status && activeClusterStatuses.includes(status);
-	}, [status]);
+		return status && activeClusterStatuses.includes(status) && allClusterInstancesRunning(cluster);
+	}, [status, cluster]);
 	const clusterHasFailed = isFailed(status);
 	const [, setSavedClusterState] = useLocalStorage<unknown | null>(LocalStorageKeys.SavedClusterState, null);
 

--- a/src/features/cluster/allInstancesRunning.test.ts
+++ b/src/features/cluster/allInstancesRunning.test.ts
@@ -1,0 +1,41 @@
+import type { Cluster, Instance } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+import { allClusterInstancesRunning } from './allInstancesRunning';
+
+function makeCluster(statuses: (string | undefined)[]): Cluster {
+	return {
+		id: 'clu-1',
+		instances: statuses.map((status, i) => ({ id: `ins-${i}`, status } as Instance)),
+	} as Cluster;
+}
+
+describe('allClusterInstancesRunning', () => {
+	it('is true when every instance is running', () => {
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'RUNNING']))).toBe(true);
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'UPDATED']))).toBe(true);
+	});
+
+	it('is false while any instance is still cloning or provisioning', () => {
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'CLONING']))).toBe(false);
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'CLONE_PENDING']))).toBe(false);
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'CLONE_READY']))).toBe(false);
+		expect(allClusterInstancesRunning(makeCluster(['PROVISIONING']))).toBe(false);
+	});
+
+	it('treats an instance with no status as not running', () => {
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', undefined]))).toBe(false);
+	});
+
+	it('ignores deleted instances', () => {
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'TERMINATED']))).toBe(true);
+		expect(allClusterInstancesRunning(makeCluster(['RUNNING', 'TERMINATING', 'REMOVED']))).toBe(true);
+		// ... but a cluster with ONLY deleted instances is not ready.
+		expect(allClusterInstancesRunning(makeCluster(['TERMINATED']))).toBe(false);
+	});
+
+	it('is false with no cluster or no instance data', () => {
+		expect(allClusterInstancesRunning(undefined)).toBe(false);
+		expect(allClusterInstancesRunning({ id: 'clu-1' } as Cluster)).toBe(false);
+		expect(allClusterInstancesRunning(makeCluster([]))).toBe(false);
+	});
+});

--- a/src/features/cluster/allInstancesRunning.ts
+++ b/src/features/cluster/allInstancesRunning.ts
@@ -1,0 +1,19 @@
+import { isRunning } from '@/components/ui/utils/badgeStatus';
+import { deletedClusterStatuses } from '@/config/clusterStatuses';
+import { Cluster } from '@/integrations/api/api.patch';
+
+/**
+ * True once every (non-deleted) instance on the cluster reports a running status. On an initial
+ * deploy the cluster itself can go RUNNING while some instances are still PROVISIONING or CLONING —
+ * the initial admin user/password must not be created until every instance is up, or the
+ * still-cloning instances can finish with the credentials the setup flow just replaced.
+ *
+ * An instance with no status (still unknown) counts as not running, and a cluster with no
+ * instance data loaded is never considered ready.
+ */
+export function allClusterInstancesRunning(cluster: Cluster | undefined): boolean {
+	const instances = (cluster?.instances ?? []).filter(
+		(instance) => !(instance.status && deletedClusterStatuses.includes(instance.status)),
+	);
+	return instances.length > 0 && instances.every((instance) => isRunning(instance.status));
+}


### PR DESCRIPTION
## Problem

On an initial cluster deploy, the cluster can report `RUNNING` while some of its instances are still `PROVISIONING`/`CLONING`. The setup flow only gated on the **cluster** status, so a user could reach Finish Setup and create the initial admin user (replacing the temp credentials) while an instance was still cloning — letting that clone finish out of sync with the credentials that were just set.

## Change

Setup now waits until **every** (non-deleted) instance reports a running status:

- New shared predicate `allClusterInstancesRunning(cluster)` (`src/features/cluster/allInstancesRunning.ts`): all instances excluding `TERMINATING`/`TERMINATED`/`REMOVED` must be `RUNNING`/`UPDATED`; an instance with no status, or a cluster with no instance data, counts as not ready.
- `FinishSetup` (the choke point where the password is actually set): redirects back to the existing `starting-up` waiting page until instances are ready, and the submit handler independently refuses to fire the mutation (defense in depth against stale poll data).
- `ClusterHome` and `ClusterInstanceSignIn`: route to `starting-up` instead of `finish-setup` until ready, so users land on the waiting page in one hop.
- `StartingUp`: keeps showing the progress page ("Here we go!" with the per-instance progress bar, 2s poll) and only flips to "It's ready!" + the Finish Setup CTA once all instances are running.

The Finish Setup button on the clusters-list card still renders (the list payload has no per-instance data), but clicking it lands on the `FinishSetup` redirect, so the gate holds.

## Notes

- Deliberate behavior: if an instance ends up `FAILED` while the cluster reports `RUNNING`, setup stays held on the starting-up page (the progress bar shows the failed segment in red). Creating the admin user on a partially failed initial deploy is exactly what this gate is meant to prevent.
- This is a client-side gate. If we want a hard guarantee, the CM/instance API could also reject the initial password reset while any instance is mid-clone — happy to file a follow-up issue.

## Testing

- New unit tests for the predicate (`allInstancesRunning.test.ts`): running/updated, cloning/pending/provisioning, unknown status, deleted-instance exclusion, empty/missing instance data.
- Full suite: 254 test files / 1792 tests pass; `tsc -b`, `oxlint`, and `dprint check` clean.

— devain (Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
