### PR TITLE
fix(polling): stop 10s polls once the endpoint answers 403

### DIFF
--- a/src/features/cluster/domains/queries/getChallengeCertificates.ts
+++ b/src/features/cluster/domains/queries/getChallengeCertificates.ts
@@ -1,5 +1,6 @@
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getSearchByValue } from '@/integrations/api/instance/database/getSearchByValue';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
 export interface ChallengeCertificate {
@@ -31,7 +32,10 @@ export function getChallengeCertificatesQueryOptions(clusterId?: string) {
 			return data;
 		},
 		enabled: !!clusterId,
-		refetchInterval: 5000,
+		// Same always-on shape as the 10s pollers: gated only on `clusterId`, so a
+		// user without access to the cluster's data 403s every 5s until they navigate.
+		refetchInterval: pollUnlessForbidden(5000),
+		retry: retryUnlessForbidden(),
 	});
 }
 

--- a/src/features/cluster/queries/getClusterInfoQuery.test.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.test.ts
@@ -1,0 +1,43 @@
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { getClusterInfoQueryOptions } from './getClusterInfoQuery';
+
+/** The subset of `Query` the `refetchInterval` callback reads. */
+type ErrorStateQuery = { state: { error: unknown } };
+
+function axiosErrorWithStatus(status: number): AxiosError {
+	const err = new AxiosError(`Request failed with status code ${status}`);
+	err.response = { status } as AxiosError['response'];
+	return err;
+}
+
+function resolveInterval(refetch: boolean | number | undefined, error: unknown) {
+	const { refetchInterval } = getClusterInfoQueryOptions('clu-test', refetch);
+	expect(typeof refetchInterval).toBe('function');
+	const resolve = refetchInterval as unknown as (q: ErrorStateQuery) => number | false;
+	return resolve({ state: { error } });
+}
+
+describe('getClusterInfoQueryOptions polling', () => {
+	it('defaults to a 10s poll when refetch is true', () => {
+		expect(resolveInterval(true, null)).toBe(10_000);
+	});
+
+	it('honors an explicit interval', () => {
+		expect(resolveInterval(2_000, null)).toBe(2_000);
+	});
+
+	it('does not poll when refetch is omitted', () => {
+		expect(resolveInterval(undefined, null)).toBe(false);
+	});
+
+	it('stops polling after a 403 rather than retrying every 10s (RUM 2026-07-27)', () => {
+		// One session emitted 349 doomed GET /Cluster/{id} requests in ~58 minutes.
+		expect(resolveInterval(true, axiosErrorWithStatus(403))).toBe(false);
+	});
+
+	it('keeps polling after a recoverable failure', () => {
+		expect(resolveInterval(true, axiosErrorWithStatus(500))).toBe(10_000);
+		expect(resolveInterval(true, new Error('Network Error'))).toBe(10_000);
+	});
+});

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/config/apiClient';
 import { Cluster } from '@/integrations/api/api.patch';
+import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export async function getClusterInfo(clusterId: string) {
@@ -14,10 +15,14 @@ export function getClusterInfoQueryOptions(clusterId?: string | false, refetch?:
 		retry: false,
 		staleTime: 1_900,
 		enabled: !!clusterId,
-		refetchInterval: refetch
-			? refetch === true
-				? 10_000
-				: refetch
-			: undefined,
+		// A cluster the user can't read answers 403 on every poll — stop the timer
+		// rather than retrying it every 10s for the life of the page.
+		refetchInterval: pollUnlessForbidden(
+			refetch
+				? refetch === true
+					? 10_000
+					: refetch
+				: undefined,
+		),
 	});
 }

--- a/src/features/organization/queries/getOrganizationQuery.ts
+++ b/src/features/organization/queries/getOrganizationQuery.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/config/apiClient';
 import { Organization } from '@/integrations/api/api.patch';
+import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 // `useParams({ strict: false })` can yield `undefined`, and a navigation that
@@ -25,8 +26,10 @@ export function getOrganizationQueryOptions(orgId: string | undefined) {
 	return queryOptions({
 		queryKey: [orgId],
 		queryFn: () => getOrganization(orgId as string),
+		// `retry: false` already surfaces the error on the first failure, so the poll
+		// wrapper below sees a 403 immediately — no `retryUnlessForbidden` needed.
 		retry: false,
 		enabled: isValidOrganizationId(orgId),
-		refetchInterval: 10000,
+		refetchInterval: pollUnlessForbidden(10000),
 	});
 }

