### PR TITLE
fix(release): restore release-notes generation (pin conventional-changelog preset to v9)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   form-data: ^4.0.6
   dompurify: ^3.4.11
   js-yaml: ^4.2.0
+  conventional-changelog-conventionalcommits: ^9.3.1
   mdast-util-to-hast: ^13.2.1
 
 patchedDependencies:
@@ -3431,9 +3432,9 @@ packages:
     resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
     engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
-    engines: {node: '>=22'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.2.0:
     resolution: {integrity: sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==}
@@ -7814,7 +7815,7 @@ snapshots:
   '@commitlint/config-conventional@21.2.0':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-conventionalcommits: 10.2.1
+      conventional-changelog-conventionalcommits: 9.3.1
 
   '@commitlint/config-validator@21.2.0':
     dependencies:
@@ -10912,9 +10913,9 @@ snapshots:
     dependencies:
       '@conventional-changelog/template': 1.2.1
 
-  conventional-changelog-conventionalcommits@10.2.1:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,15 @@ overrides:
   form-data: '^4.0.6'
   dompurify: '^3.4.11'
   js-yaml: '^4.2.0'
+  # @semantic-release/release-notes-generator (latest, 14.1.1) still bundles the
+  # Handlebars-based conventional-changelog-writer@8 + conventional-commits-parser@6.
+  # It loads the `conventionalcommits` preset from the project root at runtime, and
+  # @commitlint/config-conventional@21.2.0 bumped that preset to ^10.0.0. Preset v10
+  # rewrote its templates as functions for the new @conventional-changelog/template
+  # engine (writer@9), which writer@8 can't render — so every release note collapsed
+  # to just its header line (regression first shipped in v2.131.0). Hold the preset on
+  # 9.x until release-notes-generator ships a writer@9-based major.
+  'conventional-changelog-conventionalcommits': '^9.3.1'
   mdast-util-to-hast: '^13.2.1'
 patchedDependencies:
   '@tanstack/router-core@1.171.15': patches/@tanstack__router-core@1.171.15.patch


### PR DESCRIPTION
## What broke

Every GitHub release from **v2.131.0** onward has had empty notes — just the `## [x.y.z](compare) (date)` header line, no `### Features` / `### Bug Fixes` sections. **v2.130.0** (2026-07-02) was the last good one.

## Root cause

The `conventionalcommits` preset is **not a declared dependency** of `@semantic-release/release-notes-generator` — the generator loads it from the project root at runtime, so its version floats with the rest of the tree.

Commit `2b3ed70` (*"fix(deps): update all non-major dependencies"*, in the v2.131.0 window) bumped `@commitlint/config-conventional` 21.1.0 → 21.2.0, moving its preset dep `^9.2.0` → **`^10.0.0`**. Since that's the only package declaring the preset, the whole tree jumped `conventional-changelog-conventionalcommits` **9.3.1 → 10.2.1**.

The incompatibility:
- `release-notes-generator@14.1.1` (the latest — there is no newer version) bundles the **Handlebars-based** `conventional-changelog-writer@8`.
- Preset **v9** ships its templates as Handlebars strings (`{{#each commitGroups}}…`) → writer@8 renders them fine.
- Preset **v10** rewrote those templates as **JS functions** for the new `@conventional-changelog/template` engine (meant for writer@9). Fed to writer@8, only the header survives — every commit group renders empty.

Reproduced both sides against the exact `.releaserc.json` config and real commits: preset v10 → header only; preset v9 → fully categorized.

## The fix

A single pnpm override in `pnpm-workspace.yaml` — same pattern as the existing `jsdom>undici` pin, holding a transitive dep back until the consumer catches up:

```yaml
'conventional-changelog-conventionalcommits': '^9.3.1'
```

Verified: lockfile now resolves **only 9.3.1** (no v10); an isolated run with the locked combo produces correct categorized notes; and `@commitlint/config-conventional@21.2.0` still lints correctly on preset v9 (it only uses the preset's stable `parserOpts`). Takes effect on the next release via `pnpm release` in `deploy-stage.yaml`.

## Also done (outside this diff)

Backfilled the notes for all **57 already-published releases** (v2.131.0 → v2.154.4) by regenerating from each tag range with the fixed v9 preset and splicing the sections under the original header (preserving real release dates).

## Watch out
- **Renovate** will retry bumping `@commitlint/config-conventional` (dragging the preset to v10). The override holds it; don't drop the pin until `release-notes-generator` ships a `writer@9`-based major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)