### PR TITLE
feat(cluster): cluster plan usage card + Usage tab [#1297]

### DIFF
--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -264,7 +264,7 @@ export function ClusterHome() {
 					</div>
 				)}
 
-			<ClusterUsageCard base={base} />
+			<ClusterUsageCard clusterId={cluster.id} base={base} />
 		</ClusterHomeShell>
 	);
 }

--- a/src/features/cluster/ClusterHome.tsx
+++ b/src/features/cluster/ClusterHome.tsx
@@ -6,6 +6,7 @@ import { getInstanceClient } from '@/config/getInstanceClient';
 import { authStore } from '@/features/auth/store/authStore';
 import { allClusterInstancesRunning } from '@/features/cluster/allInstancesRunning';
 import { ClusterPageLayout } from '@/features/cluster/components/ClusterPageLayout';
+import { ClusterUsageCard } from '@/features/cluster/components/ClusterUsageCard';
 import { getClusterInfoQueryOptions } from '@/features/cluster/queries/getClusterInfoQuery';
 import { ClusterStateMenu } from '@/features/clusters/components/ClusterStateMenu';
 import { useInstanceAuth } from '@/hooks/useAuth';
@@ -262,6 +263,8 @@ export function ClusterHome() {
 						</div>
 					</div>
 				)}
+
+			<ClusterUsageCard base={base} />
 		</ClusterHomeShell>
 	);
 }

--- a/src/features/cluster/components/ClusterPageLayout.tsx
+++ b/src/features/cluster/components/ClusterPageLayout.tsx
@@ -4,7 +4,7 @@ import { useOrganizationClusterPermissions } from '@/hooks/usePermissions';
 import { clusterIsSelfManaged } from '@/integrations/api/clusterIsSelfManaged';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { GaugeIcon, GlobeIcon, LayoutDashboardIcon, ServerIcon, TagIcon } from 'lucide-react';
