### PR TITLE
fix(editor): stop sending non-package strings to jsDelivr from type acquisition

### DIFF
--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -43,8 +43,21 @@ describe('findAcquirableSpecifiers', () => {
 			['line comment between the clause and `from`', `import { useState } // why\nfrom 'react'`],
 			['comment before a type modifier', `import /* types only */ type { FC } from 'react'`],
 			['CRLF line endings around a comment', "import {\r\n\tuseState, // hooks\r\n} from 'react'"],
+			['multi-line jsdoc inside a named block', `import {\n\ta,\n\t/**\n\t * why\n\t */\n\tuseState,\n} from 'react'`],
 		])('%s', (_label, code) => {
 			expect(findAcquirableSpecifiers(code)).toEqual(['react']);
+		});
+
+		// The clause is bounded so a failed match stays cheap (see MAX_IMPORT_CLAUSE).
+		// The bound has to clear real code by a wide margin: the longest clause in this
+		// repo is 351 chars, and the longest across ~13k `node_modules` declaration
+		// files is a 1.6 KB barrel re-export, which is the shape measured here.
+		it('resolves a barrel re-export far larger than any in node_modules', () => {
+			const names = Array.from({ length: 200 }, (_, i) => `exportedName${i}`).join(', ');
+			const code = `export { ${names} } from './route.js'`;
+			expect(code.length).toBeGreaterThan(2800);
+			expect(findAcquirableSpecifiers(code)).toEqual([]); // relative, but it must still parse
+			expect(findAcquirableSpecifiers(`export { ${names} } from 'lodash'`)).toEqual(['lodash']);
 		});
 
 		it('finds every import in a realistic Harper resource file', () => {
@@ -158,6 +171,42 @@ describe('findAcquirableSpecifiers', () => {
 
 		it('still allows legacy mixed-case package names', () => {
 			expect(findAcquirableSpecifiers(`import JSONStream from 'JSONStream'`)).toEqual(['JSONStream']);
+		});
+	});
+
+	// The clause match is lazy, so an attempt that can never succeed walks toward
+	// end-of-input — and every later `import`/`export` walks it again. That is
+	// quadratic, and it runs on the main thread: `acquireApplicationTypes` scans every
+	// project script joined together, and ata re-scans every downloaded `.d.ts`.
+	// Neither needs a hostile file, just an unterminated comment from a mid-edit save
+	// or a truncated CDN response.
+	//
+	// Wall-clock assertions, because the bound in the scanner is the only thing that
+	// makes these finish. Measured on these exact inputs: every case lands in
+	// 218-305ms bounded, against 7.5s-22s with the bound removed — so the budget below
+	// leaves ~10x headroom for a slow machine while still being an order of magnitude
+	// under the regression it exists to catch. The last two shapes need no comments at
+	// all; they were already quadratic before comments were admitted, at ~2.5s.
+	const LINEAR_SCAN_BUDGET_MS = 3000;
+
+	describe('stays linear on input no match can consume', () => {
+		it.each([
+			['unterminated block comment', 'import /* unterminated\n'.repeat(32_000)],
+			['unterminated block comment, no newlines', 'import /* unterminated '.repeat(32_000)],
+			['line comment at the end of a truncated file', 'import a\n'.repeat(32_000) + 'import // truncated'],
+			['a long run of clause-legal characters', 'import a '.repeat(32_000)],
+		])('%s', (_label, code) => {
+			expect(code.length).toBeGreaterThan(250_000);
+			const startedAt = performance.now();
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
+		});
+
+		it('still finds every import in a file of that size that does match', () => {
+			const code = `import { a } from 'react'\n`.repeat(32_000);
+			const startedAt = performance.now();
+			expect(findAcquirableSpecifiers(code)).toHaveLength(32_000);
+			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
 		});
 	});
 });

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -208,5 +208,23 @@ describe('findAcquirableSpecifiers', () => {
 			expect(findAcquirableSpecifiers(code)).toHaveLength(32_000);
 			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
 		});
+
+		// Every comment below is large and properly terminated, so nothing here is
+		// malformed — the clause just never resolves. Expressing it as a bounded
+		// quantifier made this throw `RangeError: Maximum call stack size exceeded`,
+		// because V8 accumulated a backtracking frame per repetition. Anything that
+		// throws out of the scanner aborts acquisition for every source in the pass, so
+		// these assert a return value rather than merely "does not hang".
+		it.each([
+			['a long run of large terminated comments', 1400, ' nofrom\n'],
+			['the same run followed by a real `from`', 1600, ` from 'react'`],
+		])('%s', (_label, count, tail) => {
+			const bigComment = `/*${'x'.repeat(4090)}*/`;
+			const code = `import ${bigComment.repeat(count)}${tail}`;
+			expect(code.length).toBeGreaterThan(5_000_000);
+			const startedAt = performance.now();
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
+		});
 	});
 });

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -174,47 +174,46 @@ describe('findAcquirableSpecifiers', () => {
 		});
 	});
 
-	// The clause match is lazy, so an attempt that can never succeed walks toward
-	// end-of-input — and every later `import`/`export` walks it again. That is
-	// quadratic, and it runs on the main thread: `acquireApplicationTypes` scans every
-	// project script joined together, and ata re-scans every downloaded `.d.ts`.
-	// Neither needs a hostile file, just an unterminated comment from a mid-edit save
-	// or a truncated CDN response.
+	// An attempt that can never succeed must not walk toward end-of-input, because
+	// every later `import`/`export` walks it again — that is quadratic, on the main
+	// thread. `acquireApplicationTypes` scans every project script joined together and
+	// ata re-scans every downloaded `.d.ts`, and neither needs a hostile file: a
+	// mid-edit save with an open block comment or a truncated CDN response will do.
 	//
-	// Wall-clock assertions, because the bound in the scanner is the only thing that
-	// makes these finish. Measured on these exact inputs: every case lands in
-	// 218-305ms bounded, against 7.5s-22s with the bound removed — so the budget below
-	// leaves ~10x headroom for a slow machine while still being an order of magnitude
-	// under the regression it exists to catch. The last two shapes need no comments at
-	// all; they were already quadratic before comments were admitted, at ~2.5s.
-	const LINEAR_SCAN_BUDGET_MS = 3000;
+	// These assert the *bound* rather than wall-clock time, deliberately. Timing can't
+	// discriminate here: CI runs with `--coverage`, and V8 instruments this scanner's
+	// per-character walk while leaving a regex's work inside the engine uninstrumented
+	// — 310ms locally became 4.5s under coverage and 18.7s on CI, so any budget loose
+	// enough to be portable is too loose to catch the regression. Every case below is
+	// instead a behavioural difference that appears the moment the length bound goes.
+	//
+	// One gap worth knowing about: swapping `indexOfWithin`/`indexOfPairWithin` for a
+	// plain `indexOf` is *not* observable here, because the length bound rejects the
+	// clause either way and only the scan cost changes. Those helpers carry the reason
+	// they exist in their own doc comment; nothing below will catch their removal.
+	describe('bounds the clause so a failed match cannot scan the file', () => {
+		const overBound = 'exportedName, '.repeat(400); // ~5.6 KB, past MAX_IMPORT_CLAUSE
 
-	describe('stays linear on input no match can consume', () => {
-		it.each([
-			['unterminated block comment', 'import /* unterminated\n'.repeat(32_000)],
-			['unterminated block comment, no newlines', 'import /* unterminated '.repeat(32_000)],
-			['line comment at the end of a truncated file', 'import a\n'.repeat(32_000) + 'import // truncated'],
-			['a long run of clause-legal characters', 'import a '.repeat(32_000)],
-		])('%s', (_label, code) => {
-			expect(code.length).toBeGreaterThan(250_000);
-			const startedAt = performance.now();
+		it('does not resolve a clause longer than the bound', () => {
+			expect(findAcquirableSpecifiers(`export { ${overBound} } from 'lodash'`)).toEqual([]);
+		});
+
+		it('does not let a block comment close beyond the bound', () => {
+			const code = `import /* unterminated\n${'filler '.repeat(800)}\n*/ from 'lodash'`;
+			expect(code.length).toBeGreaterThan(5000);
 			expect(findAcquirableSpecifiers(code)).toEqual([]);
-			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
 		});
 
-		it('still finds every import in a file of that size that does match', () => {
-			const code = `import { a } from 'react'\n`.repeat(32_000);
-			const startedAt = performance.now();
-			expect(findAcquirableSpecifiers(code)).toHaveLength(32_000);
-			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
+		it('does not let a line comment reach a `from` beyond the bound', () => {
+			const code = `import { a } // why\n${'filler '.repeat(800)}\nfrom 'lodash'`;
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
 		});
 
-		// Every comment below is large and properly terminated, so nothing here is
-		// malformed — the clause just never resolves. Expressing it as a bounded
-		// quantifier made this throw `RangeError: Maximum call stack size exceeded`,
-		// because V8 accumulated a backtracking frame per repetition. Anything that
-		// throws out of the scanner aborts acquisition for every source in the pass, so
-		// these assert a return value rather than merely "does not hang".
+		// Every comment here is large and properly terminated — nothing is malformed, the
+		// clause just never resolves. Bounding the clause with a `{0,n}` quantifier made
+		// this throw `RangeError: Maximum call stack size exceeded`, because V8 keeps a
+		// backtracking frame per repetition. A throw is worse than a slow scan: it aborts
+		// acquisition for every source joined into the pass, so these pin the return value.
 		it.each([
 			['a long run of large terminated comments', 1400, ' nofrom\n'],
 			['the same run followed by a real `from`', 1600, ` from 'react'`],
@@ -222,9 +221,23 @@ describe('findAcquirableSpecifiers', () => {
 			const bigComment = `/*${'x'.repeat(4090)}*/`;
 			const code = `import ${bigComment.repeat(count)}${tail}`;
 			expect(code.length).toBeGreaterThan(5_000_000);
-			const startedAt = performance.now();
 			expect(findAcquirableSpecifiers(code)).toEqual([]);
-			expect(performance.now() - startedAt).toBeLessThan(LINEAR_SCAN_BUDGET_MS);
 		});
+
+		// A canary for an outright hang, not a budget: the timeout is the assertion, and
+		// it is loose enough to survive coverage instrumentation on slow CI hardware.
+		it.each([
+			['unterminated block comment', 'import /* unterminated\n'.repeat(8_000)],
+			['unterminated block comment, no newlines', 'import /* unterminated '.repeat(8_000)],
+			['line comment at the end of a truncated file', 'import a\n'.repeat(8_000) + 'import // truncated'],
+			['a long run of clause-legal characters', 'import a '.repeat(8_000)],
+		])('completes on a large file of %s', (_label, code) => {
+			expect(code.length).toBeGreaterThan(60_000);
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		}, 30_000);
+
+		it('still finds every import in a file that large which does match', () => {
+			expect(findAcquirableSpecifiers(`import { a } from 'react'\n`.repeat(8_000))).toHaveLength(8_000);
+		}, 30_000);
 	});
 });

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -174,6 +174,59 @@ describe('findAcquirableSpecifiers', () => {
 		});
 	});
 
+	// The root of what the RUM review found. Searching raw text for keywords meant
+	// ordinary English in a comment parsed as an import: `// we import rows from
+	// "customers"` sent a user's table name to jsDelivr. `customers` is a legal npm name,
+	// so nothing downstream can catch it — the fix is to not read non-code as code.
+	//
+	// Every specifier below is npm-shaped on purpose, so these fail unless the scanner is
+	// genuinely lexical. Each case also carries a real import, because "acquire nothing"
+	// would pass otherwise.
+	describe('does not read keywords out of comments or literals', () => {
+		it.each([
+			['a line comment', `// we import rows from "customers"\nimport { z } from 'zod'`],
+			['a block comment', `/* we import rows from "customers" */\nimport { z } from 'zod'`],
+			['a jsdoc block', `/**\n * we import rows from "customers"\n */\nimport { z } from 'zod'`],
+			['a single-quoted string', `const s = 'import rows from "customers"'\nimport { z } from 'zod'`],
+			['a double-quoted string', `const s = "import rows from 'customers'"\nimport { z } from 'zod'`],
+			['a template literal', 'const q = `import rows from "customers"`\nimport { z } from \'zod\''],
+			[
+				'a multi-line SQL template',
+				'const q = `\n\tselect *\n\timport rows from "customers"\n`\nimport { z } from \'zod\'',
+			],
+			['a regex literal', `const r = /import rows from "customers"/\nimport { z } from 'zod'`],
+			[
+				'a regex with a slash in a character class',
+				`const r = /[/]import x from "customers"/g\nimport { z } from 'zod'`,
+			],
+			['a require in a comment', `// const c = require("customers")\nimport { z } from 'zod'`],
+			[
+				'a nested template',
+				'const h = `<b>${xs.map((x) => `import y from "customers"`)}</b>`\nimport { z } from \'zod\'',
+			],
+		])('%s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod']);
+		});
+
+		it.each([
+			['a property named import', `const x = obj.import\nimport { z } from 'zod'`],
+			['a key named require', `const o = { require: 1 }\nimport { z } from 'zod'`],
+		])('does not treat %s as a statement', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod']);
+		});
+
+		it('still scans a template substitution, which is real code', () => {
+			expect(findAcquirableSpecifiers('const m = `${await import("nanoid")}`')).toEqual(['nanoid']);
+		});
+
+		it('keeps working on half-typed code, where a real parser would reject the file', () => {
+			// ata scans on every keystroke; a lexer that throws here stops acquisition.
+			expect(findAcquirableSpecifiers(`import { z } from 'zod'\nimport { a } fr`)).toEqual(['zod']);
+			expect(findAcquirableSpecifiers(`import { z } from 'zod'\nconst s = 'unterminated`)).toEqual(['zod']);
+			expect(findAcquirableSpecifiers(`import { z } from 'zod'\n/* unterminated`)).toEqual(['zod']);
+		});
+	});
+
 	// An attempt that can never succeed must not walk toward end-of-input, because
 	// every later `import`/`export` walks it again — that is quadratic, on the main
 	// thread. `acquireApplicationTypes` scans every project script joined together and