--- a/src/features/organization/queries/getOrganizationRoleInfo.ts
+++ b/src/features/organization/queries/getOrganizationRoleInfo.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/config/apiClient';
 import { SchemaRole } from '@/integrations/api/api.gen';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export interface GetOrganizationRoleInfoResponse extends SchemaRole {
@@ -17,7 +18,8 @@ export function getOrganizationRoleInfoQueryOptions({
 	return queryOptions({
 		queryKey: [organizationId, 'roles', roleId] as const,
 		queryFn: () => getOrganizationRoleInfo(roleId),
-		refetchInterval: 10 * 1000,
+		refetchInterval: pollUnlessForbidden(10 * 1000),
+		retry: retryUnlessForbidden(),
 	});
 }
 

--- a/src/features/organization/queries/getOrganizationRoles.ts
+++ b/src/features/organization/queries/getOrganizationRoles.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/config/apiClient';
 import { SchemaOrganizationRole } from '@/integrations/api/api.gen';
+import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 async function getOrganizationRoles(organizationId: string): Promise<SchemaOrganizationRole[]> {
@@ -11,7 +12,9 @@ export function getOrganizationRolesQueryOptions(organizationId: string) {
 	return queryOptions({
 		queryKey: [organizationId, 'roles'],
 		queryFn: () => getOrganizationRoles(organizationId),
+		// `retry: false` surfaces the error immediately, so the wrapper sees a 403 on
+		// the first failure without a `retryUnlessForbidden` predicate.
 		retry: false,
-		refetchInterval: 10 * 1000, // 10 seconds
+		refetchInterval: pollUnlessForbidden(10 * 1000), // 10 seconds, until a 403
 	});
 }

--- a/src/integrations/api/instance/auth/getListRoles.ts
+++ b/src/integrations/api/instance/auth/getListRoles.ts
@@ -1,12 +1,15 @@
 import { InstanceClientConfig, InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { LocalRole } from '@/integrations/api/api.patch';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export function getListRolesQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
 		queryKey: [entityId, 'list_roles'] as const,
 		queryFn: () => getListRoles({ instanceClient }),
-		refetchInterval: 10_000,
+		// Superuser-only like `list_users` above — the same 403-forever shape.
+		refetchInterval: pollUnlessForbidden(10_000),
+		retry: retryUnlessForbidden(),
 	});
 }
 

--- a/src/integrations/api/instance/auth/getListUsers.ts
+++ b/src/integrations/api/instance/auth/getListUsers.ts
@@ -1,12 +1,16 @@
 import { InstanceClientConfig, InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { LocalUser } from '@/integrations/api/api.patch';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export function getListUsersQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
 	return queryOptions({
 		queryKey: [entityId, 'list_users'] as const,
 		queryFn: () => getListUsers({ instanceClient }),
-		refetchInterval: 10_000,
+		// `list_users` is a superuser-only operation, so a read-only member sitting on
+		// the Users tab 403s on every tick — stop rather than poll it forever.
+		refetchInterval: pollUnlessForbidden(10_000),
+		retry: retryUnlessForbidden(),
 	});
 }
 

--- a/src/integrations/api/instance/ssh/getSSHKey.ts
+++ b/src/integrations/api/instance/ssh/getSSHKey.ts
@@ -1,4 +1,5 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 interface GetSSHKeyFormData extends InstanceClientIdConfig {
@@ -24,6 +25,7 @@ export function getSSHKeyQueryOptions(params: GetSSHKeyFormData) {
 	return queryOptions({
 		queryKey: [params.entityId, 'get_ssh_key', params.name] as const,
 		queryFn: () => getSSHKey(params),
-		refetchInterval: 10_000,
+		refetchInterval: pollUnlessForbidden(10_000),
+		retry: retryUnlessForbidden(),
 	});
 }

--- a/src/integrations/api/instance/status/getStatus.test.ts
+++ b/src/integrations/api/instance/status/getStatus.test.ts
@@ -6,6 +6,12 @@ import { getStatusQueryOptions, getSystemStatusById } from './getStatus';
 /** The subset of `Query` the `refetchInterval` callback reads. */
 type ErrorStateQuery = { state: { error: unknown } };
 
+function httpError(status: number): AxiosError {
+	const err = new AxiosError(`Request failed with status code ${status}`);
+	err.response = { status } as AxiosError['response'];
+	return err;
+}
+
 describe('getStatusQueryOptions polling', () => {
 	function refetchIntervalFor(error: unknown) {
 		const { refetchInterval } = getStatusQueryOptions({
@@ -18,11 +24,7 @@ describe('getStatusQueryOptions polling', () => {
 		return resolve({ state: { error } });
 	}
 
-	function axiosErrorWithStatus(status: number): AxiosError {
-		const err = new AxiosError(`Request failed with status code ${status}`);
-		err.response = { status } as AxiosError['response'];
-		return err;
-	}
+	const axiosErrorWithStatus = httpError;
 
 	it('polls every 10s while healthy', () => {
 		expect(refetchIntervalFor(null)).toBe(10_000);

--- a/src/integrations/api/instance/status/getStatus.test.ts
+++ b/src/integrations/api/instance/status/getStatus.test.ts
@@ -1,5 +1,41 @@
+import type { AxiosInstance } from 'axios';
+import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
-import { getSystemStatusById } from './getStatus';
+import { getStatusQueryOptions, getSystemStatusById } from './getStatus';
+
+/** The subset of `Query` the `refetchInterval` callback reads. */
+type ErrorStateQuery = { state: { error: unknown } };
+
+describe('getStatusQueryOptions polling', () => {
+	function refetchIntervalFor(error: unknown) {
+		const { refetchInterval } = getStatusQueryOptions({
+			entityId: 'ins-test' as never,
+			instanceClient: {} as AxiosInstance,
+		}, true);
+		// The option is a function so it can consult the query's error state.
+		expect(typeof refetchInterval).toBe('function');
+		const resolve = refetchInterval as unknown as (q: ErrorStateQuery) => number | false;
+		return resolve({ state: { error } });
+	}
+
+	function axiosErrorWithStatus(status: number): AxiosError {
+		const err = new AxiosError(`Request failed with status code ${status}`);
+		err.response = { status } as AxiosError['response'];
+		return err;
+	}
+
+	it('polls every 10s while healthy', () => {
+		expect(refetchIntervalFor(null)).toBe(10_000);
+	});
+
+	it('stops polling after a 403 so it cannot loop forever (RUM 2026-07-27)', () => {
+		expect(refetchIntervalFor(axiosErrorWithStatus(403))).toBe(false);
+	});
+
+	it('keeps polling after a recoverable 5xx', () => {
+		expect(refetchIntervalFor(axiosErrorWithStatus(503))).toBe(10_000);
+	});
+});
 
 describe('getSystemStatusById', () => {
 	it('returns the status for a given id when it exists', () => {

--- a/src/integrations/api/instance/status/getStatus.ts
+++ b/src/integrations/api/instance/status/getStatus.ts
@@ -1,5 +1,5 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
-import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export interface SystemStatus {
@@ -46,6 +46,10 @@ export function getStatusQueryOptions({ entityId, instanceClient }: InstanceClie
 		// timer instead of re-asking every 10s (one such row emitted 348 doomed
 		// requests in under an hour).
 		refetchInterval: pollUnlessForbidden(10_000),
+		// Without this the default `retry: 3` would swallow the first three 403s into
+		// `failureReason`, so the poll above could not stop until ~30s (and 3 more
+		// doomed requests) later, given the 10s retryDelay.
+		retry: retryUnlessForbidden(),
 		retryDelay: 10_000,
 		throwOnError: false,
 		enabled,

--- a/src/integrations/api/instance/status/getStatus.ts
+++ b/src/integrations/api/instance/status/getStatus.ts
@@ -1,4 +1,5 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
+import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export interface SystemStatus {
@@ -41,7 +42,10 @@ export function getStatusQueryOptions({ entityId, instanceClient }: InstanceClie
 	return queryOptions({
 		queryKey: ['get_status', entityId] as const,
 		staleTime: 9_000,
-		refetchInterval: 10_000,
+		// An instance the user can't operate answers 403 on every poll — stop the
+		// timer instead of re-asking every 10s (one such row emitted 348 doomed
+		// requests in under an hour).
+		refetchInterval: pollUnlessForbidden(10_000),
 		retryDelay: 10_000,
 		throwOnError: false,
 		enabled,

--- a/src/react-query/pollUnlessForbidden.integration.test.ts
+++ b/src/react-query/pollUnlessForbidden.integration.test.ts
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+import { getStatusQueryOptions } from '@/integrations/api/instance/status/getStatus';
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+import { AxiosError } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * End-to-end against a REAL QueryClient, driving the real `getStatusQueryOptions`.
+ *
+ * The unit tests next to each query prove the predicate returns the right number;
+ * they cannot prove React Query ever consults it. This file pins the three behaviors
+ * the fix actually rests on:
+ *   1. a 403 halts the poll timer (and the retries that would delay it),
+ *   2. a transient 5xx does NOT halt it, and
+ *   3. a later success re-arms it — so "stopped" never means "dead until reload".
+ *
+ * jsdom is REQUIRED, not incidental. query-core computes
+ * `isServer = typeof window === 'undefined'`, and `QueryObserver#updateRefetchInterval`
+ * returns before `setInterval` when `isServer()` is true. Under vitest's default node
+ * environment no interval is ever armed, so every polling assertion passes vacuously —
+ * a 5xx test "keeping polling" would actually just be counting retries.
+ */
+describe('poll-stops-on-403, end to end', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		queryClient = new QueryClient();
+	});
+
+	afterEach(() => {
+		queryClient.clear();
+		vi.useRealTimers();
+	});
+
+	function httpError(status: number): AxiosError {
+		const err = new AxiosError(`Request failed with status code ${status}`);
+		err.response = { status } as AxiosError['response'];
+		return err;
+	}
+
+	const okStatus = { data: { systemStatus: [], restartRequired: false, componentStatus: [] } };
+
+	/** Subscribe an observer to the real production query options. */
+	function observe(post: ReturnType<typeof vi.fn>) {
+		const observer = new QueryObserver(
+			queryClient,
+			getStatusQueryOptions(
+				{ entityId: 'ins-test' as never, instanceClient: { post } as unknown as AxiosInstance },
+				true,
+			),
+		);
+		return { observer, unsubscribe: observer.subscribe(() => {}) };
+	}
+
+	it('polls on a 10s timer while healthy (guards the jsdom requirement above)', async () => {
+		const post = vi.fn().mockResolvedValue(okStatus);
+		const { unsubscribe } = observe(post);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// 1 mount fetch + ~6 polls. If this ever drops to 1, the environment stopped
+		// arming intervals and every other assertion here is vacuous.
+		expect(post.mock.calls.length).toBeGreaterThan(4);
+		unsubscribe();
+	});
+
+	it('makes exactly one request on a 403 — no retries, no further polls', async () => {
+		const post = vi.fn().mockRejectedValue(httpError(403));
+		const { unsubscribe } = observe(post);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// Without `retryUnlessForbidden` the default retry: 3 would fire 3 doomed
+		// requests before the timer could even see the error; without
+		// `pollUnlessForbidden` it would then poll for as long as the page is open.
+		expect(post).toHaveBeenCalledTimes(1);
+		unsubscribe();
+	});
+
+	it('keeps polling through a transient 5xx so the UI self-heals', async () => {
+		const post = vi.fn().mockRejectedValue(httpError(503));
+		const { unsubscribe } = observe(post);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// Retries alone would cap at 3; anything beyond that is the poll timer still running.
+		expect(post.mock.calls.length).toBeGreaterThan(3);
+		unsubscribe();
+	});
+
+	it('re-arms the timer once access is restored', async () => {
+		const post = vi.fn().mockRejectedValue(httpError(403));
+		const { observer, unsubscribe } = observe(post);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(post).toHaveBeenCalledTimes(1);
+
+		// What a window-focus or remount refetch does after permissions are granted.
+		post.mockResolvedValue(okStatus);
+		await observer.refetch();
+		const afterRecovery = post.mock.calls.length;
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		expect(post.mock.calls.length).toBeGreaterThan(afterRecovery);
+		unsubscribe();
+	});
+});

--- a/src/react-query/pollUnlessForbidden.test.ts
+++ b/src/react-query/pollUnlessForbidden.test.ts
@@ -1,0 +1,64 @@
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { isForbiddenError, pollUnlessForbidden } from './pollUnlessForbidden';
+
+/** Minimal stand-in for the `query` argument `refetchInterval` receives — the
+ *  wrapper only ever reads `state.error`. */
+function queryWithError(error: unknown) {
+	return { state: { error } };
+}
+
+function axiosErrorWithStatus(status: number): AxiosError {
+	const err = new AxiosError(`Request failed with status code ${status}`);
+	err.response = { status } as AxiosError['response'];
+	return err;
+}
+
+describe('isForbiddenError', () => {
+	it('detects an axios 403', () => {
+		expect(isForbiddenError(axiosErrorWithStatus(403))).toBe(true);
+	});
+
+	it('detects a bare { status } shape', () => {
+		expect(isForbiddenError({ status: 403 })).toBe(true);
+	});
+
+	it('is false for other statuses, including 401', () => {
+		expect(isForbiddenError(axiosErrorWithStatus(401))).toBe(false);
+		expect(isForbiddenError(axiosErrorWithStatus(500))).toBe(false);
+	});
+
+	it('is false for non-HTTP errors and nullish input', () => {
+		expect(isForbiddenError(new Error('Network Error'))).toBe(false);
+		expect(isForbiddenError(null)).toBe(false);
+		expect(isForbiddenError(undefined)).toBe(false);
+	});
+});
+
+describe('pollUnlessForbidden', () => {
+	it('keeps the interval while the query is healthy', () => {
+		expect(pollUnlessForbidden(10_000)(queryWithError(null))).toBe(10_000);
+	});
+
+	it('stops polling once the query errors with 403', () => {
+		expect(pollUnlessForbidden(10_000)(queryWithError(axiosErrorWithStatus(403)))).toBe(false);
+	});
+
+	it('keeps polling through transient failures so the UI self-heals', () => {
+		// 5xx / network / 401 are recoverable states (instance restarting, session
+		// re-established) — only a 403 is stable enough to stop on.
+		for (const status of [401, 500, 502, 503]) {
+			expect(pollUnlessForbidden(10_000)(queryWithError(axiosErrorWithStatus(status)))).toBe(10_000);
+		}
+		expect(pollUnlessForbidden(10_000)(queryWithError(new Error('Network Error')))).toBe(10_000);
+	});
+
+	it('normalizes a disabled interval to false', () => {
+		expect(pollUnlessForbidden(undefined)(queryWithError(null))).toBe(false);
+		expect(pollUnlessForbidden(false)(queryWithError(null))).toBe(false);
+	});
+
+	it('preserves a custom (non-10s) interval', () => {
+		expect(pollUnlessForbidden(2_000)(queryWithError(null))).toBe(2_000);
+	});
+});

--- a/src/react-query/pollUnlessForbidden.test.ts
+++ b/src/react-query/pollUnlessForbidden.test.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
-import { isForbiddenError, pollUnlessForbidden } from './pollUnlessForbidden';
+import { isForbiddenError, pollUnlessForbidden, retryUnlessForbidden } from './pollUnlessForbidden';
 
 /** Minimal stand-in for the `query` argument `refetchInterval` receives — the
  *  wrapper only ever reads `state.error`. */
@@ -60,5 +60,30 @@ describe('pollUnlessForbidden', () => {
 
 	it('preserves a custom (non-10s) interval', () => {
 		expect(pollUnlessForbidden(2_000)(queryWithError(null))).toBe(2_000);
+	});
+});
+
+describe('retryUnlessForbidden', () => {
+	it('never retries a 403', () => {
+		// Without this the 403 sits in `failureReason` for three more requests and
+		// `pollUnlessForbidden` cannot see it until ~30s later.
+		expect(retryUnlessForbidden()(1, axiosErrorWithStatus(403))).toBe(false);
+	});
+
+	it('matches the default retry: 3 budget for transient failures', () => {
+		const retry = retryUnlessForbidden();
+		expect(retry(1, axiosErrorWithStatus(503))).toBe(true);
+		expect(retry(2, axiosErrorWithStatus(503))).toBe(true);
+		expect(retry(3, axiosErrorWithStatus(503))).toBe(false);
+	});
+
+	it('still retries a 401, which the auth layer resolves by re-authenticating', () => {
+		expect(retryUnlessForbidden()(1, axiosErrorWithStatus(401))).toBe(true);
+	});
+
+	it('honors a custom retry budget', () => {
+		const retry = retryUnlessForbidden(1);
+		expect(retry(0, new Error('Network Error'))).toBe(true);
+		expect(retry(1, new Error('Network Error'))).toBe(false);
 	});
 });

--- a/src/react-query/pollUnlessForbidden.ts
+++ b/src/react-query/pollUnlessForbidden.ts
@@ -45,3 +45,20 @@ export function isForbiddenError(err: unknown): boolean {
 export function pollUnlessForbidden(interval: number | false | undefined) {
 	return (query: QueryErrorState) => (isForbiddenError(query.state.error) ? false : (interval ?? false));
 }
+
+/**
+ * `retry` predicate that gives up immediately on 403 but otherwise keeps React
+ * Query's default retry count.
+ *
+ * Needed to make `pollUnlessForbidden` engage on the FIRST 403. `state.error` is
+ * only populated once retries are exhausted (until then the failure lives in
+ * `failureReason`), so on a query left at the default `retry: 3` the poll timer
+ * cannot see the 403 until three more doomed requests have gone out — ~30s later
+ * on a query that also sets `retryDelay: 10_000`.
+ *
+ * `failureCount < maxRetries` is exactly the semantics of the numeric form
+ * (`retry: 3`), so transient failures keep the retry behavior they had before.
+ */
+export function retryUnlessForbidden(maxRetries = 3) {
+	return (failureCount: number, error: unknown) => !isForbiddenError(error) && failureCount < maxRetries;
+}

--- a/src/react-query/pollUnlessForbidden.ts
+++ b/src/react-query/pollUnlessForbidden.ts
@@ -1,0 +1,47 @@
+/** The only part of React Query's `Query` this wrapper reads. Typed structurally
+ *  (rather than as `Query`) because `Query` is invariant in its data type, so a
+ *  concrete `Query<StatusResponse, …>` will not accept a `(query: Query) => …`
+ *  callback. A supertype parameter accepts every instantiation. */
+interface QueryErrorState {
+	state: { error: unknown };
+}
+
+/** HTTP status off an axios-style error, tolerating both the axios shape
+ *  (`error.response.status`) and a bare `{ status }`. */
+function errorStatus(err: unknown): number | undefined {
+	return (err as { response?: { status?: number } })?.response?.status
+		?? (err as { status?: number })?.status;
+}
+
+/** A 403 means the caller is authenticated but not permitted on this resource.
+ *  Unlike a 401 (session lost — the auth layer clears auth and redirects), a 403
+ *  is stable: the same request will keep failing until permissions change, so
+ *  repeating it is pure waste. */
+export function isForbiddenError(err: unknown): boolean {
+	return errorStatus(err) === 403;
+}
+
+/**
+ * Wrap a fixed poll interval so polling STOPS once the endpoint answers 403.
+ *
+ * `refetchInterval` fires on a timer regardless of the query's error state, so a
+ * poll against a resource the user may not touch retries forever. On 2026-07-27 a
+ * single session sat on `/$organizationId/$clusterId/instances/` for ~58 minutes
+ * while three 10s polls — `GET /Cluster/{id}` and `POST /HDBInstance/{id}/operation`
+ * for two instances — all 403'd: ~1,045 doomed requests and 525 handled errors, each
+ * one a `console.error` + a toast through the global React Query error handler
+ * (`queryClient.ts`). That one session was 525 of the 526 403s Studio reported to RUM
+ * that day. 403s are deliberately kept in RUM (see `shouldKeepEvent`), so an
+ * unbounded 403 poll also drowns real signal in Error Tracking.
+ *
+ * Stopping is not permanent: returning `false` only cancels the *timer*. The query
+ * still refetches on remount and on window focus (`refetchOnWindowFocus` defaults to
+ * true), so if the user is granted access the UI recovers on their next interaction
+ * without a reload — it just no longer hammers the endpoint in the background.
+ *
+ * Only 403 stops the timer. 5xx, network failures, and timeouts are transient
+ * (instance restarting, unreachable) and should keep polling so the UI self-heals.
+ */
+export function pollUnlessForbidden(interval: number | false | undefined) {
+	return (query: QueryErrorState) => (isForbiddenError(query.state.error) ? false : (interval ?? false));
+}

--- a/src/react-query/queryClient.test.ts
+++ b/src/react-query/queryClient.test.ts
@@ -182,4 +182,29 @@ describe('errorHandler', () => {
 			expect.objectContaining({ description: '{"code":500}' }),
 		);
 	});
+
+	it('collapses repeated 403s onto one toast id (RUM 2026-07-27)', () => {
+		const forbidden = {
+			response: { status: 403, data: 'Forbidden' },
+		} as AxiosError<string>;
+
+		errorHandler(forbidden);
+		errorHandler(forbidden);
+
+		// A stable id means sonner replaces the toast instead of stacking — one
+		// session produced 525 of these in under an hour before polling was capped.
+		expect(toast.error).toHaveBeenCalledTimes(2);
+		for (const call of (toast.error as unknown as { mock: { calls: unknown[][] } }).mock.calls) {
+			expect(call[1]).toEqual(expect.objectContaining({ id: 'request-forbidden' }));
+		}
+	});
+
+	it('leaves non-403, non-timeout errors un-collapsed so distinct failures all show', () => {
+		errorHandler({ response: { status: 500, data: 'Server Error' } } as AxiosError<string>);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			'Error',
+			expect.objectContaining({ id: undefined }),
+		);
+	});
 });

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -35,8 +35,13 @@ export function errorHandler(rawErr: unknown) {
 	// queries can timeout in parallel and stack up identical toasts; collapse
 	// them onto a single id so the user sees one instead of a wall.
 	const isTimeout = axiosWrappedErr?.code === 'ECONNABORTED' || axiosWrappedErr?.code === 'ETIMEDOUT';
+	// Same collapse for 403s. `pollUnlessForbidden` stops polls that 403, but other
+	// repeat sources remain (route preloads and background queries firing while
+	// signed out, #1546), and a permission failure repeated N times is still one
+	// thing for the user to know.
+	const isForbidden = axiosWrappedErr?.response?.status === 403;
 	toast.error(errorTitle, {
-		id: isTimeout ? 'request-timeout' : undefined,
+		id: isTimeout ? 'request-timeout' : isForbidden ? 'request-forbidden' : undefined,
 		description: errorMsg,
 		action: {
 			label: 'Dismiss',


### PR DESCRIPTION
## Summary

Datadog RUM for the last 24h (2026-07-27) shows handled `AxiosError: Request failed with status code 403` at **526 events, up from 133** the prior 24h. **525 of the 526 came from a single session** — not a fleet-wide regression, but it exposes a real defect: **a poll that 403s never stops.**

That session sat on `/$organizationId/$clusterId/instances/` for a cluster it lacks permission on. Three 10s polls ran side by side and every tick 403'd, for ~58 minutes:

| Endpoint | 403 responses | Source |
| --- | --- | --- |
| `GET /Cluster/{clusterId}` | 349 | `Instances.tsx` → `getClusterInfoQueryOptions(clusterId, true)` |
| `POST /HDBInstance/{id}/operation` | 348 | `InstanceStatusCell.tsx` → `getStatusQueryOptions` |
| `POST /HDBInstance/{id}/operation` (2nd row) | 348 | same, second instance row |

**~1,045 requests that could never succeed**, at a measured median interval of 10.2s.

## Root cause

`refetchInterval` fires on a timer regardless of the query's error state. A 403 is *stable* — unlike a 401 (session lost; the auth layer clears auth and redirects, and `unauthorizedResponseHandler` deliberately leaves 403 alone), a 403 means "authenticated but not permitted" and will keep failing until permissions change. Nothing broke the loop.

Each failure also hit the global React Query error handler in `queryClient.ts`, which does `console.error` **and** `toast.error` — so that session generated **525 console errors and 525 toasts**. The console errors are what reach RUM, and `shouldKeepEvent` deliberately does *not* drop 403s (they usually indicate a UI bug worth seeing, per #1386), so an unbounded 403 poll drowns real signal in Error Tracking.

## Fix

Two small helpers in `src/react-query/pollUnlessForbidden.ts`:

- **`pollUnlessForbidden(interval)`** wraps a fixed `refetchInterval` so the timer stops once the query's last error is a 403.
- **`retryUnlessForbidden(max = 3)`** rejects a 403 immediately while keeping `failureCount < 3` for everything else. Without it `state.error` stays empty until retries are exhausted, so the poll timer could not see a 403 until three more doomed requests had gone out — ~30s later on a query that also sets `retryDelay: 10_000`.

Applied to every **always-on** poller (the original two plus the rest, after review):

| Query | Interval | Wrapper |
| --- | --- | --- |
| `getClusterInfoQuery` | 10s | poll (already `retry: false`) |
| `getStatus` | 10s | poll + retry |
| `getListUsers` / `getListRoles` | 10s | poll + retry |
| `getSSHKey` | 10s | poll + retry |
| `getOrganizationRoleInfo` | 10s | poll + retry |
| `getOrganizationQuery` / `getOrganizationRoles` | 10s | poll (already `retry: false`) |
| `getChallengeCertificates` | 5s | poll + retry |

Deliberately narrow:

- **Only 403 stops the timer.** 5xx, network failures, and timeouts stay on the poll so the UI still self-heals when an instance is restarting or briefly unreachable.
- **Stopping is not permanent.** Returning `false` cancels only the *timer*; `refetchOnWindowFocus` (default true) and remount still refetch. A user granted access recovers on their next interaction, no reload. This is now asserted, not just documented.
- **`getInstanceHealth` is left alone** — it swallows errors into a boolean, so `state.error` is always null and the wrapper would be a no-op. Other unwrapped `refetchInterval`s are conditional or self-terminating (`getReadLog`, `listDeployments`, `getDeployment`, `useGetStripeInvoices`).

Also collapses repeated 403 toasts onto a single sonner id, matching the existing timeout collapse in the same function.

## Not a duplicate

- **#1546** — signed-*out* requests firing on `/` and `/sign-in`. Its proposed fix (gate queries on an authenticated session) does **not** cover this: here the user *is* authenticated and simply lacks permission on that cluster. This PR is the missing backoff half.
- **#1386** (closed) — same Datadog fingerprint group, but was resolved by *filtering telemetry* (`shouldKeepEvent` drops 401s), not by changing polling behavior. Its own suggestion #2 — "consider whether instances in a terminal/broken state should have polling stopped" — is what this PR finally implements, for the 403 case.
- **#1527** — 500s on the same endpoints; explicitly left polling, per above.

## Testing

- `pollUnlessForbidden.test.ts` — both predicates across 403 / 401 / 5xx / network / custom budgets.
- Call-site regression tests in `getClusterInfoQuery.test.ts` and `getStatus.test.ts`, so the wiring can't silently regress if someone reverts `refetchInterval` to a bare number.
- **`pollUnlessForbidden.integration.test.ts`** — a real `QueryClient` + `QueryObserver` with fake timers, driving the real `getStatusQueryOptions`. Writing this surfaced a trap worth knowing about: query-core computes `isServer = typeof window === 'undefined'`, and `QueryObserver#updateRefetchInterval` returns **before** `setInterval` when that is true. Under vitest's default **node** environment no interval is ever armed, so any polling assertion there passes vacuously — a "keeps polling on 5xx" test written in node is really just counting retries. The file is jsdom and carries a canary test that fails if intervals stop being armed. Mutation-checked: reverting the fix turns the 403 case from 1 request into 7.
- Toast-collapse tests in `queryClient.test.ts`.
- Full suite: **1,820 passed, 11 skipped**; `tsc -b`, `oxlint`, and `dprint check` all clean.

Not browser-verified: reproducing it needs an account lacking permission on a cluster that still renders the instances page. Verification is mechanism-level, now including real React Query timer behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