+import { ChartColumnIncreasing, GaugeIcon, GlobeIcon, LayoutDashboardIcon, ServerIcon, TagIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 
 /**
@@ -25,6 +25,9 @@ export function ClusterPageLayout({ children }: { children: ReactNode }) {
 
 	const items = [
 		{ to: base, label: 'Overview', icon: LayoutDashboardIcon, exact: true },
+		// Usage is a read-only monitoring view (like Overview), so it sits with it at the top. Managed
+		// clusters only — self-hosted clusters run under their own license, not a Fabric plan.
+		view && !selfManaged && { to: `${base}/usage`, label: 'Usage', icon: ChartColumnIncreasing },
 		// Scaling and Version open the cluster editor (matching the card's "Edit Scaling" / "Edit
 		// Version"), not the /scaling update-progress screen. Both are exact so /edit/version doesn't
 		// also light up Scaling (/edit). Self-hosted clusters don't scale from here — their editor

--- a/src/features/cluster/components/ClusterUsageCard.test.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ClusterUsageCard } from '@/features/cluster/components/ClusterUsageCard';
+import type {
+	ClusterUsage,
+	ClusterUsageRegion,
+	UsageMetrics,
+	UsageValue,
+} from '@/integrations/api/cluster/getClusterUsage';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Router Link only needs to render an anchor here.
+vi.mock('@tanstack/react-router', () => ({
+	Link: ({ to, children }: { to: string; children?: unknown }) => <a href={to}>{children as never}</a>,
+}));
+
+const mockUseClusterUsage = vi.hoisted(() => vi.fn());
+vi.mock('@/integrations/api/cluster/getClusterUsage', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@/integrations/api/cluster/getClusterUsage')>()),
+	useClusterUsage: mockUseClusterUsage,
+}));
+
+afterEach(() => {
+	cleanup();
+	mockUseClusterUsage.mockReset();
+});
+
+const v = (used: number, limit: number | null, over: Partial<UsageValue> = {}): UsageValue => ({
+	used,
+	limit,
+	unlimited: false,
+	limitKnown: limit !== null,
+	...over,
+});
+
+const metrics = (over: Partial<UsageMetrics> = {}): UsageMetrics => ({
+	reads: v(9_200_000, 10_000_000),
+	readBytes: v(45e9, 54e9),
+	writes: v(2_300_000, 5_000_000),
+	writeBytes: v(8e9, 21e9),
+	realTimeMessages: v(1_412_004, null, { unlimited: true, limitKnown: true }),
+	realTimeBytes: v(6e9, null, { unlimited: true, limitKnown: true }),
+	cpuTimeHours: v(1.6, 2),
+	storageBytes: v(13e9, 20e9),
+	...over,
+});
+
+const region = (over: Partial<ClusterUsageRegion> = {}): ClusterUsageRegion => ({
+	region: 'US',
+	regionIds: ['us-1'],
+	planId: 'fabric-block-level-2',
+	planName: 'Standard',
+	planLevel: 2,
+	expiresAt: '2026-08-12T00:00:00.000Z',
+	status: 'active',
+	activeBlockCount: 1,
+	metrics: metrics(),
+	rateLimits: null,
+	resourcesPerInstance: null,
+	...over,
+});
+
+const usage = (over: Partial<ClusterUsage> = {}): ClusterUsage => ({
+	clusterId: 'clu-1',
+	selfManaged: false,
+	renewsAt: '2026-08-12T00:00:00.000Z',
+	totals: null,
+	mostConstrained: null,
+	regions: [region()],
+	...over,
+});
+
+function renderCard() {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<ClusterUsageCard clusterId="clu-1" base="/org-1/clu-1" />
+		</QueryClientProvider>,
+	);
+}
+
+describe('ClusterUsageCard', () => {
+	it('shows the four headline meters for a single-region cluster', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage() });
+		renderCard();
+		expect(screen.getByText('Plan usage')).toBeTruthy();
+		for (const label of ['Reads', 'Writes', 'Storage', 'Compute']) {
+			expect(screen.getByText(label)).toBeTruthy();
+		}
+		// The full breakdown (e.g. the byte-volume pairs) stays on the tab.
+		expect(screen.queryByText('Read data')).toBeNull();
+		// The renewal date renders in the viewer's timezone, so don't pin the exact day.
+		expect(screen.getByText(/^Standard plan · renews Aug \d{1,2}$/)).toBeTruthy();
+	});
+
+	it('links to the Usage tab', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage() });
+		renderCard();
+		expect(screen.getByRole('link', { name: /View all usage/ }).getAttribute('href')).toBe('/org-1/clu-1/usage');
+	});
+
+	it('shows only the most-constrained region for a multi-region cluster', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [region({ region: 'Europe' }), region(), region({ region: 'Asia Pacific' })],
+				mostConstrained: {
+					metric: 'reads',
+					region: 'Europe',
+					regionIds: ['eu-2'],
+					used: 10_000_000,
+					limit: 10_000_000,
+					utilization: 1,
+				},
+			}),
+		});
+		renderCard();
+		expect(screen.getByText('Most constrained of 3 regions')).toBeTruthy();
+		expect(screen.getByText('Europe · Reads')).toBeTruthy();
+		expect(screen.getByText('100%')).toBeTruthy();
+		// No per-metric grid in the multi-region case.
+		expect(screen.queryByText('Compute')).toBeNull();
+	});
+
+	it('explains itself when a multi-region cluster has no metered ceiling', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ region: 'Europe' }), region()], mostConstrained: null }),
+		});
+		renderCard();
+		expect(screen.getByText(/No metered limits on the current plan/)).toBeTruthy();
+	});
+
+	it('renders nothing while loading, on error, for self-managed, or with no regions', () => {
+		for (const data of [undefined, usage({ selfManaged: true, regions: [] }), usage({ regions: [] })]) {
+			mockUseClusterUsage.mockReturnValue({ data });
+			const { container } = renderCard();
+			expect(container.textContent).toBe('');
+			cleanup();
+		}
+	});
+});

--- a/src/features/cluster/components/ClusterUsageCard.test.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.test.tsx
@@ -144,6 +144,45 @@ describe('ClusterUsageCard', () => {
 		expect(screen.queryByText(/null/)).toBeNull();
 	});
 
+	it('labels the date "next renewal" once there is more than one region', () => {
+		// `renewsAt` is the EARLIEST expiry among the active regions, so "renews" would claim the whole
+		// cluster renews then when a later region does not.
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [
+					region({ region: 'Europe', expiresAt: '2026-08-12T00:00:00.000Z' }),
+					region({ expiresAt: '2026-09-30T00:00:00.000Z' }),
+				],
+			}),
+		});
+		renderCard();
+		expect(screen.getByText(/^Standard plan · next renewal Aug \d{1,2}$/)).toBeTruthy();
+	});
+
+	it('drops the plan name when the regions are on different plans', () => {
+		// One region on Standard and another on Enterprise is supported; neither name is cluster-wide.
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [
+					region({ region: 'Europe', planName: 'Standard' }),
+					region({ planName: 'Enterprise' }),
+				],
+			}),
+		});
+		renderCard();
+		expect(screen.getByText(/^next renewal Aug \d{1,2}$/)).toBeTruthy();
+		expect(screen.queryByText(/Standard/)).toBeNull();
+		expect(screen.queryByText(/Enterprise/)).toBeNull();
+	});
+
+	it('drops the plan name when one region could not resolve its plan', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ region: 'Europe', planName: null }), region()] }),
+		});
+		renderCard();
+		expect(screen.getByText(/^next renewal Aug \d{1,2}$/)).toBeTruthy();
+	});
+
 	it('explains itself when a multi-region cluster has no metered ceiling', () => {
 		mockUseClusterUsage.mockReturnValue({
 			data: usage({ regions: [region({ region: 'Europe' }), region()], mostConstrained: null }),

--- a/src/features/cluster/components/ClusterUsageCard.test.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.test.tsx
@@ -124,6 +124,26 @@ describe('ClusterUsageCard', () => {
 		expect(screen.queryByText('Compute')).toBeNull();
 	});
 
+	it('falls back to a generic region label when the most-constrained region is unnamed', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [region({ region: null }), region()],
+				mostConstrained: {
+					metric: 'reads',
+					region: null,
+					regionIds: ['us-1'],
+					used: 5_000_000,
+					limit: 10_000_000,
+					utilization: 0.5,
+				},
+			}),
+		});
+		renderCard();
+		expect(screen.getByText('Region · Reads')).toBeTruthy();
+		// Never interpolate the raw null into a customer-facing label.
+		expect(screen.queryByText(/null/)).toBeNull();
+	});
+
 	it('explains itself when a multi-region cluster has no metered ceiling', () => {
 		mockUseClusterUsage.mockReturnValue({
 			data: usage({ regions: [region({ region: 'Europe' }), region()], mostConstrained: null }),

--- a/src/features/cluster/components/ClusterUsageCard.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.tsx
@@ -1,24 +1,28 @@
 import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
+import { usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight } from 'lucide-react';
 
-// ⚠️ MOCKUP — placeholder data, not wired to an API yet (issue #1297).
-// Shape mirrors the planned `GET /Cluster/:id/usage` response so this drops
-// straight onto real data later. Framing per product decision: "used X of Y
-// this cycle" (blocks auto-renew & re-bill on exhaustion for paid tiers; for
-// the free tier the same bar doubles as the hard-limit warning).
+// Plan-usage summary on the managed cluster overview (issue #1297). Framing is "used X of Y this
+// cycle": purchased blocks auto-renew and re-bill on exhaustion for paid tiers, while for the free
+// tier the same bar doubles as the hard-limit warning. Shows only the four headline metrics; the
+// full breakdown lives on the Usage tab.
 
-// Sample data — a mid-usage "Standard" cluster, with Reads pushed near the cap
-// to show the warning state. The overview card shows only the four headline
-// metrics; the full list lives on the Usage tab.
-const SAMPLE: UsageMetric[] = [
-	{ label: 'Reads', used: 9_200_000, limit: 10_000_000, format: fmtCount },
-	{ label: 'Writes', used: 2_300_000, limit: 5_000_000, format: fmtCount },
-	{ label: 'Storage', used: 13_314_398_617, limit: 21_474_836_480, format: fmtBytes },
-	{ label: 'Compute', used: 1.6, limit: 2, format: fmtHours },
-];
+export function ClusterUsageCard({ clusterId, base }: { clusterId: string; base: string }) {
+	const { data } = useClusterUsage(clusterId);
 
-export function ClusterUsageCard({ base }: { base: string }) {
+	// Nothing to show until there's an active plan with recorded usage (also covers loading, errors,
+	// and self-hosted clusters, which report no totals).
+	if (!data || data.selfManaged || !data.totals) { return null; }
+
+	const { totals } = data;
+	const metrics: UsageMetric[] = [
+		{ label: 'Reads', used: totals.reads.used, limit: totals.reads.limit, format: fmtCount },
+		{ label: 'Writes', used: totals.writes.used, limit: totals.writes.limit, format: fmtCount },
+		{ label: 'Storage', used: totals.storageBytes.used, limit: totals.storageBytes.limit, format: fmtBytes },
+		{ label: 'Compute', used: totals.cpuTimeHours.used, limit: totals.cpuTimeHours.limit, format: fmtHours },
+	];
+
 	return (
 		<section className="mt-6 rounded-2xl border border-border bg-card p-5">
 			<div className="flex items-center justify-between gap-3">
@@ -30,12 +34,10 @@ export function ClusterUsageCard({ base }: { base: string }) {
 					View all usage <ArrowRight className="size-3" />
 				</Link>
 			</div>
-			<p className="mt-0.5 text-xs text-muted-foreground">
-				Standard plan · this cycle renews Aug 12 · updated 4 min ago
-			</p>
+			<p className="mt-0.5 text-xs text-muted-foreground">{usageSubtitle(data)}</p>
 
 			<div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
-				{SAMPLE.map((m) => <UsageMeter key={m.label} {...m} />)}
+				{metrics.map((m) => <UsageMeter key={m.label} {...m} />)}
 			</div>
 		</section>
 	);

--- a/src/features/cluster/components/ClusterUsageCard.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.tsx
@@ -54,16 +54,14 @@ function MultiRegion({ data }: { data: ClusterUsage }) {
 	const mc = data.mostConstrained;
 	return (
 		<div>
-			<p className="mb-3 text-xs text-muted-foreground">
-				{data.regions.length} regions — usage is metered per region.
-			</p>
+			<p className="mb-1.5 text-xs text-muted-foreground">Most constrained of {data.regions.length} regions</p>
 			{mc
 				? (
 					<UsageMeter
 						{...toMeter(
 							mc.metric,
 							{ used: mc.used, limit: mc.limit, unlimited: false, limitKnown: true },
-							`Most constrained · ${mc.region} ${METRIC_LABEL[mc.metric]}`,
+							`${mc.region} · ${METRIC_LABEL[mc.metric]}`,
 						)}
 					/>
 				)

--- a/src/features/cluster/components/ClusterUsageCard.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.tsx
@@ -61,7 +61,9 @@ function MultiRegion({ data }: { data: ClusterUsage }) {
 						{...toMeter(
 							mc.metric,
 							{ used: mc.used, limit: mc.limit, unlimited: false, limitKnown: true },
-							`${mc.region} · ${METRIC_LABEL[mc.metric]}`,
+							// `region` is nullable on the endpoint — fall back the same way the Usage tab does
+							// rather than interpolating a literal "null" into a customer-facing label.
+							`${mc.region ?? 'Region'} · ${METRIC_LABEL[mc.metric]}`,
 						)}
 					/>
 				)

--- a/src/features/cluster/components/ClusterUsageCard.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.tsx
@@ -1,27 +1,19 @@
-import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
-import { usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
+import { METRIC_LABEL, toMeter, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
+import { ClusterUsage, usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight } from 'lucide-react';
 
-// Plan-usage summary on the managed cluster overview (issue #1297). Framing is "used X of Y this
-// cycle": purchased blocks auto-renew and re-bill on exhaustion for paid tiers, while for the free
-// tier the same bar doubles as the hard-limit warning. Shows only the four headline metrics; the
-// full breakdown lives on the Usage tab.
+// Plan-usage summary on the managed cluster overview (issue #1297). Quota is per region, so:
+//   • one region  → the four headline meters for that region.
+//   • many regions → the single most-constrained region×metric (an average would hide a hot region),
+//     with the full per-region breakdown a click away on the Usage tab.
 
 export function ClusterUsageCard({ clusterId, base }: { clusterId: string; base: string }) {
 	const { data } = useClusterUsage(clusterId);
 
-	// Nothing to show until there's an active plan with recorded usage (also covers loading, errors,
-	// and self-hosted clusters, which report no totals).
-	if (!data || data.selfManaged || !data.totals) { return null; }
-
-	const { totals } = data;
-	const metrics: UsageMetric[] = [
-		{ label: 'Reads', used: totals.reads.used, limit: totals.reads.limit, format: fmtCount },
-		{ label: 'Writes', used: totals.writes.used, limit: totals.writes.limit, format: fmtCount },
-		{ label: 'Storage', used: totals.storageBytes.used, limit: totals.storageBytes.limit, format: fmtBytes },
-		{ label: 'Compute', used: totals.cpuTimeHours.used, limit: totals.cpuTimeHours.limit, format: fmtHours },
-	];
+	// Nothing to show until there's a managed plan with reportable regions (also covers loading, errors,
+	// and self-hosted clusters).
+	if (!data || data.selfManaged || data.regions.length === 0) { return null; }
 
 	return (
 		<section className="mt-6 rounded-2xl border border-border bg-card p-5">
@@ -36,9 +28,50 @@ export function ClusterUsageCard({ clusterId, base }: { clusterId: string; base:
 			</div>
 			<p className="mt-0.5 text-xs text-muted-foreground">{usageSubtitle(data)}</p>
 
-			<div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
-				{metrics.map((m) => <UsageMeter key={m.label} {...m} />)}
+			<div className="mt-4">
+				{data.regions.length === 1 ? <SingleRegion data={data} /> : <MultiRegion data={data} />}
 			</div>
 		</section>
+	);
+}
+
+function SingleRegion({ data }: { data: ClusterUsage }) {
+	const m = data.regions[0].metrics;
+	const meters: UsageMetric[] = [
+		toMeter('reads', m.reads),
+		toMeter('writes', m.writes),
+		toMeter('storageBytes', m.storageBytes),
+		toMeter('cpuTimeHours', m.cpuTimeHours),
+	];
+	return (
+		<div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+			{meters.map((meter) => <UsageMeter key={meter.label} {...meter} />)}
+		</div>
+	);
+}
+
+function MultiRegion({ data }: { data: ClusterUsage }) {
+	const mc = data.mostConstrained;
+	return (
+		<div>
+			<p className="mb-3 text-xs text-muted-foreground">
+				{data.regions.length} regions — usage is metered per region.
+			</p>
+			{mc
+				? (
+					<UsageMeter
+						{...toMeter(
+							mc.metric,
+							{ used: mc.used, limit: mc.limit, unlimited: false, limitKnown: true },
+							`Most constrained · ${mc.region} ${METRIC_LABEL[mc.metric]}`,
+						)}
+					/>
+				)
+				: (
+					<p className="text-sm text-muted-foreground">
+						No metered limits on the current plan — see the breakdown for details.
+					</p>
+				)}
+		</div>
 	);
 }

--- a/src/features/cluster/components/ClusterUsageCard.tsx
+++ b/src/features/cluster/components/ClusterUsageCard.tsx
@@ -1,0 +1,42 @@
+import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
+import { Link } from '@tanstack/react-router';
+import { ArrowRight } from 'lucide-react';
+
+// ⚠️ MOCKUP — placeholder data, not wired to an API yet (issue #1297).
+// Shape mirrors the planned `GET /Cluster/:id/usage` response so this drops
+// straight onto real data later. Framing per product decision: "used X of Y
+// this cycle" (blocks auto-renew & re-bill on exhaustion for paid tiers; for
+// the free tier the same bar doubles as the hard-limit warning).
+
+// Sample data — a mid-usage "Standard" cluster, with Reads pushed near the cap
+// to show the warning state. The overview card shows only the four headline
+// metrics; the full list lives on the Usage tab.
+const SAMPLE: UsageMetric[] = [
+	{ label: 'Reads', used: 9_200_000, limit: 10_000_000, format: fmtCount },
+	{ label: 'Writes', used: 2_300_000, limit: 5_000_000, format: fmtCount },
+	{ label: 'Storage', used: 13_314_398_617, limit: 21_474_836_480, format: fmtBytes },
+	{ label: 'Compute', used: 1.6, limit: 2, format: fmtHours },
+];
+
+export function ClusterUsageCard({ base }: { base: string }) {
+	return (
+		<section className="mt-6 rounded-2xl border border-border bg-card p-5">
+			<div className="flex items-center justify-between gap-3">
+				<h2 className="text-sm font-medium text-foreground">Plan usage</h2>
+				<Link
+					to={`${base}/usage`}
+					className="inline-flex items-center gap-1 text-xs text-primary hover:underline dark:text-violet-300"
+				>
+					View all usage <ArrowRight className="size-3" />
+				</Link>
+			</div>
+			<p className="mt-0.5 text-xs text-muted-foreground">
+				Standard plan · this cycle renews Aug 12 · updated 4 min ago
+			</p>
+
+			<div className="mt-4 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
+				{SAMPLE.map((m) => <UsageMeter key={m.label} {...m} />)}
+			</div>
+		</section>
+	);
+}

--- a/src/features/cluster/components/UsageMeter.test.tsx
+++ b/src/features/cluster/components/UsageMeter.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fmtBytes, fmtCount, METERED_ORDER, toMeter, UsageMeter } from '@/features/cluster/components/UsageMeter';
+import type { UsageValue } from '@/integrations/api/cluster/getClusterUsage';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+afterEach(() => cleanup());
+
+const value = (over: Partial<UsageValue> = {}): UsageValue => ({
+	used: 400,
+	limit: 1000,
+	unlimited: false,
+	limitKnown: true,
+	...over,
+});
+
+// The bar is the only element carrying an inline width, so it identifies the fill.
+function fillWidth(container: HTMLElement): string | undefined {
+	const filled = container.querySelector<HTMLElement>('[style*="width"]');
+	return filled?.style.width;
+}
+
+describe('UsageMeter', () => {
+	it('renders a percentage and a proportional bar for a finite limit', () => {
+		const { container } = render(<UsageMeter {...toMeter('reads', value())} />);
+		expect(screen.getByText('Reads')).toBeTruthy();
+		expect(screen.getByText('40%')).toBeTruthy();
+		expect(fillWidth(container)).toBe('40%');
+	});
+
+	it('renders "Unlimited" with no percentage when the plan grants no ceiling', () => {
+		render(<UsageMeter {...toMeter('realTimeMessages', value({ limit: null, unlimited: true }))} />);
+		expect(screen.getByText('Unlimited')).toBeTruthy();
+		expect(screen.queryByText(/%$/)).toBeNull();
+	});
+
+	it('renders "—" (never "Unlimited") when the plan could not be resolved', () => {
+		render(<UsageMeter {...toMeter('reads', value({ limit: null, limitKnown: false }))} />);
+		expect(screen.getByText('—')).toBeTruthy();
+		expect(screen.queryByText('Unlimited')).toBeNull();
+	});
+
+	it('caps the bar at 100% when usage exceeds the limit', () => {
+		const { container } = render(<UsageMeter {...toMeter('reads', value({ used: 1500 }))} />);
+		expect(screen.getByText('100%')).toBeTruthy();
+		expect(fillWidth(container)).toBe('100%');
+	});
+
+	it('treats a zero limit as unknown rather than dividing by zero', () => {
+		render(<UsageMeter {...toMeter('reads', value({ used: 5, limit: 0 }))} />);
+		expect(screen.getByText('—')).toBeTruthy();
+		expect(screen.queryByText('NaN%')).toBeNull();
+		expect(screen.queryByText('Infinity%')).toBeNull();
+	});
+
+	it('treats a negative limit as unlimited (server -1 sentinel reaching the UI unmapped)', () => {
+		render(<UsageMeter {...toMeter('reads', value({ limit: -1 }))} />);
+		expect(screen.getByText('Unlimited')).toBeTruthy();
+	});
+
+	it('flags a near-limit metric so it reads as a warning', () => {
+		const { container } = render(<UsageMeter {...toMeter('reads', value({ used: 950 }))} />);
+		expect(screen.getByText('95%')).toBeTruthy();
+		expect(container.innerHTML).toContain('yellow');
+	});
+
+	it('formats counts compactly and bytes as file sizes', () => {
+		expect(fmtCount(9_200_000)).toBe('9.2M');
+		expect(fmtBytes(21_000_000_000)).toContain('GB');
+	});
+
+	it('covers every metric the endpoint reports, count/data pairs adjacent', () => {
+		expect(METERED_ORDER).toEqual([
+			'reads',
+			'readBytes',
+			'writes',
+			'writeBytes',
+			'realTimeMessages',
+			'realTimeBytes',
+			'cpuTimeHours',
+			'storageBytes',
+		]);
+	});
+});

--- a/src/features/cluster/components/UsageMeter.tsx
+++ b/src/features/cluster/components/UsageMeter.tsx
@@ -18,8 +18,11 @@ export const fmtHours = (n: number) => `${new Intl.NumberFormat(undefined, { max
 export const fmtBytes = (n: number) => humanFileSize(n);
 
 export function UsageMeter({ label, used, limit, format }: UsageMetric) {
-	const unlimited = limit === null;
-	const pct = unlimited ? 0 : Math.min(100, Math.round((used / limit) * 100));
+	// Treat a negative limit as unlimited too — the server uses -1 for that, so the meter stays correct
+	// even if a raw response reaches it without -1 being mapped to null. Guard limit === 0 so the
+	// percentage never divides by zero (which would render NaN and break the bar).
+	const unlimited = limit === null || limit < 0;
+	const pct = unlimited || limit === 0 ? 0 : Math.min(100, Math.round((used / limit) * 100));
 	const warn = pct >= 90;
 
 	return (

--- a/src/features/cluster/components/UsageMeter.tsx
+++ b/src/features/cluster/components/UsageMeter.tsx
@@ -1,0 +1,57 @@
+import { humanFileSize } from '@/lib/humanFileSize';
+
+// Shared usage-meter primitive for the cluster Plan-usage card and Usage tab (issue #1297).
+// Framing: "used X of Y this cycle". `limit === null` means the plan allows unlimited
+// (the server sends -1), rendered as a hatched track + "Unlimited" rather than a percentage.
+
+export interface UsageMetric {
+	label: string;
+	used: number;
+	/** null → unlimited (plan limit is -1) */
+	limit: number | null;
+	format: (n: number) => string;
+}
+
+export const fmtCount = (n: number) =>
+	new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n);
+export const fmtHours = (n: number) => `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(n)} hr`;
+export const fmtBytes = (n: number) => humanFileSize(n);
+
+export function UsageMeter({ label, used, limit, format }: UsageMetric) {
+	const unlimited = limit === null;
+	const pct = unlimited ? 0 : Math.min(100, Math.round((used / limit) * 100));
+	const warn = pct >= 90;
+
+	return (
+		<div>
+			<div className="flex items-baseline justify-between gap-2 text-sm">
+				<span className="text-foreground">{label}</span>
+				<span className="text-muted-foreground tabular-nums">
+					<span className="text-foreground">{format(used)}</span>
+					{unlimited ? ' used' : <>/ {format(limit)}</>}
+				</span>
+			</div>
+			<div className="mt-1.5 flex items-center gap-2">
+				<div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+					{unlimited
+						? (
+							// Diagonal hatching stands in for "no ceiling". `--color-border` is too close to the
+							// track in dark mode, so give dark its own brighter stripe; bands are widened for legibility.
+							<div className="h-full w-full bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,var(--color-border)_5px,var(--color-border)_9px)] dark:bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,rgba(255,255,255,0.32)_5px,rgba(255,255,255,0.32)_9px)]" />
+						)
+						: (
+							<div
+								className={`h-full rounded-full ${warn ? 'bg-yellow' : 'bg-primary dark:bg-violet-400'}`}
+								style={{ width: `${pct}%` }}
+							/>
+						)}
+				</div>
+				<span
+					className={`w-14 shrink-0 text-right text-xs tabular-nums ${warn ? 'text-yellow' : 'text-muted-foreground'}`}
+				>
+					{unlimited ? 'Unlimited' : `${pct}%`}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/features/cluster/components/UsageMeter.tsx
+++ b/src/features/cluster/components/UsageMeter.tsx
@@ -1,14 +1,18 @@
+import type { UsageMetricKey, UsageValue } from '@/integrations/api/cluster/getClusterUsage';
 import { humanFileSize } from '@/lib/humanFileSize';
 
 // Shared usage-meter primitive for the cluster Plan-usage card and Usage tab (issue #1297).
-// Framing: "used X of Y this cycle". `limit === null` means the plan allows unlimited
-// (the server sends -1), rendered as a hatched track + "Unlimited" rather than a percentage.
+// Framing: "used X of Y this cycle". Three ceiling states, mirroring the endpoint's per-metric shape:
+//   unlimited        → plan grants no ceiling (-1); hatched bar + "Unlimited".
+//   !limitKnown      → the plan couldn't be resolved; no bar + "—" (never shown as reassuring Unlimited).
+//   finite limit     → normal used/limit meter, amber ≥90%.
 
 export interface UsageMetric {
 	label: string;
 	used: number;
-	/** null → unlimited (plan limit is -1) */
 	limit: number | null;
+	unlimited: boolean;
+	limitKnown: boolean;
 	format: (n: number) => string;
 }
 
@@ -17,12 +21,58 @@ export const fmtCount = (n: number) =>
 export const fmtHours = (n: number) => `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(n)} hr`;
 export const fmtBytes = (n: number) => humanFileSize(n);
 
-export function UsageMeter({ label, used, limit, format }: UsageMetric) {
-	// Treat a negative limit as unlimited too — the server uses -1 for that, so the meter stays correct
-	// even if a raw response reaches it without -1 being mapped to null. Guard limit === 0 so the
-	// percentage never divides by zero (which would render NaN and break the bar).
-	const unlimited = limit === null || limit < 0;
-	const pct = unlimited || limit === 0 ? 0 : Math.min(100, Math.round((used / limit) * 100));
+// Display metadata keyed by the endpoint's metric keys, shared by the card + tab.
+export const METRIC_LABEL: Record<UsageMetricKey, string> = {
+	reads: 'Reads',
+	readBytes: 'Read data',
+	writes: 'Writes',
+	writeBytes: 'Write data',
+	realTimeMessages: 'Real-time messages',
+	realTimeBytes: 'Real-time data',
+	cpuTimeHours: 'Compute',
+	storageBytes: 'Storage',
+};
+
+export const METRIC_FORMAT: Record<UsageMetricKey, (n: number) => string> = {
+	reads: fmtCount,
+	readBytes: fmtBytes,
+	writes: fmtCount,
+	writeBytes: fmtBytes,
+	realTimeMessages: fmtCount,
+	realTimeBytes: fmtBytes,
+	cpuTimeHours: fmtHours,
+	storageBytes: fmtBytes,
+};
+
+// Order the full breakdown shows, count/data pairs adjacent.
+export const METERED_ORDER: UsageMetricKey[] = [
+	'reads',
+	'readBytes',
+	'writes',
+	'writeBytes',
+	'realTimeMessages',
+	'realTimeBytes',
+	'cpuTimeHours',
+	'storageBytes',
+];
+
+export function toMeter(key: UsageMetricKey, value: UsageValue, labelOverride?: string): UsageMetric {
+	return {
+		label: labelOverride ?? METRIC_LABEL[key],
+		used: value.used,
+		limit: value.limit,
+		unlimited: value.unlimited,
+		limitKnown: value.limitKnown,
+		format: METRIC_FORMAT[key],
+	};
+}
+
+export function UsageMeter({ label, used, limit, unlimited, limitKnown, format }: UsageMetric) {
+	// Defensive: a negative limit is also "unlimited" (server sentinel), and a null/0 finite limit can't
+	// be a denominator — treat as unknown so we never divide by zero (NaN) or invent a ceiling.
+	const isUnlimited = unlimited || (limit != null && limit < 0);
+	const isKnown = limitKnown && !isUnlimited && limit != null && limit > 0;
+	const pct = isKnown ? Math.min(100, Math.round((used / limit) * 100)) : 0;
 	const warn = pct >= 90;
 
 	return (
@@ -31,28 +81,31 @@ export function UsageMeter({ label, used, limit, format }: UsageMetric) {
 				<span className="text-foreground">{label}</span>
 				<span className="text-muted-foreground tabular-nums">
 					<span className="text-foreground">{format(used)}</span>
-					{unlimited ? ' used' : <>/ {format(limit)}</>}
+					{isKnown ? <>/ {format(limit)}</> : ' used'}
 				</span>
 			</div>
 			<div className="mt-1.5 flex items-center gap-2">
 				<div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-					{unlimited
+					{isKnown
 						? (
-							// Diagonal hatching stands in for "no ceiling". `--color-border` is too close to the
-							// track in dark mode, so give dark its own brighter stripe; bands are widened for legibility.
-							<div className="h-full w-full bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,var(--color-border)_5px,var(--color-border)_9px)] dark:bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,rgba(255,255,255,0.32)_5px,rgba(255,255,255,0.32)_9px)]" />
-						)
-						: (
 							<div
 								className={`h-full rounded-full ${warn ? 'bg-yellow' : 'bg-primary dark:bg-violet-400'}`}
 								style={{ width: `${pct}%` }}
 							/>
-						)}
+						)
+						: isUnlimited
+						? (
+							// Diagonal hatching stands in for "no ceiling". `--color-border` is too close to the
+							// track in dark mode, so give dark its own brighter stripe; bands widened for legibility.
+							<div className="h-full w-full bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,var(--color-border)_5px,var(--color-border)_9px)] dark:bg-[repeating-linear-gradient(-45deg,transparent,transparent_5px,rgba(255,255,255,0.32)_5px,rgba(255,255,255,0.32)_9px)]" />
+						)
+						// Unknown limit: leave the track empty rather than imply either a full bar or unlimited.
+						: null}
 				</div>
 				<span
-					className={`w-14 shrink-0 text-right text-xs tabular-nums ${warn ? 'text-yellow' : 'text-muted-foreground'}`}
+					className={`w-16 shrink-0 text-right text-xs tabular-nums ${warn ? 'text-yellow' : 'text-muted-foreground'}`}
 				>
-					{unlimited ? 'Unlimited' : `${pct}%`}
+					{isKnown ? `${pct}%` : isUnlimited ? 'Unlimited' : '—'}
 				</span>
 			</div>
 		</div>

--- a/src/features/cluster/routes.ts
+++ b/src/features/cluster/routes.ts
@@ -9,6 +9,7 @@ import { FinishSetup } from './FinishSetup';
 import { Instances } from './Instances';
 import { Scaling } from './Scaling';
 import { StartingUp } from './StartingUp';
+import { UsagePage } from './usage/Page';
 
 const clusterInstancesRoute = createRoute({
 	getParentRoute: () => clusterLayoutRoute,
@@ -36,6 +37,13 @@ const clusterDomainsRoute = createRoute({
 	path: 'domains',
 	head: () => ({ meta: [{ title: 'Domains — Harper Fabric' }] }),
 	component: DomainsPage,
+});
+
+const clusterUsageRoute = createRoute({
+	getParentRoute: () => clusterLayoutRoute,
+	path: 'usage',
+	head: () => ({ meta: [{ title: 'Usage — Harper Fabric' }] }),
+	component: UsagePage,
 });
 
 // These guards intentionally read live `authStore` state rather than the `context.authentication`
@@ -113,6 +121,7 @@ export const clusterRoutes = [
 	clusterStartingUpRoute,
 	clusterScalingRoute,
 	clusterDomainsRoute,
+	clusterUsageRoute,
 	clusterFinishSetupRoute,
 	clusterSignInRoute,
 	instanceSignInRoute,

--- a/src/features/cluster/usage/Page.test.tsx
+++ b/src/features/cluster/usage/Page.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { UsagePage } from '@/features/cluster/usage/Page';
+import type {
+	ClusterUsage,
+	ClusterUsageRegion,
+	UsageMetrics,
+	UsageRateLimits,
+	UsageValue,
+} from '@/integrations/api/cluster/getClusterUsage';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({ useParams: () => ({ clusterId: 'clu-1' }) }));
+
+// The page's chrome (breadcrumbs + cluster sub-nav rail) pulls in the router/query stack; the tab body
+// is what's under test, so render it plainly.
+vi.mock('@/features/cluster/components/ClusterContentWithSubNavMenu', () => ({
+	ClusterContentWithSubNavMenu: ({ children }: { children?: unknown }) => <div>{children as never}</div>,
+}));
+
+const mockUseClusterUsage = vi.hoisted(() => vi.fn());
+vi.mock('@/integrations/api/cluster/getClusterUsage', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@/integrations/api/cluster/getClusterUsage')>()),
+	useClusterUsage: mockUseClusterUsage,
+}));
+
+afterEach(() => {
+	cleanup();
+	mockUseClusterUsage.mockReset();
+});
+
+const v = (used: number, limit: number | null, over: Partial<UsageValue> = {}): UsageValue => ({
+	used,
+	limit,
+	unlimited: false,
+	limitKnown: limit !== null,
+	...over,
+});
+
+const metrics = (over: Partial<UsageMetrics> = {}): UsageMetrics => ({
+	reads: v(9_200_000, 10_000_000),
+	readBytes: v(45e9, 54e9),
+	writes: v(2_300_000, 5_000_000),
+	writeBytes: v(8e9, 21e9),
+	realTimeMessages: v(1_412_004, null, { unlimited: true, limitKnown: true }),
+	realTimeBytes: v(6e9, null, { unlimited: true, limitKnown: true }),
+	cpuTimeHours: v(1.6, 2),
+	storageBytes: v(13e9, 20e9),
+	...over,
+});
+
+const RATE_LIMITS: UsageRateLimits = {
+	readsPerMinute: 50_000,
+	readsPerMinuteBytes: 34_000_000,
+	writesPerMinute: 10_000,
+	writesPerMinuteBytes: 5_000_000,
+	realTimeDeliveriesPerMinute: 5_000,
+	realTimeDeliveryBytesPerMinute: 50_000_000,
+	tlsHandshakes: 1_000_000,
+};
+
+const region = (over: Partial<ClusterUsageRegion> = {}): ClusterUsageRegion => ({
+	region: 'US',
+	regionIds: ['us-1'],
+	planId: 'fabric-block-level-2',
+	planName: 'Standard',
+	planLevel: 2,
+	expiresAt: '2026-08-12T00:00:00.000Z',
+	status: 'active',
+	activeBlockCount: 1,
+	metrics: metrics(),
+	rateLimits: RATE_LIMITS,
+	resourcesPerInstance: { storageGb: 20, memoryMb: 4096, cpuCores: 2, threads: 4 },
+	...over,
+});
+
+const usage = (over: Partial<ClusterUsage> = {}): ClusterUsage => ({
+	clusterId: 'clu-1',
+	selfManaged: false,
+	renewsAt: '2026-08-12T00:00:00.000Z',
+	totals: null,
+	mostConstrained: null,
+	regions: [region()],
+	...over,
+});
+
+describe('UsagePage', () => {
+	it('renders every metered metric for a region', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage(), isLoading: false });
+		render(<UsagePage />);
+		for (
+			const label of [
+				'Reads',
+				'Read data',
+				'Writes',
+				'Write data',
+				'Real-time messages',
+				'Real-time data',
+				'Compute',
+				'Storage',
+			]
+		) {
+			expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+		}
+	});
+
+	it('shows the region id and plan id subtly in the headers', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage(), isLoading: false });
+		render(<UsagePage />);
+		expect(screen.getByText('us-1')).toBeTruthy();
+		expect(screen.getByText('fabric-block-level-2')).toBeTruthy();
+	});
+
+	it('collapses and re-expands a region when its header is clicked', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage(), isLoading: false });
+		render(<UsagePage />);
+		const header = screen.getByRole('button', { name: /US/ });
+		expect(header.getAttribute('aria-expanded')).toBe('true');
+		expect(screen.getAllByText('Compute').length).toBe(1);
+
+		fireEvent.click(header);
+		expect(header.getAttribute('aria-expanded')).toBe('false');
+		expect(screen.queryByText('Compute')).toBeNull();
+
+		fireEvent.click(header);
+		expect(header.getAttribute('aria-expanded')).toBe('true');
+		expect(screen.getAllByText('Compute').length).toBe(1);
+	});
+
+	it('badges an exhausted region and a lapsed one differently, and collapses lapsed by default', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [
+					region({ region: 'Europe', status: 'exhausted', activeBlockCount: 0 }),
+					region({ region: 'Asia Pacific', regionIds: ['ap-1'], status: 'lapsed', activeBlockCount: 0 }),
+				],
+			}),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(screen.getByText('Cycle exhausted')).toBeTruthy();
+		expect(screen.getByText('No active license')).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Europe/ }).getAttribute('aria-expanded')).toBe('true');
+		// A lapsed region has no live quota, so it starts collapsed.
+		expect(screen.getByRole('button', { name: /Asia Pacific/ }).getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it('hoists rate limits and per-instance resources into one shared card when uniform', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ region: 'Europe' }), region()] }),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(screen.getByRole('button', { name: /Plan limits & resources/ })).toBeTruthy();
+		// Shown once, not once per region.
+		expect(screen.getAllByText('Reads / minute').length).toBe(1);
+		expect(screen.getAllByText('Read bandwidth / minute').length).toBe(1);
+		expect(screen.getAllByText('TLS handshakes (cycle)').length).toBe(1);
+	});
+
+	it('keeps plan info per region when the regions differ', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [
+					region({ region: 'Europe', rateLimits: { ...RATE_LIMITS, readsPerMinute: 999 } }),
+					region(),
+				],
+			}),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(screen.queryByRole('button', { name: /Plan limits & resources/ })).toBeNull();
+		expect(screen.getAllByText('Reads / minute').length).toBe(2);
+	});
+
+	it('explains the self-hosted and no-usage cases instead of rendering empty meters', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage({ selfManaged: true, regions: [] }), isLoading: false });
+		render(<UsagePage />);
+		expect(screen.getByText(/Usage isn't tracked for self-hosted clusters/)).toBeTruthy();
+		cleanup();
+
+		mockUseClusterUsage.mockReturnValue({ data: usage({ regions: [] }), isLoading: false });
+		render(<UsagePage />);
+		expect(screen.getByText(/No usage has been recorded/)).toBeTruthy();
+	});
+
+	it('shows a spinner while loading', () => {
+		mockUseClusterUsage.mockReturnValue({ data: undefined, isLoading: true });
+		const { container } = render(<UsagePage />);
+		expect(container.querySelector('.animate-spin')).toBeTruthy();
+	});
+});

