### PR TITLE
[RUM] Drop errors thrown wholly inside third-party scripts (Reo.dev)

### DIFF
--- a/src/integrations/datadog/shouldKeepEvent.test.ts
+++ b/src/integrations/datadog/shouldKeepEvent.test.ts
@@ -121,6 +121,82 @@ describe('shouldKeepEvent', () => {
 		).toBe(true);
 	});
 
+	// Regression tests for the Reo.dev analytics errors that reached Error Tracking on
+	// 2026-07-28. Stacks below are the real ones RUM recorded, truncated.
+	describe('third-party script errors', () => {
+		it('discards errors thrown wholly inside the Reo.dev bundle', () => {
+			expect(
+				shouldKeepEvent(
+					errorEvent({
+						message: 'RangeError: Invalid time zone specified: Etc/Unknown',
+						stack: [
+							'RangeError: Invalid time zone specified: Etc/Unknown',
+							'  at new DateTimeFormat @ <anonymous>',
+							'  at r @ https://static.reo.dev/6565c3e84c377ad/177.reo.js:2:81872',
+							'  at s.year @ https://static.reo.dev/6565c3e84c377ad/177.reo.js:2:82437',
+						].join('\n'),
+					}),
+				),
+			).toBe(false);
+		});
+
+		// The Datadog SDK patches `fetch`, so its bundle tops the stack of a beacon that
+		// Reo.dev itself issued. That instrumentation frame must not make the error look
+		// like Studio's own.
+		it('discards third-party errors whose stack is topped by the Datadog fetch wrapper', () => {
+			expect(
+				shouldKeepEvent(
+					errorEvent({
+						message: 'Failed to fetch',
+						stack: [
+							'TypeError: Failed to fetch',
+							'  at <anonymous> @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3213',
+							'  at pn @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3396',
+							'  at <anonymous> @ https://static.reo.dev/6565c3e84c377ad/reo.js:2:188638',
+							'  at l @ https://static.reo.dev/6565c3e84c377ad/reo.js:2:180136',
+						].join('\n'),
+					}),
+				),
+			).toBe(false);
+		});
+
+		it('keeps errors with the same message when Studio code is on the stack', () => {
+			expect(
+				shouldKeepEvent(
+					errorEvent({
+						message: 'Failed to fetch',
+						stack: [
+							'TypeError: Failed to fetch',
+							'  at <anonymous> @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3213',
+							'  at getOrganization @ https://fabric.harper.fast/assets/index-A1b2C3d4.js:5:1234',
+						].join('\n'),
+					}),
+				),
+			).toBe(true);
+		});
+
+		it('keeps errors with no third-party frame at all', () => {
+			expect(
+				shouldKeepEvent(
+					errorEvent({
+						message: 'Uncaught "ResizeObserver loop completed with undelivered notifications."',
+						stack: [
+							'Error: ResizeObserver loop completed with undelivered notifications.',
+							'  at undefined @ https://fabric.harper.fast/#/org-abc123',
+						].join('\n'),
+					}),
+				),
+			).toBe(true);
+		});
+
+		it('keeps errors with a stackless or frameless stack', () => {
+			expect(shouldKeepEvent(errorEvent({ message: 'TypeError: x is not a function' }))).toBe(true);
+			expect(
+				shouldKeepEvent(errorEvent({ message: 'Boom', stack: 'Error: Boom\n  at <anonymous>' })),
+			).toBe(true);
+		});
+	});
+
 	it('keeps non-timeout network failures that are not attributable to an instance endpoint', () => {
 		// Without an instance/cluster URL we cannot tell a real backend failure from an
 		// expected one, so a bare "Network Error" stays visible (unlike timeouts).

--- a/src/integrations/datadog/shouldKeepEvent.ts
+++ b/src/integrations/datadog/shouldKeepEvent.ts
@@ -31,11 +31,20 @@ const INSTRUMENTATION_FRAME = /\/assets\/vendor-datadog-[^/\s]*\.js/;
  * Datadog SDK's own instrumentation), i.e. no Studio code is on the stack at all.
  */
 function originatesInThirdPartyScript(stack: string) {
-	const frames = stack.split('\n').filter(line => /https?:\/\//.test(line));
-	if (!frames.some(frame => THIRD_PARTY_SCRIPT_FRAME.test(frame))) {
-		return false;
+	let sawThirdPartyFrame = false;
+	for (const line of stack.split('\n')) {
+		// Skips the leading message line and any frame the browser couldn't resolve to a URL.
+		if (!/https?:\/\//.test(line)) {
+			continue;
+		}
+		if (THIRD_PARTY_SCRIPT_FRAME.test(line)) {
+			sawThirdPartyFrame = true;
+		} else if (!INSTRUMENTATION_FRAME.test(line)) {
+			// Studio code is on the stack, so the error is ours to answer for.
+			return false;
+		}
 	}
-	return frames.every(frame => THIRD_PARTY_SCRIPT_FRAME.test(frame) || INSTRUMENTATION_FRAME.test(frame));
+	return sawThirdPartyFrame;
 }
 
 /**

--- a/src/integrations/datadog/shouldKeepEvent.ts
+++ b/src/integrations/datadog/shouldKeepEvent.ts
@@ -7,8 +7,35 @@ export interface DatadogErrorEvent {
 	error?: {
 		message?: string;
 		source?: string;
+		stack?: string;
 		resource?: { url?: string };
 	};
+}
+
+/**
+ * Scripts we embed but do not ship or control — currently only the Reo.dev analytics
+ * bundle (`src/integrations/reo/reo.ts` loads it from this CDN). Errors thrown inside
+ * them are vendor bugs we can neither reproduce nor fix.
+ */
+const THIRD_PARTY_SCRIPT_FRAME = /https?:\/\/static\.reo\.dev\//;
+
+/**
+ * The Datadog browser SDK monkey-patches `fetch`/XHR, so its own bundle sits at the top
+ * of every stack it instruments — including stacks whose real origin is third-party.
+ * Treat it as instrumentation rather than as a Studio frame when attributing an error.
+ */
+const INSTRUMENTATION_FRAME = /\/assets\/vendor-datadog-[^/\s]*\.js/;
+
+/**
+ * True when every located frame in the stack belongs to a third-party script (or to the
+ * Datadog SDK's own instrumentation), i.e. no Studio code is on the stack at all.
+ */
+function originatesInThirdPartyScript(stack: string) {
+	const frames = stack.split('\n').filter(line => /https?:\/\//.test(line));
+	if (!frames.some(frame => THIRD_PARTY_SCRIPT_FRAME.test(frame))) {
+		return false;
+	}
+	return frames.every(frame => THIRD_PARTY_SCRIPT_FRAME.test(frame) || INSTRUMENTATION_FRAME.test(frame));
 }
 
 /**
@@ -67,6 +94,19 @@ export function shouldKeepEvent(event: DatadogErrorEvent) {
 	// worker OOM of issue #1407), and the stale-deploy trigger now self-recovers via
 	// `installStaleDeployReload` — this repeated per-call echo adds nothing but volume.
 	if (/Missing requestHandler or method: /.test(message)) {
+		return false;
+	}
+
+	// Errors thrown entirely inside an embedded third-party script are that vendor's bugs,
+	// not Studio's: we can't reproduce them, fix them, or act on them, and they arrive with
+	// stacks that point only at minified vendor code. Reo.dev alone contributed two distinct
+	// "issues" to Error Tracking within a day of first appearing (2026-07-28): a
+	// `RangeError: Invalid time zone specified: Etc/Unknown` from its own `DateTimeFormat`
+	// call, and a `TypeError: Failed to fetch` when its beacon is blocked. Attribute on the
+	// stack rather than the message, so a genuine Studio error that happens to share a
+	// message is still kept.
+	const stack = event.error?.stack ?? '';
+	if (stack && originatesInThirdPartyScript(stack)) {
 		return false;
 	}
 


### PR DESCRIPTION
## What

Adds a `shouldKeepEvent` clause that discards RUM error events whose stack contains **no Studio frame at all** — every located frame belongs to an embedded third-party script (currently only `static.reo.dev`) or to the Datadog SDK's own instrumentation.

## Why

The Reo.dev analytics bundle — loaded by [reo.ts](src/integrations/reo/reo.ts) — began reporting its own errors into Studio's Error Tracking on **2026-07-28**. Two distinct issues appeared within a day; neither existed in the preceding 7 days (checked 2026-07-22 → 07-29):

| Error | Events (24h) | Sessions | Origin |
| --- | --- | --- | --- |
| `RangeError: Invalid time zone specified: Etc/Unknown` | 4 | 2 | Reo's own `new DateTimeFormat` on a client whose timezone resolves to `Etc/Unknown` |
| `TypeError: Failed to fetch` | 4 | 2 | Reo's beacon blocked, surfaced through the Datadog SDK's `fetch` wrapper |

Representative stacks as recorded by RUM (truncated):

```
RangeError: Invalid time zone specified: Etc/Unknown
  at new DateTimeFormat @ <anonymous>
  at r @ https://static.reo.dev/6565c3e84c377ad/177.reo.js:2:81872
  at s.year @ https://static.reo.dev/6565c3e84c377ad/177.reo.js:2:82437
```

```
TypeError: Failed to fetch
  at <anonymous> @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3213
  at pn @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3396
  at <anonymous> @ https://static.reo.dev/6565c3e84c377ad/reo.js:2:188638
```

Both fire on `#/sign-in` and `#/sign-up`. Neither is a Studio bug — we can't reproduce or fix minified vendor code — and both otherwise create standing Error Tracking issues, the same noise problem the existing clauses in this file address (`Object Not Found Matching Id` from a browser extension, Monaco's `Missing requestHandler` echoes).

## Design notes

- **Attribution is by stack, not by message.** A genuine Studio `TypeError: Failed to fetch` is still kept — there's a test for exactly that.
- **`vendor-datadog-*.js` frames count as instrumentation, not Studio code.** The Datadog SDK monkey-patches `fetch`/XHR, so its bundle tops the stack of a beacon that Reo itself issued. Without this the second error above would look like ours.
- Events with no stack, or a stack with no resolvable URLs, are untouched (kept).

## Testing

`shouldKeepEvent.test.ts` gains 5 cases using the real stacks above as fixtures, covering both drops plus three keep-paths (Studio frame present, no third-party frame, stackless). 26 tests pass; `tsc -b`, `oxlint`, and `dprint check` are clean.

## Not addressed here

The largest error signal in the same 24h window — an 86-event `ResizeObserver loop completed with undelivered notifications` burst on the org overview page — is filed separately as an issue rather than filtered, since it may indicate a real layout feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)