### PR TITLE
fix(org-users): skip user references the server cannot resolve

### DIFF
--- a/src/features/organization/users/index.tsx
+++ b/src/features/organization/users/index.tsx
@@ -7,11 +7,10 @@ import { getOrganizationRolesQueryOptions } from '@/features/organization/querie
 import { dataTableColumns } from '@/features/organization/users/constants/tableDefinition';
 import { AddUserModal } from '@/features/organization/users/modals/AddUserModal';
 import { EditUserModal } from '@/features/organization/users/modals/EditUserModal';
-import { isAdminRoleName } from '@/features/organization/users/orgUserRemovalPolicy';
+import { collectOrgUsers, countOrgAdmins } from '@/features/organization/users/orgRoleMembers';
 import { useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
 import { SchemaUser } from '@/integrations/api/api.gen';
-import { sortByEmail } from '@/lib/arrays/sort/byEmail';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { Row } from '@tanstack/react-table';
@@ -28,34 +27,8 @@ export function OrgConfigUsersIndex() {
 		isFetching,
 		isRefetching,
 	} = useSuspenseQuery(getOrganizationRolesQueryOptions(organizationId));
-	const cloudUsers = useMemo(() => {
-		const users: Record<SchemaUser['id'], SchemaUser> = {};
-		for (const organizationRole of organizationRoles) {
-			if (organizationRole.users) {
-				for (const user of organizationRole.users) {
-					if (!users[user.id]) {
-						users[user.id] = { ...user, roles: [] };
-					}
-					users[user.id].roles!.push(organizationRole);
-				}
-			}
-		}
-		return Object.values(users).sort(sortByEmail);
-	}, [organizationRoles]);
-
-	// Distinct members holding an admin role — used to keep the last admin from removing their own
-	// admin role or leaving (which would leave the org with no one able to manage it).
-	const orgAdminCount = useMemo(() => {
-		const adminUserIds = new Set<SchemaUser['id']>();
-		for (const organizationRole of organizationRoles) {
-			if (isAdminRoleName(organizationRole.roleName)) {
-				for (const user of organizationRole.users ?? []) {
-					adminUserIds.add(user.id);
-				}
-			}
-		}
-		return adminUserIds.size;
-	}, [organizationRoles]);
+	const cloudUsers = useMemo(() => collectOrgUsers(organizationRoles), [organizationRoles]);
+	const orgAdminCount = useMemo(() => countOrgAdmins(organizationRoles), [organizationRoles]);
 
 	const selectedUser = useMemo(() => cloudUsers?.find((user) => user.id === orgUserId), [cloudUsers, orgUserId]);
 

--- a/src/features/organization/users/orgRoleMembers.test.ts
+++ b/src/features/organization/users/orgRoleMembers.test.ts
@@ -1,0 +1,76 @@
+import { collectOrgUsers, countOrgAdmins } from '@/features/organization/users/orgRoleMembers';
+import { SchemaOrganizationRole, SchemaUser } from '@/integrations/api/api.gen';
+import { describe, expect, it } from 'vitest';
+
+function user(id: string, email: string): SchemaUser {
+	return { id, email, firstname: 'First', lastname: 'Last' };
+}
+
+function role(id: string, roleName: string, users: Array<SchemaUser | null>): SchemaOrganizationRole {
+	return {
+		id,
+		roleName,
+		organizationId: 'org-test',
+		userIds: users.map((u, i) => u?.id ?? `usr-dangling-${i}`),
+		// The server emits `null` for a `userIds` entry it cannot resolve; the generated type
+		// does not admit that, so the cast is what the real payload looks like at runtime.
+		users: users as SchemaUser[],
+	};
+}
+
+const alice = user('usr-alice', 'alice@example.com');
+const bob = user('usr-bob', 'bob@example.com');
+
+describe('collectOrgUsers', () => {
+	it('unions members across roles and sorts them by email', () => {
+		const users = collectOrgUsers([role('rol-1', 'admin', [bob]), role('rol-2', 'reader', [alice])]);
+		expect(users.map((u) => u.email)).toEqual(['alice@example.com', 'bob@example.com']);
+	});
+
+	it('collects every role a member holds', () => {
+		const users = collectOrgUsers([role('rol-1', 'admin', [alice]), role('rol-2', 'reader', [alice])]);
+		expect(users).toHaveLength(1);
+		expect(users[0].roles?.map((r) => r.roleName)).toEqual(['admin', 'reader']);
+	});
+
+	// Regression: a role whose `userIds` points at a user record that no longer exists resolves to
+	// `[null]`, which used to throw "Cannot read properties of null (reading 'id')" and replace the
+	// whole Users page with an error boundary.
+	it('skips unresolved user references instead of throwing', () => {
+		const roles = [role('rol-1', 'admin', [alice]), role('rol-2', 'roletwo', [null])];
+		expect(() => collectOrgUsers(roles)).not.toThrow();
+		expect(collectOrgUsers(roles).map((u) => u.email)).toEqual(['alice@example.com']);
+	});
+
+	it('still returns the resolvable members of a partially dangling role', () => {
+		const users = collectOrgUsers([role('rol-1', 'admin', [alice, null, bob])]);
+		expect(users.map((u) => u.email)).toEqual(['alice@example.com', 'bob@example.com']);
+	});
+
+	it('handles a role with no users array at all', () => {
+		const bare: SchemaOrganizationRole = { id: 'rol-1', roleName: 'empty', organizationId: 'org-test', userIds: [] };
+		expect(collectOrgUsers([bare])).toEqual([]);
+	});
+});
+
+describe('countOrgAdmins', () => {
+	it('counts distinct members holding an admin role', () => {
+		expect(countOrgAdmins([role('rol-1', 'admin', [alice, bob]), role('rol-2', 'reader', [alice])])).toBe(2);
+	});
+
+	it('does not double-count a member holding two admin roles', () => {
+		expect(countOrgAdmins([role('rol-1', 'admin', [alice]), role('rol-2', 'Admin', [alice])])).toBe(1);
+	});
+
+	// Same dangling-reference guard as above: an unresolved admin reference must not throw, and must
+	// not inflate the count that gates "last admin cannot leave".
+	it('skips unresolved user references without inflating the count', () => {
+		const roles = [role('rol-1', 'admin', [alice, null])];
+		expect(() => countOrgAdmins(roles)).not.toThrow();
+		expect(countOrgAdmins(roles)).toBe(1);
+	});
+
+	it('ignores non-admin roles', () => {
+		expect(countOrgAdmins([role('rol-1', 'reader', [alice, bob])])).toBe(0);
+	});
+});

--- a/src/features/organization/users/orgRoleMembers.ts
+++ b/src/features/organization/users/orgRoleMembers.ts
@@ -1,0 +1,52 @@
+/**
+ * Derives the org's member list (and its admin headcount) from the roles payload.
+ *
+ * A user belongs to an org only by holding org roles, so the member list is the union of every
+ * role's `users`, with each member carrying the roles they hold.
+ *
+ * `OrganizationRole.users` is the server's resolution of `userIds`, and an id it cannot resolve
+ * comes back as a literal `null` element rather than being omitted — a dangling reference left
+ * behind when a user record goes away while roles still point at it. The generated type says
+ * `users?: SchemaUser[]` (elements non-nullable), so nothing catches this at compile time and a
+ * single stale reference used to take the whole Users page down with
+ * "Cannot read properties of null (reading 'id')". Both readers below skip unresolved entries so
+ * one bad record degrades to a missing row instead of an error boundary.
+ */
+import { SchemaOrganizationRole, SchemaUser } from '@/integrations/api/api.gen';
+import { sortByEmail } from '@/lib/arrays/sort/byEmail';
+import { isAdminRoleName } from './orgUserRemovalPolicy';
+
+/** Resolved members of a role, with unresolved (`null`) references dropped. */
+function resolvedUsers(organizationRole: SchemaOrganizationRole): SchemaUser[] {
+	return (organizationRole.users ?? []).filter((user): user is SchemaUser => user != null);
+}
+
+/** Distinct org members, each with the roles they hold, sorted by email. */
+export function collectOrgUsers(organizationRoles: SchemaOrganizationRole[]): SchemaUser[] {
+	const users: Record<SchemaUser['id'], SchemaUser> = {};
+	for (const organizationRole of organizationRoles) {
+		for (const user of resolvedUsers(organizationRole)) {
+			if (!users[user.id]) {
+				users[user.id] = { ...user, roles: [] };
+			}
+			users[user.id].roles!.push(organizationRole);
+		}
+	}
+	return Object.values(users).sort(sortByEmail);
+}
+
+/**
+ * Distinct members holding an admin role — used to keep the last admin from removing their own
+ * admin role or leaving (which would leave the org with no one able to manage it).
+ */
+export function countOrgAdmins(organizationRoles: SchemaOrganizationRole[]): number {
+	const adminUserIds = new Set<SchemaUser['id']>();
+	for (const organizationRole of organizationRoles) {
+		if (isAdminRoleName(organizationRole.roleName)) {
+			for (const user of resolvedUsers(organizationRole)) {
+				adminUserIds.add(user.id);
+			}
+		}
+	}
+	return adminUserIds.size;
+}

--- a/src/features/organization/users/orgRoleMembers.ts
+++ b/src/features/organization/users/orgRoleMembers.ts
@@ -21,15 +21,22 @@ function resolvedUsers(organizationRole: SchemaOrganizationRole): SchemaUser[] {
 	return (organizationRole.users ?? []).filter((user): user is SchemaUser => user != null);
 }
 
+/**
+ * A collected member. `SchemaUser.roles` is optional on the wire, but every member we build here
+ * is seeded with `roles: []`, so requiring it lets the accumulator push without a non-null
+ * assertion.
+ */
+export type OrgMember = SchemaUser & { roles: SchemaOrganizationRole[] };
+
 /** Distinct org members, each with the roles they hold, sorted by email. */
-export function collectOrgUsers(organizationRoles: SchemaOrganizationRole[]): SchemaUser[] {
-	const users: Record<SchemaUser['id'], SchemaUser> = {};
+export function collectOrgUsers(organizationRoles: SchemaOrganizationRole[]): OrgMember[] {
+	const users: Record<SchemaUser['id'], OrgMember> = {};
 	for (const organizationRole of organizationRoles) {
 		for (const user of resolvedUsers(organizationRole)) {
 			if (!users[user.id]) {
 				users[user.id] = { ...user, roles: [] };
 			}
-			users[user.id].roles!.push(organizationRole);
+			users[user.id].roles.push(organizationRole);
 		}
 	}
 	return Object.values(users).sort(sortByEmail);


### PR DESCRIPTION
## Problem

Navigating to an organization's **Users** page threw `TypeError: Cannot read properties of null (reading 'id')`, which the error boundary turned into a "Component Error" card — the entire page is replaced, so Users is unreachable for the affected org. Reproduced on `stage` with the Acme, Inc. org (`org-qpz5akmyrp1d0opj`).

## Root cause

`OrganizationRole.users` is the server's resolution of `userIds`. An id it *cannot* resolve comes back as a literal `null` element rather than being omitted:

```json
{
  "id": "rol-db1unfn9kthuug1b",
  "roleName": "roletwo",
  "organizationId": "org-qpz5akmyrp1d0opj",
  "userIds": ["usr-1kmtpihk58mkgwdr"],
  "users": [null]
}
```

That's a dangling reference — the user record is gone while the role still points at it. The loop building the member list guarded that `users` existed but not that each element was non-null, so `user.id` threw on the first stale entry.

Nothing caught this at compile time because the generated type declares `users?: components["schemas"]["User"][]` — elements are non-nullable in the schema but not in practice.

## Fix

Move the member/admin aggregation out of the component into a pure module (`orgRoleMembers.ts`) and filter unresolved entries in both readers. One bad record now degrades to a missing row instead of an error boundary.

The admin-count reader had the **identical latent bug** — it would have crashed the same way had the stale reference landed on an admin role instead. Both are fixed, and both are covered.

Extracting to a module follows the existing `orgUserRemovalPolicy.ts` + test pattern already in this folder, and makes the regression cheap to test without standing up jsdom, the router, and react-query.

## Testing

New `orgRoleMembers.test.ts` (9 cases). Verified the three dangling-reference cases genuinely reproduce the bug: with the null filter removed they fail with the exact production error, `TypeError: Cannot read properties of null (reading 'id')`.

Full suite green — 264 files, 1978 passed. `tsc -b`, `oxlint`, and `dprint` all clean.

Browser-verified against the real Acme, Inc. data on `stage`: the page renders all 4 resolvable members (the unresolved `roletwo` reference is silently dropped), no error boundary, and the Edit User modal still opens and lists all 6 roles.

**Before** — the page was replaced by a "Component Error" card reading `Cannot read properties of null (reading 'id')`.

**After** — the Users table renders all four resolvable members; the unresolved `roletwo` reference is dropped rather than fatal.

## Out of scope

This is the UI half. The underlying defect is server-side: deleting a user doesn't clean up `OrganizationRole.userIds`, leaving the dangling FK. Filed separately as #1586.

Related visible symptom of the same bad data, not addressed here: the Roles page counts members via `userIds.length`, so it reports `roletwo` as having 1 member when it effectively has 0. That one doesn't crash, it just over-reports — it should resolve once the data is cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