--- a/src/features/cluster/usage/Page.test.tsx
+++ b/src/features/cluster/usage/Page.test.tsx
@@ -6,6 +6,7 @@ import type {
 	ClusterUsage,
 	ClusterUsageRegion,
 	UsageMetrics,
+	UsageRateLimit,
 	UsageRateLimits,
 	UsageValue,
 } from '@/integrations/api/cluster/getClusterUsage';
@@ -51,15 +52,25 @@ const metrics = (over: Partial<UsageMetrics> = {}): UsageMetrics => ({
 	...over,
 });
 
+const rate = (value: number | null, over: Partial<UsageRateLimit> = {}): UsageRateLimit => ({
+	value,
+	unlimited: false,
+	known: value !== null,
+	...over,
+});
+
 const RATE_LIMITS: UsageRateLimits = {
-	readsPerMinute: 50_000,
-	readsPerMinuteBytes: 34_000_000,
-	writesPerMinute: 10_000,
-	writesPerMinuteBytes: 5_000_000,
-	realTimeDeliveriesPerMinute: 5_000,
-	realTimeDeliveryBytesPerMinute: 50_000_000,
-	tlsHandshakes: 1_000_000,
+	readsPerMinute: rate(50_000),
+	readsPerMinuteBytes: rate(34_000_000),
+	writesPerMinute: rate(10_000),
+	writesPerMinuteBytes: rate(5_000_000),
+	realTimeDeliveriesPerMinute: rate(5_000),
+	realTimeDeliveryBytesPerMinute: rate(50_000_000),
+	tlsHandshakes: rate(1_000_000),
 };
