### PR TITLE
docs(agents): document Conventional Commits enforcement in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,22 @@
 Hard-won, project-specific gotchas. Skim the relevant section before touching related
 code — each of these has cost a debugging session.
 
+## Commits — Conventional Commits are enforced in CI
+
+Every commit message needs a Conventional Commits prefix: `type(scope): subject`
+(`@commitlint/config-conventional` types — `feat`, `fix`, `docs`, `chore`, `test`,
+`refactor`, `perf`, `ci`, `build`, `style`, `revert`; scope optional; subject case is
+unrestricted, per `commitlint.config.cjs`). The **Verify Commits** workflow
+(`.github/workflows/verify-commits.yaml`) runs commitlint on every PR and on pushes to
+`dev`/`stage`/`prod` — a single unprefixed commit fails the check, and history that already
+landed on a deploy branch has to be rewritten and force-pushed to fix it.
+
+Don't count on the local hook to catch this first. `.husky/commit-msg` only runs after
+`pnpm install` has run the `prepare: husky` script, which is what points `core.hooksPath`
+at `.husky`. In a fresh clone or worktree that skipped install, `core.hooksPath` is unset,
+the hook never fires, and a non-conforming message commits silently — CI is the first thing
+that objects.
+
 ## Routing — keep `getParentRoute` and `addChildren` in lockstep
 
 In the TanStack Router setup (`src/router/rootRouteTree.ts`), every route's declared


### PR DESCRIPTION
Adds an `AGENTS.md` section documenting that the **Verify Commits** workflow enforces Conventional Commits (`type(scope): subject`, `@commitlint/config-conventional`) on every PR and on pushes to `dev`/`stage`/`prod` — and that nothing warns locally first, so CI is the first thing that objects.

Context: unprefixed commit messages on the #1574 deploy branches failed Verify Commits, which meant rewriting history that had already landed. This makes the convention discoverable for agents and humans working from bare worktrees.

## Rebased on stage, replayed onto `AGENTS.md`

Per @dawsontoth — the original commit edited `CLAUDE.md`, which #1573 renamed to `AGENTS.md` (with `CLAUDE.md` left as a pointer, per @kriszyp). This branch is now a single commit on top of current `stage`, with the section added to `AGENTS.md` instead. The stale `CLAUDE.md` in the branch name is cosmetic — renaming the branch would orphan this PR.

## The local-hook claim is now the verified mechanism, not the guess

The first version blamed a missing `node_modules` for the hook "failing open". Checked it instead of assuming, in a fresh clone that had never run `pnpm install`:

- `git config --get core.hooksPath` → **unset**. `.husky/commit-msg` is only wired up by the `prepare: husky` script, which `pnpm install` runs — skip install and git never looks in `.husky` at all.
- Committed `not a conventional message` in that checkout: it landed, no hook output, exit 0.

So the hook doesn't run and pass — it doesn't run. The section says that now, and names `core.hooksPath` so the fix is obvious to whoever hits it.

Every other fact in the section was re-checked against current `stage`: the workflow triggers (`.github/workflows/verify-commits.yaml`), the 11 `config-conventional` types, and `subject-case` being disabled in `commitlint.config.cjs`.

## Verification

`dprint check AGENTS.md` → exit 0. Markdown-only diff, one file, +16 lines; no code, config, or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