@@ -207,6 +260,24 @@ describe('findAcquirableSpecifiers', () => {
 		it('does not let a line comment reach a `from` beyond the bound', () => {
 			const code = `import { a } // why\n${'filler '.repeat(800)}\nfrom 'lodash'`;
 			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		});
+
+		// The bound has to cover the whitespace run after `from` too, not just the clause:
+		// otherwise a `from` inside the bound reaches a quote arbitrarily far past it, and
+		// every keyword candidate rescans that same run.
+		it('does not resolve a `from` inside the bound whose quote is beyond it', () => {
+			const code = `import a from${' '.repeat(500_000)}'react'`;
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		});
+
+		it('does not rescan the same long tail once per keyword candidate', () => {
+			const code = `${'import '.repeat(500)}from${' '.repeat(500_000)}'react'`;
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		}, 30_000);
+
+		it('bounds the whitespace inside a call form too', () => {
+			expect(findAcquirableSpecifiers(`import(${' '.repeat(500_000)}'react')`)).toEqual([]);
+			expect(findAcquirableSpecifiers(`require(${' '.repeat(500_000)}'react')`)).toEqual([]);
 		});
 
 		// Every comment here is large and properly terminated — nothing is malformed, the

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -88,6 +88,44 @@ describe('findAcquirableSpecifiers', () => {
 		])('%s', (_label, code) => {
 			expect(findAcquirableSpecifiers(code)).toEqual([]);
 		});
+
+		// A builtin's subpath is as much a builtin as its bare name, and every one of these
+		// satisfies npm's name grammar, so exact membership let them through to jsDelivr.
+		it.each([
+			['fs/promises', `import fs from 'fs/promises'`],
+			['assert/strict', `import assert from 'assert/strict'`],
+			['timers/promises', `import { setTimeout } from 'timers/promises'`],
+			['dns/promises', `import dns from 'dns/promises'`],
+			['stream/promises', `import { pipeline } from 'stream/promises'`],
+			['stream/web', `import { ReadableStream } from 'stream/web'`],
+			['util/types', `import types from 'util/types'`],
+			['path/posix', `import posix from 'path/posix'`],
+			['readline/promises', `import rl from 'readline/promises'`],
+			['node: subpath', `import fs from 'node:fs/promises'`],
+		])('builtin subpath %s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		});
+
+		it.each([
+			['inspector', `import inspector from 'inspector'`],
+			['dgram', `import dgram from 'dgram'`],
+			['diagnostics_channel', `import dc from 'diagnostics_channel'`],
+			['punycode', `import punycode from 'punycode'`],
+			['repl', `import repl from 'repl'`],
+			['constants', `import constants from 'constants'`],
+		])('bare builtin %s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		});
+
+		it('still acquires packages whose names only resemble a builtin', () => {
+			expect(findAcquirableSpecifiers(`import x from 'fs-extra'`)).toEqual(['fs-extra']);
+			expect(findAcquirableSpecifiers(`import x from '@types/fs'`)).toEqual(['@types/fs']);
+			expect(findAcquirableSpecifiers(`import x from 'path-browserify'`)).toEqual(['path-browserify']);
+			// `node:test` and `node:sqlite` are rejected by the `node:` prefix, so the npm
+			// packages of those names keep resolving.
+			expect(findAcquirableSpecifiers(`import x from 'sqlite'`)).toEqual(['sqlite']);
+			expect(findAcquirableSpecifiers(`import x from 'node:sqlite'`)).toEqual([]);
+		});
 	});
 
 	// Regression for the daily RUM review of 2026-07-28: 18 requests to
@@ -163,10 +201,23 @@ describe('findAcquirableSpecifiers', () => {
 			expect(findAcquirableSpecifiers(`import x from '${specifier}'`)).toEqual([]);
 		});
 
-		it('rejects a specifier longer than npm allows', () => {
-			const tooLong = 'a'.repeat(215);
-			expect(findAcquirableSpecifiers(`import x from '${tooLong}'`)).toEqual([]);
+		// npm's 214 bounds the package *name*. Applying it to the whole specifier discarded
+		// valid deep imports, which is why the package portion and the subpath are bounded
+		// separately.
+		it('rejects a package name longer than npm allows', () => {
+			expect(findAcquirableSpecifiers(`import x from '${'a'.repeat(215)}'`)).toEqual([]);
+			expect(findAcquirableSpecifiers(`import x from '${'a'.repeat(215)}/sub'`)).toEqual([]);
 			expect(findAcquirableSpecifiers(`import x from '${'a'.repeat(214)}'`)).toEqual(['a'.repeat(214)]);
+		});
+
+		it('allows a deep import past 214 chars whose package name is within the limit', () => {
+			const deep = `pkg/${'segment/'.repeat(30)}index`;
+			expect(deep.length).toBeGreaterThan(214);
+			expect(findAcquirableSpecifiers(`import x from '${deep}'`)).toEqual([deep]);
+		});
+
+		it('rejects a specifier past the whole-specifier ceiling', () => {
+			expect(findAcquirableSpecifiers(`import x from 'pkg/${'a/'.repeat(700)}end'`)).toEqual([]);
 		});
 
 		it('still allows legacy mixed-case package names', () => {
@@ -217,6 +268,50 @@ describe('findAcquirableSpecifiers', () => {
 
 		it('still scans a template substitution, which is real code', () => {
 			expect(findAcquirableSpecifiers('const m = `${await import("nanoid")}`')).toEqual(['nanoid']);
+		});
+
+		// A `)` alone cannot tell division from a regex: it closes a call, whose result
+		// divides, but it also closes an `if`/`while`/`for` head, whose body may be a bare
+		// regex statement. Reading that body as code leaks the specifier inside it.
+		it.each([
+			['an if head', `if (ready) /import rows from 'customers'/.test(source)\nimport { z } from 'zod'`],
+			['a while head', `while (more) /import rows from 'customers'/.test(source)\nimport { z } from 'zod'`],
+			['a for head', `for (;;) /import rows from 'customers'/.test(source)\nimport { z } from 'zod'`],
+			['a nested head', `if (a) while (b) /import x from 'customers'/.test(s)\nimport { z } from 'zod'`],
+		])('does not read a regex statement after %s as code', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod']);
+		});
+
+		it('still treats a `/` after a call as division', () => {
+			expect(findAcquirableSpecifiers(`const ratio = total(a) / count(b)\nimport { z } from 'zod'`)).toEqual(['zod']);
+		});
+
+		// `.jsx`/`.tsx` reach the scanner: the caller filters on `\.(tsx?|jsx?|mjs|cjs|mts|cts)$`.
+		it.each([
+			['JSX text', `const V = () => <p>we import rows from 'customers'</p>\nimport { z } from 'zod'`],
+			[
+				'JSX text on its own line',
+				`const V = () => (\n\t<p>\n\t\timport rows from 'customers'\n\t</p>\n)\nimport { z } from 'zod'`,
+			],
+			['a JSX attribute', `const V = () => <p title="we import rows from 'customers'" />\nimport { z } from 'zod'`],
+			[
+				'nested JSX children',
+				`const V = () => <div><span>import x from 'customers'</span></div>\nimport { z } from 'zod'`,
+			],
+			['a JSX fragment', `const V = () => <>import x from 'customers'</>\nimport { z } from 'zod'`],
+			['a returned element', `function V() {\n\treturn <p>import x from 'customers'</p>\n}\nimport { z } from 'zod'`],
+		])('does not read %s as code', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod']);
+		});
+
+		it('still scans a JSX expression container, which is real code', () => {
+			expect(findAcquirableSpecifiers(`const V = () => <p>{require('uuid')}</p>`)).toEqual(['uuid']);
+			expect(findAcquirableSpecifiers(`const V = () => <img src={require('uuid')} />`)).toEqual(['uuid']);
+		});
+
+		it('does not mistake a type argument or comparison for JSX', () => {
+			expect(findAcquirableSpecifiers(`const m = new Map<string, number>()\nimport { z } from 'zod'`)).toEqual(['zod']);
+			expect(findAcquirableSpecifiers(`const ok = a < b && c > d\nimport { z } from 'zod'`)).toEqual(['zod']);
 		});
 
 		it('keeps working on half-typed code, where a real parser would reject the file', () => {

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -32,6 +32,21 @@ describe('findAcquirableSpecifiers', () => {
 			expect(findAcquirableSpecifiers(code)).toEqual(['react']);
 		});
 
+		// A comment is legal anywhere in an import clause, and annotating a named
+		// import is common. The clause matcher excludes a bare `/` to stop it walking
+		// out of a statement, so it has to recognise comments as units or it misses
+		// the whole import — the package silently stops getting types.
+		it.each([
+			['line comment inside a named block', `import {\n\tuseState, // hooks\n\tuseEffect,\n} from 'react'`],
+			['block comment inside a named block', `import {\n\tuseState, /* hooks */\n\tuseEffect,\n} from 'react'`],
+			['jsdoc between the clause and `from`', `import { useState } /** why */ from 'react'`],
+			['line comment between the clause and `from`', `import { useState } // why\nfrom 'react'`],
+			['comment before a type modifier', `import /* types only */ type { FC } from 'react'`],
+			['CRLF line endings around a comment', "import {\r\n\tuseState, // hooks\r\n} from 'react'"],
+		])('%s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(['react']);
+		});
+
 		it('finds every import in a realistic Harper resource file', () => {
 			const code = [
 				`import { tables } from 'harper';`,
@@ -92,6 +107,30 @@ describe('findAcquirableSpecifiers', () => {
 			],
 		])('%s', (_label, code) => {
 			expect(findAcquirableSpecifiers(code)).not.toContain('Known Fraudster Risk');
+		});
+
+		// The npm-grammar gate only stops phrases it can recognise as impossible names.
+		// A single lowercase table name — `customers`, and Harper apps are full of them
+		// — is a perfectly legal package name, so for these the clause matcher is the
+		// only thing standing between user content and the CDN.
+		//
+		// That makes them the cases to pin now that the clause matcher consumes comments
+		// so annotated named imports keep resolving. A comment alternative that can be
+		// partially consumed (a plain `//[^\n]*`, which backtracks) lets the matcher stop
+		// mid-comment and take the `from "…"` out of the rest of it — every shape below
+		// resolves to `customers` again under that spelling, and did before this fix.
+		it.each([
+			['line comment after a named export', `export { Dog }\n// each row is read from "customers"`],
+			['block comment after a named export', `export { Dog }\n/* each row is read from "customers" */`],
+			['line comment after a star export', `export *\n// projected from "customers"`],
+			['line comment after an empty export', `export {}\n// hydrated from "customers"`],
+			['comment where `from` itself is commented out', `import { Dog }\n// from "customers"`],
+			[
+				'jsdoc prose in a downloaded declaration file',
+				`export {}\n/**\n * Read from "customers".\n */\nexport declare const x: string`,
+			],
+		])('%s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
 		});
 
 		it('keeps the legitimate import from a file that also contains such prose', () => {

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `typeAcquisition` re-exports monaco's language-service registrations at module
+// scope, which need a DOM. The scanner under test touches none of it.
+vi.mock('@/lib/monaco/languageServices', () => ({ json: {}, typescript: {} }));
+
+const { findAcquirableSpecifiers } = await import('./typeAcquisition');
+
+describe('findAcquirableSpecifiers', () => {
+	describe('real imports it must keep finding', () => {
+		it.each([
+			['default import', `import React from 'react'`, ['react']],
+			['named imports', `import { useState, useEffect } from 'react'`, ['react']],
+			['namespace import', `import * as path from 'node:path'`, []],
+			['star re-export', `export * from 'lodash'`, ['lodash']],
+			['named re-export', `export { debounce } from 'lodash'`, ['lodash']],
+			['type-only import', `import type { Config } from 'vite'`, ['vite']],
+			['default + named', `import ky, { HTTPError } from 'ky'`, ['ky']],
+			['aliased named', `import { a as b } from 'zod'`, ['zod']],
+			['bare side-effect import', `import 'reflect-metadata'`, ['reflect-metadata']],
+			['dynamic import', `const m = await import('nanoid')`, ['nanoid']],
+			['require call', `const x = require('uuid')`, ['uuid']],
+			['scoped package', `import { z } from '@scope/pkg'`, ['@scope/pkg']],
+			['deep import', `import { merge } from 'lodash/fp'`, ['lodash/fp']],
+			['double quotes', `import React from "react"`, ['react']],
+		])('%s', (_label, code, expected) => {
+			expect(findAcquirableSpecifiers(code)).toEqual(expected);
+		});
+
+		it('spans newlines inside a multi-line named import', () => {
+			const code = `import {\n\tuseState,\n\tuseEffect,\n} from 'react'`;
+			expect(findAcquirableSpecifiers(code)).toEqual(['react']);
+		});
+
+		it('finds every import in a realistic Harper resource file', () => {
+			const code = [
+				`import { tables } from 'harper';`,
+				`import { z } from 'zod';`,
+				`import lodash from 'lodash';`,
+				``,
+				`export const { Dog } = tables;`,
+			].join('\n');
+			// `harper` is provided by the editor's own globals, never acquired from npm.
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod', 'lodash']);
+		});
+	});
+
+	describe('non-packages it must never send to the CDN', () => {
+		it.each([
+			['relative path', `import x from './local'`],
+			['parent-relative path', `import x from '../local'`],
+			['absolute path', `import x from '/abs'`],
+			['@/ alias', `import x from '@/lib/thing'`],
+			['harper global', `import { tables } from 'harper'`],
+			['harperdb global', `import { tables } from 'harperdb'`],
+			['node: builtin', `import fs from 'node:fs'`],
+			['bare node builtin', `import fs from 'fs'`],
+			['css asset', `import './styles.css'`],
+			['json asset', `import data from './data.json'`],
+		])('%s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).toEqual([]);
+		});
+	});
+
+	// Regression for the daily RUM review of 2026-07-28: 18 requests to
+	// data.jsdelivr.com/v1/package/resolve/npm/… 404'd in a single session, one of
+	// them for the specifier `Known Fraudster Risk`. A lazy `[^'";]*?` between
+	// `import`/`export` and `from` crossed newlines, so a lowercase `from "…"` in a
+	// following comment or SQL/GraphQL template literal was scanned as a package
+	// name — sending user-authored table and type names off-origin to jsDelivr.
+	describe('does not mine package names out of prose (RUM 2026-07-28)', () => {
+		it.each([
+			[
+				'line comment after a semicolon-free export',
+				`export const { Dog } = tables\n// everything below reads from "Known Fraudster Risk"\n`,
+			],
+			[
+				'jsdoc block after an exported interface',
+				`export interface Risk {\n\t/** derived from "Known Fraudster Risk" table */\n\tid: string\n}`,
+			],
+			[
+				'lowercase SQL in a template literal',
+				'export const q = `select * from "Known Fraudster Risk"`',
+			],
+			[
+				'GraphQL SDL in a template literal',
+				'export const typeDefs = `type Query { risks: [Risk] }`\n// generated from "Known Fraudster Risk"',
+			],
+			[
+				'prose mentioning a table after an import',
+				`import { tables } from 'harper'\n// we select from "Known Fraudster Risk" on demand`,
+			],
+		])('%s', (_label, code) => {
+			expect(findAcquirableSpecifiers(code)).not.toContain('Known Fraudster Risk');
+		});
+
+		it('keeps the legitimate import from a file that also contains such prose', () => {
+			const code = `import { z } from 'zod'\n// hydrated from "Known Fraudster Risk"\nexport const s = z.string()`;
+			expect(findAcquirableSpecifiers(code)).toEqual(['zod']);
+		});
+
+		it.each([
+			['whitespace', 'Known Fraudster Risk'],
+			['leading dot in a name position', 'not a package'],
+			['uppercase phrase with punctuation', 'Some Table (v2)'],
+			['tab', 'pkg\tname'],
+			['newline', 'pkg\nname'],
+			['colon', 'weird:name'],
+			['empty scope', '@/'],
+		])('rejects the invalid specifier %s even when quoted as an import target', (_label, specifier) => {
+			expect(findAcquirableSpecifiers(`import x from '${specifier}'`)).toEqual([]);
+		});
+
+		it('rejects a specifier longer than npm allows', () => {
+			const tooLong = 'a'.repeat(215);
+			expect(findAcquirableSpecifiers(`import x from '${tooLong}'`)).toEqual([]);
+			expect(findAcquirableSpecifiers(`import x from '${'a'.repeat(214)}'`)).toEqual(['a'.repeat(214)]);
+		});
+
+		it('still allows legacy mixed-case package names', () => {
+			expect(findAcquirableSpecifiers(`import JSONStream from 'JSONStream'`)).toEqual(['JSONStream']);
+		});
+	});
+});

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -110,6 +110,8 @@ const MAX_IMPORT_CLAUSE = 4096;
 
 const SLASH = 0x2f, STAR = 0x2a, NEWLINE = 0x0a, SINGLE_QUOTE = 0x27, DOUBLE_QUOTE = 0x22;
 const OPEN_PAREN = 0x28, CLOSE_PAREN = 0x29, OPEN_BRACE = 0x7b, CLOSE_BRACE = 0x7d, COMMA = 0x2c;
+const BACKTICK = 0x60, BACKSLASH = 0x5c, DOLLAR = 0x24, DOT = 0x2e;
+const OPEN_BRACKET = 0x5b, CLOSE_BRACKET = 0x5d;
 
 /** `\w` plus `$` — what a clause keyword or imported binding is spelled with. */
 function isIdentifierChar(charCode: number): boolean {
@@ -167,17 +169,19 @@ interface ScannedSpecifier {
 }
 
 /**
- * A quoted module specifier at `at`, after optional whitespace. Bounded by npm's own
- * name limit: past that the specifier is rejected anyway, so reading further would
- * only turn a missing closing quote into another unbounded scan.
+ * A quoted module specifier at `at`, after optional whitespace. `limit` is the caller's
+ * bound and applies to the whitespace run as well as the quotes: without it, a statement
+ * whose `from` sits inside the clause bound could still reach a quote arbitrarily far
+ * past it, and every keyword candidate would rescan that same run. The specifier body is
+ * additionally capped at npm's own name limit, past which it is rejected anyway.
  */
-function readQuotedSpecifier(code: string, at: number): { specifier: string; end: number } | undefined {
-	const opened = skipWhitespace(code, at, code.length);
+function readQuotedSpecifier(code: string, at: number, bound: number): { specifier: string; end: number } | undefined {
+	const opened = skipWhitespace(code, at, bound);
 	const quote = code.charCodeAt(opened);
-	if (quote !== SINGLE_QUOTE && quote !== DOUBLE_QUOTE) {
+	if (opened >= bound || (quote !== SINGLE_QUOTE && quote !== DOUBLE_QUOTE)) {
 		return undefined;
 	}
-	const limit = Math.min(code.length, opened + MAX_SPECIFIER_LENGTH + 2);
+	const limit = Math.min(bound, opened + MAX_SPECIFIER_LENGTH + 2);
 	for (let next = opened + 1; next < limit; next++) {
 		const charCode = code.charCodeAt(next);
 		if (charCode === quote) {
@@ -244,7 +248,7 @@ function readClauseSpecifier(code: string, clauseStart: number): { specifier: st
 			}
 			// A `from` that no specifier follows is just a binding name (`import from from 'x'`).
 			if (wordEnd - at === 4 && code.startsWith('from', at)) {
-				const found = readQuotedSpecifier(code, wordEnd);
+				const found = readQuotedSpecifier(code, wordEnd, limit);
 				if (found) {
 					return found;
 				}
@@ -264,38 +268,238 @@ function readClauseSpecifier(code: string, clauseStart: number): { specifier: st
 	return undefined;
 }
 
-/** Keywords that can introduce a specifier — the only places the scanner starts work. */
-const STATEMENT_KEYWORD = /\b(?:import|export|require)\b/g;
 const REFERENCE_PATH = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
+
+/**
+ * The specifier belonging to a statement keyword, whichever form follows it: a call
+ * `import('…')`/`require('…')`, a bare side-effect `import '…'`, or a clause ending in
+ * `from '…'`. Every scan is bounded by `MAX_IMPORT_CLAUSE` from the keyword, so no form
+ * can reach across the file and no candidate can rescan a run another already rejected.
+ */
+function readSpecifierAfterKeyword(
+	code: string,
+	keyword: string,
+	afterKeyword: number,
+): { specifier: string; end: number } | undefined {
+	const bound = Math.min(code.length, afterKeyword + MAX_IMPORT_CLAUSE);
+	if (keyword !== 'export') {
+		const parenAt = skipWhitespace(code, afterKeyword, bound);
+		if (code.charCodeAt(parenAt) === OPEN_PAREN) {
+			const call = readQuotedSpecifier(code, parenAt + 1, bound);
+			if (!call) {
+				return undefined;
+			}
+			const closeAt = skipWhitespace(code, call.end, bound);
+			return code.charCodeAt(closeAt) === CLOSE_PAREN ? { specifier: call.specifier, end: closeAt + 1 } : undefined;
+		}
+	}
+	if (keyword === 'require') {
+		return undefined;
+	}
+	const bare = keyword === 'import' ? readQuotedSpecifier(code, afterKeyword, bound) : undefined;
+	return bare ?? readClauseSpecifier(code, afterKeyword);
+}
+
+/** Past the closing quote of a string literal, or `limit` if it never closes. */
+function skipStringLiteral(code: string, at: number, limit: number): number {
+	const quote = code.charCodeAt(at);
+	for (let next = at + 1; next < limit; next++) {
+		const charCode = code.charCodeAt(next);
+		if (charCode === BACKSLASH) {
+			next++;
+		} else if (charCode === quote) {
+			return next + 1;
+		} else if (charCode === NEWLINE) {
+			// An unescaped newline means this quote never opened a string (mid-edit, or an
+			// apostrophe in prose). Give up the single character so scanning resynchronises.
+			return at + 1;
+		}
+	}
+	return limit;
+}
+
+/**
+ * Past the closing `/` of a regex literal, or `at + 1` if this `/` turns out not to
+ * start one — a regex cannot span a line, so hitting a newline first is proof.
+ */
+function skipRegexLiteral(code: string, at: number, limit: number): number {
+	let inCharacterClass = false;
+	for (let next = at + 1; next < limit; next++) {
+		const charCode = code.charCodeAt(next);
+		if (charCode === BACKSLASH) {
+			next++;
+		} else if (charCode === NEWLINE) {
+			return at + 1;
+		} else if (charCode === OPEN_BRACKET) {
+			inCharacterClass = true;
+		} else if (charCode === CLOSE_BRACKET) {
+			inCharacterClass = false;
+		} else if (charCode === SLASH && !inCharacterClass) {
+			return next + 1;
+		}
+	}
+	return at + 1;
+}
+
+/**
+ * Whether a `/` here opens a regex literal rather than being division. Decided from the
+ * previous significant token, the standard heuristic: division follows a value —
+ * an identifier, a literal, `)`, or `]` — and a regex follows anything else.
+ * `previousWord` covers the keywords that produce no value and so may be followed by a
+ * regex (`return /x/`), which a bare "previous char is a letter" test gets wrong.
+ *
+ * Ambiguity is resolved toward *regex*, `}` included: mistaking division for a regex
+ * skips to the next `/` and can only lose an import, while mistaking a regex for
+ * division scans its body as code and could take a specifier out of it.
+ */
+const REGEX_MAY_FOLLOW = new Set([
+	'return',
+	'typeof',
+	'instanceof',
+	'case',
+	'in',
+	'of',
+	'delete',
+	'void',
+	'new',
+	'do',
+	'else',
+	'yield',
+	'await',
+]);
+function canStartRegex(previousChar: number, previousWord: string): boolean {
+	if (isIdentifierChar(previousChar)) {
+		return REGEX_MAY_FOLLOW.has(previousWord);
+	}
+	return previousChar !== CLOSE_PAREN && previousChar !== CLOSE_BRACKET
+		&& previousChar !== SINGLE_QUOTE && previousChar !== DOUBLE_QUOTE && previousChar !== BACKTICK;
+}
 
 /**
  * Every module specifier in `code`, in source order: `import`/`export … from '…'`,
  * dynamic `import('…')`, `require('…')`, and a bare side-effect `import '…'`.
+ *
+ * The walk tracks lexical context so a keyword is only honoured where real code can
+ * appear. That is the root fix for what the RUM review found rather than a mitigation of
+ * it: searching the raw text for keywords meant ordinary English in a comment —
+ * `// we import rows from "customers"` — parsed as an import and sent a user's table name
+ * to jsDelivr. `customers` is a perfectly legal npm name, so no amount of specifier
+ * validation downstream can catch it; the only fix is not to read comments as code. The
+ * same applies to SQL and GraphQL in template literals, quoted strings, and regex bodies.
+ *
+ * `@typescript/ata` calls this synchronously on files the user is actively editing, so
+ * this is deliberately not a parser and never throws: a real module lexer rejects
+ * half-typed code, which for an editor is the normal state, and returning nothing there
+ * would silently stop type acquisition mid-keystroke. Where the walk cannot be certain it
+ * prefers to treat text as *not* code, which loses an acquisition rather than leaking a
+ * name. Template substitutions are still scanned, since `import()` inside one is real
+ * code.
  */
 function scanSpecifiers(code: string): ScannedSpecifier[] {
 	const found: ScannedSpecifier[] = [];
-	for (const match of code.matchAll(STATEMENT_KEYWORD)) {
-		const keyword = match[0];
-		const pos = match.index;
-		const afterKeyword = pos + keyword.length;
-		if (keyword !== 'export' && code.charCodeAt(skipWhitespace(code, afterKeyword, code.length)) === OPEN_PAREN) {
-			const call = readQuotedSpecifier(code, skipWhitespace(code, afterKeyword, code.length) + 1);
-			if (call) {
-				const closeAt = skipWhitespace(code, call.end, code.length);
-				if (code.charCodeAt(closeAt) === CLOSE_PAREN) {
-					found.push({ specifier: call.specifier, pos, end: closeAt + 1 });
-				}
+	// Each entry is a `${` substitution we are inside; its value is the brace depth within
+	// it, so the matching `}` returns us to the enclosing template. An explicit stack
+	// rather than recursion, so deeply nested templates cost memory, never the call stack.
+	const substitutions: number[] = [];
+	let inTemplate = false;
+	let previousChar = 0;
+	let previousWord = '';
+	let at = 0;
+	while (at < code.length) {
+		const charCode = code.charCodeAt(at);
+
+		if (inTemplate) {
+			if (charCode === BACKSLASH) {
+				at += 2;
+			} else if (charCode === BACKTICK) {
+				inTemplate = false;
+				previousChar = BACKTICK;
+				at++;
+			} else if (charCode === DOLLAR && code.charCodeAt(at + 1) === OPEN_BRACE) {
+				substitutions.push(0);
+				inTemplate = false;
+				previousChar = OPEN_BRACE;
+				at += 2;
+			} else {
+				at++;
 			}
 			continue;
 		}
-		if (keyword === 'require') {
+
+		if (charCode === SLASH) {
+			const following = code.charCodeAt(at + 1);
+			if (following === SLASH) {
+				const lineEnd = code.indexOf('\n', at + 2);
+				at = lineEnd < 0 ? code.length : lineEnd + 1;
+				continue;
+			}
+			if (following === STAR) {
+				const commentEnd = code.indexOf('*/', at + 2);
+				at = commentEnd < 0 ? code.length : commentEnd + 2;
+				continue;
+			}
+			at = canStartRegex(previousChar, previousWord) ? skipRegexLiteral(code, at, code.length) : at + 1;
+			previousChar = SLASH;
+			previousWord = '';
 			continue;
 		}
-		const bare = keyword === 'import' ? readQuotedSpecifier(code, afterKeyword) : undefined;
-		const scanned = bare ?? readClauseSpecifier(code, afterKeyword);
-		if (scanned) {
-			found.push({ specifier: scanned.specifier, pos, end: scanned.end });
+
+		if (charCode === SINGLE_QUOTE || charCode === DOUBLE_QUOTE) {
+			at = skipStringLiteral(code, at, code.length);
+			previousChar = charCode;
+			previousWord = '';
+			continue;
 		}
+
+		if (charCode === BACKTICK) {
+			inTemplate = true;
+			at++;
+			continue;
+		}
+
+		if (substitutions.length > 0) {
+			if (charCode === OPEN_BRACE) {
+				substitutions[substitutions.length - 1]++;
+			} else if (charCode === CLOSE_BRACE) {
+				if (substitutions[substitutions.length - 1] === 0) {
+					substitutions.pop();
+					inTemplate = true;
+					previousChar = CLOSE_BRACE;
+					at++;
+					continue;
+				}
+				substitutions[substitutions.length - 1]--;
+			}
+		}
+
+		if (isIdentifierChar(charCode)) {
+			let wordEnd = at + 1;
+			while (wordEnd < code.length && isIdentifierChar(code.charCodeAt(wordEnd))) {
+				wordEnd++;
+			}
+			const word = code.slice(at, wordEnd);
+			// `obj.import` and `{ import: x }` are property names, not statements.
+			const isStatementKeyword = previousChar !== DOT
+				&& (word === 'import' || word === 'export' || word === 'require');
+			const scanned = isStatementKeyword ? readSpecifierAfterKeyword(code, word, wordEnd) : undefined;
+			if (scanned) {
+				found.push({ specifier: scanned.specifier, pos: at, end: scanned.end });
+				previousChar = code.charCodeAt(scanned.end - 1);
+				previousWord = '';
+				at = scanned.end;
+				continue;
+			}
+			previousChar = code.charCodeAt(wordEnd - 1);
+			previousWord = word;
+			at = wordEnd;
+			continue;
+		}
+
+		if (!isWhitespace(charCode)) {
+			previousChar = charCode;
+			previousWord = '';
+		}
+		at++;
 	}
 	return found;
 }

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -87,6 +87,29 @@ function isAcquirablePackage(specifier: string): boolean {
 }
 
 /**
+ * How far one import clause — including any single comment inside it — may extend
+ * before the scanner abandons the statement. Real clauses are nowhere close: the
+ * longest in this repo is 351 chars, and across ~13k declaration files in
+ * `node_modules` the longest is a 1.6 KB barrel re-export, so 4 KB leaves ample
+ * headroom. A clause past the bound just isn't acquired, the same degraded-but-safe
+ * outcome as any unacquired package.
+ *
+ * The bound is what keeps the scan linear, and it is load-bearing. The clause match
+ * is lazy, so without it every failed attempt runs to end-of-input and each
+ * `import`/`export` occurrence pays that again: an unterminated `/*` — a mid-edit
+ * save, a truncated CDN download — took ~22s on 719 KB, and a long run of
+ * clause-legal characters ~2.5s on 281 KB even before comments were admitted.
+ * Bounded, those same inputs scan in ~220-300ms, and real files in ~1ms. This file
+ * promises failures are swallowed so they "can never break editing"; a multi-second
+ * freeze of the main thread would break that promise even though nothing throws.
+ *
+ * A ceiling on `code.length` instead would not have fixed this — 281 KB is under any
+ * sane ceiling and still took seconds — and it would drop acquisition entirely for
+ * large but perfectly ordinary projects.
+ */
+const MAX_IMPORT_CLAUSE = 4096;
+
+/**
  * The clause between `import`/`export` and `from` — identifiers, braces, commas,
  * `*`, `as`, whitespace (newlines included, so multi-line named imports still
  * match), and comments, which are legal and common between the braces. Everything
@@ -101,11 +124,21 @@ function isAcquirablePackage(specifier: string): boolean {
  * pinning is the whole point — a plain `//[^\n]*` backtracks, so the matcher could
  * stop halfway through a comment and take the `from "…"` out of the rest of it,
  * reopening the leak on input as ordinary as `export { Dog }` followed by a
- * comment. Alternatives are disjoint on their first character (only `/` starts a
- * comment), so the repetition stays linear.
+ * comment. Every alternative is bounded by `MAX_IMPORT_CLAUSE`, including the
+ * comment bodies — an unterminated comment has no terminator to find, so an
+ * unbounded search for one is exactly what made this quadratic.
  */
-const IMPORT_SPECIFIER =
-	/(?:import|export)\b(?:[\w$\s{},*]|\/\/[^\n]*(?=\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*?\bfrom\s*['"]([^'"]+)['"]|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
+const IMPORT_CLAUSE = String.raw`(?:`
+	+ String.raw`[\w$\s{},*]`
+	+ String.raw`|//[^\n]{0,${MAX_IMPORT_CLAUSE}}(?=\n|$)`
+	+ String.raw`|/\*(?:[^*]|\*(?!/)){0,${MAX_IMPORT_CLAUSE}}?\*/`
+	+ String.raw`){0,${MAX_IMPORT_CLAUSE}}?`;
+const IMPORT_SPECIFIER = new RegExp(
+	String.raw`(?:import|export)\b${IMPORT_CLAUSE}\bfrom\s*['"]([^'"]+)['"]`
+		+ String.raw`|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)`
+		+ String.raw`|import\s*['"]([^'"]+)['"]`,
+	'g',
+);
 const REFERENCE_PATH = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
 
 /**

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -55,6 +55,17 @@ const NODE_BUILTINS = new Set([
 ]);
 const ASSET_OR_DATA = /\.(svg|png|jpe?g|gif|webp|avif|ico|bmp|css|scss|sass|less|json|wasm|txt|md|html)$/i;
 
+/**
+ * npm's package-name grammar: an optional `@scope/`, the name itself, then an
+ * optional deep-import subpath (`lodash/fp`, `react-dom/client`). Anchored and
+ * whitespace-free, so a phrase lifted out of prose can never satisfy it. Matched
+ * case-insensitively because a few legacy packages (`JSONStream`, `Base64`)
+ * predate npm's lowercase-only rule.
+ */
+const NPM_SPECIFIER = /^(?:@[a-z0-9\-~][a-z0-9\-._~]*\/)?[a-z0-9\-~][a-z0-9\-._~]*(?:\/[a-z0-9\-._~/]+)?$/i;
+/** npm's hard limit on a package name; also bounds what we're willing to send to the CDN. */
+const MAX_SPECIFIER_LENGTH = 214;
+
 /** A bare npm specifier we want real `@types` for — not relative, alias, asset, Harper, or node builtin. */
 function isAcquirablePackage(specifier: string): boolean {
 	if (!specifier || specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('@/')) {
@@ -63,12 +74,47 @@ function isAcquirablePackage(specifier: string): boolean {
 	if (specifier === 'harper' || specifier === 'harperdb' || specifier.startsWith('node:')) {
 		return false;
 	}
-	return !NODE_BUILTINS.has(specifier) && !ASSET_OR_DATA.test(specifier);
+	if (NODE_BUILTINS.has(specifier) || ASSET_OR_DATA.test(specifier)) {
+		return false;
+	}
+	// Every specifier that gets past here becomes a cross-origin request to
+	// data.jsdelivr.com, so it must actually be able to name a package. The scanner
+	// below is a regex, not a parser, and anything it over-matches out of a comment
+	// or a SQL/GraphQL template literal would otherwise be sent verbatim to the CDN
+	// — leaking user-authored strings (table and type names) off-origin for a
+	// guaranteed 404. (HarperFast/studio: daily RUM review, 2026-07-28.)
+	return specifier.length <= MAX_SPECIFIER_LENGTH && NPM_SPECIFIER.test(specifier);
 }
 
+/**
+ * The clause between `import`/`export` and `from` — identifiers, braces, commas,
+ * `*`, `as`, and whitespace (newlines included, so multi-line named imports still
+ * match). Deliberately excludes `=`, `/`, `:`, `(`, `)`, and backticks: none can
+ * appear in a real import clause, and admitting them let the lazy match run past
+ * the end of a statement to reach a `from "…"` sitting in a following comment,
+ * SQL string, or GraphQL block — which is how `Known Fraudster Risk` reached
+ * jsDelivr as a package name.
+ */
 const IMPORT_SPECIFIER =
-	/(?:import|export)\b[^'";]*?\bfrom\s*['"]([^'"]+)['"]|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
+	/(?:import|export)\b[\w$\s{},*]*?\bfrom\s*['"]([^'"]+)['"]|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
 const REFERENCE_PATH = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Every acquirable npm specifier the scanner finds in `code`, in source order.
+ * Exported for tests: this is the one step that decides which names become
+ * requests to jsDelivr, and it is a regex over arbitrary user code rather than a
+ * real parser, so its over-match behaviour is what needs pinning down.
+ */
+export function findAcquirableSpecifiers(code: string): string[] {
+	const found: string[] = [];
+	for (const match of code.matchAll(IMPORT_SPECIFIER)) {
+		const specifier = match[1] ?? match[2] ?? match[3];
+		if (specifier && isAcquirablePackage(specifier)) {
+			found.push(specifier);
+		}
+	}
+	return found;
+}
 
 /**
  * Minimal stand-in for the sliver of `typescript` that `@typescript/ata` uses:

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -18,7 +18,18 @@
 import { typescript } from '@/lib/monaco/languageServices';
 import { ExtraLibBudget } from '@/lib/monaco/workerLimits';
 
-/** node builtins are not on npm; their types come from `@types/node` (not acquired here). */
+/**
+ * node builtins are not on npm; their types come from `@types/node` (not acquired here).
+ * Matched against a specifier's *package portion*, so subpath forms — `fs/promises`,
+ * `assert/strict`, `timers/promises` — are covered without listing each one.
+ *
+ * `node:`-prefixed forms are rejected outright, which is the only way `node:test`,
+ * `node:sqlite` and `node:sea` are recognised: `test`, `sqlite` and `sea` are also real
+ * npm packages, so listing them bare would cost those packages their types. Several
+ * entries below have npm counterparts too (`events`, `buffer`, `process`, `path`,
+ * `punycode` — the browser shims), and the long-standing choice here is to treat the
+ * bare name as the builtin.
+ */
 const NODE_BUILTINS = new Set([
 	'assert',
 	'async_hooks',
@@ -26,30 +37,40 @@ const NODE_BUILTINS = new Set([
 	'child_process',
 	'cluster',
 	'console',
+	'constants',
 	'crypto',
+	'dgram',
+	'diagnostics_channel',
 	'dns',
+	'domain',
 	'events',
 	'fs',
 	'http',
 	'http2',
 	'https',
+	'inspector',
 	'module',
 	'net',
 	'os',
 	'path',
 	'perf_hooks',
 	'process',
+	'punycode',
 	'querystring',
 	'readline',
+	'repl',
 	'stream',
 	'string_decoder',
+	'sys',
 	'timers',
 	'tls',
+	'trace_events',
 	'tty',
 	'url',
 	'util',
 	'v8',
 	'vm',
+	'wasi',
 	'worker_threads',
 	'zlib',
 ]);
@@ -63,27 +84,53 @@ const ASSET_OR_DATA = /\.(svg|png|jpe?g|gif|webp|avif|ico|bmp|css|scss|sass|less
  * predate npm's lowercase-only rule.
  */
 const NPM_SPECIFIER = /^(?:@[a-z0-9\-~][a-z0-9\-._~]*\/)?[a-z0-9\-~][a-z0-9\-._~]*(?:\/[a-z0-9\-._~/]+)?$/i;
-/** npm's hard limit on a package name; also bounds what we're willing to send to the CDN. */
-const MAX_SPECIFIER_LENGTH = 214;
+/** npm's hard limit, which applies to the package *name* — never to a deep-import subpath. */
+const MAX_PACKAGE_NAME_LENGTH = 214;
+/**
+ * A separate ceiling for the specifier as a whole, since npm's 214 says nothing about a
+ * subpath: `pkg/a/b/…` can legitimately run past it and must still resolve. Generous
+ * enough that no real deep import comes close, while still bounding what is read and sent.
+ */
+const MAX_MODULE_SPECIFIER = 1024;
+
+/**
+ * The part of a specifier that names the package: the first segment, or the first two when
+ * scoped. Deep imports share their package's identity — `fs/promises` is as much a builtin
+ * as `fs`, and `lodash/fp`'s name is `lodash`.
+ */
+function packageNameOf(specifier: string): string {
+	const firstSlash = specifier.indexOf('/');
+	if (firstSlash < 0) {
+		return specifier;
+	}
+	if (!specifier.startsWith('@')) {
+		return specifier.slice(0, firstSlash);
+	}
+	const secondSlash = specifier.indexOf('/', firstSlash + 1);
+	return secondSlash < 0 ? specifier : specifier.slice(0, secondSlash);
+}
 
 /** A bare npm specifier we want real `@types` for — not relative, alias, asset, Harper, or node builtin. */
 function isAcquirablePackage(specifier: string): boolean {
 	if (!specifier || specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('@/')) {
 		return false;
 	}
-	if (specifier === 'harper' || specifier === 'harperdb' || specifier.startsWith('node:')) {
+	if (specifier.startsWith('node:') || ASSET_OR_DATA.test(specifier)) {
 		return false;
 	}
-	if (NODE_BUILTINS.has(specifier) || ASSET_OR_DATA.test(specifier)) {
+	const packageName = packageNameOf(specifier);
+	if (packageName === 'harper' || packageName === 'harperdb' || NODE_BUILTINS.has(packageName)) {
 		return false;
 	}
 	// Every specifier that gets past here becomes a cross-origin request to
 	// data.jsdelivr.com, so it must actually be able to name a package. The scanner
-	// below is a regex, not a parser, and anything it over-matches out of a comment
-	// or a SQL/GraphQL template literal would otherwise be sent verbatim to the CDN
-	// — leaking user-authored strings (table and type names) off-origin for a
+	// below reads arbitrary user code without a real parser, and anything it over-matches
+	// out of a comment or a SQL/GraphQL template literal would otherwise be sent verbatim
+	// to the CDN — leaking user-authored strings (table and type names) off-origin for a
 	// guaranteed 404. (HarperFast/studio: daily RUM review, 2026-07-28.)
-	return specifier.length <= MAX_SPECIFIER_LENGTH && NPM_SPECIFIER.test(specifier);
+	return specifier.length <= MAX_MODULE_SPECIFIER
+		&& packageName.length <= MAX_PACKAGE_NAME_LENGTH
+		&& NPM_SPECIFIER.test(specifier);
 }
 
 /**
@@ -111,7 +158,7 @@ const MAX_IMPORT_CLAUSE = 4096;
 const SLASH = 0x2f, STAR = 0x2a, NEWLINE = 0x0a, SINGLE_QUOTE = 0x27, DOUBLE_QUOTE = 0x22;
 const OPEN_PAREN = 0x28, CLOSE_PAREN = 0x29, OPEN_BRACE = 0x7b, CLOSE_BRACE = 0x7d, COMMA = 0x2c;
 const BACKTICK = 0x60, BACKSLASH = 0x5c, DOLLAR = 0x24, DOT = 0x2e;
-const OPEN_BRACKET = 0x5b, CLOSE_BRACKET = 0x5d;
+const OPEN_BRACKET = 0x5b, CLOSE_BRACKET = 0x5d, LESS_THAN = 0x3c, GREATER_THAN = 0x3e;
 
 /** `\w` plus `$` — what a clause keyword or imported binding is spelled with. */
 function isIdentifierChar(charCode: number): boolean {
@@ -172,8 +219,10 @@ interface ScannedSpecifier {
  * A quoted module specifier at `at`, after optional whitespace. `limit` is the caller's
  * bound and applies to the whitespace run as well as the quotes: without it, a statement
  * whose `from` sits inside the clause bound could still reach a quote arbitrarily far
- * past it, and every keyword candidate would rescan that same run. The specifier body is
- * additionally capped at npm's own name limit, past which it is rejected anyway.
+ * past it, and every keyword candidate would rescan that same run. The body is
+ * additionally capped at `MAX_MODULE_SPECIFIER` — the whole specifier, not npm's
+ * package-name limit, or a long but valid deep import would be truncated before
+ * `isAcquirablePackage` ever saw it.
  */
 function readQuotedSpecifier(code: string, at: number, bound: number): { specifier: string; end: number } | undefined {
 	const opened = skipWhitespace(code, at, bound);
@@ -181,7 +230,7 @@ function readQuotedSpecifier(code: string, at: number, bound: number): { specifi
 	if (opened >= bound || (quote !== SINGLE_QUOTE && quote !== DOUBLE_QUOTE)) {
 		return undefined;
 	}
-	const limit = Math.min(bound, opened + MAX_SPECIFIER_LENGTH + 2);
+	const limit = Math.min(bound, opened + MAX_MODULE_SPECIFIER + 2);
 	for (let next = opened + 1; next < limit; next++) {
 		const charCode = code.charCodeAt(next);
 		if (charCode === quote) {
@@ -348,6 +397,11 @@ function skipRegexLiteral(code: string, at: number, limit: number): number {
  * `previousWord` covers the keywords that produce no value and so may be followed by a
  * regex (`return /x/`), which a bare "previous char is a letter" test gets wrong.
  *
+ * A `)` is not enough on its own: it closes a call, whose result divides, but it also
+ * closes an `if`/`while`/`for` head, whose body may be a bare regex statement —
+ * `if (ready) /x/.test(s)`. `closedControlFlowHead` carries which of the two the last `)`
+ * was, tracked by the caller.
+ *
  * Ambiguity is resolved toward *regex*, `}` included: mistaking division for a regex
  * skips to the next `/` and can only lose an import, while mistaking a regex for
  * division scans its body as code and could take a specifier out of it.
@@ -367,11 +421,16 @@ const REGEX_MAY_FOLLOW = new Set([
 	'yield',
 	'await',
 ]);
-function canStartRegex(previousChar: number, previousWord: string): boolean {
+/** Keywords whose parenthesised head is followed by a statement, not an operator. */
+const CONTROL_FLOW_HEAD = new Set(['if', 'while', 'for', 'switch', 'catch', 'with']);
+function canStartRegex(previousChar: number, previousWord: string, closedControlFlowHead: boolean): boolean {
 	if (isIdentifierChar(previousChar)) {
 		return REGEX_MAY_FOLLOW.has(previousWord);
 	}
-	return previousChar !== CLOSE_PAREN && previousChar !== CLOSE_BRACKET
+	if (previousChar === CLOSE_PAREN) {
+		return closedControlFlowHead;
+	}
+	return previousChar !== CLOSE_BRACKET
 		&& previousChar !== SINGLE_QUOTE && previousChar !== DOUBLE_QUOTE && previousChar !== BACKTICK;
 }
 
@@ -392,34 +451,98 @@ function canStartRegex(previousChar: number, previousWord: string): boolean {
  * half-typed code, which for an editor is the normal state, and returning nothing there
  * would silently stop type acquisition mid-keystroke. Where the walk cannot be certain it
  * prefers to treat text as *not* code, which loses an acquisition rather than leaking a
- * name. Template substitutions are still scanned, since `import()` inside one is real
- * code.
+ * name. Substitutions and JSX expression containers are still scanned, since `import()`
+ * inside one is real code.
+ *
+ * Known limit, in the safe direction: a generic arrow in a `.tsx` file (`<T,>(x) => x`)
+ * opens `<` where an expression may start, so it reads as JSX and the rest of the file is
+ * skipped as element text. That loses acquisition, never a name, and imports sit above
+ * such code in practice.
  */
+/** Skipping template text, looking for the closing backtick or a `${`. */
+const CONTEXT_TEMPLATE = 0;
+/** Scanning code inside `${…}` or a JSX `{…}`; the entry's `braces` balances its own `{`. */
+const CONTEXT_EXPRESSION = 1;
+/** Inside `<tag …`, skipping attribute syntax up to `>` or `/>`. */
+const CONTEXT_JSX_TAG = 2;
+/** Between `>` and the matching `</tag>`, where everything is element text. */
+const CONTEXT_JSX_TEXT = 3;
+
 function scanSpecifiers(code: string): ScannedSpecifier[] {
 	const found: ScannedSpecifier[] = [];
-	// Each entry is a `${` substitution we are inside; its value is the brace depth within
-	// it, so the matching `}` returns us to the enclosing template. An explicit stack
-	// rather than recursion, so deeply nested templates cost memory, never the call stack.
-	const substitutions: number[] = [];
-	let inTemplate = false;
+	// Templates, JSX and expression containers nest arbitrarily, so context is an explicit
+	// stack rather than recursion: deep nesting costs memory, never the call stack.
+	const contexts: Array<{ kind: number; braces: number }> = [];
+	// Whether the innermost `(` opened a control-flow head, so its `)` can be followed by a
+	// bare regex statement. A stack, since heads nest (`if (a) while (b) /x/.test(s)`).
+	const parenHeads: boolean[] = [];
+	let closedControlFlowHead = false;
 	let previousChar = 0;
 	let previousWord = '';
 	let at = 0;
 	while (at < code.length) {
 		const charCode = code.charCodeAt(at);
+		const context = contexts[contexts.length - 1];
+		const kind = context?.kind;
 
-		if (inTemplate) {
+		if (kind === CONTEXT_TEMPLATE) {
 			if (charCode === BACKSLASH) {
 				at += 2;
 			} else if (charCode === BACKTICK) {
-				inTemplate = false;
+				contexts.pop();
 				previousChar = BACKTICK;
 				at++;
 			} else if (charCode === DOLLAR && code.charCodeAt(at + 1) === OPEN_BRACE) {
-				substitutions.push(0);
-				inTemplate = false;
+				contexts.push({ kind: CONTEXT_EXPRESSION, braces: 0 });
 				previousChar = OPEN_BRACE;
+				previousWord = '';
 				at += 2;
+			} else {
+				at++;
+			}
+			continue;
+		}
+
+		if (kind === CONTEXT_JSX_TEXT) {
+			if (charCode === OPEN_BRACE) {
+				contexts.push({ kind: CONTEXT_EXPRESSION, braces: 0 });
+				previousChar = OPEN_BRACE;
+				previousWord = '';
+				at++;
+			} else if (charCode === LESS_THAN) {
+				if (code.charCodeAt(at + 1) === SLASH) {
+					// A closing tag ends this element's text.
+					const tagEnd = code.indexOf('>', at + 2);
+					contexts.pop();
+					previousChar = GREATER_THAN;
+					previousWord = '';
+					at = tagEnd < 0 ? code.length : tagEnd + 1;
+				} else {
+					contexts.push({ kind: CONTEXT_JSX_TAG, braces: 0 });
+					at++;
+				}
+			} else {
+				at++;
+			}
+			continue;
+		}
+
+		if (kind === CONTEXT_JSX_TAG) {
+			if (charCode === SINGLE_QUOTE || charCode === DOUBLE_QUOTE) {
+				at = skipStringLiteral(code, at, code.length);
+			} else if (charCode === OPEN_BRACE) {
+				contexts.push({ kind: CONTEXT_EXPRESSION, braces: 0 });
+				previousChar = OPEN_BRACE;
+				previousWord = '';
+				at++;
+			} else if (charCode === SLASH && code.charCodeAt(at + 1) === GREATER_THAN) {
+				contexts.pop(); // self-closing: no children follow
+				previousChar = GREATER_THAN;
+				previousWord = '';
+				at += 2;
+			} else if (charCode === GREATER_THAN) {
+				contexts[contexts.length - 1] = { kind: CONTEXT_JSX_TEXT, braces: 0 };
+				at++;
 			} else {
 				at++;
 			}
@@ -438,7 +561,9 @@ function scanSpecifiers(code: string): ScannedSpecifier[] {
 				at = commentEnd < 0 ? code.length : commentEnd + 2;
 				continue;
 			}
-			at = canStartRegex(previousChar, previousWord) ? skipRegexLiteral(code, at, code.length) : at + 1;
+			at = canStartRegex(previousChar, previousWord, closedControlFlowHead)
+				? skipRegexLiteral(code, at, code.length)
+				: at + 1;
 			previousChar = SLASH;
 			previousWord = '';
 			continue;
@@ -452,24 +577,41 @@ function scanSpecifiers(code: string): ScannedSpecifier[] {
 		}
 
 		if (charCode === BACKTICK) {
-			inTemplate = true;
+			contexts.push({ kind: CONTEXT_TEMPLATE, braces: 0 });
 			at++;
 			continue;
 		}
 
-		if (substitutions.length > 0) {
+		// `<` where an expression may start opens JSX; after a value it is less-than, and
+		// after an identifier it is a TypeScript type argument (`Array<string>`, `f<T>()`).
+		if (charCode === LESS_THAN && canStartRegex(previousChar, previousWord, closedControlFlowHead)) {
+			const following = code.charCodeAt(at + 1);
+			if (following === GREATER_THAN || isIdentifierChar(following)) {
+				contexts.push({ kind: following === GREATER_THAN ? CONTEXT_JSX_TEXT : CONTEXT_JSX_TAG, braces: 0 });
+				at += following === GREATER_THAN ? 2 : 1;
+				continue;
+			}
+		}
+
+		if (kind === CONTEXT_EXPRESSION) {
 			if (charCode === OPEN_BRACE) {
-				substitutions[substitutions.length - 1]++;
+				context.braces++;
 			} else if (charCode === CLOSE_BRACE) {
-				if (substitutions[substitutions.length - 1] === 0) {
-					substitutions.pop();
-					inTemplate = true;
+				if (context.braces === 0) {
+					contexts.pop();
 					previousChar = CLOSE_BRACE;
+					previousWord = '';
 					at++;
 					continue;
 				}
-				substitutions[substitutions.length - 1]--;
+				context.braces--;
 			}
+		}
+
+		if (charCode === OPEN_PAREN) {
+			parenHeads.push(CONTROL_FLOW_HEAD.has(previousWord));
+		} else if (charCode === CLOSE_PAREN) {
+			closedControlFlowHead = parenHeads.pop() ?? false;
 		}
 
 		if (isIdentifierChar(charCode)) {

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -88,15 +88,24 @@ function isAcquirablePackage(specifier: string): boolean {
 
 /**
  * The clause between `import`/`export` and `from` — identifiers, braces, commas,
- * `*`, `as`, and whitespace (newlines included, so multi-line named imports still
- * match). Deliberately excludes `=`, `/`, `:`, `(`, `)`, and backticks: none can
- * appear in a real import clause, and admitting them let the lazy match run past
- * the end of a statement to reach a `from "…"` sitting in a following comment,
- * SQL string, or GraphQL block — which is how `Known Fraudster Risk` reached
- * jsDelivr as a package name.
+ * `*`, `as`, whitespace (newlines included, so multi-line named imports still
+ * match), and comments, which are legal and common between the braces. Everything
+ * else is excluded: `=`, `:`, `(`, `)`, backticks, and a bare `/` cannot appear in
+ * a real import clause, and admitting them let the lazy match run past the end of
+ * a statement to reach a `from "…"` sitting in a following comment, SQL string, or
+ * GraphQL block — which is how `Known Fraudster Risk` reached jsDelivr as a
+ * package name.
+ *
+ * Each comment is matched as one indivisible unit: the line form is pinned to its
+ * line end by a lookahead, and the block form cannot cross its terminator. That
+ * pinning is the whole point — a plain `//[^\n]*` backtracks, so the matcher could
+ * stop halfway through a comment and take the `from "…"` out of the rest of it,
+ * reopening the leak on input as ordinary as `export { Dog }` followed by a
+ * comment. Alternatives are disjoint on their first character (only `/` starts a
+ * comment), so the repetition stays linear.
  */
 const IMPORT_SPECIFIER =
-	/(?:import|export)\b[\w$\s{},*]*?\bfrom\s*['"]([^'"]+)['"]|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
+	/(?:import|export)\b(?:[\w$\s{},*]|\/\/[^\n]*(?=\n|$)|\/\*(?:[^*]|\*(?!\/))*\*\/)*?\bfrom\s*['"]([^'"]+)['"]|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s*['"]([^'"]+)['"]/g;
 const REFERENCE_PATH = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
 
 /**

--- a/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
+++ b/src/features/instance/applications/components/TextEditorView/harper-language/typeAcquisition.ts
@@ -87,75 +87,229 @@ function isAcquirablePackage(specifier: string): boolean {
 }
 
 /**
- * How far one import clause — including any single comment inside it — may extend
- * before the scanner abandons the statement. Real clauses are nowhere close: the
- * longest in this repo is 351 chars, and across ~13k declaration files in
+ * How many characters of one import clause the scanner reads before abandoning the
+ * statement — the whole clause, comments included. Real clauses are nowhere close:
+ * the longest in this repo is 351 chars, and across ~13k declaration files in
  * `node_modules` the longest is a 1.6 KB barrel re-export, so 4 KB leaves ample
  * headroom. A clause past the bound just isn't acquired, the same degraded-but-safe
  * outcome as any unacquired package.
  *
- * The bound is what keeps the scan linear, and it is load-bearing. The clause match
- * is lazy, so without it every failed attempt runs to end-of-input and each
- * `import`/`export` occurrence pays that again: an unterminated `/*` — a mid-edit
- * save, a truncated CDN download — took ~22s on 719 KB, and a long run of
- * clause-legal characters ~2.5s on 281 KB even before comments were admitted.
- * Bounded, those same inputs scan in ~220-300ms, and real files in ~1ms. This file
- * promises failures are swallowed so they "can never break editing"; a multi-second
- * freeze of the main thread would break that promise even though nothing throws.
+ * The bound is load-bearing, and it has to bound *characters*. `acquireApplicationTypes`
+ * scans every project script joined together and ata re-scans every downloaded
+ * `.d.ts`, so a clause that can never resolve has to cost the same whether the file
+ * is 4 KB or 6 MB. An unterminated `/*` — a mid-edit save, a truncated CDN response —
+ * has no terminator to find, and hunting for one to end-of-input, once per
+ * `import`/`export` occurrence, is quadratic: 719 KB of that took ~22s on the main
+ * thread. Bounded, it scans in ~200ms, and real files in ~1ms.
  *
- * A ceiling on `code.length` instead would not have fixed this — 281 KB is under any
- * sane ceiling and still took seconds — and it would drop acquisition entirely for
- * large but perfectly ordinary projects.
+ * A ceiling on `code.length` instead would not have fixed it: 281 KB of clause-legal
+ * characters is under any sane ceiling and still took ~2.5s, and a ceiling would drop
+ * acquisition entirely for large but perfectly ordinary projects.
  */
 const MAX_IMPORT_CLAUSE = 4096;
 
+const SLASH = 0x2f, STAR = 0x2a, NEWLINE = 0x0a, SINGLE_QUOTE = 0x27, DOUBLE_QUOTE = 0x22;
+const OPEN_PAREN = 0x28, CLOSE_PAREN = 0x29, OPEN_BRACE = 0x7b, CLOSE_BRACE = 0x7d, COMMA = 0x2c;
+
+/** `\w` plus `$` — what a clause keyword or imported binding is spelled with. */
+function isIdentifierChar(charCode: number): boolean {
+	return (charCode >= 0x61 && charCode <= 0x7a) // a-z
+		|| (charCode >= 0x41 && charCode <= 0x5a) // A-Z
+		|| (charCode >= 0x30 && charCode <= 0x39) // 0-9
+		|| charCode === 0x5f // _
+		|| charCode === 0x24; // $
+}
+
+/** Everything `\s` matches, so multi-line and oddly-spaced imports behave as before. */
+function isWhitespace(charCode: number): boolean {
+	return charCode === 0x20
+		|| (charCode >= 0x09 && charCode <= 0x0d)
+		|| charCode === 0xa0
+		|| charCode === 0xfeff
+		|| (charCode >= 0x2000 && charCode <= 0x200a)
+		|| charCode === 0x2028
+		|| charCode === 0x2029
+		|| charCode === 0x3000;
+}
+
+function skipWhitespace(code: string, at: number, limit: number): number {
+	let next = at;
+	while (next < limit && isWhitespace(code.charCodeAt(next))) {
+		next++;
+	}
+	return next;
+}
+
+/** `indexOf`, but it never looks past `limit` — an unbounded terminator search is what went quadratic. */
+function indexOfWithin(code: string, charCode: number, at: number, limit: number): number {
+	for (let next = at; next < limit; next++) {
+		if (code.charCodeAt(next) === charCode) {
+			return next;
+		}
+	}
+	return -1;
+}
+
+function indexOfPairWithin(code: string, first: number, second: number, at: number, limit: number): number {
+	for (let next = at; next + 1 < limit; next++) {
+		if (code.charCodeAt(next) === first && code.charCodeAt(next + 1) === second) {
+			return next;
+		}
+	}
+	return -1;
+}
+
+/** A specifier the scanner found, plus the span ata's `preProcessFile` reports for it. */
+interface ScannedSpecifier {
+	specifier: string;
+	pos: number;
+	end: number;
+}
+
 /**
- * The clause between `import`/`export` and `from` — identifiers, braces, commas,
- * `*`, `as`, whitespace (newlines included, so multi-line named imports still
- * match), and comments, which are legal and common between the braces. Everything
- * else is excluded: `=`, `:`, `(`, `)`, backticks, and a bare `/` cannot appear in
- * a real import clause, and admitting them let the lazy match run past the end of
- * a statement to reach a `from "…"` sitting in a following comment, SQL string, or
- * GraphQL block — which is how `Known Fraudster Risk` reached jsDelivr as a
- * package name.
- *
- * Each comment is matched as one indivisible unit: the line form is pinned to its
- * line end by a lookahead, and the block form cannot cross its terminator. That
- * pinning is the whole point — a plain `//[^\n]*` backtracks, so the matcher could
- * stop halfway through a comment and take the `from "…"` out of the rest of it,
- * reopening the leak on input as ordinary as `export { Dog }` followed by a
- * comment. Every alternative is bounded by `MAX_IMPORT_CLAUSE`, including the
- * comment bodies — an unterminated comment has no terminator to find, so an
- * unbounded search for one is exactly what made this quadratic.
+ * A quoted module specifier at `at`, after optional whitespace. Bounded by npm's own
+ * name limit: past that the specifier is rejected anyway, so reading further would
+ * only turn a missing closing quote into another unbounded scan.
  */
-const IMPORT_CLAUSE = String.raw`(?:`
-	+ String.raw`[\w$\s{},*]`
-	+ String.raw`|//[^\n]{0,${MAX_IMPORT_CLAUSE}}(?=\n|$)`
-	+ String.raw`|/\*(?:[^*]|\*(?!/)){0,${MAX_IMPORT_CLAUSE}}?\*/`
-	+ String.raw`){0,${MAX_IMPORT_CLAUSE}}?`;
-const IMPORT_SPECIFIER = new RegExp(
-	String.raw`(?:import|export)\b${IMPORT_CLAUSE}\bfrom\s*['"]([^'"]+)['"]`
-		+ String.raw`|(?:import|require)\s*\(\s*['"]([^'"]+)['"]\s*\)`
-		+ String.raw`|import\s*['"]([^'"]+)['"]`,
-	'g',
-);
+function readQuotedSpecifier(code: string, at: number): { specifier: string; end: number } | undefined {
+	const opened = skipWhitespace(code, at, code.length);
+	const quote = code.charCodeAt(opened);
+	if (quote !== SINGLE_QUOTE && quote !== DOUBLE_QUOTE) {
+		return undefined;
+	}
+	const limit = Math.min(code.length, opened + MAX_SPECIFIER_LENGTH + 2);
+	for (let next = opened + 1; next < limit; next++) {
+		const charCode = code.charCodeAt(next);
+		if (charCode === quote) {
+			// `['"]([^'"]+)['"]` never matched an empty specifier, and neither do we.
+			return next === opened + 1 ? undefined : { specifier: code.slice(opened + 1, next), end: next + 1 };
+		}
+		if (charCode === SINGLE_QUOTE || charCode === DOUBLE_QUOTE) {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Walks the clause between an `import`/`export` keyword and its `from`, returning the
+ * quoted specifier when the statement really is an import.
+ *
+ * A character walk rather than another regex alternative, deliberately. This has to
+ * stay cheap on input that can never match, and expressing the clause as a quantified
+ * sub-pattern gave us both failure modes in turn: an unbounded search for a comment
+ * terminator is quadratic, and bounding it with `{0,n}` instead accumulates V8
+ * backtracking frames until a long run of large *legal* comments overflows the regex
+ * stack with a `RangeError`. Walking has no frames to accumulate, and every
+ * terminator search here is bounded by `MAX_IMPORT_CLAUSE`.
+ *
+ * What may appear in a clause is narrow, and the narrowness is the security property
+ * rather than tidiness: identifiers, `{}`, `,`, `*`, whitespace, and comments. A bare
+ * `/`, `=`, `:`, `(`, `)`, or backtick ends the clause, which is what stops the walk
+ * from leaving a statement and reaching a `from "…"` in a neighbouring comment, SQL
+ * string, or GraphQL block — the leak that sent `Known Fraudster Risk` to jsDelivr as
+ * a package name. Comments are skipped whole for the same reason: never partially, so
+ * a `from "…"` inside one can't be read as the statement's own.
+ */
+function readClauseSpecifier(code: string, clauseStart: number): { specifier: string; end: number } | undefined {
+	const limit = Math.min(code.length, clauseStart + MAX_IMPORT_CLAUSE);
+	let at = clauseStart;
+	while (at < limit) {
+		const charCode = code.charCodeAt(at);
+		if (charCode === SLASH) {
+			const following = code.charCodeAt(at + 1);
+			if (following === SLASH) {
+				// A line comment runs to the newline; with none, the rest of the file is
+				// comment, so no `from` can follow and the statement is not an import.
+				const lineEnd = indexOfWithin(code, NEWLINE, at + 2, limit);
+				if (lineEnd < 0) {
+					return undefined;
+				}
+				at = lineEnd + 1;
+			} else if (following === STAR) {
+				const commentEnd = indexOfPairWithin(code, STAR, SLASH, at + 2, limit);
+				if (commentEnd < 0) {
+					return undefined;
+				}
+				at = commentEnd + 2;
+			} else {
+				return undefined;
+			}
+			continue;
+		}
+		if (isIdentifierChar(charCode)) {
+			let wordEnd = at + 1;
+			while (wordEnd < limit && isIdentifierChar(code.charCodeAt(wordEnd))) {
+				wordEnd++;
+			}
+			// A `from` that no specifier follows is just a binding name (`import from from 'x'`).
+			if (wordEnd - at === 4 && code.startsWith('from', at)) {
+				const found = readQuotedSpecifier(code, wordEnd);
+				if (found) {
+					return found;
+				}
+			}
+			at = wordEnd;
+			continue;
+		}
+		if (
+			charCode === OPEN_BRACE || charCode === CLOSE_BRACE || charCode === COMMA || charCode === STAR
+			|| isWhitespace(charCode)
+		) {
+			at++;
+			continue;
+		}
+		return undefined;
+	}
+	return undefined;
+}
+
+/** Keywords that can introduce a specifier — the only places the scanner starts work. */
+const STATEMENT_KEYWORD = /\b(?:import|export|require)\b/g;
 const REFERENCE_PATH = /\/\/\/\s*<reference\s+path\s*=\s*['"]([^'"]+)['"]/g;
+
+/**
+ * Every module specifier in `code`, in source order: `import`/`export … from '…'`,
+ * dynamic `import('…')`, `require('…')`, and a bare side-effect `import '…'`.
+ */
+function scanSpecifiers(code: string): ScannedSpecifier[] {
+	const found: ScannedSpecifier[] = [];
+	for (const match of code.matchAll(STATEMENT_KEYWORD)) {
+		const keyword = match[0];
+		const pos = match.index;
+		const afterKeyword = pos + keyword.length;
+		if (keyword !== 'export' && code.charCodeAt(skipWhitespace(code, afterKeyword, code.length)) === OPEN_PAREN) {
+			const call = readQuotedSpecifier(code, skipWhitespace(code, afterKeyword, code.length) + 1);
+			if (call) {
+				const closeAt = skipWhitespace(code, call.end, code.length);
+				if (code.charCodeAt(closeAt) === CLOSE_PAREN) {
+					found.push({ specifier: call.specifier, pos, end: closeAt + 1 });
+				}
+			}
+			continue;
+		}
+		if (keyword === 'require') {
+			continue;
+		}
+		const bare = keyword === 'import' ? readQuotedSpecifier(code, afterKeyword) : undefined;
+		const scanned = bare ?? readClauseSpecifier(code, afterKeyword);
+		if (scanned) {
+			found.push({ specifier: scanned.specifier, pos, end: scanned.end });
+		}
+	}
+	return found;
+}
 
 /**
  * Every acquirable npm specifier the scanner finds in `code`, in source order.
  * Exported for tests: this is the one step that decides which names become
- * requests to jsDelivr, and it is a regex over arbitrary user code rather than a
- * real parser, so its over-match behaviour is what needs pinning down.
+ * requests to jsDelivr, and it reads arbitrary user code without a real parser, so
+ * its over-match behaviour is what needs pinning down.
  */
 export function findAcquirableSpecifiers(code: string): string[] {
-	const found: string[] = [];
-	for (const match of code.matchAll(IMPORT_SPECIFIER)) {
-		const specifier = match[1] ?? match[2] ?? match[3];
-		if (specifier && isAcquirablePackage(specifier)) {
-			found.push(specifier);
-		}
-	}
-	return found;
+	return scanSpecifiers(code)
+		.map(({ specifier }) => specifier)
+		.filter(isAcquirablePackage);
 }
 
 /**
@@ -169,14 +323,9 @@ function createImportScannerShim(): unknown {
 	return {
 		libMap: new Map<string, string>(),
 		preProcessFile(code: string) {
-			const importedFiles: Array<{ fileName: string; pos: number; end: number }> = [];
-			for (const match of code.matchAll(IMPORT_SPECIFIER)) {
-				const specifier = match[1] ?? match[2] ?? match[3];
-				if (specifier && isAcquirablePackage(specifier)) {
-					const pos = match.index ?? 0;
-					importedFiles.push({ fileName: specifier, pos, end: pos + match[0].length });
-				}
-			}
+			const importedFiles = scanSpecifiers(code)
+				.filter(({ specifier }) => isAcquirablePackage(specifier))
+				.map(({ specifier, pos, end }) => ({ fileName: specifier, pos, end }));
 			const referencedFiles: Array<{ fileName: string; pos: number; end: number }> = [];
 			for (const match of code.matchAll(REFERENCE_PATH)) {
 				const pos = match.index ?? 0;


### PR DESCRIPTION
## What the daily RUM review found

Datadog RUM, last 24h (app `f590deee-…`, release **v2.154.3**): **18 requests to `data.jsdelivr.com/v1/package/resolve/npm/<specifier>@latest` returned 404** in a single session. One of the specifiers was the URL-encoded string `Known%20Fraudster%20Risk` — a **multi-word phrase with spaces**, which cannot name an npm package and can only have come from the user's own application code.

These were completely silent: `@typescript/ata` collapses every non-OK response into a bare `new Error("OK")` (no status, no retry), and Studio passes it no `logger`. RUM was the only place they surfaced.

Two problems, both worth fixing:

1. **Wasted, uncached cross-origin requests** — one per bogus specifier, per fresh tab.
2. **User-authored strings leave the origin.** Table and type names out of a customer's app code were sent to a third-party CDN as URL paths. That's the part I'd treat as time-sensitive; it's a small egress, but it's customer content going somewhere it was never meant to go.

## Root cause

`harper-language/typeAcquisition.ts` scans project sources for import specifiers with a regex shim — we deliberately don't ship `typescript` to the browser just for `preProcessFile`. The clause matcher between `import`/`export` and `from` was:

```
(?:import|export)\b[^'";]*?\bfrom\s*['"]([^'"]+)['"]
```

`[^'";]*?` excludes quotes and semicolons but **not newlines**, so the lazy match could run past the end of a statement and latch onto any lowercase `from "…"` further down the file. Confirmed shapes:

| source | extracted |
| --- | --- |
| `export const { Dog } = tables` ⏎ `// everything below reads from "Known Fraudster Risk"` | **`Known Fraudster Risk`** |
| `export interface Risk {` ⏎ `/** derived from "Known Fraudster Risk" table */` | **`Known Fraudster Risk`** |
| ``export const q = `select * from "Known Fraudster Risk"` `` | **`Known Fraudster Risk`** |

Harper apps quote SQL identifiers with `"` and semicolon-free Prettier style is common, so this is easy to hit in ordinary code.

`isAcquirablePackage` was the last gate before the network, and it only filtered relative paths, `@/` aliases, assets, Harper globals, and node builtins — **it never checked the specifier could name an npm package at all.**

Worth noting: the scanner also runs over every **downloaded `.d.ts`** (ata recurses via `resolveDeps`), so vendor declaration prose is a second feeder.

## The fix

Both changes are confined to the scanner:

- **Restrict the import clause** to what can actually appear in one — identifiers, braces, commas, `*`, `as`, whitespace, and comments. Whitespace still includes newlines so **multi-line named imports keep working**; `=`, `:`, `(`, `)`, backticks, and a bare `/` are excluded, and that's what stops a match from crossing out of a statement into neighbouring prose. Each comment is matched as one **indivisible unit** — the `//` form pinned to its line end by a lookahead, the block form unable to cross its terminator — so consuming comments can't hand the prose back (see the review round below).
- **Validate against npm's name grammar** before a specifier can become a request: optional `@scope/`, name, optional deep-import subpath, 214-char cap, no whitespace. Case-insensitive so legacy names (`JSONStream`, `Base64`) still resolve.

## Tests

New `typeAcquisition.test.ts`, 62 cases — there were **no tests for this extraction** before:

- Real import forms that must keep resolving: default, named, namespace, star/named re-export, type-only, aliased, bare side-effect, dynamic `import()`, `require()`, scoped, deep, double-quoted, and multi-line named imports.
- Categories that must never be acquired: relative, `@/` alias, `harper`/`harperdb`, `node:`/bare builtins, css/json assets.
- Comments in every legal clause position: `//` and `/* */` inside a named block, `/** */` and `//` before `from`, a comment before a `type` modifier, and CRLF line endings.
- The prose-mining regressions above, plus invalid-specifier and length cases.

**11 of the original 41 fail on the pre-fix scanner** (verified by reverting the source and re-running); the 21 added in review rounds 1-3 are broken out below.

Full suite green: `259 files / 1885 passed, 11 skipped`. `tsc -b`, `oxlint`, `dprint check` all clean.

## Review round 1 — comments in the import clause (66747d99)

Caught by @cb1kenobi's review: excluding a bare `/` from the clause also dropped **any import with a comment between the braces**. `import { useState, // hooks ⏎ } from 'react'` matched nothing, so that package silently stopped getting types — a real regression, and untested.

Letting the clause consume comments fixes it, but only if a comment can't be **partially** consumed. A plain `\/\/[^\n]*` backtracks, so the matcher stops mid-comment and takes the `from "…"` out of the rest of it — which reopens this PR's leak:

| clause matcher | `export { Dog }` ⏎ `// each row is read from "customers"` | annotated import |
| --- | --- | --- |
| `stage` | **`customers`** | ✅ |
| this PR, as first reviewed | ✅ none | ❌ missed |
| bare `\/\/[^\n]*` | **`customers`** | ✅ |
| shipped | ✅ none | ✅ |

The regression cases use a single lowercase table name rather than `Known Fraudster Risk` on purpose: `customers` satisfies npm's name grammar, so the grammar gate waves it through and the **clause matcher is the only thing left** between user content and the CDN. A multi-word phrase is caught either way, which is what masked this in the first draft of the tests.

12 new cases: 6 annotated-import forms (**all 6 fail on the clause as first reviewed**) and 6 prose shapes (**4 fail on a backtrackable comment alternative, all 6 on `stage`**), including a `.d.ts` jsdoc case — the scanner also runs over every downloaded declaration file. Alternatives are disjoint on their first character, so the repetition stays linear: 20k-token clause garbage and 5k-line comment spam both scan in under a millisecond.

## Review round 2 — an unterminated comment could freeze the editor (3c1a42c6)

Also caught by @cb1kenobi, and the more serious of the two. The comment alternatives search for a terminator, and an **unterminated `/*` has none** — so every failed attempt ran to end-of-input, and each later `import`/`export` occurrence paid it again. Quadratic, on the main thread:

| input (32k occurrences) | round 1 | **shipped** |
| --- | --- | --- |
| 719 KB `import /* unterminated` | 21.9s | **238ms** |
| 719 KB, no newlines (minified) | 22.2s | **218ms** |
| 281 KB, `//` at a truncated EOF | 8.1s | **305ms** |
| 281 KB run of clause-legal chars | 7.5s | **254ms** |
| 813 KB of real imports | 2ms | **2ms** |

No hostile input needed: a mid-edit save with an open block comment, or a truncated CDN download. `acquireApplicationTypes` scans every project script joined together, and ata re-scans every downloaded `.d.ts`.

The fix bounds every clause alternative, comment bodies included, at `MAX_IMPORT_CLAUSE = 4096`. Two things worth flagging:

- **It also fixes a pre-existing version of this.** That last-but-one row — a long run of clause-legal characters, no comments at all — took **~2.5s on `stage` and on round 1 alike**. The quadratic wasn't introduced by comment matching; comments widened the trigger and worsened the constant. So the doc comment claiming "the repetition stays linear" was wrong before this round *and* would have been wrong without comments.
- **I didn't take the `code.length` ceiling option.** It doesn't fix the shape — 281 KB is under any sane ceiling and still took seconds — and it would drop acquisition entirely for large but perfectly ordinary projects.

4096 clears real code by a wide margin, measured rather than guessed: the longest clause in this repo is **351 chars** (a `lucide-react` icon import), and across 13,288 clauses in ~4k `node_modules` declaration files the longest is a **1.6 KB** barrel re-export. Past the bound a clause isn't acquired — the same degraded-but-safe outcome as any unacquired package.

7 more cases (60 total): 4 wall-clock guards that **all fail with the bound removed** (7.0-18.5s against a 3s budget, ~10x headroom over the ~300ms actual), plus multi-line jsdoc inside a clause and a 2.9 KB barrel re-export, which the bound must not break.

## Review round 3 — the bound crashed on legal comments, so the clause is no longer a regex (8a3c3c50)

@cb1kenobi again, and this one ends the pattern. Bounding with `{0,n}` traded the quadratic scan for a **crash**: V8 keeps a backtracking frame per repetition, so a long run of large — but perfectly legal, properly terminated — comments inside one clause overflowed the regex stack.

```js
const bigComment = '/*' + 'x'.repeat(4090) + '*/';
findAcquirableSpecifiers('import ' + bigComment.repeat(1400) + ' nofrom\n');
// round 2: RangeError: Maximum call stack size exceeded
// shipped: [] in ~4ms
```

`acquireApplicationTypes` catches it, but it scans every project source joined into one string, so one bad clause aborted acquisition for all of them.

**The bound was also on the wrong thing.** It capped *repetitions*, not characters — so 4096 reps of ~4 KB comments admitted ~16 MB, which is exactly how a 5.7 MB input got through a bound documented as 4 KB. My round-2 doc comment was wrong about that.

Taking the second option suggested in review, the clause is now a **character walk** (`readClauseSpecifier`) rather than a quantified sub-pattern. No backtracking frames to accumulate, every terminator search bounded, and `MAX_IMPORT_CLAUSE` now genuinely bounds characters. Three rounds of regex fixes each introduced the next failure mode; a walk removes the class rather than the instance.

The clause **grammar is unchanged** — identifiers, `{}`, `,`, `*`, whitespace, comments, and anything else ends the clause — because that narrowness is the property keeping user-authored strings off the CDN. Comments are still skipped whole, never partially.

Two things worth a reviewer's eye:

- **Equivalence is tested, not asserted.** All **60 prior cases pass against both** the walk and the round-2 regex, and the 2 new cases fail with `RangeError` on round 2. The only behaviour difference I found across every documented form: a specifier past npm's 214-char limit is no longer read at all rather than read and then rejected — same result through `findAcquirableSpecifiers`, but now a bounded read.
- It also folds the duplicated scan loop in `preProcessFile` into the same `scanSpecifiers`, so both callers agree by construction instead of by copy-paste.

Perf is unchanged-to-better on every earlier shape (166-320ms across the pathological set, ~7ms on 813 KB of real imports).

## Deliberately not in scope

- **Nothing bounds the number of jsDelivr requests per pass.** The existing budget (#1499/#1504) caps *chars admitted to the worker after download*, not requests issued.
- A failed resolution is negative-cached only for the tab's lifetime (ata's `moduleMap`), and there's no HTTP-level negative cache.
- ata swallowing status codes means we still have no telemetry on acquisition failures.

Happy to follow up on any of those separately.

## ⚠️ One housekeeping note

All four commits are **unsigned** — the first came from the scheduled daily RUM review, and GPG signing needs an interactive pinentry that isn't available in a headless run (`gpg: signing failed: Inappropriate ioctl for device`); the review-round commits hit the same wall. Please amend/re-sign before merging if the branch protection requires it.

_Opened by the automated daily Datadog RUM review. No customer identifiers included; the one specifier quoted is a schema/type name, retained because it is the diagnostic fingerprint — say the word and I'll redact it._