+
+// The value cell of a "Plan limits & resources" row, found via its label.
+const rowValue = (label: string) => screen.getByText(label).parentElement?.textContent?.replace(label, '');
 
 const region = (over: Partial<ClusterUsageRegion> = {}): ClusterUsageRegion => ({
 	region: 'US',
@@ -164,7 +175,7 @@ describe('UsagePage', () => {
 		mockUseClusterUsage.mockReturnValue({
 			data: usage({
 				regions: [
-					region({ region: 'Europe', rateLimits: { ...RATE_LIMITS, readsPerMinute: 999 } }),
+					region({ region: 'Europe', rateLimits: { ...RATE_LIMITS, readsPerMinute: rate(999) } }),
 					region(),
 				],
 			}),
@@ -173,6 +184,74 @@ describe('UsagePage', () => {
 		render(<UsagePage />);
 		expect(screen.queryByRole('button', { name: /Plan limits & resources/ })).toBeNull();
 		expect(screen.getAllByText('Reads / minute').length).toBe(2);
+	});
+
+	it('renders the effective ceiling the endpoint reports', () => {
+		// Already scaled to the region's distribution tier server-side — the page states it verbatim.
+		mockUseClusterUsage.mockReturnValue({ data: usage(), isLoading: false });
+		render(<UsagePage />);
+		expect(rowValue('Reads / minute')).toBe('50,000');
+	});
+
+	it('reads a plan with no ceiling as Unlimited, never as the -1 sentinel', () => {
+		// fabric-block-dedicated-unlimited-{2..5} store -1 for every limit.
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [
+					region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: rate(null, { unlimited: true, known: true }) } }),
+				],
+			}),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(rowValue('Reads / minute')).toBe('Unlimited');
+		expect(screen.queryByText('-1')).toBeNull();
+	});
+
+	it('shows "—" for a ceiling the endpoint could not determine', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: rate(null) } })] }),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(rowValue('Reads / minute')).toBe('—');
+	});
+
+	it('drops a ceiling the plan does not declare rather than inventing one', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: null } })] }),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(screen.queryByText('Reads / minute')).toBeNull();
+		expect(screen.getByText('Writes / minute')).toBeTruthy();
+	});
+
+	it('will not state a bare per-block number from a pre-normalization server as the regional ceiling', () => {
+		// Deploy-order guard: an older central-manager sends raw plan values here. Understating a ceiling
+		// reads as a real, lower limit, so an un-normalized value must degrade to "—" instead.
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [region({
+					rateLimits: { ...RATE_LIMITS, readsPerMinute: 50_000 as unknown as UsageRateLimit },
+				})],
+			}),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(rowValue('Reads / minute')).toBe('—');
+	});
+
+	it('drops a non-positive per-instance resource instead of rendering a sentinel', () => {
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({
+				regions: [region({ resourcesPerInstance: { storageGb: -1, memoryMb: 4096, cpuCores: 2, threads: 4 } })],
+			}),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(screen.queryByText('Storage', { selector: 'dt' })).toBeNull();
+		expect(rowValue('Memory')).toBe('4 GB');
 	});
 
 	it('explains the self-hosted and no-usage cases instead of rendering empty meters', () => {

--- a/src/features/cluster/usage/Page.test.tsx
+++ b/src/features/cluster/usage/Page.test.tsx
@@ -52,10 +52,10 @@ const metrics = (over: Partial<UsageMetrics> = {}): UsageMetrics => ({
 	...over,
 });
 
-const rate = (value: number | null, over: Partial<UsageRateLimit> = {}): UsageRateLimit => ({
-	value,
+const rate = (limit: number | null, over: Partial<UsageRateLimit> = {}): UsageRateLimit => ({
+	limit,
 	unlimited: false,
-	known: value !== null,
+	limitKnown: limit !== null,
 	...over,
 });
 
@@ -193,12 +193,24 @@ describe('UsagePage', () => {
 		expect(rowValue('Reads / minute')).toBe('50,000');
 	});
 
+	it('takes a metered value through the ceiling formatter unchanged — one vocabulary, not two', () => {
+		// A UsageValue is a rate ceiling plus `used`, so it satisfies UsageRateLimit: this assignment
+		// type-checks, and the same formatter renders it. Guards the shared shape against drifting apart.
+		const metered: UsageValue = v(9_200_000, 50_000);
+		mockUseClusterUsage.mockReturnValue({
+			data: usage({ regions: [region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: metered } })] }),
+			isLoading: false,
+		});
+		render(<UsagePage />);
+		expect(rowValue('Reads / minute')).toBe('50,000');
+	});
+
 	it('reads a plan with no ceiling as Unlimited, never as the -1 sentinel', () => {
 		// fabric-block-dedicated-unlimited-{2..5} store -1 for every limit.
 		mockUseClusterUsage.mockReturnValue({
 			data: usage({
 				regions: [
-					region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: rate(null, { unlimited: true, known: true }) } }),
+					region({ rateLimits: { ...RATE_LIMITS, readsPerMinute: rate(null, { unlimited: true, limitKnown: true }) } }),
 				],
 			}),
 			isLoading: false,

--- a/src/features/cluster/usage/Page.test.tsx
+++ b/src/features/cluster/usage/Page.test.tsx
@@ -186,6 +186,38 @@ describe('UsagePage', () => {
 		expect(screen.getByText(/No usage has been recorded/)).toBeTruthy();
 	});
 
+	it('distinguishes a failed fetch from an empty cycle', () => {
+		mockUseClusterUsage.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+		render(<UsagePage />);
+		expect(screen.getByRole('alert').textContent).toMatch(/Couldn't load usage data/);
+		// "No usage recorded" on a billing surface would read as a zero bill.
+		expect(screen.queryByText(/No usage has been recorded/)).toBeNull();
+	});
+
+	it('also flags the paused-retry case, where isLoading and isError are both false', () => {
+		// react-query parks an offline retry at pending/paused, so neither flag is set and there's
+		// no data — reached against stage by failing the request. Must not read as an empty cycle.
+		mockUseClusterUsage.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+		render(<UsagePage />);
+		expect(screen.getByRole('alert').textContent).toMatch(/Couldn't load usage data/);
+		expect(screen.queryByText(/No usage has been recorded/)).toBeNull();
+	});
+
+	it('still calls an actually-empty cycle empty', () => {
+		// Data arrived and genuinely reports no regions — that IS "nothing used yet", not a failure.
+		mockUseClusterUsage.mockReturnValue({ data: usage({ regions: [] }), isLoading: false });
+		render(<UsagePage />);
+		expect(screen.getByText(/No usage has been recorded/)).toBeTruthy();
+		expect(screen.queryByRole('alert')).toBeNull();
+	});
+
+	it('keeps showing cached usage when a background refetch fails', () => {
+		mockUseClusterUsage.mockReturnValue({ data: usage(), isLoading: false, isError: true });
+		render(<UsagePage />);
+		expect(screen.queryByRole('alert')).toBeNull();
+		expect(screen.getAllByText('Compute').length).toBe(1);
+	});
+
 	it('shows a spinner while loading', () => {
 		mockUseClusterUsage.mockReturnValue({ data: undefined, isLoading: true });
 		const { container } = render(<UsagePage />);

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -34,9 +34,11 @@ export function UsagePage() {
 	return (
 		<ClusterContentWithSubNavMenu className="max-w-4xl pb-20">
 			<h1 className="text-2xl font-light text-foreground">Usage</h1>
-			{data?.selfManaged
+			{!data
+				? <LoadError />
+				: data.selfManaged
 				? <Empty>Usage isn't tracked for self-hosted clusters — they run under their own license.</Empty>
-				: !data || data.regions.length === 0
+				: data.regions.length === 0
 				? <Empty>No usage has been recorded for the current cycle yet.</Empty>
 				: (
 					// Quota is enforced per region — each region is its own collapsible group of meters.
@@ -233,6 +235,23 @@ function rowsFrom(
 
 function Empty({ children }: { children: ReactNode }) {
 	return <p className="mt-3 text-sm text-muted-foreground">{children}</p>;
+}
+
+// Shown whenever loading finished and left us with no data at all. Keyed on `!data` rather than
+// `isError` on purpose: a failed fetch is only one way to get here — a retry paused because the
+// browser went offline leaves the query `pending`/`paused`, so `isLoading` and `isError` are BOTH
+// false with no data (observed against stage). Every one of those means "we couldn't load this",
+// and on a billing surface "no usage has been recorded" would instead read as a zero bill.
+// Because it keys on absent data, a failed *background* refetch still renders the cached numbers.
+function LoadError() {
+	return (
+		<div
+			role="alert"
+			className="mt-5 rounded-xl border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+		>
+			Couldn't load usage data — refresh to try again.
+		</div>
+	);
 }
 
 function SubSection({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -1,88 +1,179 @@
 import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
 import { METERED_ORDER, toMeter, UsageMeter } from '@/features/cluster/components/UsageMeter';
-import { ClusterUsageRegion, usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
+import {
+	ClusterUsageRegion,
+	UsageRateLimits,
+	UsageResourcesPerInstance,
+	useClusterUsage,
+} from '@/integrations/api/cluster/getClusterUsage';
 import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { useParams } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
-import { ReactNode } from 'react';
+import { ChevronRight, Loader2 } from 'lucide-react';
+import { ReactNode, useState } from 'react';
 
 export function UsagePage() {
 	const { clusterId } = useParams({ strict: false }) as { clusterId?: string };
 	const { data, isLoading } = useClusterUsage(clusterId);
 
+	if (isLoading) {
+		return (
+			<ClusterContentWithSubNavMenu className="max-w-4xl pb-20">
+				<h1 className="text-2xl font-light text-foreground">Usage</h1>
+				<div className="flex justify-center py-16 text-muted-foreground">
+					<Loader2 className="size-6 animate-spin" />
+				</div>
+			</ClusterContentWithSubNavMenu>
+		);
+	}
+
+	// Rate limits + per-instance resources are usually identical across a cluster's regions (same plan),
+	// so when they're uniform we show them once in a shared card instead of repeating them per region.
+	const shared = data && !data.selfManaged ? uniformPlanInfo(data.regions) : null;
+
 	return (
-		<ClusterContentWithSubNavMenu className="max-w-4xl">
+		<ClusterContentWithSubNavMenu className="max-w-4xl pb-20">
 			<h1 className="text-2xl font-light text-foreground">Usage</h1>
-			{isLoading
-				? (
-					<div className="flex justify-center py-16 text-muted-foreground">
-						<Loader2 className="size-6 animate-spin" />
-					</div>
-				)
-				: data?.selfManaged
+			{data?.selfManaged
 				? <Empty>Usage isn't tracked for self-hosted clusters — they run under their own license.</Empty>
 				: !data || data.regions.length === 0
 				? <Empty>No usage has been recorded for the current cycle yet.</Empty>
 				: (
-					<>
-						<p className="mt-1 text-sm text-muted-foreground">{usageSubtitle(data)}</p>
-						{/* Quota is enforced per region — each region is its own set of meters. */}
+					// Quota is enforced per region — each region is its own collapsible group of meters.
+					<div className="mt-5 space-y-3">
 						{data.regions.map((region) => (
-							<RegionSection key={region.region ?? region.regionIds.join()} region={region} />
+							<RegionSection
+								key={region.region ?? region.regionIds.join()}
+								region={region}
+								showPlanInfo={shared == null}
+							/>
 						))}
-					</>
+						{shared && (
+							<CollapsibleCard
+								header={<HeaderText title="Plan limits & resources" />}
+								aside={shared.planId ?? undefined}
+							>
+								<PlanInfo rateLimits={shared.rateLimits} resourcesPerInstance={shared.resourcesPerInstance} />
+							</CollapsibleCard>
+						)}
+					</div>
 				)}
 		</ClusterContentWithSubNavMenu>
 	);
 }
 
-function RegionSection({ region }: { region: ClusterUsageRegion }) {
+function RegionSection({ region, showPlanInfo }: { region: ClusterUsageRegion; showPlanInfo: boolean }) {
 	const meters = METERED_ORDER.map((key) => toMeter(key, region.metrics[key]));
+	const meta = [
+		region.planName ? `${region.planName} plan` : null,
+		region.status === 'exhausted'
+			? 'consumed — awaiting renewal'
+			: region.status === 'lapsed'
+			? 'not renewed'
+			: region.expiresAt
+			? `renews ${fmtDate(region.expiresAt)}`
+			: null,
+	].filter(Boolean).join(' · ');
 
-	const rl = region.rateLimits;
+	return (
+		// Lapsed regions have no live quota — collapse them by default so the active ones lead.
+		<CollapsibleCard
+			defaultOpen={region.status !== 'lapsed'}
+			aside={region.regionIds.length > 0 ? region.regionIds.join(', ') : undefined}
+			header={
+				<HeaderText title={region.region ?? 'Region'} meta={meta}>
+					{region.status === 'exhausted' && (
+						<span className="rounded-full bg-yellow/10 px-2 py-0.5 text-[11px] text-yellow">Cycle exhausted</span>
+					)}
+					{region.status === 'lapsed' && (
+						<span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+							No active license
+						</span>
+					)}
+				</HeaderText>
+			}
+		>
+			<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
+				{meters.map((meter) => <UsageMeter key={meter.label} {...meter} />)}
+			</div>
+			{showPlanInfo && <PlanInfo rateLimits={region.rateLimits} resourcesPerInstance={region.resourcesPerInstance} />}
+		</CollapsibleCard>
+	);
+}
+
+function CollapsibleCard(
+	{ header, aside, defaultOpen = true, children }: {
+		header: ReactNode;
+		aside?: ReactNode;
+		defaultOpen?: boolean;
+		children: ReactNode;
+	},
+) {
+	const [open, setOpen] = useState(defaultOpen);
+	return (
+		<section className="overflow-hidden rounded-xl border border-border">
+			<button
+				type="button"
+				onClick={() => setOpen((o) => !o)}
+				aria-expanded={open}
+				className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent/40"
+			>
+				<ChevronRight
+					className={`size-4 shrink-0 text-muted-foreground transition-transform ${open ? 'rotate-90' : ''}`}
+				/>
+				<div className="min-w-0 flex-1">{header}</div>
+				{aside && (
+					<span className="shrink-0 self-start pt-0.5 font-mono text-[11px] text-muted-foreground/70">{aside}</span>
+				)}
+			</button>
+			{open && <div className="border-t border-border px-4 py-4">{children}</div>}
+		</section>
+	);
+}
+
+function HeaderText({ title, meta, children }: { title: string; meta?: string; children?: ReactNode }) {
+	return (
+		<>
+			<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+				<span className="text-sm font-medium text-foreground">{title}</span>
+				{children}
+			</div>
+			{meta && <div className="mt-0.5 text-xs text-muted-foreground">{meta}</div>}
+		</>
+	);
+}
+
+function PlanInfo(
+	{ rateLimits, resourcesPerInstance }: {
+		rateLimits: UsageRateLimits | null;
+		resourcesPerInstance: UsageResourcesPerInstance | null;
+	},
+) {
+	const rl = rateLimits;
 	const rateRows = rl
 		? rowsFrom([
 			['Reads / minute', rl.readsPerMinute, addCommasToNumbers],
+			['Read bandwidth / minute', rl.readsPerMinuteBytes, humanFileSize],
 			['Writes / minute', rl.writesPerMinute, addCommasToNumbers],
+			['Write bandwidth / minute', rl.writesPerMinuteBytes, humanFileSize],
 			['Real-time deliveries / minute', rl.realTimeDeliveriesPerMinute, addCommasToNumbers],
+			['Real-time bandwidth / minute', rl.realTimeDeliveryBytesPerMinute, humanFileSize],
 			['TLS handshakes (cycle)', rl.tlsHandshakes, addCommasToNumbers],
 		])
 		: [];
 
-	const rpi = region.resourcesPerInstance;
+	const rpi = resourcesPerInstance;
 	const perInstanceRows = rpi
 		? rowsFrom([
 			['Storage', rpi.storageGb, (n) => `${addCommasToNumbers(n)} GB`],
-			['Memory', rpi.memoryMb, (n) => humanFileSize(n * 1024 * 1024)],
+			['Memory', rpi.memoryMb, (n) => humanFileSize(n * 1000 * 1000)],
 			['vCPU', rpi.cpuCores, (n) => `${n} ${n === 1 ? 'core' : 'cores'}`],
 			['Threads', rpi.threads, (n) => String(n)],
 		])
 		: [];
 
 	return (
-		<section className="mt-8 border-t border-border/60 pt-6 first:border-t-0 first:pt-0">
-			<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-				<h2 className="text-base font-medium text-foreground">{region.region ?? 'Region'}</h2>
-				{region.exhausted && (
-					<span className="rounded-full bg-yellow/10 px-2 py-0.5 text-[11px] text-yellow">Cycle exhausted</span>
-				)}
-			</div>
-			<p className="mt-0.5 mb-4 text-xs text-muted-foreground">
-				{[
-					region.planName ? `${region.planName} plan` : null,
-					region.exhausted
-						? 'consumed — awaiting renewal'
-						: region.expiresAt
-						? `renews ${fmtDate(region.expiresAt)}`
-						: null,
-				].filter(Boolean).join(' · ')}
-			</p>
-
-			<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
-				{meters.map((meter) => <UsageMeter key={meter.label} {...meter} />)}
-			</div>
-
+		<>
 			{rateRows.length > 0 && (
 				<SubSection
 					title="Rate limits"
@@ -91,18 +182,44 @@ function RegionSection({ region }: { region: ClusterUsageRegion }) {
 					<InfoGrid rows={rateRows} />
 				</SubSection>
 			)}
-
 			{perInstanceRows.length > 0 && (
 				<SubSection title="Per-instance resources" subtitle="Provisioned capacity on each instance.">
 					<InfoGrid rows={perInstanceRows} />
 				</SubSection>
 			)}
-		</section>
+		</>
 	);
 }
 
 function fmtDate(iso: string): string {
 	return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(iso));
+}
+
+// True (with the shared rate/per-instance) only when every region declares the same, non-empty plan info.
+function uniformPlanInfo(
+	regions: ClusterUsageRegion[],
+):
+	| {
+		rateLimits: UsageRateLimits | null;
+		resourcesPerInstance: UsageResourcesPerInstance | null;
+		planId: string | null;
+	}
+	| null
+{
+	if (regions.length === 0) { return null; }
+	const first = regions[0];
+	if (first.rateLimits == null && first.resourcesPerInstance == null) { return null; }
+	const key = (r: ClusterUsageRegion) => JSON.stringify([r.rateLimits, r.resourcesPerInstance]);
+	const k0 = key(first);
+	// Show the shared plan id only when it's the same across every region too.
+	const samePlan = regions.every((r) => r.planId === first.planId);
+	return regions.every((r) => key(r) === k0)
+		? {
+			rateLimits: first.rateLimits,
+			resourcesPerInstance: first.resourcesPerInstance,
+			planId: samePlan ? first.planId : null,
+		}
+		: null;
 }
 
 // Build label/value rows, dropping any metric the plan didn't declare (null/undefined).
@@ -120,7 +237,7 @@ function Empty({ children }: { children: ReactNode }) {
 
 function SubSection({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
 	return (
-		<div className="mt-6">
+		<div className="mt-6 first:mt-0">
 			<h3 className="text-sm font-medium text-foreground">{title}</h3>
 			<p className="mt-0.5 mb-3 text-xs text-muted-foreground">{subtitle}</p>
 			{children}

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -2,6 +2,7 @@ import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/Clus
 import { METERED_ORDER, toMeter, UsageMeter } from '@/features/cluster/components/UsageMeter';
 import {
 	ClusterUsageRegion,
+	UsageRateLimit,
 	UsageRateLimits,
 	UsageResourcesPerInstance,
 	useClusterUsage,
@@ -153,7 +154,7 @@ function PlanInfo(
 ) {
 	const rl = rateLimits;
 	const rateRows = rl
-		? rowsFrom([
+		? rateRowsFrom([
 			['Reads / minute', rl.readsPerMinute, addCommasToNumbers],
 			['Read bandwidth / minute', rl.readsPerMinuteBytes, humanFileSize],
 			['Writes / minute', rl.writesPerMinute, addCommasToNumbers],
@@ -224,13 +225,28 @@ function uniformPlanInfo(
 		: null;
 }
 
-// Build label/value rows, dropping any metric the plan didn't declare (null/undefined).
+// Build label/value rows, dropping any resource the plan didn't declare (null/undefined) or left at a
+// non-positive placeholder — same as the purchase-time plan panel, so a sentinel can't render as "-1 GB".
 function rowsFrom(
 	entries: Array<[string, number | null | undefined, (n: number) => string]>,
 ): Array<[string, string]> {
 	return entries
-		.filter((e): e is [string, number, (n: number) => string] => e[1] != null)
+		.filter((e): e is [string, number, (n: number) => string] => typeof e[1] === 'number' && e[1] > 0)
 		.map(([label, value, format]): [string, string] => [label, format(value)]);
+}
+
+// Same, for the throughput ceilings, which arrive as {value, unlimited, known}: a ceiling the plan
+// doesn't declare (null) gets no row, "no ceiling" reads Unlimited, and anything we can't pin down —
+// including the bare numbers a pre-normalization server sends — reads "—" rather than a hard number.
+function rateRowsFrom(
+	entries: Array<[string, UsageRateLimit | null, (n: number) => string]>,
+): Array<[string, string]> {
+	return entries
+		.filter((e): e is [string, UsageRateLimit, (n: number) => string] => e[1] != null)
+		.map(([label, limit, format]): [string, string] => [
+			label,
+			limit.unlimited ? 'Unlimited' : limit.known && limit.value != null ? format(limit.value) : '—',
+		]);
 }
 
 function Empty({ children }: { children: ReactNode }) {

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -1,0 +1,101 @@
+import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
+import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
+import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
+import { humanFileSize } from '@/lib/humanFileSize';
+import { ReactNode } from 'react';
+
+// ⚠️ MOCKUP (issue #1297) — placeholder data covering the COMPLETE set of metrics
+// central-manager tracks, so we can decide which ones matter on the overview card.
+//
+// Three tiers of data exist server-side:
+//   1. Metered this cycle — PurchasedBlock.used* vs Plan.planLimits.total* (has real usage → bars).
+//   2. Rate limits — Plan.planLimits.*PerMinute* + tlsHandshakes (ceilings only, NO usage counter).
+//   3. Per-instance resources — Plan.resourcesPerInstance (provisioned capacity, not consumption).
+
+// 1. Metered usage this cycle (used vs limit). Ordered so the count/data pairs sit side-by-side
+//    in the 2-col grid. Real-time is left Unlimited to show that state.
+const METERED: UsageMetric[] = [
+	{ label: 'Reads', used: 9_200_000, limit: 10_000_000, format: fmtCount },
+	{ label: 'Read data', used: 45_097_156_608, limit: 53_687_091_200, format: fmtBytes },
+	{ label: 'Writes', used: 2_300_000, limit: 5_000_000, format: fmtCount },
+	{ label: 'Write data', used: 8_589_934_592, limit: 21_474_836_480, format: fmtBytes },
+	{ label: 'Real-time messages', used: 1_412_004, limit: null, format: fmtCount },
+	{ label: 'Real-time data', used: 6_442_450_944, limit: null, format: fmtBytes },
+	{ label: 'Compute', used: 1.6, limit: 2, format: fmtHours },
+	{ label: 'Storage', used: 13_314_398_617, limit: 21_474_836_480, format: fmtBytes },
+];
+
+// 2. Rate limits — throttle ceilings, no usage tracked.
+const RATE_LIMITS: Array<[string, string]> = [
+	['Reads / minute', `${addCommasToNumbers(50_000)}`],
+	['Writes / minute', `${addCommasToNumbers(10_000)}`],
+	['Real-time deliveries / minute', `${addCommasToNumbers(5_000)}`],
+	['TLS handshakes (cycle)', addCommasToNumbers(1_000_000)],
+];
+
+// 3. Per-instance provisioned resources (Plan.resourcesPerInstance).
+const PER_INSTANCE: Array<[string, string]> = [
+	['Storage', humanFileSize(21_474_836_480)],
+	['Memory', humanFileSize(4_294_967_296)],
+	['vCPU', '2 cores'],
+	['Threads', '4'],
+];
+
+export function UsagePage() {
+	return (
+		<ClusterContentWithSubNavMenu className="max-w-4xl">
+			<div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+				<h1 className="text-2xl font-light text-foreground">Usage</h1>
+				<span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+					Preview · sample data
+				</span>
+			</div>
+			<p className="mt-1 text-sm text-muted-foreground">
+				Standard plan · this cycle renews Aug 12, 2026 · updated 4 minutes ago
+			</p>
+
+			<Section
+				title="This cycle"
+				subtitle="Consumption against your plan's allotment. Renews (and re-bills) when full."
+			>
+				<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
+					{METERED.map((m) => <UsageMeter key={m.label} {...m} />)}
+				</div>
+			</Section>
+
+			<Section
+				title="Rate limits"
+				subtitle="Throughput ceilings — not part of the cycle allotment, and not currently metered."
+			>
+				<InfoGrid rows={RATE_LIMITS} />
+			</Section>
+
+			<Section title="Per-instance resources" subtitle="Provisioned capacity on each of your 2 instances.">
+				<InfoGrid rows={PER_INSTANCE} />
+			</Section>
+		</ClusterContentWithSubNavMenu>
+	);
+}
+
+function Section({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
+	return (
+		<section className="mt-8">
+			<h2 className="text-sm font-medium text-foreground">{title}</h2>
+			<p className="mt-0.5 mb-4 text-xs text-muted-foreground">{subtitle}</p>
+			{children}
+		</section>
+	);
+}
+
+function InfoGrid({ rows }: { rows: Array<[string, string]> }) {
+	return (
+		<dl className="grid grid-cols-1 gap-x-10 gap-y-2 sm:grid-cols-2">
+			{rows.map(([label, value]) => (
+				<div key={label} className="flex items-baseline justify-between gap-2 border-b border-border/60 py-1.5 text-sm">
+					<dt className="text-muted-foreground">{label}</dt>
+					<dd className="text-foreground tabular-nums">{value}</dd>
+				</div>
+			))}
+		</dl>
+	);
+}

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -1,80 +1,110 @@
 import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
 import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
+import { ClusterUsage, usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
 import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
 import { humanFileSize } from '@/lib/humanFileSize';
+import { useParams } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
 import { ReactNode } from 'react';
 
-// ⚠️ MOCKUP (issue #1297) — placeholder data covering the COMPLETE set of metrics
-// central-manager tracks, so we can decide which ones matter on the overview card.
-//
-// Three tiers of data exist server-side:
-//   1. Metered this cycle — PurchasedBlock.used* vs Plan.planLimits.total* (has real usage → bars).
-//   2. Rate limits — Plan.planLimits.*PerMinute* + tlsHandshakes (ceilings only, NO usage counter).
-//   3. Per-instance resources — Plan.resourcesPerInstance (provisioned capacity, not consumption).
-
-// 1. Metered usage this cycle (used vs limit). Ordered so the count/data pairs sit side-by-side
-//    in the 2-col grid. Real-time is left Unlimited to show that state.
-const METERED: UsageMetric[] = [
-	{ label: 'Reads', used: 9_200_000, limit: 10_000_000, format: fmtCount },
-	{ label: 'Read data', used: 45_097_156_608, limit: 53_687_091_200, format: fmtBytes },
-	{ label: 'Writes', used: 2_300_000, limit: 5_000_000, format: fmtCount },
-	{ label: 'Write data', used: 8_589_934_592, limit: 21_474_836_480, format: fmtBytes },
-	{ label: 'Real-time messages', used: 1_412_004, limit: null, format: fmtCount },
-	{ label: 'Real-time data', used: 6_442_450_944, limit: null, format: fmtBytes },
-	{ label: 'Compute', used: 1.6, limit: 2, format: fmtHours },
-	{ label: 'Storage', used: 13_314_398_617, limit: 21_474_836_480, format: fmtBytes },
-];
-
-// 2. Rate limits — throttle ceilings, no usage tracked.
-const RATE_LIMITS: Array<[string, string]> = [
-	['Reads / minute', `${addCommasToNumbers(50_000)}`],
-	['Writes / minute', `${addCommasToNumbers(10_000)}`],
-	['Real-time deliveries / minute', `${addCommasToNumbers(5_000)}`],
-	['TLS handshakes (cycle)', addCommasToNumbers(1_000_000)],
-];
-
-// 3. Per-instance provisioned resources (Plan.resourcesPerInstance).
-const PER_INSTANCE: Array<[string, string]> = [
-	['Storage', humanFileSize(21_474_836_480)],
-	['Memory', humanFileSize(4_294_967_296)],
-	['vCPU', '2 cores'],
-	['Threads', '4'],
-];
-
 export function UsagePage() {
+	const { clusterId } = useParams({ strict: false }) as { clusterId?: string };
+	const { data, isLoading } = useClusterUsage(clusterId);
+
 	return (
 		<ClusterContentWithSubNavMenu className="max-w-4xl">
-			<div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-				<h1 className="text-2xl font-light text-foreground">Usage</h1>
-				<span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-					Preview · sample data
-				</span>
-			</div>
-			<p className="mt-1 text-sm text-muted-foreground">
-				Standard plan · this cycle renews Aug 12, 2026 · updated 4 minutes ago
-			</p>
+			<h1 className="text-2xl font-light text-foreground">Usage</h1>
+			{isLoading
+				? (
+					<div className="flex justify-center py-16 text-muted-foreground">
+						<Loader2 className="size-6 animate-spin" />
+					</div>
+				)
+				: data?.selfManaged
+				? <Empty>Usage isn't tracked for self-hosted clusters — they run under their own license.</Empty>
+				: !data?.totals
+				? <Empty>No usage has been recorded for the current cycle yet.</Empty>
+				: <UsageContent data={data} />}
+		</ClusterContentWithSubNavMenu>
+	);
+}
+
+function UsageContent({ data }: { data: ClusterUsage }) {
+	const t = data.totals;
+	if (!t) { return null; }
+	const metered: UsageMetric[] = [
+		{ label: 'Reads', used: t.reads.used, limit: t.reads.limit, format: fmtCount },
+		{ label: 'Read data', used: t.readBytes.used, limit: t.readBytes.limit, format: fmtBytes },
+		{ label: 'Writes', used: t.writes.used, limit: t.writes.limit, format: fmtCount },
+		{ label: 'Write data', used: t.writeBytes.used, limit: t.writeBytes.limit, format: fmtBytes },
+		{ label: 'Real-time messages', used: t.realTimeMessages.used, limit: t.realTimeMessages.limit, format: fmtCount },
+		{ label: 'Real-time data', used: t.realTimeBytes.used, limit: t.realTimeBytes.limit, format: fmtBytes },
+		{ label: 'Compute', used: t.cpuTimeHours.used, limit: t.cpuTimeHours.limit, format: fmtHours },
+		{ label: 'Storage', used: t.storageBytes.used, limit: t.storageBytes.limit, format: fmtBytes },
+	];
+
+	const rl = data.regions[0]?.rateLimits;
+	const rateRows = rl
+		? rowsFrom([
+			['Reads / minute', rl.readsPerMinute, addCommasToNumbers],
+			['Writes / minute', rl.writesPerMinute, addCommasToNumbers],
+			['Real-time deliveries / minute', rl.realTimeDeliveriesPerMinute, addCommasToNumbers],
+			['TLS handshakes (cycle)', rl.tlsHandshakes, addCommasToNumbers],
+		])
+		: [];
+
+	const rpi = data.regions[0]?.resourcesPerInstance;
+	const perInstanceRows = rpi
+		? rowsFrom([
+			['Storage', rpi.storageGb, (n) => `${addCommasToNumbers(n)} GB`],
+			['Memory', rpi.memoryMb, (n) => humanFileSize(n * 1024 * 1024)],
+			['vCPU', rpi.cpuCores, (n) => `${n} ${n === 1 ? 'core' : 'cores'}`],
+			['Threads', rpi.threads, (n) => String(n)],
+		])
+		: [];
+
+	return (
+		<>
+			<p className="mt-1 text-sm text-muted-foreground">{usageSubtitle(data)}</p>
 
 			<Section
 				title="This cycle"
 				subtitle="Consumption against your plan's allotment. Renews (and re-bills) when full."
 			>
 				<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
-					{METERED.map((m) => <UsageMeter key={m.label} {...m} />)}
+					{metered.map((m) => <UsageMeter key={m.label} {...m} />)}
 				</div>
 			</Section>
 
-			<Section
-				title="Rate limits"
-				subtitle="Throughput ceilings — not part of the cycle allotment, and not currently metered."
-			>
-				<InfoGrid rows={RATE_LIMITS} />
-			</Section>
+			{rateRows.length > 0 && (
+				<Section
+					title="Rate limits"
+					subtitle="Throughput ceilings — not part of the cycle allotment, and not currently metered."
+				>
+					<InfoGrid rows={rateRows} />
+				</Section>
+			)}
 
-			<Section title="Per-instance resources" subtitle="Provisioned capacity on each of your 2 instances.">
-				<InfoGrid rows={PER_INSTANCE} />
-			</Section>
-		</ClusterContentWithSubNavMenu>
+			{perInstanceRows.length > 0 && (
+				<Section title="Per-instance resources" subtitle="Provisioned capacity on each instance.">
+					<InfoGrid rows={perInstanceRows} />
+				</Section>
+			)}
+		</>
 	);
+}
+
+// Build label/value rows, dropping any metric the plan didn't declare (null/undefined).
+function rowsFrom(
+	entries: Array<[string, number | null | undefined, (n: number) => string]>,
+): Array<[string, string]> {
+	return entries
+		.filter((e): e is [string, number, (n: number) => string] => e[1] != null)
+		.map(([label, value, format]): [string, string] => [label, format(value)]);
+}
+
+function Empty({ children }: { children: ReactNode }) {
+	return <p className="mt-3 text-sm text-muted-foreground">{children}</p>;
 }
 
 function Section({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -1,6 +1,6 @@
 import { ClusterContentWithSubNavMenu } from '@/features/cluster/components/ClusterContentWithSubNavMenu';
-import { fmtBytes, fmtCount, fmtHours, UsageMeter, UsageMetric } from '@/features/cluster/components/UsageMeter';
-import { ClusterUsage, usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
+import { METERED_ORDER, toMeter, UsageMeter } from '@/features/cluster/components/UsageMeter';
+import { ClusterUsageRegion, usageSubtitle, useClusterUsage } from '@/integrations/api/cluster/getClusterUsage';
 import { addCommasToNumbers } from '@/lib/addCommasToNumbers';
 import { humanFileSize } from '@/lib/humanFileSize';
 import { useParams } from '@tanstack/react-router';
@@ -22,28 +22,25 @@ export function UsagePage() {
 				)
 				: data?.selfManaged
 				? <Empty>Usage isn't tracked for self-hosted clusters — they run under their own license.</Empty>
-				: !data?.totals
+				: !data || data.regions.length === 0
 				? <Empty>No usage has been recorded for the current cycle yet.</Empty>
-				: <UsageContent data={data} />}
+				: (
+					<>
+						<p className="mt-1 text-sm text-muted-foreground">{usageSubtitle(data)}</p>
+						{/* Quota is enforced per region — each region is its own set of meters. */}
+						{data.regions.map((region) => (
+							<RegionSection key={region.region ?? region.regionIds.join()} region={region} />
+						))}
+					</>
+				)}
 		</ClusterContentWithSubNavMenu>
 	);
 }
 
-function UsageContent({ data }: { data: ClusterUsage }) {
-	const t = data.totals;
-	if (!t) { return null; }
-	const metered: UsageMetric[] = [
-		{ label: 'Reads', used: t.reads.used, limit: t.reads.limit, format: fmtCount },
-		{ label: 'Read data', used: t.readBytes.used, limit: t.readBytes.limit, format: fmtBytes },
-		{ label: 'Writes', used: t.writes.used, limit: t.writes.limit, format: fmtCount },
-		{ label: 'Write data', used: t.writeBytes.used, limit: t.writeBytes.limit, format: fmtBytes },
-		{ label: 'Real-time messages', used: t.realTimeMessages.used, limit: t.realTimeMessages.limit, format: fmtCount },
-		{ label: 'Real-time data', used: t.realTimeBytes.used, limit: t.realTimeBytes.limit, format: fmtBytes },
-		{ label: 'Compute', used: t.cpuTimeHours.used, limit: t.cpuTimeHours.limit, format: fmtHours },
-		{ label: 'Storage', used: t.storageBytes.used, limit: t.storageBytes.limit, format: fmtBytes },
-	];
+function RegionSection({ region }: { region: ClusterUsageRegion }) {
+	const meters = METERED_ORDER.map((key) => toMeter(key, region.metrics[key]));
 
-	const rl = data.regions[0]?.rateLimits;
+	const rl = region.rateLimits;
 	const rateRows = rl
 		? rowsFrom([
 			['Reads / minute', rl.readsPerMinute, addCommasToNumbers],
@@ -53,7 +50,7 @@ function UsageContent({ data }: { data: ClusterUsage }) {
 		])
 		: [];
 
-	const rpi = data.regions[0]?.resourcesPerInstance;
+	const rpi = region.resourcesPerInstance;
 	const perInstanceRows = rpi
 		? rowsFrom([
 			['Storage', rpi.storageGb, (n) => `${addCommasToNumbers(n)} GB`],
@@ -64,34 +61,48 @@ function UsageContent({ data }: { data: ClusterUsage }) {
 		: [];
 
 	return (
-		<>
-			<p className="mt-1 text-sm text-muted-foreground">{usageSubtitle(data)}</p>
+		<section className="mt-8 border-t border-border/60 pt-6 first:border-t-0 first:pt-0">
+			<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+				<h2 className="text-base font-medium text-foreground">{region.region ?? 'Region'}</h2>
+				{region.exhausted && (
+					<span className="rounded-full bg-yellow/10 px-2 py-0.5 text-[11px] text-yellow">Cycle exhausted</span>
+				)}
+			</div>
+			<p className="mt-0.5 mb-4 text-xs text-muted-foreground">
+				{[
+					region.planName ? `${region.planName} plan` : null,
+					region.exhausted
+						? 'consumed — awaiting renewal'
+						: region.expiresAt
+						? `renews ${fmtDate(region.expiresAt)}`
+						: null,
+				].filter(Boolean).join(' · ')}
+			</p>
 
-			<Section
-				title="This cycle"
-				subtitle="Consumption against your plan's allotment. Renews (and re-bills) when full."
-			>
-				<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
-					{metered.map((m) => <UsageMeter key={m.label} {...m} />)}
-				</div>
-			</Section>
+			<div className="grid grid-cols-1 gap-x-10 gap-y-4 sm:grid-cols-2">
+				{meters.map((meter) => <UsageMeter key={meter.label} {...meter} />)}
+			</div>
 
 			{rateRows.length > 0 && (
-				<Section
+				<SubSection
 					title="Rate limits"
-					subtitle="Throughput ceilings — not part of the cycle allotment, and not currently metered."
+					subtitle="Throughput ceilings — not part of the cycle allotment, and not metered."
 				>
 					<InfoGrid rows={rateRows} />
-				</Section>
+				</SubSection>
 			)}
 
 			{perInstanceRows.length > 0 && (
-				<Section title="Per-instance resources" subtitle="Provisioned capacity on each instance.">
+				<SubSection title="Per-instance resources" subtitle="Provisioned capacity on each instance.">
 					<InfoGrid rows={perInstanceRows} />
-				</Section>
+				</SubSection>
 			)}
-		</>
+		</section>
 	);
+}
+
+function fmtDate(iso: string): string {
+	return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(iso));
 }
 
 // Build label/value rows, dropping any metric the plan didn't declare (null/undefined).
@@ -107,13 +118,13 @@ function Empty({ children }: { children: ReactNode }) {
 	return <p className="mt-3 text-sm text-muted-foreground">{children}</p>;
 }
 
-function Section({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
+function SubSection({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
 	return (
-		<section className="mt-8">
-			<h2 className="text-sm font-medium text-foreground">{title}</h2>
-			<p className="mt-0.5 mb-4 text-xs text-muted-foreground">{subtitle}</p>
+		<div className="mt-6">
+			<h3 className="text-sm font-medium text-foreground">{title}</h3>
+			<p className="mt-0.5 mb-3 text-xs text-muted-foreground">{subtitle}</p>
 			{children}
-		</section>
+		</div>
 	);
 }
 

--- a/src/features/cluster/usage/Page.tsx
+++ b/src/features/cluster/usage/Page.tsx
@@ -235,17 +235,18 @@ function rowsFrom(
 		.map(([label, value, format]): [string, string] => [label, format(value)]);
 }
 
-// Same, for the throughput ceilings, which arrive as {value, unlimited, known}: a ceiling the plan
-// doesn't declare (null) gets no row, "no ceiling" reads Unlimited, and anything we can't pin down —
-// including the bare numbers a pre-normalization server sends — reads "—" rather than a hard number.
+// Same, for ceilings carrying the {limit, unlimited, limitKnown} states — rate ceilings here, but a
+// metered value satisfies it too. A ceiling the plan doesn't declare (null) gets no row, "no ceiling"
+// reads Unlimited, and anything we can't pin down — including the bare numbers a pre-normalization
+// server sends — reads "—" rather than a hard number.
 function rateRowsFrom(
 	entries: Array<[string, UsageRateLimit | null, (n: number) => string]>,
 ): Array<[string, string]> {
 	return entries
 		.filter((e): e is [string, UsageRateLimit, (n: number) => string] => e[1] != null)
-		.map(([label, limit, format]): [string, string] => [
+		.map(([label, ceiling, format]): [string, string] => [
 			label,
-			limit.unlimited ? 'Unlimited' : limit.known && limit.value != null ? format(limit.value) : '—',
+			ceiling.unlimited ? 'Unlimited' : ceiling.limitKnown && ceiling.limit != null ? format(ceiling.limit) : '—',
 		]);
 }
 

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -1,0 +1,103 @@
+import { apiClient } from '@/config/apiClient';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+
+// Response of central-manager's GET /Cluster/:id/usage (HarperFast/central-manager#503).
+// `limit === null` means the plan allows unlimited (server sends -1, or the limit is unknown).
+
+export interface UsageValue {
+	used: number;
+	limit: number | null;
+}
+
+export interface UsageMetrics {
+	reads: UsageValue;
+	readBytes: UsageValue;
+	writes: UsageValue;
+	writeBytes: UsageValue;
+	realTimeMessages: UsageValue;
+	realTimeBytes: UsageValue;
+	cpuTimeHours: UsageValue;
+	storageBytes: UsageValue;
+}
+
+export interface UsageRateLimits {
+	readsPerMinute: number | null;
+	readsPerMinuteBytes: number | null;
+	writesPerMinute: number | null;
+	writesPerMinuteBytes: number | null;
+	realTimeDeliveriesPerMinute: number | null;
+	realTimeDeliveryBytesPerMinute: number | null;
+	tlsHandshakes: number | null;
+}
+
+export interface UsageResourcesPerInstance {
+	storageGb?: number | null;
+	memoryMb?: number | null;
+	cpuCores?: number | null;
+	threads?: number | null;
+	readIopsLimit?: number | null;
+	writeIopsLimit?: number | null;
+}
+
+export interface ClusterUsageRegion {
+	regionId: string | null;
+	region: string | null;
+	planId: string | null;
+	planName: string | null;
+	planLevel: number | null;
+	expiresAt: string | null;
+	blockCount: number;
+	metrics: UsageMetrics;
+	rateLimits: UsageRateLimits | null;
+	resourcesPerInstance: UsageResourcesPerInstance | null;
+}
+
+export interface ClusterUsage {
+	clusterId: string;
+	selfManaged: boolean;
+	asOf: string | null;
+	renewsAt: string | null;
+	totals: UsageMetrics | null;
+	regions: ClusterUsageRegion[];
+}
+
+export function getClusterUsageQueryOptions(clusterId?: string) {
+	return queryOptions({
+		queryKey: ['clusterUsage', clusterId],
+		queryFn: async (): Promise<ClusterUsage> => {
+			// Not in the generated OpenAPI types yet (sub-path of /Cluster/{id}); typed by hand above.
+			const { data } = await apiClient.get(`/Cluster/${clusterId}/usage` as never);
+			return data as ClusterUsage;
+		},
+		enabled: !!clusterId,
+		// Usage lags to the instance-reporting cadence, so it doesn't need to be fresh-to-the-second.
+		staleTime: 60_000,
+	});
+}
+
+export function useClusterUsage(clusterId?: string) {
+	return useQuery(getClusterUsageQueryOptions(clusterId));
+}
+
+/** "Standard plan · this cycle renews Aug 12 · updated 4 minutes ago" — shared by the card + tab. */
+export function usageSubtitle(data: ClusterUsage): string {
+	const planName = data.regions[0]?.planName;
+	return [
+		planName ? `${planName} plan` : null,
+		data.renewsAt ? `this cycle renews ${formatCycleDate(data.renewsAt)}` : null,
+		data.asOf ? `updated ${formatAgo(data.asOf)}` : null,
+	].filter(Boolean).join(' · ');
+}
+
+function formatCycleDate(iso: string): string {
+	return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(iso));
+}
+
+function formatAgo(iso: string): string {
+	const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+	const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60_000);
+	if (Math.abs(minutes) < 60) { return rtf.format(-minutes, 'minute'); }
+	const hours = Math.round(minutes / 60);
+	if (Math.abs(hours) < 24) { return rtf.format(-hours, 'hour'); }
+	return rtf.format(-Math.round(hours / 24), 'day');
+}

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -2,11 +2,17 @@ import { apiClient } from '@/config/apiClient';
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
 // Response of central-manager's GET /Cluster/:id/usage (HarperFast/central-manager#503).
-// `limit === null` means the plan allows unlimited (server sends -1, or the limit is unknown).
+// Quota is enforced per region, so per-region `metrics` are the real meters; `totals` carries absolute
+// consumption only (no cluster-wide ceiling), and `mostConstrained` is the single tightest region×metric.
 
 export interface UsageValue {
 	used: number;
+	/** null when `unlimited` OR `!limitKnown` */
 	limit: number | null;
+	/** plan grants no ceiling (server sentinel -1) */
+	unlimited: boolean;
+	/** false when the plan couldn't be resolved — render "—", never "Unlimited" */
+	limitKnown: boolean;
 }
 
 export interface UsageMetrics {
@@ -19,6 +25,8 @@ export interface UsageMetrics {
 	cpuTimeHours: UsageValue;
 	storageBytes: UsageValue;
 }
+
+export type UsageMetricKey = keyof UsageMetrics;
 
 export interface UsageRateLimits {
 	readsPerMinute: number | null;
@@ -40,24 +48,35 @@ export interface UsageResourcesPerInstance {
 }
 
 export interface ClusterUsageRegion {
-	regionId: string | null;
 	region: string | null;
+	regionIds: string[];
 	planId: string | null;
 	planName: string | null;
 	planLevel: number | null;
 	expiresAt: string | null;
-	blockCount: number;
+	exhausted: boolean;
+	activeBlockCount: number;
+	exhaustedBlockCount: number;
 	metrics: UsageMetrics;
 	rateLimits: UsageRateLimits | null;
 	resourcesPerInstance: UsageResourcesPerInstance | null;
 }
 
+export interface MostConstrained {
+	metric: UsageMetricKey;
+	region: string | null;
+	regionIds: string[];
+	used: number;
+	limit: number;
+	utilization: number;
+}
+
 export interface ClusterUsage {
 	clusterId: string;
 	selfManaged: boolean;
-	asOf: string | null;
 	renewsAt: string | null;
 	totals: UsageMetrics | null;
+	mostConstrained: MostConstrained | null;
 	regions: ClusterUsageRegion[];
 }
 
@@ -79,25 +98,15 @@ export function useClusterUsage(clusterId?: string) {
 	return useQuery(getClusterUsageQueryOptions(clusterId));
 }
 
-/** "Standard plan · this cycle renews Aug 12 · updated 4 minutes ago" — shared by the card + tab. */
+/** "Standard plan · renews Aug 12" — shared by the card + tab. */
 export function usageSubtitle(data: ClusterUsage): string {
 	const planName = data.regions[0]?.planName;
 	return [
 		planName ? `${planName} plan` : null,
-		data.renewsAt ? `this cycle renews ${formatCycleDate(data.renewsAt)}` : null,
-		data.asOf ? `updated ${formatAgo(data.asOf)}` : null,
+		data.renewsAt ? `renews ${formatCycleDate(data.renewsAt)}` : null,
 	].filter(Boolean).join(' · ');
 }
 
 function formatCycleDate(iso: string): string {
 	return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(iso));
-}
-
-function formatAgo(iso: string): string {
-	const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-	const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60_000);
-	if (Math.abs(minutes) < 60) { return rtf.format(-minutes, 'minute'); }
-	const hours = Math.round(minutes / 60);
-	if (Math.abs(hours) < 24) { return rtf.format(-hours, 'hour'); }
-	return rtf.format(-Math.round(hours / 24), 'day');
 }

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -28,14 +28,34 @@ export interface UsageMetrics {
 
 export type UsageMetricKey = keyof UsageMetrics;
 
+/**
+ * One throughput ceiling, in the same three states the metered values carry: a finite `value`,
+ * `unlimited` (the plan grants no ceiling), or `!known` — the endpoint couldn't determine it, rendered
+ * "—". Never a sentinel: the -1 the unlimited plans store is resolved server-side.
+ */
+export interface UsageRateLimit {
+	value: number | null;
+	unlimited: boolean;
+	known: boolean;
+}
+
+/**
+ * EFFECTIVE per-region ceilings, not a copy of the plan row: the endpoint resolves the -1 sentinel and
+ * scales the tier-dependent ceilings (reads, read bandwidth, real-time, TLS) by the region's purchased
+ * block multiplier, so these are the region's real numbers rather than one block's. `null` means the
+ * plan declares no such ceiling, and the UI drops the row instead of inventing one.
+ *
+ * A server that predates that normalization sends bare numbers here; with no `known`/`unlimited` flags
+ * to trust they render as "—", never as a real (understated) ceiling. See `rateRowsFrom`.
+ */
 export interface UsageRateLimits {
-	readsPerMinute: number | null;
-	readsPerMinuteBytes: number | null;
-	writesPerMinute: number | null;
-	writesPerMinuteBytes: number | null;
-	realTimeDeliveriesPerMinute: number | null;
-	realTimeDeliveryBytesPerMinute: number | null;
-	tlsHandshakes: number | null;
+	readsPerMinute: UsageRateLimit | null;
+	readsPerMinuteBytes: UsageRateLimit | null;
+	writesPerMinute: UsageRateLimit | null;
+	writesPerMinuteBytes: UsageRateLimit | null;
+	realTimeDeliveriesPerMinute: UsageRateLimit | null;
+	realTimeDeliveryBytesPerMinute: UsageRateLimit | null;
+	tlsHandshakes: UsageRateLimit | null;
 }
 
 export interface UsageResourcesPerInstance {
@@ -101,12 +121,21 @@ export function useClusterUsage(clusterId?: string) {
 	return useQuery(getClusterUsageQueryOptions(clusterId));
 }
 
-/** "Standard plan · renews Aug 12" — shared by the card + tab. */
+/**
+ * "Standard plan · renews Aug 12" — the cluster-wide summary line above the overview meters.
+ *
+ * Neither fact is cluster-wide unless the regions agree on it: a cluster can run a different current plan
+ * per region, and `renewsAt` is the EARLIEST expiry among the active ones. So the plan is named only when
+ * every region names the same one, and with more than one region the date is labelled "next renewal"
+ * rather than asserting the whole cluster renews then. The per-region truth is on the Usage tab.
+ */
 export function usageSubtitle(data: ClusterUsage): string {
-	const planName = data.regions[0]?.planName;
+	const { regions } = data;
+	const uniformPlanName = regions.every((r) => r.planName === regions[0]?.planName) ? regions[0]?.planName : null;
+	const renewal = regions.length > 1 ? 'next renewal' : 'renews';
 	return [
-		planName ? `${planName} plan` : null,
-		data.renewsAt ? `renews ${formatCycleDate(data.renewsAt)}` : null,
+		uniformPlanName ? `${uniformPlanName} plan` : null,
+		data.renewsAt ? `${renewal} ${formatCycleDate(data.renewsAt)}` : null,
 	].filter(Boolean).join(' · ');
 }
 

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -42,8 +42,9 @@ export interface UsageRateLimit {
 /**
  * EFFECTIVE per-region ceilings, not a copy of the plan row: the endpoint resolves the -1 sentinel and
  * scales the tier-dependent ceilings (reads, read bandwidth, real-time, TLS) by the region's purchased
- * block multiplier, so these are the region's real numbers rather than one block's. `null` means the
- * plan declares no such ceiling, and the UI drops the row instead of inventing one.
+ * block multiplier, so these are the region's real numbers rather than one block's
+ * (HarperFast/central-manager#635). `null` means the plan declares no such ceiling, and the UI drops
+ * the row instead of inventing one.
  *
  * A server that predates that normalization sends bare numbers here; with no `known`/`unlimited` flags
  * to trust they render as "—", never as a real (understated) ceiling. See `rateRowsFrom`.

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -54,13 +54,16 @@ export interface ClusterUsageRegion {
 	planName: string | null;
 	planLevel: number | null;
 	expiresAt: string | null;
-	exhausted: boolean;
+	/** active = live quota; exhausted = burned through (re-billing); lapsed = expired/not-renewed */
+	status: 'active' | 'exhausted' | 'lapsed';
 	activeBlockCount: number;
-	exhaustedBlockCount: number;
 	metrics: UsageMetrics;
 	rateLimits: UsageRateLimits | null;
 	resourcesPerInstance: UsageResourcesPerInstance | null;
 }
+
+/** Absolute consumption summed across regions — no ceiling of any kind. */
+export type UsageTotals = Record<UsageMetricKey, { used: number }>;
 
 export interface MostConstrained {
 	metric: UsageMetricKey;
@@ -75,7 +78,7 @@ export interface ClusterUsage {
 	clusterId: string;
 	selfManaged: boolean;
 	renewsAt: string | null;
-	totals: UsageMetrics | null;
+	totals: UsageTotals | null;
 	mostConstrained: MostConstrained | null;
 	regions: ClusterUsageRegion[];
 }

--- a/src/integrations/api/cluster/getClusterUsage.ts
+++ b/src/integrations/api/cluster/getClusterUsage.ts
@@ -29,15 +29,12 @@ export interface UsageMetrics {
 export type UsageMetricKey = keyof UsageMetrics;
 
 /**
- * One throughput ceiling, in the same three states the metered values carry: a finite `value`,
- * `unlimited` (the plan grants no ceiling), or `!known` — the endpoint couldn't determine it, rendered
- * "—". Never a sentinel: the -1 the unlimited plans store is resolved server-side.
+ * One throughput ceiling: a metered value minus `used`, sharing its exact three states — a finite
+ * `limit`, `unlimited` (the plan grants no ceiling), or `!limitKnown`, rendered "—". Deriving it from
+ * `UsageValue` is what lets one formatter take a metric ceiling and a rate ceiling alike. Never a
+ * sentinel: the -1 the unlimited plans store is resolved server-side.
  */
-export interface UsageRateLimit {
-	value: number | null;
-	unlimited: boolean;
-	known: boolean;
-}
+export type UsageRateLimit = Omit<UsageValue, 'used'>;
 
 /**
  * EFFECTIVE per-region ceilings, not a copy of the plan row: the endpoint resolves the -1 sentinel and
@@ -46,8 +43,8 @@ export interface UsageRateLimit {
  * (HarperFast/central-manager#635). `null` means the plan declares no such ceiling, and the UI drops
  * the row instead of inventing one.
  *
- * A server that predates that normalization sends bare numbers here; with no `known`/`unlimited` flags
- * to trust they render as "—", never as a real (understated) ceiling. See `rateRowsFrom`.
+ * A server that predates that normalization sends bare numbers here; with no `limitKnown`/`unlimited`
+ * flags to trust they render as "—", never as a real (understated) ceiling. See `rateRowsFrom`.
  */
 export interface UsageRateLimits {
 	readsPerMinute: UsageRateLimit | null;


### PR DESCRIPTION
## Cluster usage-vs-plan display (#1297)

Adds a **Plan usage** card to the managed cluster overview and a **Usage** tab, backed by the central-manager endpoint from **HarperFast/central-manager#503** (`GET /Cluster/:id/usage`, approved and merged).

Closes #1297.

### Verified against live data
The endpoint is deployed to dev + stage, and both surfaces render real cluster data (screenshots below): actual plan name and renewal date, real limits, and real storage sourced from `InstanceMonitoring`.

### Model
Quota is enforced **per region**, never cluster-wide (exhaustion, renewal, billing and the signed license ceiling are all per-region), so the UI meters per region rather than summing into one misleading bar.

### Overview card
- **Single region** → the four headline meters (Reads / Writes / Storage / Compute).
- **Multiple regions** → the single **most-constrained** region×metric, so a hot region can't hide behind an average.

### Usage tab
- One **collapsible card per region**, with status driving the header:
  - **active** → "renews {date}"
  - **exhausted** (burned through a counter cap → re-billing) → amber **"Cycle exhausted"**
  - **lapsed** (expired / not renewed, under cap) → **"No active license"**, collapsed by default
- All **8 metered metrics** as used/limit bars.
- **Rate limits** (per-minute counts *and* bandwidth) + **per-instance resources** in a single shared **"Plan limits & resources"** card when uniform across regions; per-region when they differ.
  These are the **effective per-region** ceilings, not the raw plan row: the endpoint resolves the `-1` sentinel and scales the tier-dependent ones by `Region.purchasedBlockMultiplier` (HarperFast/central-manager#635), so each reads as a number, **Unlimited**, or **"—"**.
- Region ids and plan id shown subtly (monospace, right-aligned) in the card headers.

### Meter states
Finite ceiling → used/limit bar, amber at ≥90%. Plan limit `-1` → hatched **"Unlimited"**. Unresolved plan → **"—"** (never the reassuring "Unlimited" — this is a billing surface). A zero/negative limit can't produce `NaN`/`Infinity`.

### Completeness
Cross-checked field-by-field against the new-cluster plan modal: everything it shows is here, plus used-vs-limit rather than limits alone. Only Cloud Instance Type is out of scope (needs a CM field; dedicated/GPU only).

### Tests
36 cases across the three usage surfaces (`vitest`, jsdom): the meter's three ceiling states and guards, the card's single- vs multi-region branches, its four hide conditions and its subtitle-uniformity rules, and the tab's collapse/expand, status badges, shared-vs-per-region plan info, rate-ceiling states, and empty/error/loading states. Cluster-feature suite **119 passing**, full suite **1890 passing**. `tsc`, `oxlint`, `dprint` clean.

### Depends on
HarperFast/central-manager#635 — the endpoint change that makes `rateLimits` effective per-region values. This branch degrades safely without it (ceilings render **"—"** rather than an understated per-block number), so the two can ship in either order, but real ceilings appear only once #635 is deployed.

### Follow-up
Regenerate the SDK types from #503's OpenAPI to drop the hand-typed response (works fine as-is; a regen is a large unrelated diff, so it belongs on its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

