### PR TITLE
fix(status): stop the connections chart diving to ~0 on single-node buckets

### DIFF
--- a/src/features/instance/status/analytics/__tests__/fixtures/connections/node-drop.json
+++ b/src/features/instance/status/analytics/__tests__/fixtures/connections/node-drop.json
@@ -1,0 +1,65 @@
+[
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n1",
+		"time": 1700000040000,
+		"connections": 100,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n1",
+		"time": 1700000100000,
+		"connections": 100,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n1",
+		"time": 1700000160000,
+		"connections": 100,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n1",
+		"time": 1700000220000,
+		"connections": 100,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n2",
+		"time": 1700000040000,
+		"connections": 200,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n2",
+		"time": 1700000100000,
+		"connections": 200,
+		"count": 1,
+		"period": 0
+	},
+	{
+		"metric": "mqtt-connections",
+		"type": "mqtt",
+		"node": "n2",
+		"time": 1700000220000,
+		"connections": 200,
+		"count": 1,
+		"period": 0
+	}
+]

--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
@@ -59,7 +59,17 @@ describe('bytes-sent tolerance', () => {
 
 	it('mqtt-traffic-sent (msg/sec) total ≈ Σ count/period × 1000 within 0.5%', () => {
 		const records = JSON.parse(readFileSync(join(import.meta.dirname, '../fixtures/bytes/bytes-sent.json'), 'utf8'));
-		const out = mqttTrafficSentDerived.recompute(records, { startTime: 0, endTime: Number.MAX_SAFE_INTEGER }, []);
+		// The window is load-bearing here, unlike the two cases above: this goes
+		// through `recompute`, which opts into `downsampleToWindow`, so the range
+		// decides the render lattice. The old `0 → MAX_SAFE_INTEGER` sentinel
+		// (harmless while runPipeline ignored `window`) now reads as a ~285-century
+		// window and folds every point into one bucket, which would collapse the
+		// Σ-of-rates this test is actually checking. Use the fixture's own span —
+		// ~59 min, so the 1 h preset's 1 min lattice, and the samples sit ~115 s
+		// apart and stay one-per-bucket.
+		const times = (records as { time: number }[]).map((r) => r.time).filter(Number.isFinite);
+		const window = { startTime: Math.min(...times), endTime: Math.max(...times) };
+		const out = mqttTrafficSentDerived.recompute(records, window, []);
 
 		const refTotal = records.reduce((s: number, r: any) => {
 			if (typeof r.count !== 'number' || typeof r.period !== 'number' || r.period <= 0) { return s; }

--- a/src/features/instance/status/analytics/__tests__/pipeline/carryForward.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/carryForward.test.ts
@@ -3,6 +3,7 @@ import {
 	buildStalenessHorizons,
 	estimateEmissionIntervalMs,
 	isGaugeCrossNodeSum,
+	MAX_STALENESS_MS,
 	STALENESS_INTERVALS,
 } from '../../pipeline/carryForward';
 
@@ -76,12 +77,58 @@ describe('buildStalenessHorizons', () => {
 		const horizons = buildStalenessHorizons(
 			new Map([
 				['fast', [0, 90_000, 180_000]],
+				// 10-minute cadence: 2 x that would be 20 min, so the cap binds.
 				['slow', [0, 600_000, 1_200_000]],
 			]),
 			FLOOR,
 		);
 		expect(horizons.get('fast')).toBe(STALENESS_INTERVALS * 90_000);
-		expect(horizons.get('slow')).toBe(STALENESS_INTERVALS * 600_000);
+		expect(horizons.get('slow')).toBe(MAX_STALENESS_MS);
+	});
+
+	it('caps a node observed only twice, far apart, instead of trusting the gap', () => {
+		// The shape kriszyp flagged: observations at 00:00 and 12:00 read as a
+		// 12-hour "cadence", which uncapped meant a 24-hour horizon — the node's
+		// stale count would then be summed into every later bucket for the rest
+		// of the window, hiding a real drop to zero.
+		const HOUR = 3_600_000;
+		const horizons = buildStalenessHorizons(new Map([['quiet', [0, 12 * HOUR]]]), FLOOR);
+		expect(horizons.get('quiet')).toBe(MAX_STALENESS_MS);
+		expect(horizons.get('quiet')).toBeLessThan(STALENESS_INTERVALS * 12 * HOUR);
+	});
+
+	it('caps when one normal gap and one outage average into a multi-hour median', () => {
+		// Three samples, gaps [60 s, 6 h] → median 3h0m30s. Also the reviewer's
+		// second scenario, and the median offers no protection here.
+		const horizons = buildStalenessHorizons(new Map([['n1', [0, 60_000, 60_000 + 6 * 3_600_000]]]), FLOOR);
+		expect(horizons.get('n1')).toBe(MAX_STALENESS_MS);
+	});
+
+	it('lets the bucket floor exceed the cap, so ≥2 buckets still holds', () => {
+		// On a spec whose own bucket is coarser than the 5-minute backstop,
+		// spanning two buckets matters more than the backstop — the floor is
+		// applied after the cap for exactly this case.
+		const coarseFloor = 4 * 3_600_000; // 4h buckets
+		const horizons = buildStalenessHorizons(new Map([['n1', [0, 12 * 3_600_000]]]), coarseFloor);
+		expect(horizons.get('n1')).toBe(STALENESS_INTERVALS * coarseFloor);
+	});
+
+	it('never exceeds max(MAX_STALENESS_MS, 2 x floor) for any observation shape', () => {
+		const shapes: number[][] = [
+			[0, 90_000],
+			[0, 12 * 3_600_000],
+			[0, 1_000, 30 * 24 * 3_600_000],
+			[5],
+			[0, 0, 0],
+			[0, 60_000, 120_000, 30 * 24 * 3_600_000],
+		];
+		for (const floor of [1_000, FLOOR, 600_000]) {
+			const ceiling = Math.max(MAX_STALENESS_MS, STALENESS_INTERVALS * floor);
+			for (const [i, times] of shapes.entries()) {
+				const h = buildStalenessHorizons(new Map([['n', times]]), floor).get('n')!;
+				expect(h, `shape ${i} @ floor ${floor}`).toBeLessThanOrEqual(ceiling);
+			}
+		}
 	});
 
 	it('floors at the bucket size so the horizon always spans two buckets', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/carryForward.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/carryForward.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildStalenessHorizons,
+	estimateEmissionIntervalMs,
+	isGaugeCrossNodeSum,
+	STALENESS_INTERVALS,
+} from '../../pipeline/carryForward';
+
+describe('isGaugeCrossNodeSum', () => {
+	it('accepts the two gauge shapes that ship (max/sum, last/sum)', () => {
+		expect(isGaugeCrossNodeSum('max', 'sum')).toBe(true); // connections
+		expect(isGaugeCrossNodeSum('last', 'sum')).toBe(true); // database-size
+	});
+
+	it('rejects additive counters — a missing row there really is zero', () => {
+		// mqtt-traffic-*, bytes-sent/received, fsWrite: carrying the previous
+		// bucket's throughput forward would invent traffic that never happened.
+		expect(isGaugeCrossNodeSum('sum', 'sum')).toBe(false);
+	});
+
+	it('rejects every crossNode aggregator other than sum', () => {
+		// max/mean/CWM across nodes already degrade gracefully when a node is
+		// absent — they don't understate the way a partial sum does.
+		for (const cross of ['max', 'min', 'mean', 'last', 'p95', 'count-weighted-mean'] as const) {
+			expect(isGaugeCrossNodeSum('max', cross), `max/${cross}`).toBe(false);
+			expect(isGaugeCrossNodeSum('last', cross), `last/${cross}`).toBe(false);
+		}
+	});
+
+	it('rejects mean/p95 temporal aggregators paired with a cross-node sum', () => {
+		for (const temporal of ['mean', 'p50', 'p95', 'p99', 'count-weighted-mean', 'min'] as const) {
+			expect(isGaugeCrossNodeSum(temporal, 'sum'), `${temporal}/sum`).toBe(false);
+		}
+	});
+});
+
+describe('estimateEmissionIntervalMs', () => {
+	it('returns the interval for an evenly spaced series', () => {
+		expect(estimateEmissionIntervalMs([0, 90_000, 180_000, 270_000])).toBe(90_000);
+	});
+
+	it('is order-independent', () => {
+		expect(estimateEmissionIntervalMs([270_000, 0, 180_000, 90_000])).toBe(90_000);
+	});
+
+	it('averages the two middle gaps on an even gap count', () => {
+		// gaps: 60_000, 120_000 → (60_000 + 120_000) / 2
+		expect(estimateEmissionIntervalMs([0, 60_000, 180_000])).toBe(90_000);
+	});
+
+	it('ignores zero-length gaps from duplicate instants', () => {
+		// Harper registers mqtt-connections with `byThread: true`; a build that
+		// forwards per-thread rows unaggregated yields several rows per instant.
+		expect(estimateEmissionIntervalMs([0, 0, 0, 90_000, 90_000, 180_000])).toBe(90_000);
+	});
+
+	it('uses the median so scattered absences do not inflate the estimate', () => {
+		// A node whose count keeps crossing zero (core's `> 0` guard) emits in
+		// bursts. Its active cadence is 90 s; the mean of these gaps is 234 s,
+		// the median is still 90 s.
+		const times = [0, 90_000, 180_000, 900_000, 990_000, 1_080_000, 1_800_000];
+		expect(estimateEmissionIntervalMs(times)).toBe(90_000);
+	});
+
+	it('returns null when there is no gap to measure', () => {
+		expect(estimateEmissionIntervalMs([])).toBeNull();
+		expect(estimateEmissionIntervalMs([1_000])).toBeNull();
+		expect(estimateEmissionIntervalMs([1_000, 1_000])).toBeNull();
+	});
+});
+
+describe('buildStalenessHorizons', () => {
+	const FLOOR = 60_000;
+
+	it('scales each node by its own observed cadence', () => {
+		const horizons = buildStalenessHorizons(
+			new Map([
+				['fast', [0, 90_000, 180_000]],
+				['slow', [0, 600_000, 1_200_000]],
+			]),
+			FLOOR,
+		);
+		expect(horizons.get('fast')).toBe(STALENESS_INTERVALS * 90_000);
+		expect(horizons.get('slow')).toBe(STALENESS_INTERVALS * 600_000);
+	});
+
+	it('floors at the bucket size so the horizon always spans two buckets', () => {
+		// A node emitting faster than the bucket lattice still needs a horizon
+		// wide enough to absorb the phase drift the lattice introduces.
+		const horizons = buildStalenessHorizons(new Map([['n1', [0, 10_000, 20_000]]]), FLOOR);
+		expect(horizons.get('n1')).toBe(STALENESS_INTERVALS * FLOOR);
+	});
+
+	it('falls back to the bucket size for a node seen exactly once', () => {
+		const horizons = buildStalenessHorizons(new Map([['n1', [12_345]]]), FLOOR);
+		expect(horizons.get('n1')).toBe(STALENESS_INTERVALS * FLOOR);
+	});
+
+	it('emits no entry for a node it never saw', () => {
+		const horizons = buildStalenessHorizons(new Map([['n1', [0, 60_000]]]), FLOOR);
+		expect(horizons.has('n2')).toBe(false);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
@@ -182,6 +182,33 @@ describe('connections — cluster-wide gaps stay gaps', () => {
 		expect(points.at(-1)!.x).toBe(T0 + 20 * LATTICE);
 		expect(points.at(-1)!.y).toBe(BUSY);
 	});
+
+	it('carries a node again once it comes back after going stale', () => {
+		// Guards the staleness eviction: an aged-out node is dropped from the
+		// carry-forward state, so it must be re-registered when it reports again
+		// rather than staying permanently excluded.
+		//
+		// Both nodes need a few closely-spaced samples first so their *own*
+		// median gap reads as one bucket. Give `quiet` only two samples either
+		// side of the silence and the silence itself becomes its median gap —
+		// horizon 2 x 21 buckets — and nothing ever ages out.
+		const rows = [
+			...[0, 1, 2, 20, 21, 22].map((i) => connectionRow('busy', T0 + i * LATTICE, BUSY)),
+			// `quiet` reports at cadence, goes silent well past 2 x that…
+			...[0, 1, 2].map((i) => connectionRow('quiet', T0 + i * LATTICE, QUIET)),
+			// …then returns, and drops out of the very next bucket again.
+			connectionRow('quiet', T0 + 21 * LATTICE, QUIET),
+		];
+		const byX = new Map(mqttPoints(rows).map((p) => [p.x, p.y]));
+		// Fresh.
+		expect(byX.get(T0 + 2 * LATTICE)).toBe(BUSY + QUIET);
+		// Aged out: busy alone.
+		expect(byX.get(T0 + 20 * LATTICE)).toBe(BUSY);
+		// Back, and observed.
+		expect(byX.get(T0 + 21 * LATTICE)).toBe(BUSY + QUIET);
+		// Back, absent from this bucket, but fresh enough to carry again.
+		expect(byX.get(T0 + 22 * LATTICE)).toBe(BUSY + QUIET);
+	});
 });
 
 describe('connections — node-drop fixture', () => {

--- a/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
@@ -1,0 +1,268 @@
+// Regression coverage for #1576 — the Connections panel dove to ~0 whenever a
+// single time bucket held only one node of the cluster.
+//
+// The pre-existing connections/database-size suites only exercise uniform
+// `period: 60000` rows with every node present at every timestamp, so the
+// artifact could not surface there. These cases reproduce the reported shape:
+// `period: 0` rows on a 90 s emission cadence, snapped onto the spec's 60 s
+// fallback lattice, with the two nodes half a cadence out of phase.
+import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import type { AnalyticsDataPoint, SeriesPoint, TimeRange } from '../../types/analytics';
+import nodeDrop from '../fixtures/connections/node-drop.json';
+
+const connectionsSpec = wrapperMetrics['connections'].spec;
+const databaseSizeSpec = wrapperMetrics['database-size'].spec;
+const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
+
+/** `spec.bucket.fallbackMs` — what `period: 0` degrades to, and therefore the
+ *  lattice every one of these rows gets snapped onto. */
+const LATTICE = 60_000;
+/** Emission cadence observed on the reporting instance (90 s, despite
+ *  `analytics.aggregatePeriod: 60`). 90 mod 60 = 30, which is what makes the
+ *  two nodes' snapped buckets beat against the lattice. */
+const CADENCE = 90_000;
+/** Lattice-aligned epoch, so every snapped bucket below is exact. */
+const T0 = 28_333_334 * LATTICE;
+/** Half a cadence — the second node's phase offset. */
+const PHASE = CADENCE / 2;
+
+const BUSY = 285; // us-west-1's steady connection count
+const QUIET = 3; // Milan's, while it had any at all
+
+const WINDOW: TimeRange = { startTime: T0 - LATTICE, endTime: T0 + 100 * CADENCE };
+
+/** Round-to-nearest, matching the pipeline's `snapToBucketTime`. */
+const snap = (t: number) => Math.round(t / LATTICE) * LATTICE;
+
+function connectionRow(node: string, time: number, connections: number): AnalyticsDataPoint {
+	// `period: 0` is what harper-pro stamps on gauge rows — no aggregation
+	// period, which is the root of the lattice mismatch.
+	return { metric: 'mqtt-connections', type: 'mqtt', node, time, connections, count: 1, period: 0 };
+}
+
+/** Two nodes on the same cadence, out of phase: `busy` never misses a period,
+ *  `quiet` reports only on the sample indices given. */
+function staggeredCluster(samples: number, quietIndices: readonly number[]): AnalyticsDataPoint[] {
+	const rows: AnalyticsDataPoint[] = [];
+	for (let i = 0; i < samples; i++) {
+		rows.push(connectionRow('busy', T0 + i * CADENCE, BUSY));
+	}
+	for (const j of quietIndices) {
+		rows.push(connectionRow('quiet', T0 + PHASE + j * CADENCE, QUIET));
+	}
+	return rows;
+}
+
+/** Buckets holding rows from exactly one node — the ones that used to render
+ *  as a vertical dive to that node's own value. */
+function soloNodeBuckets(rows: AnalyticsDataPoint[]): number[] {
+	const byBucket = new Map<number, Set<string>>();
+	for (const r of rows) {
+		const b = snap(r.time);
+		const nodes = byBucket.get(b) ?? new Set<string>();
+		nodes.add(r.node);
+		byBucket.set(b, nodes);
+	}
+	return [...byBucket.entries()].filter(([, nodes]) => nodes.size === 1).map(([b]) => b).sort((a, b) => a - b);
+}
+
+const mqttPoints = (rows: AnalyticsDataPoint[]): SeriesPoint[] => {
+	const out = runPipeline(connectionsSpec, rows, WINDOW, ['busy', 'quiet'], { snapToPeriod: true });
+	return out.series.find((s) => s.key === 'mqtt')!.points;
+};
+
+describe('connections — staggered per-node cadence (#1576)', () => {
+	const SAMPLES = 40;
+	// Quiet node present for every period it could be: the raggedness here comes
+	// purely from phase, not from core's `> 0` guard.
+	const rows = staggeredCluster(SAMPLES, [...Array(SAMPLES).keys()]);
+
+	it('the fixture really does produce single-node buckets', () => {
+		// Guard on the setup itself — if the lattice/phase arithmetic ever stops
+		// producing solo buckets, the assertions below would pass vacuously.
+		const solo = soloNodeBuckets(rows);
+		expect(solo.length).toBeGreaterThan(0);
+		// Both directions occur: buckets with only `busy`, and the ones that
+		// caused the reported dives, with only `quiet`.
+		const quietOnly = solo.filter((b) => rows.some((r) => snap(r.time) === b && r.node === 'quiet'));
+		expect(quietOnly.length).toBeGreaterThan(0);
+	});
+
+	it('never renders the cluster total as one node alone', () => {
+		const points = mqttPoints(rows);
+		const ys = points.map((p) => p.y!);
+		// Pre-fix this bottomed out at QUIET (3) — "connections dropped to 0".
+		expect(Math.min(...ys)).toBeGreaterThanOrEqual(BUSY);
+		expect(Math.max(...ys)).toBeLessThanOrEqual(BUSY + QUIET);
+	});
+
+	it('carries the absent node forward rather than inventing bucket times', () => {
+		// Same x positions as before the fix: carry-forward fills values inside
+		// existing buckets, it never adds new ones.
+		const expectedBuckets = [...new Set(rows.map((r) => snap(r.time)))].sort((a, b) => a - b);
+		expect(mqttPoints(rows).map((p) => p.x)).toEqual(expectedBuckets);
+	});
+
+	it('counts only observed samples, not carried ones', () => {
+		// `SeriesPoint.count` drives confidence gating and the tooltip's sample
+		// count; a carried value is not a new observation.
+		const points = mqttPoints(rows);
+		const solo = new Set(soloNodeBuckets(rows));
+		for (const p of points) {
+			expect(p.count, `bucket ${p.x}`).toBe(solo.has(p.x) ? 1 : 2);
+		}
+	});
+});
+
+describe('connections — bounded staleness horizon', () => {
+	const SAMPLES = 40;
+	// Quiet node reports for its first five periods, then goes genuinely idle:
+	// core stops emitting rows for it entirely once its count hits 0.
+	const QUIET_SAMPLES = 5;
+	const rows = staggeredCluster(SAMPLES, [...Array(QUIET_SAMPLES).keys()]);
+	// Its cadence reads as 90 s, so its last value may be carried for 180 s.
+	const horizon = 2 * CADENCE;
+	const lastQuietBucket = snap(T0 + PHASE + (QUIET_SAMPLES - 1) * CADENCE);
+
+	it('stops carrying the idle node once its last sample ages past the horizon', () => {
+		const points = mqttPoints(rows);
+		const stale = points.filter((p) => p.x > lastQuietBucket + horizon);
+		expect(stale.length).toBeGreaterThan(0);
+		for (const p of stale) {
+			expect(p.y, `bucket ${p.x}`).toBe(BUSY);
+		}
+	});
+
+	it('still bridges the buckets inside the horizon', () => {
+		const points = mqttPoints(rows);
+		const bridged = points.filter((p) => p.x > T0 && p.x <= lastQuietBucket);
+		expect(bridged.length).toBeGreaterThan(0);
+		for (const p of bridged) {
+			expect(p.y, `bucket ${p.x}`).toBe(BUSY + QUIET);
+		}
+	});
+
+	it('does not back-fill buckets before the node was ever seen', () => {
+		// LOCF only looks backwards. The quiet node's first row is half a cadence
+		// after T0, so the first bucket is the busy node alone — legitimately.
+		const first = mqttPoints(rows)[0];
+		expect(first.x).toBe(T0);
+		expect(first.y).toBe(BUSY);
+	});
+});
+
+describe('connections — cluster-wide gaps stay gaps', () => {
+	it('emits no point for a bucket where no node reported', () => {
+		// A real outage: neither node emits for 20 minutes. Carry-forward must
+		// not paper over it, because it never creates bucket times.
+		const rows = [
+			connectionRow('busy', T0, BUSY),
+			connectionRow('quiet', T0, QUIET),
+			connectionRow('busy', T0 + 20 * LATTICE, BUSY),
+			connectionRow('quiet', T0 + 20 * LATTICE, QUIET),
+		];
+		const points = mqttPoints(rows);
+		expect(points.map((p) => p.x)).toEqual([T0, T0 + 20 * LATTICE]);
+		expect(points.map((p) => p.y)).toEqual([BUSY + QUIET, BUSY + QUIET]);
+	});
+
+	it('does not resurrect a node across an outage longer than its horizon', () => {
+		// `busy` returns after the outage; `quiet` never does. Its last sample is
+		// 20 buckets old, far past 2 × its cadence, so it must not be summed in.
+		const rows = [
+			connectionRow('busy', T0, BUSY),
+			connectionRow('busy', T0 + LATTICE, BUSY),
+			connectionRow('quiet', T0, QUIET),
+			connectionRow('quiet', T0 + LATTICE, QUIET),
+			connectionRow('busy', T0 + 20 * LATTICE, BUSY),
+		];
+		const points = mqttPoints(rows);
+		expect(points.at(-1)!.x).toBe(T0 + 20 * LATTICE);
+		expect(points.at(-1)!.y).toBe(BUSY);
+	});
+});
+
+describe('connections — node-drop fixture', () => {
+	// Uniform 60 s lattice, one node simply missing from the middle bucket —
+	// the minimal shape, mirroring table-size's node-drop.json.
+	const rows = nodeDrop as unknown as AnalyticsDataPoint[];
+
+	it('holds the cluster total flat across the dropped bucket', () => {
+		const out = runPipeline(connectionsSpec, rows, WINDOW, ['n1', 'n2'], { snapToPeriod: true });
+		const points = out.series.find((s) => s.key === 'mqtt')!.points;
+		expect(points.map((p) => p.x)).toEqual([
+			1_700_000_040_000,
+			1_700_000_100_000,
+			1_700_000_160_000,
+			1_700_000_220_000,
+		]);
+		// Pre-fix the third bucket read 100 (n1 alone) instead of 300.
+		expect(points.map((p) => p.y)).toEqual([300, 300, 300, 300]);
+	});
+
+	it('per-node mode is untouched — each node keeps its own sparse series', () => {
+		// The chip-selector / "stack by node" views read per-node values
+		// directly; carry-forward belongs to the cross-node sum only.
+		const out = runPipeline(connectionsSpec, rows, WINDOW, ['n1', 'n2'], {
+			perNode: true,
+			snapToPeriod: true,
+		});
+		const n2 = out.series.find((s) => s.node === 'n2')!;
+		expect(n2.points.length).toBe(3);
+		expect(n2.points.map((p) => p.y)).toEqual([200, 200, 200]);
+	});
+});
+
+describe('database-size — same gauge shape (last/sum)', () => {
+	// `last`/`sum` over a stacked area, timestamped by `id`: identical latent
+	// bug, called out in #1576 alongside connections.
+	// No `time` field at all — Harper serializes this metric's timestamp as `id`,
+	// which is why the spec sets `timestamp: 'id'`. AnalyticsDataPoint still
+	// declares `time` as required, so the double assertion is load-bearing.
+	const row = (node: string, id: number, size: number): AnalyticsDataPoint =>
+		({ metric: 'database-size', database: 'data', node, id, size, period: 0 }) as unknown as AnalyticsDataPoint;
+
+	it('holds the replicated total flat when one node misses a bucket', () => {
+		const rows = [
+			row('n1', T0, 1_000),
+			row('n2', T0, 2_000),
+			row('n1', T0 + LATTICE, 1_000),
+			// n2 absent here
+			row('n1', T0 + 2 * LATTICE, 1_000),
+			row('n2', T0 + 2 * LATTICE, 2_000),
+		];
+		const out = runPipeline(databaseSizeSpec, rows, WINDOW, ['n1', 'n2'], { snapToPeriod: true });
+		const points = out.series.find((s) => s.key === 'data')!.points;
+		expect(points.map((p) => p.y)).toEqual([3_000, 3_000, 3_000]);
+	});
+});
+
+describe('bytes-sent — additive counters are left alone', () => {
+	// sum/sum. A node with no row genuinely contributed no bytes; carrying its
+	// previous rate forward would invent traffic.
+	const row = (node: string, time: number, bytes: number): AnalyticsDataPoint =>
+		({
+			metric: 'bytes-sent',
+			type: 'egress',
+			node,
+			time,
+			count: 1,
+			mean: bytes,
+			period: LATTICE,
+		}) as AnalyticsDataPoint;
+
+	it('does not carry an absent node into the cross-node sum', () => {
+		const rows = [
+			row('n1', T0, 60_000),
+			row('n2', T0, 60_000),
+			row('n1', T0 + LATTICE, 60_000),
+			// n2 absent — this bucket must read n1's rate alone.
+		];
+		const out = runPipeline(bytesSentSpec, rows, WINDOW, ['n1', 'n2'], { snapToPeriod: true });
+		const points = out.series.find((s) => s.key === 'egress')!.points;
+		// rate = count × mean / period × 1000 = 60_000 / 60_000 × 1000 = 1000 B/s
+		expect(points.map((p) => p.y)).toEqual([2_000, 1_000]);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/cross-node-gauge-gaps.test.ts
@@ -7,6 +7,7 @@
 // `period: 0` rows on a 90 s emission cadence, snapped onto the spec's 60 s
 // fallback lattice, with the two nodes half a cadence out of phase.
 import { describe, expect, it } from 'vitest';
+import { MAX_STALENESS_MS } from '../../pipeline/carryForward';
 import { runPipeline } from '../../pipeline/pipeline';
 import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
 import type { AnalyticsDataPoint, SeriesPoint, TimeRange } from '../../types/analytics';
@@ -208,6 +209,60 @@ describe('connections — cluster-wide gaps stay gaps', () => {
 		expect(byX.get(T0 + 21 * LATTICE)).toBe(BUSY + QUIET);
 		// Back, absent from this bucket, but fresh enough to carry again.
 		expect(byX.get(T0 + 22 * LATTICE)).toBe(BUSY + QUIET);
+	});
+});
+
+describe('connections — a sparse node cannot buy an unbounded horizon', () => {
+	// kriszyp's #1587 review: two widely separated observations make the median
+	// read as a multi-hour "cadence", so uncapped the quiet node's stale count
+	// would be summed into every bucket another node supplies for the rest of
+	// the window — hiding a real drop to zero. MAX_STALENESS_MS caps it.
+	const HOUR = 60 * LATTICE;
+	const GAP = 12 * HOUR;
+	// `quiet` observed exactly twice, 12 h apart. `busy` reports every minute
+	// across the whole window, so every bucket after T0 exists.
+	const rows: AnalyticsDataPoint[] = [
+		connectionRow('quiet', T0, QUIET),
+		connectionRow('quiet', T0 + GAP, QUIET),
+	];
+	for (let t = 0; t <= GAP + 30 * LATTICE; t += LATTICE) {
+		rows.push(connectionRow('busy', T0 + t, BUSY));
+	}
+	const wideWindow: TimeRange = { startTime: T0 - LATTICE, endTime: T0 + GAP + 60 * LATTICE };
+	const byX = new Map(
+		runPipeline(connectionsSpec, rows, wideWindow, ['busy', 'quiet'], { snapToPeriod: true })
+			.series.find((s) => s.key === 'mqtt')!.points.map((p) => [p.x, p.y]),
+	);
+
+	it('still sums both nodes where quiet actually reported', () => {
+		expect(byX.get(T0)).toBe(BUSY + QUIET);
+		expect(byX.get(T0 + GAP)).toBe(BUSY + QUIET);
+	});
+
+	it('drops the sparse node a few minutes after each observation, not 24 h later', () => {
+		// 12 h cadence x 2 would have been a 24 h horizon; capped it is 5 min.
+		expect(byX.get(T0 + 10 * LATTICE)).toBe(BUSY);
+		expect(byX.get(T0 + 60 * LATTICE)).toBe(BUSY);
+		expect(byX.get(T0 + GAP + 10 * LATTICE)).toBe(BUSY);
+	});
+
+	it('carries it only within the capped horizon', () => {
+		// MAX_STALENESS_MS is 5 min, so the bucket one minute later still counts
+		// it and the one ten minutes later does not.
+		expect(byX.get(T0 + LATTICE)).toBe(BUSY + QUIET);
+		expect(byX.get(T0 + GAP + LATTICE)).toBe(BUSY + QUIET);
+	});
+
+	it('never leaves a stale carry anywhere in the long tail', () => {
+		// The actual regression: no bucket beyond the capped horizon may include
+		// the quiet node. Pre-cap, every one of these was BUSY + QUIET.
+		const tailStart = T0 + MAX_STALENESS_MS + LATTICE;
+		const stale = [...byX.entries()]
+			.filter(([x]) => x >= tailStart && x < T0 + GAP)
+			.filter(([, y]) => y !== BUSY);
+		expect(stale).toEqual([]);
+		// …and the tail is actually populated, so this isn't vacuous.
+		expect([...byX.keys()].filter((x) => x >= tailStart && x < T0 + GAP).length).toBeGreaterThan(600);
 	});
 });
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+	downsampleAggregator,
+	downsampleDerivedSeriesData,
+	downsamplePoints,
+	isRateTransform,
+} from '../../pipeline/downsample';
+import type { SeriesData, SeriesPoint } from '../../types/analytics';
+
+describe('isRateTransform', () => {
+	it('detects a direct rate transform', () => {
+		expect(isRateTransform({ kind: 'rate' })).toBe(true);
+	});
+
+	it('detects a rate nested in a compose', () => {
+		expect(isRateTransform({ kind: 'compose', steps: [{ kind: 'scale', factor: 2 }, { kind: 'rate' }] })).toBe(true);
+	});
+
+	it('is false for undefined and for non-rate transforms', () => {
+		expect(isRateTransform(undefined)).toBe(false);
+		expect(isRateTransform({ kind: 'raw' })).toBe(false);
+		expect(isRateTransform({ kind: 'ratio' })).toBe(false);
+		expect(isRateTransform({ kind: 'scale', factor: 1000 })).toBe(false);
+		expect(isRateTransform({ kind: 'compose', steps: [{ kind: 'raw' }, { kind: 'ratio' }] })).toBe(false);
+	});
+});
+
+describe('downsampleAggregator', () => {
+	it('collapses rate fields with mean whatever the spec says temporally', () => {
+		// The whole point: a `sum` over per-second values must not re-sum across
+		// time, or bytes-sent reads 3x high on a 5 min lattice.
+		expect(downsampleAggregator('sum', { kind: 'rate' })).toBe('mean');
+		expect(downsampleAggregator('max', { kind: 'rate' })).toBe('mean');
+	});
+
+	it('keeps sum for extensive (non-rate) quantities', () => {
+		expect(downsampleAggregator('sum', undefined)).toBe('sum');
+		expect(downsampleAggregator('sum', { kind: 'raw' })).toBe('sum');
+	});
+
+	it('preserves gauge aggregators', () => {
+		expect(downsampleAggregator('max', undefined)).toBe('max');
+		expect(downsampleAggregator('last', undefined)).toBe('last');
+	});
+
+	it('collapses percentiles with max so spikes survive a wide window', () => {
+		// A p95-of-p95s is not a p95; of the two approximations, keep the worst
+		// case rather than smoothing it away.
+		expect(downsampleAggregator('p50', undefined)).toBe('max');
+		expect(downsampleAggregator('p95', undefined)).toBe('max');
+		expect(downsampleAggregator('p99', undefined)).toBe('max');
+	});
+
+	it('keeps count-weighted-mean count-weighted', () => {
+		expect(downsampleAggregator('count-weighted-mean', undefined)).toBe('count-weighted-mean');
+	});
+});
+
+describe('downsamplePoints', () => {
+	const pts = (xs: number[], ys: number[], counts?: number[]): SeriesPoint[] =>
+		xs.map((x, i) => ({ x, y: ys[i], ...(counts ? { count: counts[i] } : {}) }));
+
+	it('folds 60s points onto a 300s lattice, round-to-nearest', () => {
+		// Round-to-nearest, not floor — the same convention `snapToBucketTime`
+		// uses, so coarse bucket times stay on a grid the other panels share.
+		// 0/60k/120k round to 0; 180k/240k round up to 300k.
+		const out = downsamplePoints(pts([0, 60_000, 120_000, 180_000, 240_000], [10, 20, 30, 40, 50]), 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([0, 300_000]);
+		expect(out.map((p) => p.y)).toEqual([20, 45]);
+	});
+
+	it('sums observation counts so confidence gating still sees the real total', () => {
+		const out = downsamplePoints(pts([0, 60_000, 120_000], [1, 2, 3], [4, 5, 6]), 300_000, 'sum');
+		expect(out.length).toBe(1);
+		expect(out[0].count).toBe(15);
+	});
+
+	it('returns the original array untouched when nothing would fold', () => {
+		// The 1h/6h presets already sit on the target lattice — identity, and
+		// referentially so, to keep downstream memos stable.
+		const input = pts([0, 60_000, 120_000], [1, 2, 3]);
+		expect(downsamplePoints(input, 60_000, 'mean')).toBe(input);
+	});
+
+	it('is a no-op for a non-positive target or empty input', () => {
+		const input = pts([0, 60_000], [1, 2]);
+		expect(downsamplePoints(input, 0, 'mean')).toBe(input);
+		expect(downsamplePoints([], 300_000, 'mean')).toEqual([]);
+	});
+
+	it('keeps an all-null coarse bucket as an explicit null gap', () => {
+		const input: SeriesPoint[] = [
+			{ x: 0, y: null },
+			{ x: 60_000, y: null },
+			{ x: 600_000, y: 5 },
+		];
+		const out = downsamplePoints(input, 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([0, 600_000]);
+		expect(out[0].y).toBeNull();
+		expect(out[1].y).toBe(5);
+	});
+
+	it('ignores nulls when the bucket also holds real values', () => {
+		const out = downsamplePoints([{ x: 0, y: null }, { x: 60_000, y: 10 }], 300_000, 'mean');
+		expect(out[0].y).toBe(10);
+	});
+
+	it('lands coarse buckets on the same epoch-aligned grid as the fine snap', () => {
+		const out = downsamplePoints(pts([300_000, 360_000, 600_000], [1, 2, 3]), 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([300_000, 600_000]);
+	});
+});
+
+describe('downsampleDerivedSeriesData', () => {
+	const data: SeriesData = {
+		series: [{ key: 'a', label: 'a', points: [{ x: 0, y: 10 }, { x: 60_000, y: 20 }] }],
+	};
+
+	it('defaults to mean — the shipped derived metrics are rates and ratios', () => {
+		const out = downsampleDerivedSeriesData(data, 300_000);
+		expect(out.series[0].points).toEqual([{ x: 0, y: 15 }]);
+	});
+
+	it('honors an explicit aggregator', () => {
+		expect(downsampleDerivedSeriesData(data, 300_000, 'sum').series[0].points[0].y).toBe(30);
+	});
+
+	it('is idempotent — re-folding an already-coarse series changes nothing', () => {
+		// MetricRenderer folds every derived recompute, including mqtt-traffic's
+		// which already downsampled internally. That must not double-average.
+		const once = downsampleDerivedSeriesData(data, 300_000);
+		const twice = downsampleDerivedSeriesData(once, 300_000);
+		expect(twice.series[0].points).toEqual(once.series[0].points);
+	});
+
+	it('folds the ceiling series too', () => {
+		const withCeiling: SeriesData = {
+			...data,
+			ceiling: { key: 'rss', label: 'rss', points: [{ x: 0, y: 100 }, { x: 60_000, y: 200 }] },
+		};
+		const out = downsampleDerivedSeriesData(withCeiling, 300_000);
+		expect(out.ceiling!.points).toEqual([{ x: 0, y: 150 }]);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
@@ -75,6 +75,23 @@ describe('downsamplePoints', () => {
 		expect(out[0].count).toBe(15);
 	});
 
+	it('re-aligns points that map one-to-one but still move', () => {
+		// The dangerous shape: a 90 s lattice folded onto a 60 s target. Every
+		// point lands in a bucket of its own, so a size comparison alone reads as
+		// "nothing to do" — but k*90_000 -> round(1.5k)*60_000 moves all but the
+		// even-k ones. Leaving them put would drop the series off the target grid
+		// and break the StorageTab crosshair match (#1514).
+		const xs = [0, 90_000, 180_000, 270_000, 360_000];
+		const out = downsamplePoints(pts(xs, [1, 2, 3, 4, 5]), 60_000, 'mean');
+		expect(out.length).toBe(xs.length);
+		expect(out.map((p) => p.x)).toEqual([0, 120_000, 180_000, 300_000, 360_000]);
+		for (const p of out) {
+			expect(p.x % 60_000, `x=${p.x} off the target lattice`).toBe(0);
+		}
+		// One point per bucket, so the values pass through untouched.
+		expect(out.map((p) => p.y)).toEqual([1, 2, 3, 4, 5]);
+	});
+
 	it('returns the original array untouched when nothing would fold', () => {
 		// The 1h/6h presets already sit on the target lattice — identity, and
 		// referentially so, to keep downstream memos stable.

--- a/src/features/instance/status/analytics/__tests__/pipeline/error-rate-downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/error-rate-downsample.test.ts
@@ -1,0 +1,50 @@
+// error-rate is a ratio (1 − Σtotal/Σcount), so folding several fine buckets
+// into one coarse bucket at 7 d / 30 d must recombine Σ-correctly, not average
+// the per-bucket ratios. The spec pins `downsampleAggregator:
+// 'count-weighted-mean'` for exactly this; these lock it against the
+// ratio-of-ratios regression (#1588 review).
+import { describe, expect, it } from 'vitest';
+import { getPreset, targetBucketMs } from '../../context/timePresets';
+import { errorRateDerived, recomputeErrorRate } from '../../pipeline/derived/error-rate';
+import { downsampleDerivedSeriesData } from '../../pipeline/downsample';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const T0 = 28_333_334 * 60_000;
+const WINDOW: TimeRange = { startTime: 0, endTime: Number.MAX_SAFE_INTEGER };
+
+// Two buckets of very different request volume on one path:
+//   1000 reqs, 990 ok → ratio 0.010   (10 errors)
+//     10 reqs,   1 ok → ratio 0.900   (9 errors)
+// Σ-correct combined error rate = 19 / 1010 ≈ 0.018812.
+// Mean-of-ratios (the bug) = (0.01 + 0.9) / 2 = 0.455.
+const records: AnalyticsDataPoint[] = [
+	{ node: 'n1', path: '/a', time: T0, count: 1000, total: 990 },
+	{ node: 'n1', path: '/a', time: T0 + 60_000, count: 10, total: 1 },
+];
+
+describe('error-rate downsample fold', () => {
+	it('the spec folds with count-weighted-mean', () => {
+		expect(errorRateDerived.downsampleAggregator).toBe('count-weighted-mean');
+	});
+
+	it('folds disparate-volume buckets Σ-correctly, not as a mean of ratios', () => {
+		const raw = recomputeErrorRate(records, WINDOW, []);
+		// 30d preset → 4h bucket, so both samples (60 s apart) fold into one.
+		const target = targetBucketMs(getPreset('30d').durationMs);
+		const folded = downsampleDerivedSeriesData(raw, target, errorRateDerived.downsampleAggregator);
+		const points = folded.series.find((s) => s.key === '/a')!.points;
+		expect(points).toHaveLength(1);
+		expect(points[0].y).toBeCloseTo(19 / 1010, 6); // ≈ 0.018812, Σ-correct
+		expect(points[0].y).not.toBeCloseTo(0.455, 2); // NOT mean-of-ratios
+		// Folded count is the summed request volume, so confidence gating and
+		// the SLO threshold's minCount still see the real traffic.
+		expect(points[0].count).toBe(1010);
+	});
+
+	it('an unweighted mean fold WOULD reproduce the ratio-of-ratios bug (guard rails the choice)', () => {
+		const raw = recomputeErrorRate(records, WINDOW, []);
+		const target = targetBucketMs(getPreset('30d').durationMs);
+		const wrong = downsampleDerivedSeriesData(raw, target, 'mean');
+		expect(wrong.series.find((s) => s.key === '/a')!.points[0].y).toBeCloseTo(0.455, 3);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
@@ -81,24 +81,45 @@ describe('rendered point count per preset', () => {
 			// Never coarser than asked, and within one bucket of the target.
 			expect(after.length).toBeLessThanOrEqual(intended + 1);
 			expect(after.length).toBeLessThanOrEqual(before.length);
-			// The wide presets are the ones that were over-dense; the 1h/6h
-			// presets already sit on their own lattice and must come through
+			// `period: 0` rows bucket onto the 60 s fallback, so any preset asking
+			// for a coarser bucket than that must come out strictly shorter. The
+			// 1h preset already sits on the 60 s lattice and must come through
 			// unchanged. (Value equality, not reference — these are two separate
 			// runPipeline calls, so the arrays are distinct instances either way.)
 			if (preset.bucketMs > 60_000) {
-				expect(before.length).toBeGreaterThan(intended * 2);
+				expect(after.length).toBeLessThan(before.length);
 			} else {
 				expect(after).toEqual(before);
 			}
 		});
 	}
 
-	it('30d drops from ~43k points to ~720', () => {
+	it('30d drops from ~43k points to ~180', () => {
 		const preset = getPreset('30d');
 		const rows = gaugeRows(preset.durationMs);
 		const w = windowFor(preset.durationMs);
 		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
-		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(721);
+		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(181);
+	});
+
+	it('expanding a chart buys back detail without returning to raw density', () => {
+		// The dialog is ~4x wider, so it resolves to the preset's expanded
+		// bucket: more detail than the panel, still nowhere near one point/60 s.
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		const panel = runPipeline(connectionsSpec, rows, w, [], {
+			snapToPeriod: true,
+			downsampleToWindow: true,
+		}).series.find((s) => s.key === 'mqtt')!.points;
+		const dialog = runPipeline(connectionsSpec, rows, w, [], {
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: true,
+		}).series.find((s) => s.key === 'mqtt')!.points;
+
+		expect(dialog.length).toBeGreaterThan(panel.length);
+		expect(dialog.length).toBeLessThanOrEqual(Math.round(preset.durationMs / preset.expandedBucketMs) + 1);
 	});
 });
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
@@ -1,0 +1,168 @@
+// Chart point density per time preset.
+//
+// Studio asks Harper for `bucket_ms` sized to the selected window, but builds
+// that ignore the hint (harper-pro 5.1.22) return rows at raw emission cadence.
+// The pipeline then buckets on `spec.bucket.fallbackMs` — 60 s no matter how
+// wide the window — so a 30 d view rendered 43 200 points per series instead of
+// the 720 its preset asks for. `downsampleToWindow` folds the finished series
+// onto the preset's lattice.
+import { describe, expect, it } from 'vitest';
+import { getPreset, targetBucketMs, TIME_PRESETS } from '../../context/timePresets';
+import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const connectionsSpec = wrapperMetrics['connections'].spec;
+const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
+
+/** Observed emission cadence on the reporting instance — not a divisor of the
+ *  60 s fallback lattice, which is what made the counts ragged. */
+const CADENCE = 90_000;
+const T0 = 28_333_334 * 60_000;
+
+const windowFor = (durationMs: number): TimeRange => ({ startTime: T0, endTime: T0 + durationMs });
+
+/** Two nodes reporting a steady gauge for `durationMs`, `period: 0`. */
+function gaugeRows(durationMs: number): AnalyticsDataPoint[] {
+	const rows: AnalyticsDataPoint[] = [];
+	for (let t = 0; t < durationMs; t += CADENCE) {
+		rows.push({ type: 'mqtt', node: 'a', time: T0 + t, connections: 100, count: 1, period: 0 });
+		rows.push({ type: 'mqtt', node: 'b', time: T0 + t + CADENCE / 2, connections: 100, count: 1, period: 0 });
+	}
+	return rows;
+}
+
+const mqttPoints = (rows: AnalyticsDataPoint[], w: TimeRange, downsample: boolean) =>
+	runPipeline(connectionsSpec, rows, w, [], { snapToPeriod: true, downsampleToWindow: downsample })
+		.series.find((s) => s.key === 'mqtt')!.points;
+
+describe('targetBucketMs', () => {
+	it('resolves every preset-sized window to exactly that preset bucketMs', () => {
+		// Load-bearing: StorageTab aligns its trend grid to the context bucketMs
+		// (#1514). If these two ever disagree, crosshair sync silently breaks.
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs), p.id).toBe(p.bucketMs);
+		}
+	});
+
+	it('tolerates the sub-second drift of a live now() end bound', () => {
+		const p = getPreset('24h');
+		expect(targetBucketMs(p.durationMs + 400)).toBe(p.bucketMs);
+		expect(targetBucketMs(p.durationMs - 400)).toBe(p.bucketMs);
+	});
+
+	it('falls to the finest bucket for a degenerate window', () => {
+		const finest = TIME_PRESETS[0].bucketMs;
+		expect(targetBucketMs(0)).toBe(finest);
+		expect(targetBucketMs(-1)).toBe(finest);
+		expect(targetBucketMs(Number.NaN)).toBe(finest);
+	});
+
+	it('holds the widest preset ratio beyond 30d instead of reverting to 60s', () => {
+		const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
+		const ratio = widest.durationMs / widest.bucketMs;
+		const twice = widest.durationMs * 2;
+		expect(targetBucketMs(twice)).toBe(Math.ceil(twice / ratio));
+		// A 285-century sentinel window must not silently produce a 60s lattice.
+		expect(targetBucketMs(Number.MAX_SAFE_INTEGER)).toBeGreaterThan(widest.bucketMs);
+	});
+});
+
+describe('rendered point count per preset', () => {
+	for (const preset of TIME_PRESETS) {
+		it(`${preset.id}: folds to the preset's own resolution`, () => {
+			const rows = gaugeRows(preset.durationMs);
+			const w = windowFor(preset.durationMs);
+			const intended = Math.round(preset.durationMs / preset.bucketMs);
+
+			const before = mqttPoints(rows, w, false);
+			const after = mqttPoints(rows, w, true);
+
+			// Never coarser than asked, and within one bucket of the target.
+			expect(after.length).toBeLessThanOrEqual(intended + 1);
+			expect(after.length).toBeLessThanOrEqual(before.length);
+			// The wide presets are the ones that were over-dense; the 1h/6h
+			// presets already sit on their own lattice and must come through
+			// unchanged. (Value equality, not reference — these are two separate
+			// runPipeline calls, so the arrays are distinct instances either way.)
+			if (preset.bucketMs > 60_000) {
+				expect(before.length).toBeGreaterThan(intended * 2);
+			} else {
+				expect(after).toEqual(before);
+			}
+		});
+	}
+
+	it('30d drops from ~43k points to ~720', () => {
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
+		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(721);
+	});
+});
+
+describe('gauge values survive the fold', () => {
+	it('keeps the cluster total, not a fraction of it', () => {
+		// connections is max/sum with the #1576 carry-forward; folding must not
+		// reintroduce a dip. Both nodes hold 100, so the total is 200 throughout.
+		const preset = getPreset('7d');
+		const points = mqttPoints(gaugeRows(preset.durationMs), windowFor(preset.durationMs), true);
+		for (const p of points) {
+			expect(p.y, `bucket ${p.x}`).toBe(200);
+		}
+	});
+});
+
+describe('rate-transformed counters are NOT inflated', () => {
+	// The regression this design exists to avoid. bytes-sent is temporal 'sum'
+	// over a `rate`-transformed field: widening the *record* bucketing would sum
+	// per-second rates from different periods (measured 1000 B/s -> 3000 B/s on a
+	// 5 min lattice, and 60x at 30 d). Folding after aggregation must not.
+	const rateRows = (durationMs: number): AnalyticsDataPoint[] => {
+		const rows: AnalyticsDataPoint[] = [];
+		for (let t = 0; t < durationMs; t += CADENCE) {
+			// count x mean = 60_000 bytes over a 60 s period => 1000 B/s.
+			rows.push({ type: 'egress', node: 'a', time: T0 + t, count: 1, mean: 60_000, period: 60_000 });
+		}
+		return rows;
+	};
+
+	const egressPoints = (durationMs: number, downsample: boolean) =>
+		runPipeline(bytesSentSpec, rateRows(durationMs), windowFor(durationMs), [], {
+			snapToPeriod: true,
+			downsampleToWindow: downsample,
+		}).series.find((s) => s.key === 'egress')!.points;
+
+	for (const id of ['24h', '7d', '30d'] as const) {
+		it(`${id}: every bucket still reads 1000 B/s`, () => {
+			const preset = getPreset(id);
+			const points = egressPoints(preset.durationMs, true);
+			expect(points.length).toBeGreaterThan(0);
+			for (const p of points) {
+				expect(p.y, `bucket ${p.x}`).toBeCloseTo(1000, 6);
+			}
+		});
+	}
+
+	it('24h: fold reduces the point count without moving the value', () => {
+		const preset = getPreset('24h');
+		const before = egressPoints(preset.durationMs, false);
+		const after = egressPoints(preset.durationMs, true);
+		// One node at 90 s over 24 h is 960 snapped points; the 5 min preset asks
+		// for 288 (+1 for the inclusive end bound).
+		expect(before.length).toBeGreaterThan(900);
+		expect(after.length).toBeLessThanOrEqual(289);
+		expect(before.every((p) => Math.abs((p.y ?? 0) - 1000) < 1e-6)).toBe(true);
+		expect(after.every((p) => Math.abs((p.y ?? 0) - 1000) < 1e-6)).toBe(true);
+	});
+});
+
+describe('opting out keeps full resolution', () => {
+	it('omitting downsampleToWindow leaves the series untouched (KPI tile path)', () => {
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/per-path-rate-renderer.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/per-path-rate-renderer.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+// PerPathRateRenderer (request-rate) reaches the chart through a custom
+// Renderer, so it skips runPipeline's downsample pass and MetricRenderer's
+// derived-fold. It must fold its own computed series or a wide window renders
+// one point per 60 s next to panels capped at ~180 (#1588 review). Rendering
+// the real recharts LineChart gives no point-count signal, so swap it for a
+// prop recorder and read the series it receives.
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPreset } from '../../context/timePresets';
+import type { SeriesData, TimeRange } from '../../types/analytics';
+
+const lineChartCalls: { data: SeriesData }[] = [];
+vi.mock('../../primitives/LineChart', () => ({
+	LineChart: (props: { data: SeriesData }) => {
+		lineChartCalls.push(props);
+		return null;
+	},
+}));
+
+const { PerPathRateRenderer } = await import('../../primitives/PerPathRateRenderer');
+
+afterEach(() => {
+	cleanup();
+	lineChartCalls.length = 0;
+});
+
+const preset = getPreset('30d');
+const WINDOW: TimeRange = { startTime: 0, endTime: preset.durationMs };
+// A dense computed series — one point every 10 min across 30 d = 4320 points.
+const RAW_POINTS = Math.round(preset.durationMs / (10 * 60_000));
+const denseSeries: SeriesData = {
+	series: [{
+		key: '/a',
+		label: '/a',
+		points: Array.from({ length: RAW_POINTS }, (_, i) => ({ x: i * 10 * 60_000, y: 100, count: 5 })),
+	}],
+};
+const compute = () => denseSeries;
+
+const lastData = () => lineChartCalls.at(-1)!.data;
+
+describe('PerPathRateRenderer downsample wiring', () => {
+	it('folds the computed series to the window resolution before charting', () => {
+		render(
+			<PerPathRateRenderer records={[]} timeRange={WINDOW} nodes={[]} viewMode="aggregate" compute={compute} />,
+		);
+		const points = lastData().series.find((s) => s.key === '/a')!.points;
+		// 30d preset → 4h bucket → ~180 points, not the 4320 raw.
+		const intended = Math.round(preset.durationMs / preset.bucketMs);
+		expect(RAW_POINTS).toBeGreaterThan(4000); // sanity: the raw series really is dense
+		expect(points.length).toBeLessThanOrEqual(intended + 1);
+		expect(points.length).toBeLessThan(RAW_POINTS);
+	});
+
+	it('leaves the series at full resolution when no window is supplied', () => {
+		// Guards that the fold is driven by timeRange, not applied blindly.
+		render(<PerPathRateRenderer records={[]} nodes={[]} viewMode="aggregate" compute={compute} />);
+		expect(lastData().series.find((s) => s.key === '/a')!.points).toHaveLength(RAW_POINTS);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/stacked-row-staleness.test.ts
+++ b/src/features/instance/status/analytics/__tests__/primitives/stacked-row-staleness.test.ts
@@ -1,0 +1,275 @@
+// Regression coverage for the render-layer half of #1576.
+//
+// The pipeline fix bounded carry-forward for cross-node gauge *sums*, which is
+// what "Stack by: Type" renders. "Stack by: Node" never went through that code
+// path at all: the renderer remaps the spec's dimension to 'node', so each
+// series holds exactly one node and the pipeline's carry-forward — which never
+// invents bucket times — is a structural no-op. The only thing stitching those
+// bands across the lattice is StackedAreaChart's own forward-fill, and it was
+// unbounded, so an idle node's band was carried for the rest of the window.
+//
+// The staggered shapes below mirror cross-node-gauge-gaps.test.ts: `period: 0`
+// gauge rows on a 90 s emission cadence, snapped onto the spec's 60 s fallback
+// lattice, two nodes half a cadence out of phase.
+import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import { mergeStackedRows, type StackedRow } from '../../primitives/mergeStackedRows';
+import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../../types/analytics';
+
+/** `spec.bucket.fallbackMs` — what `period: 0` degrades to, and so the lattice
+ *  every gauge row here is snapped onto. */
+const LATTICE = 60_000;
+/** Emission cadence observed on the reporting instance. 90 mod 60 = 30, which
+ *  is what makes the nodes' snapped buckets beat against the lattice. */
+const CADENCE = 90_000;
+/** Lattice-aligned epoch, so every snapped bucket below is exact. */
+const T0 = 28_333_334 * LATTICE;
+/** Half a cadence — the second node's phase offset. */
+const PHASE = CADENCE / 2;
+
+const BUSY = 285; // us-west-1's steady connection count
+const QUIET = 3; // Milan's, while it had any at all
+
+const WINDOW: TimeRange = { startTime: T0 - LATTICE, endTime: T0 + 100 * CADENCE };
+const NODES = ['busy', 'quiet'];
+
+/** Round-to-nearest, matching the pipeline's `snapToBucketTime`. */
+const snap = (t: number) => Math.round(t / LATTICE) * LATTICE;
+
+/** The dimension remap TrafficByTypeRenderer applies for "Stack by: Node". */
+function stackByNode(spec: MetricSpec): MetricSpec {
+	if (spec.series.kind !== 'groupBy') { throw new Error('expected a groupBy spec'); }
+	return { ...spec, series: { ...spec.series, dimension: 'node' } };
+}
+
+const connectionsByNode = stackByNode(wrapperMetrics['connections'].spec);
+const bytesSentByNode = stackByNode(wrapperMetrics['bytes-sent'].spec);
+
+function connectionRow(node: string, time: number, connections: number): AnalyticsDataPoint {
+	// `period: 0` is what harper-pro stamps on gauge rows.
+	return { metric: 'mqtt-connections', type: 'mqtt', node, time, connections, count: 1, period: 0 };
+}
+
+/** Two nodes on the same cadence, half a period out of phase. `busy` reports for
+ *  every one of `samples`; `quiet` reports for its first `quietSamples` and then
+ *  goes silent, which is what core's `> 0` guard does to an idle node. */
+function staggeredCluster(samples: number, quietSamples: number): AnalyticsDataPoint[] {
+	const rows: AnalyticsDataPoint[] = [];
+	for (let i = 0; i < samples; i++) {
+		rows.push(connectionRow('busy', T0 + i * CADENCE, BUSY));
+	}
+	for (let j = 0; j < quietSamples; j++) {
+		rows.push(connectionRow('quiet', T0 + PHASE + j * CADENCE, QUIET));
+	}
+	return rows;
+}
+
+const byX = (rows: StackedRow[]) => new Map(rows.map((r) => [r.x, r]));
+
+const nodeStack = (spec: MetricSpec, rows: AnalyticsDataPoint[], nodes = NODES): SeriesData =>
+	runPipeline(spec, rows, WINDOW, nodes, { snapToPeriod: true });
+
+describe('stack-by-node — the render-layer fill is the only thing bridging the lattice', () => {
+	const SAMPLES = 40;
+	const data = nodeStack(connectionsByNode, staggeredCluster(SAMPLES, SAMPLES));
+
+	it('leaves each node reporting on only part of the shared lattice', () => {
+		// Guard on the setup: if the lattice/phase arithmetic ever stopped producing
+		// ragged per-node coverage, everything below would pass vacuously.
+		const xs = new Set(data.series.flatMap((s) => s.points.map((p) => p.x)));
+		expect(data.series.length).toBe(2);
+		for (const s of data.series) {
+			expect(s.points.length, `${s.key} covers the full lattice`).toBeLessThan(xs.size);
+		}
+	});
+
+	it('gives the pipeline no cross-node sum to carry — each series holds one node', () => {
+		// This is why the bound has to be reimplemented at the render layer: with
+		// dimension 'node' every bucket of a series has its own node present, so
+		// pipeline carry-forward has nothing to fill.
+		for (const s of data.series) {
+			expect(s.node).toBe(s.key);
+			const expected = s.key === 'busy' ? BUSY : QUIET;
+			expect(s.points.map((p) => p.y)).toEqual(s.points.map(() => expected));
+		}
+	});
+
+	it('fills both bands at every lattice position once each node has been seen', () => {
+		const merged = mergeStackedRows(data);
+		const quietFirst = snap(T0 + PHASE);
+		expect(merged.length).toBeGreaterThan(SAMPLES);
+		for (const row of merged) {
+			expect(row.busy, `busy @ ${row.x}`).toBe(BUSY);
+			// LOCF only looks backwards — the quiet node's first row is half a
+			// cadence after T0, so the opening bucket is legitimately busy alone.
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(row.x! < quietFirst ? null : QUIET);
+		}
+	});
+});
+
+describe('stack-by-node — an idle node stops contributing to the stack', () => {
+	const SAMPLES = 40;
+	const QUIET_SAMPLES = 5;
+	const data = nodeStack(connectionsByNode, staggeredCluster(SAMPLES, QUIET_SAMPLES));
+	const merged = mergeStackedRows(data);
+	const lastQuiet = snap(T0 + PHASE + (QUIET_SAMPLES - 1) * CADENCE);
+
+	it('drops the quiet band to 0 once its last sample is far enough behind', () => {
+		// Pre-fix these positions all read QUIET — the band was carried to the
+		// right-hand edge of the window, overstating the cluster total forever.
+		const stale = merged.filter((r) => r.x! > lastQuiet + 10 * LATTICE);
+		expect(stale.length).toBeGreaterThan(0);
+		for (const row of stale) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(0);
+			expect(row.busy, `busy @ ${row.x}`).toBe(BUSY);
+		}
+	});
+
+	it('still bridges the positions the quiet node skipped while it was reporting', () => {
+		const bridged = merged.filter((r) => r.x! > snap(T0 + PHASE) && r.x! <= lastQuiet);
+		expect(bridged.length).toBeGreaterThan(0);
+		for (const row of bridged) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(QUIET);
+		}
+	});
+
+	it('never brings the band back once it has expired', () => {
+		// A band that flickered 0 → QUIET → 0 would read as a node reconnecting.
+		const firstZero = merged.findIndex((r) => r.quiet === 0);
+		expect(firstZero).toBeGreaterThan(0);
+		for (const row of merged.slice(firstZero)) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(0);
+		}
+	});
+});
+
+describe('bounded carry-forward — exact horizon', () => {
+	// Uniform 60 ms lattice so the arithmetic is checkable by hand: 'b' reports
+	// three times and stops. Its median gap is 60 and the lattice step is 60, so
+	// its horizon is STALENESS_INTERVALS × 60 + one step of snap slack = 180.
+	const data: SeriesData = {
+		series: [
+			{ key: 'a', label: 'A', points: Array.from({ length: 11 }, (_, i) => ({ x: i * 60, y: 100 })) },
+			{ key: 'b', label: 'B', points: [0, 60, 120].map((x) => ({ x, y: 10 })) },
+		],
+	};
+	const rows = byX(mergeStackedRows(data));
+
+	it('carries right up to the horizon and no further', () => {
+		expect(rows.get(120)!.b, 'observed').toBe(10);
+		expect(rows.get(240)!.b, '120 stale — inside the horizon').toBe(10);
+		expect(rows.get(300)!.b, '180 stale — exactly at the horizon').toBe(10);
+		expect(rows.get(360)!.b, '240 stale — past the horizon').toBe(0);
+		expect(rows.get(600)!.b).toBe(0);
+	});
+
+	it('leaves the series that kept reporting untouched', () => {
+		for (const row of rows.values()) {
+			expect(row.a, `a @ ${row.x}`).toBe(100);
+		}
+	});
+});
+
+describe('bounded carry-forward — values the fill must not invent', () => {
+	const spine = Array.from({ length: 11 }, (_, i) => ({ x: i * 60, y: 100 }));
+
+	it('passes an observed value through, including a genuine drop to 0', () => {
+		// A real disconnect reports 0 rather than going absent, so the fill must
+		// never round it back up to the previous reading.
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: 0 }, { x: 120, y: 7 }] },
+			],
+		}));
+		expect([rows.get(0)!.b, rows.get(60)!.b, rows.get(120)!.b]).toEqual([10, 0, 7]);
+	});
+
+	it('does not back-fill positions before a series first reported', () => {
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 300, y: 10 }] },
+			],
+		}));
+		expect([rows.get(0)!.b, rows.get(240)!.b]).toEqual([null, null]);
+		expect(rows.get(300)!.b).toBe(10);
+	});
+
+	it('keeps a point that reported no value null, and carries nothing from it', () => {
+		// `y: null` is an aggregate that had no valid inputs — a known unknown,
+		// which is not the same as a series that has gone to zero.
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: null }] },
+			],
+		}));
+		expect([rows.get(60)!.b, rows.get(120)!.b, rows.get(600)!.b]).toEqual([null, null, null]);
+	});
+
+	it('invents no rows when every series stops, so a cluster-wide gap cannot read as 0', () => {
+		// x positions come only from series that actually reported. If everything
+		// goes quiet the rows stop, and the chart shows a gap rather than a stack
+		// of zeros.
+		const merged = mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: [{ x: 0, y: 100 }, { x: 60, y: 100 }] },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: 10 }] },
+			],
+		});
+		expect(merged.map((r) => r.x)).toEqual([0, 60]);
+		expect(merged.flatMap((r) => [r.a, r.b])).toEqual([100, 10, 100, 10]);
+	});
+
+	it('carries the ceiling unbounded — it is a reference line, not a band', () => {
+		// A memory-style ceiling that expired to 0 would draw a limit of nothing.
+		const merged = mergeStackedRows({
+			series: [{ key: 'a', label: 'A', points: spine }],
+			ceiling: { key: 'cap', label: 'Max', points: [{ x: 0, y: 4096 }] },
+		});
+		expect(merged.map((r) => r.__ceiling__)).toEqual(merged.map(() => 4096));
+	});
+
+	it('handles a single-point series without expiring it against a zero horizon', () => {
+		const merged = mergeStackedRows({ series: [{ key: 'a', label: 'A', points: [{ x: 0, y: 100 }] }] });
+		expect(merged).toEqual([{ x: 0, a: 100 }]);
+	});
+});
+
+describe('bytes-sent — a node that stops sending reads 0, not its last rate', () => {
+	// sum/sum, so the pipeline deliberately excludes it from carry-forward. The
+	// render layer still has to fill the positions a node skipped, and past the
+	// horizon 0 is the honest value for a rate: carrying the last throughput on
+	// would keep drawing traffic that stopped.
+	const bytesRow = (node: string, time: number, bytes: number): AnalyticsDataPoint =>
+		({
+			metric: 'bytes-sent',
+			type: 'egress',
+			node,
+			time,
+			count: 1,
+			mean: bytes,
+			period: LATTICE,
+		}) as AnalyticsDataPoint;
+	// rate = count × mean / period × 1000 = 60_000 / 60_000 × 1000 = 1000 B/s
+	const RATE = 1_000;
+
+	const rows: AnalyticsDataPoint[] = [];
+	for (let i = 0; i <= 20; i++) { rows.push(bytesRow('n1', T0 + i * LATTICE, 60_000)); }
+	for (let i = 0; i <= 2; i++) { rows.push(bytesRow('n2', T0 + i * LATTICE, 60_000)); }
+
+	const merged = byX(mergeStackedRows(nodeStack(bytesSentByNode, rows, ['n1', 'n2'])));
+
+	it('still bridges a position inside the horizon', () => {
+		// n2's cadence and the lattice are both 60 s → horizon 180 s.
+		expect(merged.get(T0 + 3 * LATTICE)!.n2).toBe(RATE);
+	});
+
+	it('stops drawing the departed node once its last sample ages out', () => {
+		expect(merged.get(T0 + 10 * LATTICE)!.n2).toBe(0);
+		expect(merged.get(T0 + 20 * LATTICE)!.n2).toBe(0);
+		expect(merged.get(T0 + 20 * LATTICE)!.n1).toBe(RATE);
+	});
+});

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -58,8 +58,12 @@ describe('TimeRangePicker', () => {
 				/>
 			</AnalyticsTestWrapper>,
 		);
-		expect(screen.getByText('Last 24 hours')).toBeTruthy();
-		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+		// Scope to the collapsed trigger (first combobox), not the whole document:
+		// a document-wide getByText would also match the option in the dropdown
+		// portal, so it wouldn't prove the *trigger* shows the resolution.
+		const trigger = screen.getAllByRole('combobox')[0];
+		expect(within(trigger).getByText('Last 24 hours')).toBeTruthy();
+		expect(within(trigger).getByText('by 10 minutes')).toBeTruthy();
 	});
 
 	it('groups the auto-refresh interval together with the refresh action', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -82,6 +82,10 @@ describe('TimeRangePicker', () => {
 		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
 		// …and the range picker stays outside it.
 		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
+		// The interval trigger carries a "reload" sub-label, mirroring the range
+		// picker's second line, so the collapsed value reads as a reload cadence.
+		expect(within(group).getByText('reload')).toBeTruthy();
+		expect(within(group).getByText('60s')).toBeTruthy();
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../hooks/useAnalyticsFreshness', () => ({
@@ -42,6 +42,46 @@ describe('TimeRangePicker', () => {
 			// since the integration is covered by StatusTabs URL sync test.
 			expect(triggers[0]).toBeTruthy();
 		}
+	});
+
+	it('shows the render resolution under the selected range on the trigger', () => {
+		// #1588 recalibrated 24h to a 10-minute bucket; the trigger should say so
+		// even while collapsed, so the resolution is visible before opening.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="24h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText('Last 24 hours')).toBeTruthy();
+		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+	});
+
+	it('groups the auto-refresh interval together with the refresh action', () => {
+		// The interval used to sit as a bare Select beside the range picker, at
+		// the same gap and weight, and got read as a chart-granularity setting.
+		// Grouping is the fix, so assert the grouping rather than the classes.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="1h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		const group = screen.getByRole('group', { name: /auto-refresh/i });
+		expect(within(group).getByLabelText(/Auto-refresh interval/i)).toBeTruthy();
+		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
+		// …and the range picker stays outside it.
+		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -86,21 +86,36 @@ export function TimeRangePicker({
 			<div
 				role="group"
 				aria-label="Auto-refresh"
-				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
+				className="flex items-stretch rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
 				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					{
+						/* Two-line to match the range picker: the interval on top, a
+					    muted "reload" beneath, so the collapsed value reads as a
+					    reload cadence rather than another time setting. The dropdown
+					    options stay single-line — "reload" on each would be noise,
+					    since (unlike the range picker's per-option bucket) it's the
+					    same word every time. */
+					}
 					<SelectTrigger
 						aria-label="Auto-refresh interval"
 						title="Auto-refresh interval"
-						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue />
+						<SelectValue>
+							<span className="flex flex-col items-start leading-tight">
+								<span>
+									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
+								</span>
+								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+							</span>
+						</SelectValue>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
 					</SelectContent>
 				</Select>
-				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<span aria-hidden="true" className="my-1.5 w-px shrink-0 bg-border" />
 				<Button
 					variant="ghost"
 					size="icon"
@@ -109,7 +124,9 @@ export function TimeRangePicker({
 					aria-busy={isFetching}
 					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
 					title={isFetching ? 'Refreshing…' : 'Refresh now'}
-					className="rounded-l-none"
+					// h-auto (overriding size-9's height) so the button fills the
+					// group's now two-line height; width stays square-ish.
+					className="h-auto w-9 rounded-l-none"
 				>
 					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
 				</Button>

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
@@ -57,15 +57,14 @@ export function TimeRangePicker({
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
 				{
-					/* h-auto so the two-line label isn't clipped by the trigger's
-				    default h-9. Explicit children on SelectValue (not a bare
-				    <SelectValue/>) so the collapsed trigger shows the same
-				    window + resolution stack the options do. */
+					/* RangeLabel rendered straight into the trigger — the collapsed
+				    value is driven by `presetId` here, not by Radix reflecting the
+				    selected item, so the two-line stack is guaranteed regardless of
+				    how a given Radix version treats <SelectValue> children. h-auto
+				    keeps both lines from being clipped by the default h-9. */
 				}
 				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
-					<SelectValue>
-						<RangeLabel presetId={presetId} />
-					</SelectValue>
+					<RangeLabel presetId={presetId} />
 				</SelectTrigger>
 				<SelectContent>
 					{TIME_PRESETS.map((p) => (
@@ -102,14 +101,16 @@ export function TimeRangePicker({
 						title="Auto-refresh interval"
 						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue>
-							<span className="flex flex-col items-start leading-tight">
-								<span>
-									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
-								</span>
-								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						{
+							/* Rendered directly, same as the range trigger — driven by
+						    `refreshMs`, not Radix's selected-item reflection. */
+						}
+						<span className="flex flex-col items-start leading-tight">
+							<span>
+								{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
 							</span>
-						</SelectValue>
+							<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						</span>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -3,8 +3,21 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
-import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
+import { formatBucketLabel, getPreset, REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
 import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness';
+
+/** Range label as two stacked lines: the window on top, the resolution it
+ *  renders at ("by 10 minutes") beneath. Shared by the dropdown options and
+ *  the collapsed trigger so both read the same. */
+function RangeLabel({ presetId }: { presetId: TimePresetId }) {
+	const preset = getPreset(presetId);
+	return (
+		<span className="flex flex-col items-start leading-tight">
+			<span>{preset.label}</span>
+			<span className="text-[11px] font-normal text-muted-foreground">by {formatBucketLabel(preset.bucketMs)}</span>
+		</span>
+	);
+}
 
 interface Props {
 	presetId: TimePresetId;
@@ -26,7 +39,10 @@ export function TimeRangePicker({
 	const updatedLabel = formatRelativeUpdate(lastFetchedAt, now);
 
 	return (
-		<div className="flex items-center gap-2">
+		// gap-3 between groups, 0 inside the refresh group — the spacing is what
+		// tells you the interval belongs to the refresh action rather than to the
+		// range picker beside it.
+		<div className="flex items-center gap-3">
 			{updatedLabel && (
 				<span
 					className="text-xs text-muted-foreground tabular-nums"
@@ -40,32 +56,64 @@ export function TimeRangePicker({
 				</span>
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
-				<SelectTrigger className="w-[180px]">
-					<SelectValue />
+				{
+					/* h-auto so the two-line label isn't clipped by the trigger's
+				    default h-9. Explicit children on SelectValue (not a bare
+				    <SelectValue/>) so the collapsed trigger shows the same
+				    window + resolution stack the options do. */
+				}
+				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
+					<SelectValue>
+						<RangeLabel presetId={presetId} />
+					</SelectValue>
 				</SelectTrigger>
 				<SelectContent>
-					{TIME_PRESETS.map((p) => <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>)}
+					{TIME_PRESETS.map((p) => (
+						<SelectItem key={p.id} value={p.id}>
+							<RangeLabel presetId={p.id} />
+						</SelectItem>
+					))}
 				</SelectContent>
 			</Select>
-			<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
-				<SelectTrigger className="w-[100px]">
-					<SelectValue />
-				</SelectTrigger>
-				<SelectContent>
-					{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
-				</SelectContent>
-			</Select>
-			<Button
-				variant="ghost"
-				size="icon"
-				onClick={onManualRefresh}
-				disabled={isFetching}
-				aria-busy={isFetching}
-				aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
-				title={isFetching ? 'Refreshing…' : 'Refresh now'}
+			{
+				/* Auto-refresh interval + refresh-now, joined into one control. Sat as
+			    a bare Select next to the range picker before, at the same gap and
+			    the same weight, so "60s" read as a second time setting — a chart
+			    granularity — rather than "re-fetch every 60s". Attaching it to the
+			    refresh icon is what disambiguates it; the shared border/background
+			    lives on this wrapper and the children opt out of their own. */
+			}
+			<div
+				role="group"
+				aria-label="Auto-refresh"
+				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
-				<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
-			</Button>
+				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					<SelectTrigger
+						aria-label="Auto-refresh interval"
+						title="Auto-refresh interval"
+						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
+					</SelectContent>
+				</Select>
+				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onManualRefresh}
+					disabled={isFetching}
+					aria-busy={isFetching}
+					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
+					title={isFetching ? 'Refreshing…' : 'Refresh now'}
+					className="rounded-l-none"
+				>
+					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_PRESET_ID,
 	DEFAULT_REFRESH_MS,
 	getPreset,
+	PANEL_POINT_TARGET,
 	REFRESH_OPTIONS,
 	targetBucketMs,
 	TIME_PRESETS,
@@ -42,6 +43,34 @@ describe('timePresets', () => {
 		// exceed ~1500 buckets — the SRE review's payload-blow-up mitigation.
 		for (const p of TIME_PRESETS) {
 			expect(p.durationMs / p.bucketMs).toBeLessThanOrEqual(1500);
+		}
+	});
+
+	it('every preset lands a panel chart inside the point target', () => {
+		// Above PANEL_POINT_TARGET.max the line is denser than the panel has
+		// pixels — payload and render cost for nothing.
+		for (const p of TIME_PRESETS) {
+			const points = p.durationMs / p.bucketMs;
+			expect(points, `${p.id} points`).toBeLessThanOrEqual(PANEL_POINT_TARGET.max);
+			// 1h is the documented exception: Harper's own aggregate period is
+			// 60 s, so there is no finer data to ask for and it undershoots.
+			if (p.id !== '1h') {
+				expect(points, `${p.id} points`).toBeGreaterThanOrEqual(PANEL_POINT_TARGET.min);
+			}
+		}
+	});
+
+	it('expanded buckets are finer than (or equal to) panel buckets', () => {
+		for (const p of TIME_PRESETS) {
+			expect(p.expandedBucketMs, p.id).toBeLessThanOrEqual(p.bucketMs);
+			expect(p.expandedBucketMs, p.id).toBeGreaterThan(0);
+		}
+	});
+
+	it('targetBucketMs reads the expanded column when asked', () => {
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs, { expanded: true }), p.id).toBe(p.expandedBucketMs);
+			expect(targetBucketMs(p.durationMs, { expanded: false }), p.id).toBe(p.bucketMs);
 		}
 	});
 

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_REFRESH_MS,
 	getPreset,
 	REFRESH_OPTIONS,
+	targetBucketMs,
 	TIME_PRESETS,
 	type TimePresetId,
 } from './timePresets';
@@ -41,6 +42,26 @@ describe('timePresets', () => {
 		// exceed ~1500 buckets — the SRE review's payload-blow-up mitigation.
 		for (const p of TIME_PRESETS) {
 			expect(p.durationMs / p.bucketMs).toBeLessThanOrEqual(1500);
+		}
+	});
+
+	it('targetBucketMs agrees with the table it is derived from', () => {
+		// The render lattice (targetBucketMs, looked up by duration) and the
+		// server hint / StorageTab trend grid (preset.bucketMs, looked up by id)
+		// must be the same number for a preset-sized window, or the Storage tab's
+		// trend timestamps stop landing on the metric panels' and syncMethod
+		// "value" crosshair sync silently breaks (#1514).
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs), p.id).toBe(p.bucketMs);
+		}
+	});
+
+	it('targetBucketMs is monotonic in the window width', () => {
+		let prev = 0;
+		for (const p of TIME_PRESETS) {
+			const cur = targetBucketMs(p.durationMs);
+			expect(cur).toBeGreaterThanOrEqual(prev);
+			prev = cur;
 		}
 	});
 

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_PRESET_ID,
 	DEFAULT_REFRESH_MS,
+	formatBucketLabel,
 	getPreset,
 	PANEL_POINT_TARGET,
 	REFRESH_OPTIONS,
@@ -119,6 +120,29 @@ describe('timePresets', () => {
 
 	it('default refresh is at least 30s — the SRE review pushed back on a 15s default', () => {
 		expect(DEFAULT_REFRESH_MS).toBeGreaterThanOrEqual(30_000);
+	});
+});
+
+describe('formatBucketLabel', () => {
+	it('formats minutes and hours, singular vs plural', () => {
+		expect(formatBucketLabel(60_000)).toBe('1 minute');
+		expect(formatBucketLabel(2 * 60_000)).toBe('2 minutes');
+		expect(formatBucketLabel(10 * 60_000)).toBe('10 minutes');
+		expect(formatBucketLabel(60 * 60_000)).toBe('1 hour');
+		expect(formatBucketLabel(4 * 60 * 60_000)).toBe('4 hours');
+	});
+
+	it('renders every shipped preset bucket as a clean minute/hour phrase', () => {
+		// No preset should surface a raw-ms fallback in the picker.
+		for (const p of TIME_PRESETS) {
+			expect(formatBucketLabel(p.bucketMs), p.id).toMatch(/^\d+ (minute|hour)s?$/);
+			expect(formatBucketLabel(p.expandedBucketMs), `${p.id} expanded`).toMatch(/^\d+ (minute|hour)s?$/);
+		}
+	});
+
+	it('falls back to seconds / ms only for odd values', () => {
+		expect(formatBucketLabel(30_000)).toBe('30 seconds');
+		expect(formatBucketLabel(1500)).toBe('1500 ms');
 	});
 });
 

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -31,6 +31,35 @@ export function getPreset(id: TimePresetId): TimePreset {
 	return p;
 }
 
+/**
+ * Densest bucket the charts should *render* for a window of `windowMs`.
+ *
+ * The same numbers the presets declare, looked up by duration instead of id.
+ * That matters because `bucketMs` reaches the server as `bucket_ms` but is
+ * otherwise unused client-side: builds that ignore the hint (harper-pro 5.1.22)
+ * return rows at raw emission cadence, and the pipeline then buckets them onto
+ * `spec.bucket.fallbackMs` — 60 s regardless of the selected window. A 30 d
+ * window rendered 43 200 points instead of 720 (#1576 follow-up).
+ *
+ * Reading the same table by duration keeps one source of truth: StorageTab
+ * aligns its trend grid to the context's `bucketMs` (#1514), so a preset-sized
+ * window MUST resolve to exactly that preset's value or the two grids diverge
+ * and crosshair sync breaks. `targetBucketMs` locks that (see timePresets.test).
+ */
+export function targetBucketMs(windowMs: number): number {
+	const finest = TIME_PRESETS[0].bucketMs;
+	if (!Number.isFinite(windowMs) || windowMs <= 0) { return finest; }
+	for (const p of TIME_PRESETS) {
+		// 1% slack: a live `endTime = Date.now()` bound makes the computed
+		// window drift a few ms off the preset's exact duration.
+		if (windowMs <= p.durationMs * 1.01) { return p.bucketMs; }
+	}
+	// Past the widest preset, hold its points-per-window ratio rather than
+	// falling back to the finest bucket and re-creating the density problem.
+	const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
+	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / widest.bucketMs)));
+}
+
 export interface RefreshOption {
 	label: string;
 	value: number;

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -45,6 +45,20 @@ export function getPreset(id: TimePresetId): TimePreset {
 	return p;
 }
 
+/** Human phrase for a bucket duration — "1 minute", "10 minutes", "4 hours".
+ *  Drives the "by X" sub-label under each range option so the operator can see
+ *  the resolution a window renders at (the server ignores our `bucket_ms`, so
+ *  the panel resolution is `targetBucketMs`, i.e. the preset's `bucketMs`).
+ *  Every shipped bucket is a whole number of minutes or hours; the seconds /
+ *  raw-ms branches are just defensive for a future odd value. */
+export function formatBucketLabel(bucketMs: number): string {
+	const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? '' : 's'}`;
+	if (bucketMs >= HOUR && bucketMs % HOUR === 0) { return plural(bucketMs / HOUR, 'hour'); }
+	if (bucketMs >= MIN && bucketMs % MIN === 0) { return plural(bucketMs / MIN, 'minute'); }
+	if (bucketMs >= 1000 && bucketMs % 1000 === 0) { return plural(bucketMs / 1000, 'second'); }
+	return `${bucketMs} ms`;
+}
+
 /**
  * Densest bucket the charts should *render* for a window of `windowMs`.
  *

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -6,7 +6,12 @@ export interface TimePreset {
 	id: TimePresetId;
 	label: string;
 	durationMs: number;
+	/** Bucket for a panel-sized chart — sized so the window lands in
+	 *  `PANEL_POINT_TARGET`. Also the `bucket_ms` hint sent to Harper. */
 	bucketMs: number;
+	/** Bucket when the chart is expanded to the near-fullscreen dialog, where
+	 *  there is roughly 4x the horizontal room. Always ≤ `bucketMs`. */
+	expandedBucketMs: number;
 }
 
 export type TimePresetId = '1h' | '6h' | '24h' | '7d' | '30d';
@@ -15,12 +20,21 @@ const MIN = 60_000;
 const HOUR = 60 * MIN;
 const DAY = 24 * HOUR;
 
+/** Points a panel-sized chart aims for. Above this the line is denser than the
+ *  panel has pixels, so the extra samples cost payload and render time and buy
+ *  nothing; the 1h preset undershoots because Harper's own aggregate period is
+ *  60 s and there is no finer data to ask for. */
+export const PANEL_POINT_TARGET = { min: 100, max: 200 } as const;
+
 export const TIME_PRESETS: readonly TimePreset[] = [
-	{ id: '1h', label: 'Last 1 hour', durationMs: HOUR, bucketMs: 1 * MIN },
-	{ id: '6h', label: 'Last 6 hours', durationMs: 6 * HOUR, bucketMs: 1 * MIN },
-	{ id: '24h', label: 'Last 24 hours', durationMs: DAY, bucketMs: 5 * MIN },
-	{ id: '7d', label: 'Last 7 days', durationMs: 7 * DAY, bucketMs: 15 * MIN },
-	{ id: '30d', label: 'Last 30 days', durationMs: 30 * DAY, bucketMs: HOUR },
+	// bucketMs is chosen to land `durationMs / bucketMs` inside
+	// PANEL_POINT_TARGET; expandedBucketMs gives the dialog ~3-4x the detail.
+	//                                                              panel  expanded
+	{ id: '1h', label: 'Last 1 hour', durationMs: HOUR, bucketMs: 1 * MIN, expandedBucketMs: 1 * MIN }, //   60    60
+	{ id: '6h', label: 'Last 6 hours', durationMs: 6 * HOUR, bucketMs: 2 * MIN, expandedBucketMs: 1 * MIN }, // 180   360
+	{ id: '24h', label: 'Last 24 hours', durationMs: DAY, bucketMs: 10 * MIN, expandedBucketMs: 5 * MIN }, // 144   288
+	{ id: '7d', label: 'Last 7 days', durationMs: 7 * DAY, bucketMs: HOUR, expandedBucketMs: 15 * MIN }, // 168   672
+	{ id: '30d', label: 'Last 30 days', durationMs: 30 * DAY, bucketMs: 4 * HOUR, expandedBucketMs: HOUR }, // 180   720
 ];
 
 export const DEFAULT_PRESET_ID: TimePresetId = '1h';
@@ -46,18 +60,19 @@ export function getPreset(id: TimePresetId): TimePreset {
  * window MUST resolve to exactly that preset's value or the two grids diverge
  * and crosshair sync breaks. `targetBucketMs` locks that (see timePresets.test).
  */
-export function targetBucketMs(windowMs: number): number {
-	const finest = TIME_PRESETS[0].bucketMs;
+export function targetBucketMs(windowMs: number, opts?: { expanded?: boolean }): number {
+	const pick = (p: TimePreset) => (opts?.expanded ? p.expandedBucketMs : p.bucketMs);
+	const finest = pick(TIME_PRESETS[0]);
 	if (!Number.isFinite(windowMs) || windowMs <= 0) { return finest; }
 	for (const p of TIME_PRESETS) {
 		// 1% slack: a live `endTime = Date.now()` bound makes the computed
 		// window drift a few ms off the preset's exact duration.
-		if (windowMs <= p.durationMs * 1.01) { return p.bucketMs; }
+		if (windowMs <= p.durationMs * 1.01) { return pick(p); }
 	}
 	// Past the widest preset, hold its points-per-window ratio rather than
 	// falling back to the finest bucket and re-creating the density problem.
 	const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
-	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / widest.bucketMs)));
+	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / pick(widest))));
 }
 
 export interface RefreshOption {

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -9,8 +9,10 @@
 // consumer can filter. No network calls: everything recomputes from the
 // records the panel already fetched.
 
+import { targetBucketMs } from '../context/timePresets';
 import { preprocessConnectionRecords } from '../pipeline/connection';
 import { derivedRegistry } from '../pipeline/derived/index';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
 import { specRegistry } from '../pipeline/index';
 import { runPipeline } from '../pipeline/pipeline';
 import { aggregateReplicationMatrix, type ReplicationQuantileField } from '../pipeline/replication-latency';
@@ -181,7 +183,16 @@ export function computeMetricCsvData(
 
 	const derived = derivedRegistry[metric];
 	if (derived) {
-		return { kind: 'series', data: derived.recompute(records, timeRange, nodes, viewMode) };
+		// Folded to the same lattice MetricRenderer draws, so a download matches
+		// the chart it was taken from rather than being 60x longer at 30 d.
+		return {
+			kind: 'series',
+			data: downsampleDerivedSeriesData(
+				derived.recompute(records, timeRange, nodes, viewMode),
+				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				derived.downsampleAggregator,
+			),
+		};
 	}
 
 	const entry = specRegistry[metric];
@@ -207,7 +218,10 @@ export function computeMetricCsvData(
 		// `connection` groups on the synthetic pathMethod field, so it needs
 		// the renderer's own preprocessing first.
 		const rows = metric === 'connection' ? preprocessConnectionRecords(records).records : records;
-		return { kind: 'series', data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 
 	const isPerNodeMode = (viewMode ?? 'per-node') === 'per-node';
@@ -224,7 +238,11 @@ export function computeMetricCsvData(
 					crossNode: field.aggregator?.crossNode ?? spec.aggregator.crossNode,
 				},
 			};
-			const out = runPipeline(innerSpec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true });
+			const out = runPipeline(innerSpec, records, timeRange, nodes, {
+				perNode: isPerNodeMode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			});
 			series.push(...out.series);
 			// Each panel's ceiling (if any) becomes a regular column — SeriesData
 			// has a single ceiling slot, which can't carry one per panel.
@@ -235,23 +253,37 @@ export function computeMetricCsvData(
 
 	if (wantsStackedAreaNodeRemap(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const remapped: MetricSpec = { ...spec, series: { ...spec.series, dimension: 'node' } };
-		return { kind: 'series', data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 	if (wantsClusterLineFold(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const inner: MetricSpec = {
 			...spec,
 			series: { kind: 'field', fields: [{ ...spec.series.field, label: 'cluster' }] },
 		};
-		return { kind: 'series', data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 	if (wantsDimensionLineSplit(spec)) {
 		return {
 			kind: 'series',
-			data: runPipeline(spec, records, timeRange, nodes, { perNode: false, snapToPeriod: true }),
+			data: runPipeline(spec, records, timeRange, nodes, {
+				perNode: false,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			}),
 		};
 	}
 	return {
 		kind: 'series',
-		data: runPipeline(spec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true }),
+		data: runPipeline(spec, records, timeRange, nodes, {
+			perNode: isPerNodeMode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+		}),
 	};
 }

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -183,8 +183,11 @@ export function computeMetricCsvData(
 
 	const derived = derivedRegistry[metric];
 	if (derived) {
-		// Folded to the same lattice MetricRenderer draws, so a download matches
-		// the chart it was taken from rather than being 60x longer at 30 d.
+		// Folded to the same lattice MetricRenderer draws for a panel, so a
+		// download matches the chart it was taken from rather than being 60x
+		// longer at 30 d. Deliberately panel resolution even when the export is
+		// triggered from the expand dialog — an exported file should be a stable
+		// artifact of (metric, window), not of transient dialog state.
 		return {
 			kind: 'series',
 			data: downsampleDerivedSeriesData(

--- a/src/features/instance/status/analytics/pipeline/carryForward.ts
+++ b/src/features/instance/status/analytics/pipeline/carryForward.ts
@@ -22,13 +22,36 @@
 // staleness window; we scale to each node's *observed* cadence instead,
 // because Harper's analytics cadence varies per deployment (the instance in
 // #1576 had `analytics.aggregatePeriod: 60` configured while rows actually
-// landed 90 s apart).
+// landed 90 s apart) — but clamped by Prometheus' 5 minutes as an absolute
+// backstop, so a bad cadence estimate can't turn bounded staleness into
+// carry-forever. See MAX_STALENESS_MS.
 import type { Aggregator } from '../types/analytics';
 
 /** Multiplier on a node's estimated emission interval that bounds how long its
  *  last observation may be carried forward. Two intervals absorbs one missed
  *  emission plus bucket-lattice phase drift, and no more. */
 export const STALENESS_INTERVALS = 2;
+
+/**
+ * Absolute ceiling on a carry-forward horizon, independent of what the cadence
+ * estimate says. Prometheus' fixed 5-minute lookback, used here as a backstop
+ * rather than as the whole policy.
+ *
+ * The median is only robust while short, normal-cadence gaps are the majority.
+ * Two pathological-but-real shapes break that:
+ *
+ *   - a node observed just twice, 12 h apart, reads as a 12 h "cadence" — so a
+ *     single brief nonzero blip would pin its stale count into every later
+ *     bucket for the rest of the window;
+ *   - three samples with one normal gap and one outage average the two into a
+ *     multi-hour median.
+ *
+ * Either one silently converts "bounded staleness" into "carry forever", which
+ * would hide exactly what this feature must not hide: a genuine transition to
+ * zero, or a node dropping out. Capping keeps a wrong cadence estimate from
+ * becoming a wrong horizon.
+ */
+export const MAX_STALENESS_MS = 300_000;
 
 /**
  * True for gauge-shaped specs — the only shape where a missing per-node row
@@ -76,19 +99,30 @@ export function estimateEmissionIntervalMs(times: readonly number[]): number | n
  * Per-node staleness horizon (ms) — how stale a node's last observation may be
  * and still count toward a later bucket's cross-node sum.
  *
- * `floorMs` (the spec's effective bucket size) is a lower bound on the cadence
- * estimate so the horizon always spans at least two buckets: that is what
- * absorbs lattice phase drift when a node's real cadence is *shorter* than the
- * bucket, or when it only ever reported once.
+ * Three bounds, in order:
+ *
+ *  - the cadence estimate is capped at `MAX_STALENESS_MS / STALENESS_INTERVALS`,
+ *    so a bogus multi-hour "cadence" (see `MAX_STALENESS_MS`) cannot buy a
+ *    multi-hour horizon;
+ *  - `floorMs` (the spec's effective bucket size) is a lower bound, so the
+ *    horizon always spans at least two buckets — that is what absorbs lattice
+ *    phase drift when a node's real cadence is *shorter* than the bucket, or
+ *    when it only ever reported once;
+ *  - the floor is applied *after* the cap, deliberately: on a spec whose bucket
+ *    is itself coarser than the cap, spanning two buckets still matters more
+ *    than the 5-minute backstop, so the floor wins there.
+ *
+ * Net: the horizon is always `≤ max(MAX_STALENESS_MS, STALENESS_INTERVALS × floorMs)`.
  */
 export function buildStalenessHorizons(
 	observationTimesByNode: ReadonlyMap<string, number[]>,
 	floorMs: number,
 ): Map<string, number> {
 	const horizons = new Map<string, number>();
+	const cadenceCap = MAX_STALENESS_MS / STALENESS_INTERVALS;
 	for (const [node, times] of observationTimesByNode) {
 		const cadence = estimateEmissionIntervalMs(times) ?? 0;
-		horizons.set(node, STALENESS_INTERVALS * Math.max(cadence, floorMs));
+		horizons.set(node, STALENESS_INTERVALS * Math.max(Math.min(cadence, cadenceCap), floorMs));
 	}
 	return horizons;
 }

--- a/src/features/instance/status/analytics/pipeline/carryForward.ts
+++ b/src/features/instance/status/analytics/pipeline/carryForward.ts
@@ -1,0 +1,94 @@
+// Bounded last-observation-carry-forward (LOCF) for cross-node gauge sums.
+//
+// Why this exists (#1576): Harper emits `mqtt-connections` only when a node's
+// count is nonzero (`if (numberOfConnections > 0)` in core's server/mqtt.ts),
+// so per-node coverage of a gauge metric is inherently ragged — a node at 0
+// emits no row at all. Those rows also carry `period: 0`, so the pipeline
+// buckets them onto its `bucket.fallbackMs` lattice (60 s), which the observed
+// 90 s emission cadence beats against: two nodes co-land in the same bucket
+// only intermittently.
+//
+// `crossNode: 'sum'` then sums only the nodes *present* in a bucket. A bucket
+// holding just the quiet node renders the cluster total as that node's 1–5
+// connections instead of ~289 — a one-sample vertical dive that reads as a
+// mass disconnect. The tell in the customer's chart was that each dive bottoms
+// out at the quiet node's own count, not at 0.
+//
+// The fix is to carry each absent node's last observation into the sum, but
+// only for a bounded time. "No row" is genuinely ambiguous between "this
+// node's sample landed in the adjacent bucket" (carry it) and "this node is
+// idle at 0" (don't) — unbounded LOCF would overstate a node that has gone
+// quiet for real. Prometheus resolves the same ambiguity with a fixed 5-minute
+// staleness window; we scale to each node's *observed* cadence instead,
+// because Harper's analytics cadence varies per deployment (the instance in
+// #1576 had `analytics.aggregatePeriod: 60` configured while rows actually
+// landed 90 s apart).
+import type { Aggregator } from '../types/analytics';
+
+/** Multiplier on a node's estimated emission interval that bounds how long its
+ *  last observation may be carried forward. Two intervals absorbs one missed
+ *  emission plus bucket-lattice phase drift, and no more. */
+export const STALENESS_INTERVALS = 2;
+
+/**
+ * True for gauge-shaped specs — the only shape where a missing per-node row
+ * means "unknown" rather than "zero".
+ *
+ * `crossNode: 'sum'` folds per-node values into a cluster total, and a
+ * temporal aggregator of `max`/`last` means each per-node value is a snapshot
+ * of a level (active sessions, bytes on disk) rather than an accumulation over
+ * the bucket. Summing a subset of snapshots understates the total.
+ *
+ * Additive counters (`sum`/`sum`, e.g. `mqtt-traffic-*`) must NOT get this
+ * treatment: there, a node with no row legitimately contributes zero, and
+ * carrying its previous bucket's throughput forward would invent traffic.
+ */
+export function isGaugeCrossNodeSum(temporal: Aggregator, crossNode: Aggregator): boolean {
+	return crossNode === 'sum' && (temporal === 'max' || temporal === 'last');
+}
+
+/**
+ * Median gap between consecutive observation instants — a robust estimate of
+ * how often a node emits. Median rather than mean so that a node which is
+ * *often absent* (Harper's `> 0` guard) is still credited with its
+ * active-cadence interval instead of an interval inflated by the gaps.
+ *
+ * `times` need not be sorted, and may contain duplicates (several records at
+ * one instant); zero-length gaps are ignored. Returns null when fewer than two
+ * distinct instants were observed — callers fall back to the spec's bucket
+ * size.
+ */
+export function estimateEmissionIntervalMs(times: readonly number[]): number | null {
+	if (times.length < 2) { return null; }
+	const sorted = [...times].sort((a, b) => a - b);
+	const gaps: number[] = [];
+	for (let i = 1; i < sorted.length; i++) {
+		const gap = sorted[i] - sorted[i - 1];
+		if (gap > 0) { gaps.push(gap); }
+	}
+	if (gaps.length === 0) { return null; }
+	gaps.sort((a, b) => a - b);
+	const mid = gaps.length >> 1;
+	return gaps.length % 2 === 1 ? gaps[mid] : (gaps[mid - 1] + gaps[mid]) / 2;
+}
+
+/**
+ * Per-node staleness horizon (ms) — how stale a node's last observation may be
+ * and still count toward a later bucket's cross-node sum.
+ *
+ * `floorMs` (the spec's effective bucket size) is a lower bound on the cadence
+ * estimate so the horizon always spans at least two buckets: that is what
+ * absorbs lattice phase drift when a node's real cadence is *shorter* than the
+ * bucket, or when it only ever reported once.
+ */
+export function buildStalenessHorizons(
+	observationTimesByNode: ReadonlyMap<string, number[]>,
+	floorMs: number,
+): Map<string, number> {
+	const horizons = new Map<string, number>();
+	for (const [node, times] of observationTimesByNode) {
+		const cadence = estimateEmissionIntervalMs(times) ?? 0;
+		horizons.set(node, STALENESS_INTERVALS * Math.max(cadence, floorMs));
+	}
+	return horizons;
+}

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -105,8 +105,9 @@ export function ConnectionRenderer(
 				perNode,
 				snapToPeriod: true,
 				downsampleToWindow: true,
+				expanded: !!fillParent,
 			}),
-		[processed, timeRange, nodes, perNode],
+		[processed, timeRange, nodes, perNode, fillParent],
 	);
 
 	// The chip selector picks one composite (pathMethod) dimension value;

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -100,7 +100,12 @@ export function ConnectionRenderer(
 	const { records: processed, dimParts } = useMemo(() => preprocessConnectionRecords(records), [records]);
 
 	const fullData = useMemo<SeriesData>(
-		() => runPipeline(connectionSpec, processed, timeRange, nodes, { perNode, snapToPeriod: true }),
+		() =>
+			runPipeline(connectionSpec, processed, timeRange, nodes, {
+				perNode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			}),
 		[processed, timeRange, nodes, perNode],
 	);
 

--- a/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
@@ -60,6 +60,16 @@ export const errorRateDerived: DerivedMetricSpec = {
 	tab: 'requests',
 	sourceMetric: 'success',
 	recompute: recomputeErrorRate,
+	// Wide-window downsampling folds several fine buckets into one; a ratio must
+	// be recombined Σ-correctly, not averaged. Each point carries count=sumCount,
+	// and ratio·count = count − total = the bucket's error count, so
+	// count-weighted-mean = Σerrors/Σcount = 1 − Σtotal/Σcount — the same
+	// Σ-arithmetic recomputeErrorRate does per bucket. Plain 'mean' here would be
+	// the ratio-of-ratios bug this file's docstring warns against (a low-traffic,
+	// high-error bucket weighted equally with a high-traffic, low-error one).
+	// error-rate has no custom Renderer, so this drives both the on-screen fold
+	// (MetricRenderer) and the CSV fold (csvExport).
+	downsampleAggregator: 'count-weighted-mean',
 	primitive: 'line',
 	yAxis: { unit: '', formatter: 'percent' },
 	// Threshold lives on the SeriesData returned by `recomputeErrorRate` — the

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
@@ -56,7 +56,7 @@ function makeMqttTrafficDerived(
 			if (isPerNode && baseSpec.series.kind === 'groupBy') {
 				spec = { ...baseSpec, series: { ...baseSpec.series, dimension: 'node' } };
 			}
-			return runPipeline(spec, records, window, nodes, { snapToPeriod: true });
+			return runPipeline(spec, records, window, nodes, { snapToPeriod: true, downsampleToWindow: true });
 		},
 		Renderer: (props) => <TrafficByTypeRenderer spec={baseSpec} typeField="type" {...props} />,
 		primitive: 'stacked-area',

--- a/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
@@ -104,7 +104,10 @@ export const requestRateDerived: DerivedMetricSpec = {
 	tab: 'requests',
 	sourceMetric: 'duration',
 	recompute: recomputeRequestRate,
-	Renderer: ({ records, timeRange, nodes, viewMode }) => (
+	// req/s is a rate, so the fold's default 'mean' is correct — no
+	// downsampleAggregator needed. fillParent is forwarded so the expand dialog
+	// both fills the canvas and folds at the finer expanded resolution.
+	Renderer: ({ records, timeRange, nodes, viewMode, fillParent }) => (
 		<PerPathRateRenderer
 			records={records}
 			timeRange={timeRange}
@@ -112,6 +115,7 @@ export const requestRateDerived: DerivedMetricSpec = {
 			viewMode={viewMode}
 			yAxis={{ unit: '/s', formatter: 'count-si' }}
 			compute={computeForRenderer}
+			fillParent={fillParent}
 		/>
 	),
 	primitive: 'line',

--- a/src/features/instance/status/analytics/pipeline/downsample.ts
+++ b/src/features/instance/status/analytics/pipeline/downsample.ts
@@ -59,8 +59,12 @@ export function downsampleAggregator(temporal: Aggregator, transform: Transform 
 export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: Aggregator): SeriesPoint[] {
 	if (targetMs <= 0 || points.length === 0) { return points; }
 	const byBucket = new Map<number, { items: { value: number | null; count?: number }[]; count: number }>();
+	let shifted = false;
 	for (const p of points) {
 		const bucket = Math.round(p.x / targetMs) * targetMs;
+		// A point can land in a bucket of its own and *still* need moving —
+		// see the early-return note below.
+		if (bucket !== p.x) { shifted = true; }
 		let entry = byBucket.get(bucket);
 		if (!entry) {
 			entry = { items: [], count: 0 };
@@ -70,9 +74,20 @@ export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: A
 		// Sum observation counts so confidence gating still sees the real total.
 		entry.count += p.count ?? 0;
 	}
-	// Nothing to gain (and a needless copy) when every point already sits in
-	// its own coarse bucket — the common case for the 1 h / 6 h presets.
-	if (byBucket.size === points.length) { return points; }
+	// Nothing to gain (and a needless copy) when every point already sits ON its
+	// own coarse bucket boundary — the common case for the 1 h preset, whose
+	// target equals the snap lattice.
+	//
+	// `byBucket.size === points.length` alone is NOT sufficient: points can map
+	// one-to-one onto buckets while every one of them still moves. Records
+	// carrying a real 90 s `period` snap onto a 90 s lattice, and folding that
+	// onto the 1 h preset's 60 s target sends k*90 000 to round(1.5k)*60 000 —
+	// 0, 120 000, 180 000, 300 000 … all distinct, none equal to their input.
+	// Returning the input there would leave the series off the target grid and
+	// break the StorageTab trend's `syncMethod="value"` crosshair match (#1514).
+	// Reachable as soon as core stops stamping `period: 0`
+	// (HarperFast/harper#1997), which is exactly what we asked it to do.
+	if (!shifted && byBucket.size === points.length) { return points; }
 	const out: SeriesPoint[] = [];
 	for (const bucket of [...byBucket.keys()].sort((a, b) => a - b)) {
 		const { items, count } = byBucket.get(bucket)!;

--- a/src/features/instance/status/analytics/pipeline/downsample.ts
+++ b/src/features/instance/status/analytics/pipeline/downsample.ts
@@ -1,0 +1,135 @@
+// Post-aggregation downsampling: fold a series' points onto the window's
+// target bucket lattice.
+//
+// Why this is a *post* pass rather than a coarser snap in `snapToBucketTime`
+// (#1576 follow-up): the pipeline's per-record bucketing assumes roughly one
+// record per (node, bucket) and folds anything more with the spec's temporal
+// aggregator. Widening that lattice therefore changes what the temporal
+// aggregator sees, and for a `rate`-transformed field with `temporal: 'sum'`
+// (bytes-sent/received, mqtt-traffic-*, fsWrite) it sums per-second rates that
+// belong to *different* time periods — measured 1000 B/s becoming 3000 B/s on a
+// 5 min lattice, and it would have been 60x at 30 d.
+//
+// Downsampling after the fact leaves every existing aggregation path — temporal,
+// cross-node, and the bounded carry-forward from #1576 — operating on exactly
+// the buckets it does today, and only reduces what the primitives have to draw.
+import type { Aggregator, FieldSpec, MetricSpec, Series, SeriesData, SeriesPoint, Transform } from '../types/analytics';
+import { aggregate } from './aggregators';
+
+/** True when a field's value has already been divided by its period, i.e. it is
+ *  an *intensive* per-second quantity. Such values must never be re-summed
+ *  across time — two consecutive 1000 B/s samples are 1000 B/s, not 2000. */
+export function isRateTransform(transform: Transform | undefined): boolean {
+	if (!transform) { return false; }
+	if (transform.kind === 'rate') { return true; }
+	if (transform.kind === 'compose') { return transform.steps.some(isRateTransform); }
+	return false;
+}
+
+/**
+ * How to fold several fine-grained points into one coarse bucket.
+ *
+ * The guiding rule is "aggregate over time the same way the spec already
+ * does", with two corrections:
+ *
+ * - **rate fields** collapse with `mean`, never `sum` (see `isRateTransform`).
+ *   Equal-weighted because Harper emits one row per node per period at a fixed
+ *   cadence, so every point in a coarse bucket covers the same span.
+ * - **percentiles** collapse with `max`. A p95-of-p95s is not a p95, and of the
+ *   two defensible approximations an operator wants the one that keeps spikes
+ *   visible rather than smoothing them away at 7 d / 30 d.
+ *
+ * `count-weighted-mean` stays count-weighted — `SeriesPoint.count` carries the
+ * per-bucket observation total, so the weighting survives the fold.
+ */
+export function downsampleAggregator(temporal: Aggregator, transform: Transform | undefined): Aggregator {
+	if (isRateTransform(transform)) { return 'mean'; }
+	switch (temporal) {
+		case 'p50':
+		case 'p95':
+		case 'p99':
+			return 'max';
+		default:
+			return temporal;
+	}
+}
+
+/** Fold `points` onto a `targetMs` lattice, round-to-nearest so coarse bucket
+ *  times stay on the same epoch-aligned grid the fine snap uses. */
+export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: Aggregator): SeriesPoint[] {
+	if (targetMs <= 0 || points.length === 0) { return points; }
+	const byBucket = new Map<number, { items: { value: number | null; count?: number }[]; count: number }>();
+	for (const p of points) {
+		const bucket = Math.round(p.x / targetMs) * targetMs;
+		let entry = byBucket.get(bucket);
+		if (!entry) {
+			entry = { items: [], count: 0 };
+			byBucket.set(bucket, entry);
+		}
+		entry.items.push({ value: p.y, count: p.count });
+		// Sum observation counts so confidence gating still sees the real total.
+		entry.count += p.count ?? 0;
+	}
+	// Nothing to gain (and a needless copy) when every point already sits in
+	// its own coarse bucket — the common case for the 1 h / 6 h presets.
+	if (byBucket.size === points.length) { return points; }
+	const out: SeriesPoint[] = [];
+	for (const bucket of [...byBucket.keys()].sort((a, b) => a - b)) {
+		const { items, count } = byBucket.get(bucket)!;
+		// `aggregate` returns null when every value is null, which preserves an
+		// explicit gap rather than dropping the bucket entirely.
+		out.push({ x: bucket, y: aggregate(agg, items), ...(count > 0 ? { count } : {}) });
+	}
+	return out;
+}
+
+/** Resolve the temporal aggregator + transform a series was built from, so the
+ *  fold matches the spec. Series are keyed by `dim`; for field-mode specs `dim`
+ *  is the field key, for groupBy every series shares the one field. */
+function fieldFor(spec: MetricSpec, series: Series): FieldSpec | undefined {
+	if (spec.series.kind === 'groupBy') { return spec.series.field; }
+	return spec.series.fields.find((f) => (typeof f.field === 'string' ? f.field : f.label) === series.dim)
+		?? spec.series.fields[0];
+}
+
+/** Fold every series (and the ceiling) in a result, choosing the aggregator
+ *  per series via `aggFor`. */
+function foldSeriesData(data: SeriesData, targetMs: number, aggFor: (s: Series) => Aggregator): SeriesData {
+	if (targetMs <= 0) { return data; }
+	const fold = (s: Series): Series => ({ ...s, points: downsamplePoints(s.points, targetMs, aggFor(s)) });
+	return {
+		...data,
+		series: data.series.map(fold),
+		...(data.ceiling ? { ceiling: fold(data.ceiling) } : {}),
+	};
+}
+
+/** Downsample a spec-driven pipeline result, matching each series' own field. */
+export function downsampleSeriesData(data: SeriesData, spec: MetricSpec, targetMs: number): SeriesData {
+	return foldSeriesData(data, targetMs, (s) => {
+		const field = fieldFor(spec, s);
+		const temporal = field?.aggregator?.temporal ?? spec.aggregator.temporal;
+		return downsampleAggregator(temporal, field?.transform);
+	});
+}
+
+/**
+ * Downsample a derived metric's hand-built SeriesData.
+ *
+ * `error-rate`, `request-rate` and `transaction-log-growth` assemble series
+ * from raw columns instead of going through `runPipeline`, so they never see
+ * the spec-driven path above. They are all intensive quantities (a ratio and
+ * two per-second rates), hence the `'mean'` default; a derived metric that
+ * measures something extensive sets `downsampleAggregator` on its spec.
+ *
+ * Idempotent: folding points that already sit on `targetMs` leaves them
+ * untouched, so applying this to a recompute that internally opted into
+ * `downsampleToWindow` (mqtt-traffic) is a no-op rather than a double average.
+ */
+export function downsampleDerivedSeriesData(
+	data: SeriesData,
+	targetMs: number,
+	agg: Aggregator = 'mean',
+): SeriesData {
+	return foldSeriesData(data, targetMs, () => agg);
+}

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -100,8 +100,13 @@ export function MainThreadRenderer(
 			series: { kind: 'field', fields: [{ field: selected.field, label: selected.label }] },
 			yAxis: selected.yAxis,
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
-	}, [selected, records, timeRange, nodes, perNode]);
+		return runPipeline(innerSpec, records, timeRange, nodes, {
+			perNode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: !!fillParent,
+		});
+	}, [selected, records, timeRange, nodes, perNode, fillParent]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -100,7 +100,7 @@ export function MainThreadRenderer(
 			series: { kind: 'field', fields: [{ field: selected.field, label: selected.label }] },
 			yAxis: selected.yAxis,
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
+		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
 	}, [selected, records, timeRange, nodes, perNode]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -58,8 +58,13 @@ export function MemoryRenderer(
 			...memorySpec,
 			series: { kind: 'field', fields: [selectedField] },
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
-	}, [selectedField, records, timeRange, nodes, perNode]);
+		return runPipeline(innerSpec, records, timeRange, nodes, {
+			perNode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: !!fillParent,
+		});
+	}, [selectedField, records, timeRange, nodes, perNode, fillParent]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -58,7 +58,7 @@ export function MemoryRenderer(
 			...memorySpec,
 			series: { kind: 'field', fields: [selectedField] },
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
+		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
 	}, [selectedField, records, timeRange, nodes, perNode]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -327,8 +327,9 @@ function runGroupBy(
 			// members were emitted at.
 			const otherObservationTimes = observationTimes ? new Map<string, number[]>() : null;
 			for (const [key] of rest) {
-				if (otherObservationTimes) {
-					for (const [node, times] of observationTimes!.get(key) ?? []) {
+				const dimObservationTimes = observationTimes?.get(key);
+				if (otherObservationTimes && dimObservationTimes) {
+					for (const [node, times] of dimObservationTimes) {
 						let merged = otherObservationTimes.get(node);
 						if (!merged) {
 							merged = [];
@@ -552,7 +553,16 @@ function aggregateOverTime(
 		}
 		for (const [node, last] of lastObserved) {
 			if (observed.has(node)) { continue; }
-			if (time - last.time > (horizonByNode.get(node) ?? 0)) { continue; }
+			if (time - last.time > (horizonByNode.get(node) ?? 0)) {
+				// Buckets are walked in ascending order, so this observation can
+				// only get staler — drop it rather than re-testing it against
+				// every remaining bucket. A node that reports again is re-added
+				// by the observed-node loop above. Matters on wide windows over a
+				// cluster whose node ids churn (rolling replacement, autoscaling),
+				// where the map would otherwise accumulate every node ever seen.
+				lastObserved.delete(node);
+				continue;
+			}
 			// Carried, not observed — count 0 so `SeriesPoint.count` (confidence
 			// gating, tooltips) keeps reflecting real samples only.
 			inputs.push({ value: last.value, count: 0 });

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -18,6 +18,12 @@
 // intervals. Harper omits a gauge row entirely when the value is 0, so absence
 // is not zero — see carryForward.ts for the full rationale (#1576).
 //
+// `downsampleToWindow` adds a final pass that folds the finished series onto
+// the lattice the requested window implies, so a 7 d / 30 d view renders the
+// few hundred points its preset asks for instead of one per 60 s. It runs
+// AFTER every aggregation above precisely so none of them change — see
+// downsample.ts.
+//
 // Known limitation — count-weighted-mean across nodes: the inner pass
 // invokes the temporal aggregator with values that share the per-node
 // bucket's totalCount as their weight. When a single (node, time) bucket
@@ -29,6 +35,7 @@
 // shipped specs this is fine: replication-latency does not flow through
 // this pipeline, mqtt-traffic-* is sum/sum (associative). Revisit if a CWM
 // crossNode spec lands.
+import { targetBucketMs } from '../context/timePresets';
 import type {
 	Aggregator,
 	AnalyticsDataPoint,
@@ -43,6 +50,7 @@ import { type AggInput, aggregate } from './aggregators';
 import { labelWithApprox } from './approxLabel';
 import { buildStalenessHorizons, isGaugeCrossNodeSum } from './carryForward';
 import { classifyConfidence } from './confidence';
+import { downsampleSeriesData } from './downsample';
 import { evalFieldExpr } from './fieldExpr';
 import { runTransform } from './runTransform';
 
@@ -65,6 +73,19 @@ export interface RunPipelineOptions {
 	 *  rendering; pipeline tests that use synthetic small-integer times
 	 *  leave it off so they keep their distinct buckets. */
 	snapToPeriod?: boolean;
+	/** When true, the finished series are folded onto the bucket lattice the
+	 *  requested `window` implies (`targetBucketMs`), after every aggregation
+	 *  pass has run. Harper builds that ignore studio's `bucket_ms` hint return
+	 *  rows at raw cadence, so without this a 30 d window renders 43 200 points
+	 *  per series instead of the 720 the preset asks for.
+	 *
+	 *  Chart render paths (and CSV export, so a download matches what was on
+	 *  screen) opt in. KPI tiles deliberately do NOT: they collapse a series to
+	 *  a single headline number, so there is no density to save, and folding
+	 *  first would change `latestValue` from "the newest bucket" to "an average
+	 *  over the newest coarse bucket". See downsample.ts for the per-aggregator
+	 *  rules. */
+	downsampleToWindow?: boolean;
 }
 
 /** Composite string key for a per-node series — React key / recharts name
@@ -78,14 +99,15 @@ export function makeSeriesKey(dim: string, node: string): string {
 export function runPipeline(
 	spec: MetricSpec,
 	records: AnalyticsDataPoint[],
-	_window: TimeRange,
+	window: TimeRange,
 	_nodes: string[],
 	options?: RunPipelineOptions,
 ): SeriesData {
-	if (spec.series.kind === 'field') {
-		return runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
-	}
-	return runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
+	const data = spec.series.kind === 'field'
+		? runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false)
+		: runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
+	if (!options?.downsampleToWindow) { return data; }
+	return downsampleSeriesData(data, spec, targetBucketMs(window.endTime - window.startTime));
 }
 
 /** Snap a record's time to its period boundary so per-node staggering

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -194,9 +194,16 @@ function runGroupBy(
 	// cluster-aggregate path which, for dimension='node', is naturally
 	// one-series-per-node.
 	const dimensionIsNode = src.dimension === 'node';
-	// Bounded per-node carry-forward only applies where the crossNode pass
-	// actually runs, and only for gauge-shaped specs (see carryForward.ts).
-	const carryForward = (!perNode || dimensionIsNode) && isGaugeCrossNodeSum(tempAgg, crossAgg);
+	// Bounded per-node carry-forward only earns its keep on the cluster-aggregate
+	// path AND only when a bucket can actually hold more than one node — i.e. a
+	// non-node dimension. When the dimension IS node, each dim's buckets contain
+	// exactly that one node (dimVal and the row's node are the same field), so
+	// the crossNode sum is identity and there is never an absent node to fill;
+	// the observation bookkeeping + horizon build would be pure overhead. That
+	// rules out both node-dimension combos: the "Stack by: Node" remap
+	// (!perNode) and the redundant perNode+node case. Gauge-shaped specs only
+	// (see carryForward.ts).
+	const carryForward = !perNode && !dimensionIsNode && isGaugeCrossNodeSum(tempAgg, crossAgg);
 
 	// Step 4.5 structure: dim → time → node → NodeBucket. Per-dimension totals
 	// are accumulated separately for topN ranking + per-series confidence

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -11,6 +11,13 @@
 // pass's AggInput[] so count-weighted-mean stays well-defined when the
 // crossNode aggregator needs it.
 //
+// Gauge-shaped specs (`crossNode: 'sum'` over `max`/`last` per-node
+// snapshots — `connections`, `database-size`) additionally get bounded
+// last-observation-carry-forward between the two passes: a node absent from a
+// bucket contributes its most recent value for up to ~2 of its own emission
+// intervals. Harper omits a gauge row entirely when the value is 0, so absence
+// is not zero — see carryForward.ts for the full rationale (#1576).
+//
 // Known limitation — count-weighted-mean across nodes: the inner pass
 // invokes the temporal aggregator with values that share the per-node
 // bucket's totalCount as their weight. When a single (node, time) bucket
@@ -34,6 +41,7 @@ import type {
 } from '../types/analytics';
 import { type AggInput, aggregate } from './aggregators';
 import { labelWithApprox } from './approxLabel';
+import { buildStalenessHorizons, isGaugeCrossNodeSum } from './carryForward';
 import { classifyConfidence } from './confidence';
 import { evalFieldExpr } from './fieldExpr';
 import { runTransform } from './runTransform';
@@ -100,8 +108,13 @@ function snapToBucketTime(spec: MetricSpec, record: AnalyticsDataPoint, time: nu
 function resolvePeriod(spec: MetricSpec, record: AnalyticsDataPoint): number {
 	const p = record.period;
 	if (typeof p === 'number' && Number.isFinite(p) && p > 0) { return p; }
-	// A misconfigured non-positive fallbackMs gets the same treatment as a
-	// bad record period — rates must never divide by zero or flip sign.
+	return fallbackPeriod(spec);
+}
+
+/** The spec's declared bucket size, sanitized. A misconfigured non-positive
+ *  `fallbackMs` gets the same treatment as a bad record period — rates must
+ *  never divide by zero or flip sign. */
+function fallbackPeriod(spec: MetricSpec): number {
 	const fallback = spec.bucket?.fallbackMs;
 	return typeof fallback === 'number' && Number.isFinite(fallback) && fallback > 0 ? fallback : 60_000;
 }
@@ -173,11 +186,27 @@ function runGroupBy(
 	perNode: boolean,
 	snapToPeriod: boolean,
 ): SeriesData {
+	const tempAgg: Aggregator = src.field.aggregator?.temporal ?? spec.aggregator.temporal;
+	const crossAgg: Aggregator = src.field.aggregator?.crossNode ?? spec.aggregator.crossNode;
+	const isApprox = tempAgg === 'count-weighted-mean' || crossAgg === 'count-weighted-mean';
+	// When the spec already groups by node, perNode is redundant — emitting
+	// one series per (node, node) would duplicate. Fall through to the
+	// cluster-aggregate path which, for dimension='node', is naturally
+	// one-series-per-node.
+	const dimensionIsNode = src.dimension === 'node';
+	// Bounded per-node carry-forward only applies where the crossNode pass
+	// actually runs, and only for gauge-shaped specs (see carryForward.ts).
+	const carryForward = (!perNode || dimensionIsNode) && isGaugeCrossNodeSum(tempAgg, crossAgg);
+
 	// Step 4.5 structure: dim → time → node → NodeBucket. Per-dimension totals
 	// are accumulated separately for topN ranking + per-series confidence
 	// gating.
 	const buckets = new Map<string | number, Map<number, Map<string, NodeBucket>>>();
 	const dimTotals = new Map<string | number, number>();
+	// dim → node → raw (pre-snap) observation instants. Only collected for
+	// gauge specs, which are the only consumers — the cadence estimate must see
+	// the true emission instants, not the snapped lattice they land on.
+	const observationTimes = carryForward ? new Map<string | number, Map<string, number[]>>() : null;
 	const resolvedTimes = resolveTimes('runGroupBy', spec, records);
 	for (let i = 0; i < records.length; i++) {
 		const r = records[i];
@@ -210,11 +239,8 @@ function runGroupBy(
 		}
 		nodeBucket.items.push({ value: v, count: recordCount });
 		nodeBucket.totalCount += recordCount;
+		if (observationTimes) { recordObservation(observationTimes, dimVal, node, resolvedTime); }
 	}
-
-	const tempAgg: Aggregator = src.field.aggregator?.temporal ?? spec.aggregator.temporal;
-	const crossAgg: Aggregator = src.field.aggregator?.crossNode ?? spec.aggregator.crossNode;
-	const isApprox = tempAgg === 'count-weighted-mean' || crossAgg === 'count-weighted-mean';
 
 	// Apply topN + otherBucket: rank dimensions by totalCount descending, keep
 	// the top N, roll the rest into an `Other` aggregate if otherBucket is on.
@@ -233,11 +259,6 @@ function runGroupBy(
 		}
 		const perTime = buckets.get(key);
 		if (!perTime) { continue; }
-		// When the spec already groups by node, perNode is redundant — emitting
-		// one series per (node, node) would duplicate. Fall through to the
-		// cluster-aggregate path which, for dimension='node', is naturally
-		// one-series-per-node.
-		const dimensionIsNode = src.dimension === 'node';
 		if (perNode && !dimensionIsNode) {
 			// Emit one Series per (dim, node). Skip the crossNode pass; each
 			// node's points come from the inner temporal aggregation alone.
@@ -274,13 +295,12 @@ function runGroupBy(
 		} else {
 			// Cluster-aggregate path (default). Two-pass: temporal-per-node,
 			// then crossNode across nodes within each time bucket.
-			const points: SeriesPoint[] = [];
-			const sortedTimes = [...perTime.keys()].sort((a, b) => a - b);
-			for (const time of sortedTimes) {
-				const byNode = perTime.get(time)!;
-				const { y, count } = aggregateTwoPass(tempAgg, crossAgg, byNode);
-				points.push({ x: time, y, count });
-			}
+			const points = aggregateOverTime(
+				tempAgg,
+				crossAgg,
+				perTime,
+				observationTimes && buildStalenessHorizons(observationTimes.get(key) ?? new Map(), fallbackPeriod(spec)),
+			);
 			series.push({
 				key: String(key),
 				label: labelWithApprox(String(key), tempAgg),
@@ -302,7 +322,23 @@ function runGroupBy(
 		const confClass = classifyConfidence(otherTotal, spec.confidence);
 		if (confClass !== 'suppress') {
 			const otherPerTime = new Map<number, Map<string, NodeBucket>>();
+			// Merged per-node observation instants across every rolled-up dim, so
+			// the Other band's carry-forward horizon reflects the same cadence its
+			// members were emitted at.
+			const otherObservationTimes = observationTimes ? new Map<string, number[]>() : null;
 			for (const [key] of rest) {
+				if (otherObservationTimes) {
+					for (const [node, times] of observationTimes!.get(key) ?? []) {
+						let merged = otherObservationTimes.get(node);
+						if (!merged) {
+							merged = [];
+							otherObservationTimes.set(node, merged);
+						}
+						// Append by loop, not spread — argument-spread blows the V8
+						// stack past ~125k elements and a long window can hold more.
+						for (const t of times) { merged.push(t); }
+					}
+				}
 				const perTime = buckets.get(key);
 				if (!perTime) { continue; }
 				for (const [time, perNodeBucket] of perTime) {
@@ -322,13 +358,12 @@ function runGroupBy(
 					}
 				}
 			}
-			const otherPoints: SeriesPoint[] = [];
-			const sortedTimes = [...otherPerTime.keys()].sort((a, b) => a - b);
-			for (const time of sortedTimes) {
-				const byNode = otherPerTime.get(time)!;
-				const { y, count } = aggregateTwoPass(tempAgg, crossAgg, byNode);
-				otherPoints.push({ x: time, y, count });
-			}
+			const otherPoints = aggregateOverTime(
+				tempAgg,
+				crossAgg,
+				otherPerTime,
+				otherObservationTimes && buildStalenessHorizons(otherObservationTimes, fallbackPeriod(spec)),
+			);
 			series.push({
 				key: 'Other',
 				label: labelWithApprox('Other', tempAgg),
@@ -359,8 +394,16 @@ function runFieldSpecs(
 	// not once per field.
 	const resolvedTimes = resolveTimes('runFieldSpecs', spec, records);
 	const seriesArrays: Series[][] = fields.map((f) => {
+		const tempAgg = f.aggregator?.temporal ?? spec.aggregator.temporal;
+		const crossAgg = f.aggregator?.crossNode ?? spec.aggregator.crossNode;
+		const isApprox = tempAgg === 'count-weighted-mean' || crossAgg === 'count-weighted-mean';
+		const fieldKey = typeof f.field === 'string' ? f.field : f.label;
+		const carryForward = !perNode && isGaugeCrossNodeSum(tempAgg, crossAgg);
+
 		// time → node → NodeBucket
 		const buckets = new Map<number, Map<string, NodeBucket>>();
+		// node → raw (pre-snap) observation instants; see runGroupBy.
+		const observationTimes = carryForward ? new Map<string, number[]>() : null;
 		for (let i = 0; i < records.length; i++) {
 			const r = records[i];
 			const resolvedTime = resolvedTimes[i];
@@ -382,11 +425,12 @@ function runFieldSpecs(
 			}
 			nodeBucket.items.push({ value: v, count: recordCount });
 			nodeBucket.totalCount += recordCount;
+			if (observationTimes) {
+				const times = observationTimes.get(node);
+				if (times) { times.push(resolvedTime); }
+				else { observationTimes.set(node, [resolvedTime]); }
+			}
 		}
-		const tempAgg = f.aggregator?.temporal ?? spec.aggregator.temporal;
-		const crossAgg = f.aggregator?.crossNode ?? spec.aggregator.crossNode;
-		const isApprox = tempAgg === 'count-weighted-mean' || crossAgg === 'count-weighted-mean';
-		const fieldKey = typeof f.field === 'string' ? f.field : f.label;
 
 		if (perNode) {
 			// Emit one Series per (field, node) — both axes carried on the
@@ -426,13 +470,12 @@ function runFieldSpecs(
 		}
 
 		// Cluster-aggregate path.
-		const points: SeriesPoint[] = [];
-		const sortedTimes = [...buckets.keys()].sort((a, b) => a - b);
-		for (const t of sortedTimes) {
-			const byNode = buckets.get(t)!;
-			const { y, count } = aggregateTwoPass(tempAgg, crossAgg, byNode);
-			points.push({ x: t, y, count });
-		}
+		const points = aggregateOverTime(
+			tempAgg,
+			crossAgg,
+			buckets,
+			observationTimes && buildStalenessHorizons(observationTimes, fallbackPeriod(spec)),
+		);
 		return [{
 			key: fieldKey,
 			label: labelWithApprox(f.label, tempAgg),
@@ -443,6 +486,80 @@ function runFieldSpecs(
 		}];
 	});
 	return { series: seriesArrays.flat(), thresholds: spec.thresholds };
+}
+
+/** Append one raw observation instant under (dim, node). */
+function recordObservation(
+	observationTimes: Map<string | number, Map<string, number[]>>,
+	dimVal: string | number,
+	node: string,
+	time: number,
+): void {
+	let byNode = observationTimes.get(dimVal);
+	if (!byNode) {
+		byNode = new Map();
+		observationTimes.set(dimVal, byNode);
+	}
+	const times = byNode.get(node);
+	if (times) { times.push(time); }
+	else { byNode.set(node, [time]); }
+}
+
+/**
+ * Walk a series' time buckets in ascending order, folding each with the
+ * two-pass aggregation.
+ *
+ * `horizonByNode` opts the series into bounded per-node carry-forward — set
+ * only for gauge-shaped specs (`crossNode: 'sum'` over `max`/`last` per-node
+ * snapshots; see carryForward.ts). A node absent from a bucket then
+ * contributes its last observed value instead of nothing, provided that
+ * observation is no older than the node's staleness horizon. Without it, a
+ * bucket that happens to hold only one node of a cluster renders as that
+ * node's value alone — the ~0 dive in #1576.
+ *
+ * Carry-forward never invents bucket times: a bucket with no node reporting
+ * stays absent, so the series keeps its original x positions and a genuine
+ * cluster-wide gap still reads as a gap.
+ */
+function aggregateOverTime(
+	temporal: Aggregator,
+	crossNode: Aggregator,
+	perTime: Map<number, Map<string, NodeBucket>>,
+	horizonByNode: Map<string, number> | null,
+): SeriesPoint[] {
+	const sortedTimes = [...perTime.keys()].sort((a, b) => a - b);
+	const points: SeriesPoint[] = [];
+	if (!horizonByNode) {
+		for (const time of sortedTimes) {
+			const { y, count } = aggregateTwoPass(temporal, crossNode, perTime.get(time)!);
+			points.push({ x: time, y, count });
+		}
+		return points;
+	}
+	const lastObserved = new Map<string, { time: number; value: number }>();
+	for (const time of sortedTimes) {
+		const byNode = perTime.get(time)!;
+		const inputs: AggInput[] = [];
+		const observed = new Set<string>();
+		let count = 0;
+		for (const [node, nodeBucket] of byNode) {
+			count += nodeBucket.totalCount;
+			const nodeY = aggregate(temporal, nodeBucket.items);
+			if (typeof nodeY !== 'number' || !Number.isFinite(nodeY)) { continue; }
+			inputs.push({ value: nodeY, count: nodeBucket.totalCount });
+			observed.add(node);
+			lastObserved.set(node, { time, value: nodeY });
+		}
+		for (const [node, last] of lastObserved) {
+			if (observed.has(node)) { continue; }
+			if (time - last.time > (horizonByNode.get(node) ?? 0)) { continue; }
+			// Carried, not observed — count 0 so `SeriesPoint.count` (confidence
+			// gating, tooltips) keeps reflecting real samples only.
+			inputs.push({ value: last.value, count: 0 });
+		}
+		points.push({ x: time, y: aggregate(crossNode, inputs), count });
+	}
+	return points;
 }
 
 /**

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -86,6 +86,11 @@ export interface RunPipelineOptions {
 	 *  over the newest coarse bucket". See downsample.ts for the per-aggregator
 	 *  rules. */
 	downsampleToWindow?: boolean;
+	/** Chart is rendering into the near-fullscreen expand dialog, which has
+	 *  roughly 4x the horizontal room — resolve to the preset's
+	 *  `expandedBucketMs` instead of its panel `bucketMs`. Only meaningful
+	 *  alongside `downsampleToWindow`. */
+	expanded?: boolean;
 }
 
 /** Composite string key for a per-node series — React key / recharts name
@@ -107,7 +112,8 @@ export function runPipeline(
 		? runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false)
 		: runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
 	if (!options?.downsampleToWindow) { return data; }
-	return downsampleSeriesData(data, spec, targetBucketMs(window.endTime - window.startTime));
+	const target = targetBucketMs(window.endTime - window.startTime, { expanded: options.expanded });
+	return downsampleSeriesData(data, spec, target);
 }
 
 /** Snap a record's time to its period boundary so per-node staggering

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -83,7 +83,8 @@ export function DimensionSelectorRenderer({
 	}, [spec, quantileFields, effectiveQuantile]);
 
 	const fullData = useMemo<SeriesData>(
-		() => runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true }),
+		() =>
+			runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true }),
 		[runtimeSpec, records, timeRange, nodes, perNode],
 	);
 

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -84,8 +84,13 @@ export function DimensionSelectorRenderer({
 
 	const fullData = useMemo<SeriesData>(
 		() =>
-			runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true }),
-		[runtimeSpec, records, timeRange, nodes, perNode],
+			runPipeline(runtimeSpec, records, timeRange, nodes, {
+				perNode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+				expanded: !!fillParent,
+			}),
+		[runtimeSpec, records, timeRange, nodes, perNode, fillParent],
 	);
 
 	// Build the dimension list (the chip-row values) from each series's

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -1,5 +1,7 @@
 import { Component, type ReactNode } from 'react';
+import { targetBucketMs } from '../context/timePresets';
 import { derivedRegistry } from '../pipeline/derived/index';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
 import { specRegistry } from '../pipeline/index';
 import { runPipeline } from '../pipeline/pipeline';
 import type { AnalyticsDataPoint, AxisSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
@@ -135,7 +137,15 @@ export function MetricRenderer({
 				/>
 			);
 		} else {
-			const seriesData = derived.recompute(records, timeRange, nodes, viewMode);
+			// Derived metrics that assemble series from raw columns never pass
+			// through runPipeline's downsample pass, so fold here instead —
+			// otherwise a 7 d / 30 d view of these panels stays at one point per
+			// 60 s while every spec-driven panel beside it is coarsened.
+			const seriesData = downsampleDerivedSeriesData(
+				derived.recompute(records, timeRange, nodes, viewMode),
+				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				derived.downsampleAggregator,
+			);
 			body = renderPrimitive(derived.primitive, seriesData, derived.yAxis, xDomain, fillParent);
 		}
 	} else {
@@ -169,7 +179,11 @@ export function MetricRenderer({
 					};
 					return {
 						title: field.label,
-						data: runPipeline(innerSpec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true }),
+						data: runPipeline(innerSpec, records, timeRange, nodes, {
+							perNode: isPerNodeMode,
+							snapToPeriod: true,
+							downsampleToWindow: true,
+						}),
 						yAxis: field.yAxis ?? outerSpec.yAxis,
 					};
 				});
@@ -179,7 +193,10 @@ export function MetricRenderer({
 					...entry.spec,
 					series: { ...entry.spec.series, dimension: 'node' },
 				};
-				const seriesData = runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true });
+				const seriesData = runPipeline(remapped, records, timeRange, nodes, {
+					snapToPeriod: true,
+					downsampleToWindow: true,
+				});
 				body = renderPrimitive('stacked-area', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsClusterLineFold(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
 				const groupSrc = entry.spec.series;
@@ -187,18 +204,23 @@ export function MetricRenderer({
 					...entry.spec,
 					series: { kind: 'field', fields: [{ ...groupSrc.field, label: 'cluster' }] },
 				};
-				const seriesData = runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true });
+				const seriesData = runPipeline(inner, records, timeRange, nodes, {
+					snapToPeriod: true,
+					downsampleToWindow: true,
+				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsDimensionLineSplit(entry.spec)) {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: false,
 					snapToPeriod: true,
+					downsampleToWindow: true,
 				});
 				body = renderPrimitive('line', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: isPerNodeMode,
 					snapToPeriod: true,
+					downsampleToWindow: true,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -143,7 +143,7 @@ export function MetricRenderer({
 			// 60 s while every spec-driven panel beside it is coarsened.
 			const seriesData = downsampleDerivedSeriesData(
 				derived.recompute(records, timeRange, nodes, viewMode),
-				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				targetBucketMs(timeRange.endTime - timeRange.startTime, { expanded: !!fillParent }),
 				derived.downsampleAggregator,
 			);
 			body = renderPrimitive(derived.primitive, seriesData, derived.yAxis, xDomain, fillParent);
@@ -183,6 +183,7 @@ export function MetricRenderer({
 							perNode: isPerNodeMode,
 							snapToPeriod: true,
 							downsampleToWindow: true,
+							expanded: !!fillParent,
 						}),
 						yAxis: field.yAxis ?? outerSpec.yAxis,
 					};
@@ -196,6 +197,7 @@ export function MetricRenderer({
 				const seriesData = runPipeline(remapped, records, timeRange, nodes, {
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive('stacked-area', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsClusterLineFold(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
@@ -207,6 +209,7 @@ export function MetricRenderer({
 				const seriesData = runPipeline(inner, records, timeRange, nodes, {
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsDimensionLineSplit(entry.spec)) {
@@ -214,6 +217,7 @@ export function MetricRenderer({
 					perNode: false,
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive('line', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else {
@@ -221,6 +225,7 @@ export function MetricRenderer({
 					perNode: isPerNodeMode,
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}

--- a/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
@@ -7,10 +7,12 @@
 
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend';
+import { targetBucketMs } from '../context/timePresets';
 import { useNodeSelection } from '../hooks/useNodeSelection';
 import { getNodeColor } from '../lib/nodeColors';
 import { shortenNodeLabel } from '../lib/nodeLabels';
-import type { AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
+import type { Aggregator, AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
 import { DimensionChipRow } from './DimensionChipRow';
 import { LineChart } from './LineChart';
 
@@ -30,6 +32,11 @@ interface Props {
 		records: AnalyticsDataPoint[],
 		options: { perNode: boolean; selectedPath: string | null },
 	) => SeriesData;
+	/** How to fold points when the window is wider than the render lattice.
+	 *  Defaults to 'mean', correct for a per-second rate (request-rate): equal
+	 *  time buckets, so the coarse rate is the mean of the fine rates. A ratio
+	 *  metric would pass 'count-weighted-mean' to stay Σ-correct. */
+	downsampleAggregator?: Aggregator;
 }
 
 export function PerPathRateRenderer({
@@ -40,6 +47,7 @@ export function PerPathRateRenderer({
 	yAxis,
 	thresholds,
 	compute,
+	downsampleAggregator,
 	fillParent,
 }: Props) {
 	const xDomain = timeRange ? [timeRange.startTime, timeRange.endTime] as [number, number] : undefined;
@@ -68,8 +76,21 @@ export function PerPathRateRenderer({
 		: (perNode ? (paths[0] ?? '') : '');
 
 	const data = useMemo<SeriesData>(
-		() => compute(records, { perNode, selectedPath: effective || null }),
-		[records, perNode, effective, compute],
+		() => {
+			const raw = compute(records, { perNode, selectedPath: effective || null });
+			// These derived metrics build series from raw columns and reach the
+			// chart through this custom Renderer, so they skip runPipeline's
+			// downsample pass and MetricRenderer's derived-fold. Fold here or a
+			// 7 d / 30 d view stays at one point per 60 s beside panels capped at
+			// ~180 (#1588). No window (standalone/test) → leave raw.
+			if (!timeRange) { return raw; }
+			return downsampleDerivedSeriesData(
+				raw,
+				targetBucketMs(timeRange.endTime - timeRange.startTime, { expanded: !!fillParent }),
+				downsampleAggregator,
+			);
+		},
+		[records, perNode, effective, compute, timeRange, fillParent, downsampleAggregator],
 	);
 
 	const { isActive, handleLegendClick } = useNodeSelection(nodes);

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -8,6 +8,7 @@ import { getChartColors } from '../lib/theme';
 import { formatAxisTick } from '../lib/time';
 import type { AxisSpec, SeriesData } from '../types/analytics';
 import { ChartTooltip, useTooltipGate } from './ChartTooltip';
+import { CEILING_KEY, mergeStackedRows } from './mergeStackedRows';
 import { sortByMagnitude } from './sortByMagnitude';
 
 interface Props {
@@ -65,6 +66,14 @@ export function StackedAreaChart(
 		[data.series],
 	);
 
+	// Merge points by x across series, forward-filling each series across the
+	// positions it did not report, bounded by its own reporting cadence. See
+	// mergeStackedRows for why the fill exists and why the bound matters (#1576).
+	// Memoized for the same reason as `nodeNames` above — this chart re-renders
+	// on every hover tick, and the merge walks every point of every series. Kept
+	// above the early return so the hook order stays stable when data is empty.
+	const merged = useMemo(() => mergeStackedRows(data), [data]);
+
 	if (data.series.length === 0) {
 		return (
 			<div role="status" aria-live="polite" className="text-(--color-text-secondary) text-sm p-4">
@@ -74,43 +83,6 @@ export function StackedAreaChart(
 	}
 
 	const chartColors = getChartColors();
-
-	// Merge points by x across series. Series often emit at slightly
-	// staggered timestamps (e.g. Harper emits per-node records at different
-	// instants within the period), so a strict equality merge produces rows
-	// with one populated cell and N-1 nulls — which renders as a sparse,
-	// mostly-empty stack. Forward-fill carries the last-known value across
-	// staggered rows so the stack stays continuous.
-	const xs = new Set<number>();
-	for (const s of data.series) { for (const p of s.points) { xs.add(p.x); } }
-	if (data.ceiling) { for (const p of data.ceiling.points) { xs.add(p.x); } }
-
-	// Pre-build x → index lookup per series for O(1) access during forward-fill.
-	const seriesPointMaps = data.series.map((s) => {
-		const m = new Map<number, number | null>();
-		for (const p of s.points) { m.set(p.x, p.y); }
-		return m;
-	});
-	const ceilingMap = data.ceiling
-		? new Map<number, number | null>(data.ceiling.points.map((p) => [p.x, p.y]))
-		: null;
-
-	const lastSeen: (number | null)[] = data.series.map(() => null);
-	let lastCeiling: number | null = null;
-
-	const merged: Record<string, number | null>[] = [...xs].sort((a, b) => a - b).map((x) => {
-		const row: Record<string, number | null> = { x };
-		data.series.forEach((s, i) => {
-			const m = seriesPointMaps[i];
-			if (m.has(x)) { lastSeen[i] = m.get(x) ?? null; }
-			row[s.key] = lastSeen[i];
-		});
-		if (ceilingMap && data.ceiling) {
-			if (ceilingMap.has(x)) { lastCeiling = ceilingMap.get(x) ?? null; }
-			row.__ceiling__ = lastCeiling;
-		}
-		return row;
-	});
 
 	const resolvedFormatter = yAxis?.formatter;
 	const resolvedUnit = yAxis?.unit;
@@ -177,7 +149,7 @@ export function StackedAreaChart(
 							? (
 								<Line
 									type="monotone"
-									dataKey="__ceiling__"
+									dataKey={CEILING_KEY}
 									name={data.ceiling.label}
 									stroke={chartColors.axisColor}
 									strokeWidth={2}

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -95,8 +95,13 @@ export function TrafficByTypeRenderer({
 	}, [spec, stackBy]);
 
 	const data: SeriesData = useMemo(
-		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
-		[runtimeSpec, filteredRecords, timeRange, nodes],
+		() =>
+			runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, {
+				snapToPeriod: true,
+				downsampleToWindow: true,
+				expanded: !!fillParent,
+			}),
+		[runtimeSpec, filteredRecords, timeRange, nodes, fillParent],
 	);
 
 	// Color each series by its key using the appropriate allocator so the
@@ -122,6 +127,7 @@ export function TrafficByTypeRenderer({
 			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], {
 				snapToPeriod: true,
 				downsampleToWindow: true,
+				expanded: !!fillParent,
 			});
 			return {
 				title: nodeId,

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -95,7 +95,7 @@ export function TrafficByTypeRenderer({
 	}, [spec, stackBy]);
 
 	const data: SeriesData = useMemo(
-		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true }),
+		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
 		[runtimeSpec, filteredRecords, timeRange, nodes],
 	);
 
@@ -119,7 +119,10 @@ export function TrafficByTypeRenderer({
 		const activeNodes = nodes.filter(isNodeActive);
 		return activeNodes.map((nodeId) => {
 			const nodeRecords = filteredRecords.filter((r) => r.node === nodeId);
-			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], { snapToPeriod: true });
+			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], {
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			});
 			return {
 				title: nodeId,
 				data: {

--- a/src/features/instance/status/analytics/primitives/mergeStackedRows.ts
+++ b/src/features/instance/status/analytics/primitives/mergeStackedRows.ts
@@ -1,0 +1,131 @@
+// Row builder for StackedAreaChart: merges every series onto the union of x
+// positions, forward-filling each across the positions it did not report —
+// bounded by the same staleness horizon the pipeline applies to cross-node
+// gauge sums (#1576, pipeline/carryForward.ts).
+//
+// Why a fill is needed at all: Harper emits per-node analytics records at
+// staggered instants, and gauge rows carry `period: 0`, so the pipeline snaps
+// them onto the spec's `bucket.fallbackMs` lattice — a 90 s cadence on a 60 s
+// lattice lands on some buckets and skips others. A strict equality merge then
+// yields rows with one populated cell and N-1 nulls, which a stacked area
+// renders as a shredded, mostly-empty stack.
+//
+// The fill is most load-bearing in "Stack by: Node" mode. There the renderer
+// remaps the spec's dimension to 'node', so a series' buckets are exactly the
+// instants that one node reported and that node is present in every one of
+// them: the pipeline's own carry-forward (which never invents bucket times) is a
+// structural no-op, and this merge is the only thing holding the bands together.
+// In "Stack by: Type" mode the cross-node fold has already put every type on the
+// shared lattice, so the fill only bridges types that genuinely report at
+// different cadences.
+//
+// Why it has to be bounded: unbounded LOCF carries a band for the rest of the
+// window, so a node that has genuinely gone idle keeps contributing its last
+// value to the stacked total forever. That is exactly the #1576 overstatement,
+// one layer up — core emits `mqtt-connections` only while the count is nonzero
+// (`if (numberOfConnections > 0)` in server/mqtt.ts), so "no row" is what an
+// idle node looks like.
+//
+// Past the horizon a band fills 0, not null:
+//   - It mirrors the pipeline. Dropping an expired node from a `crossNode: 'sum'`
+//     *is* contributing 0 to that sum.
+//   - It is what a stacked chart means. Bands add, so 0 is the neutral element;
+//     a null punches a hole through the stack and drops every band above it.
+//   - It is right for the additive counters too (`mqtt-traffic-*`,
+//     bytes-sent/received): no row for a rate series means no traffic, so 0 is
+//     the honest value — strictly better than carrying the last throughput on
+//     forever.
+// A cluster-wide gap cannot turn into spurious zeros, because the x positions
+// come only from series that actually reported: if everything stops, the rows
+// stop too.
+import { estimateEmissionIntervalMs, STALENESS_INTERVALS } from '../pipeline/carryForward';
+import type { SeriesData } from '../types/analytics';
+
+/** Recharts `dataKey` for the optional ceiling / reference line. Distinct from
+ *  any series key, which is a dimension value or a `dim|node` composite. */
+export const CEILING_KEY = '__ceiling__';
+
+/** One Recharts datum: `x` plus one entry per series key (and the ceiling). */
+export type StackedRow = Record<string, number | null>;
+
+/** Last reading a series produced, and the x position it produced it at. */
+interface LastReading {
+	at: number;
+	y: number | null;
+}
+
+export function mergeStackedRows(data: SeriesData): StackedRow[] {
+	const xs = new Set<number>();
+	for (const s of data.series) { for (const p of s.points) { xs.add(p.x); } }
+	if (data.ceiling) { for (const p of data.ceiling.points) { xs.add(p.x); } }
+	const sortedXs = [...xs].sort((a, b) => a - b);
+
+	// Pre-build x → y lookup per series for O(1) access during the fill.
+	const pointMaps = data.series.map((s) => {
+		const m = new Map<number, number | null>();
+		for (const p of s.points) { m.set(p.x, p.y); }
+		return m;
+	});
+	const horizons = buildHorizons(data, sortedXs);
+	const ceilingMap = data.ceiling
+		? new Map<number, number | null>(data.ceiling.points.map((p) => [p.x, p.y]))
+		: null;
+
+	const last: (LastReading | null)[] = data.series.map(() => null);
+	let lastCeiling: number | null = null;
+
+	return sortedXs.map((x) => {
+		const row: StackedRow = { x };
+		data.series.forEach((s, i) => {
+			// `undefined` is "no point here"; a point whose y is null reported
+			// without a value, and must not be confused with the former.
+			const observed = pointMaps[i].get(x);
+			if (observed !== undefined) { last[i] = { at: x, y: observed }; }
+			row[s.key] = fillAt(last[i], x, horizons[i]);
+		});
+		if (ceilingMap) {
+			// The ceiling is a reference line drawn over the stack, not a band in
+			// it: it adds to no total and has no zero to expire to (a ceiling that
+			// drops to 0 reads as a limit of nothing). Carried unbounded, as before.
+			const observed = ceilingMap.get(x);
+			if (observed !== undefined) { lastCeiling = observed; }
+			row[CEILING_KEY] = lastCeiling;
+		}
+		return row;
+	});
+}
+
+/** What a series contributes at `x`: its own reading where it reported, its most
+ *  recent one while that is still inside the horizon, 0 once it is not. `null`
+ *  before the series' first point — there is nothing to carry, and LOCF never
+ *  back-fills — and for a point that reported no value. */
+function fillAt(last: LastReading | null, x: number, horizonMs: number): number | null {
+	if (last === null || last.y === null) { return null; }
+	return x - last.at > horizonMs ? 0 : last.y;
+}
+
+/**
+ * Per-series staleness horizon (ms), mirroring the pipeline's
+ * `buildStalenessHorizons`: `STALENESS_INTERVALS` × the series' own median
+ * reporting gap, floored at the rendered lattice step so a horizon always spans
+ * at least two x positions (that floor is what covers a series reporting faster
+ * than the lattice, or having reported only once).
+ *
+ * Plus one lattice step of slack, which the pipeline does not need. The pipeline
+ * estimates cadence from raw emission instants; by the time a series reaches a
+ * primitive those have been snapped onto the lattice, and snapping *compresses*
+ * alternate gaps — a 90 s cadence on a 60 s lattice reports at 0/120/180/300…,
+ * so its gaps alternate 120/60 and their median reads 60 or 90 depending on how
+ * many samples the window caught, while the widest gap is 120. Absent the slack,
+ * a series could expire on the very beat pattern the snap induced. One step is
+ * the most the snap can stretch a gap by, so adding it keeps this horizon at
+ * least as generous as the pipeline's — the safe direction, since expiring a
+ * series that is merely out of phase is the artifact we are trying not to draw.
+ */
+function buildHorizons(data: SeriesData, sortedXs: readonly number[]): number[] {
+	const latticeMs = estimateEmissionIntervalMs(sortedXs) ?? 0;
+	return data.series.map((s) => {
+		const cadenceMs = estimateEmissionIntervalMs(s.points.map((p) => p.x)) ?? 0;
+		return STALENESS_INTERVALS * Math.max(cadenceMs, latticeMs) + latticeMs;
+	});
+}

--- a/src/features/instance/status/analytics/tabs/kpi/useKpiTileData.ts
+++ b/src/features/instance/status/analytics/tabs/kpi/useKpiTileData.ts
@@ -68,6 +68,11 @@ export function useKpiTileData(def: KpiTileDef): KpiTileData {
 
 	const sparkPoints = useMemo<KpiPoint[]>(() => {
 		if (current.isError) { return []; }
+		// No `downsampleToWindow` here, unlike the chart panels: these points
+		// collapse to a headline number and a sparkline, so there is no density
+		// to save, and folding onto a coarse lattice first would redefine
+		// `latestValue` from "the newest bucket" to "an average across the
+		// newest coarse bucket".
 		return collapseSeries(
 			runPipeline(def.spec, current.data, timeRange, [], { snapToPeriod: true }),
 			def.combine,
@@ -78,6 +83,8 @@ export function useKpiTileData(def: KpiTileDef): KpiTileData {
 	const previousMean = useMemo<number | null>(() => {
 		if (previous.isLoading || previous.isError) { return null; }
 		const prevRange: TimeRange = { startTime: prevStart, endTime: prevEnd };
+		// Full resolution, matching sparkPoints above — the delta compares two
+		// window means and both sides must be computed the same way.
 		return windowMean(collapseSeries(
 			runPipeline(def.spec, previous.data, prevRange, [], { snapToPeriod: true }),
 			def.combine,

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -181,6 +181,11 @@ export interface DerivedMetricSpec {
 	yAxis: MetricSpec['yAxis'];
 	thresholds?: Threshold[];
 	layout?: MetricSpec['layout'];
+	/** How to fold this metric's points when the selected window is wider than
+	 *  the render lattice (see pipeline/downsample.ts). Defaults to `'mean'`,
+	 *  which is right for the shipped derived metrics — all rates or ratios.
+	 *  Set `'sum'` for an extensive quantity, or `'max'`/`'last'` for a gauge. */
+	downsampleAggregator?: Aggregator;
 	/** Optional custom React component. When present, MetricRenderer uses
 	 *  it INSTEAD of the recompute → renderPrimitive flow — same role as
 	 *  SpecRegistryEntry.Renderer for spec-driven metrics. Lets derived


### PR DESCRIPTION
Fixes #1576.

Customer-reported (harper-pro 5.1.22): the Status → Traffic → **Connections** panel showed frequent one-sample dives to near zero, while Grafana over the same instances and window showed none. The customer was load-testing and watching connections closely; nothing actually dropped.

**Harper never reports a zero.** The tell is that each dive's depth equals the *quiet* node's own connection count at that instant, not 0 — one spike in the customer's screenshot bottoms at ~100 rather than 0, which is the Milan node sitting at ~100 connections at the time. A real connection loss can't do that.

## Root cause

Three things compound:

1. Core emits `mqtt-connections` only when the count is nonzero — `if (numberOfConnections > 0)` in harper's [`server/mqtt.ts`](https://github.com/HarperFast/harper/blob/main/server/mqtt.ts) (~L177). A node at 0 connections emits **no row at all**, so per-node coverage of the gauge is inherently ragged.
2. Those rows carry **`period: 0`**, so `resolvePeriod` falls back to the spec's `bucket.fallbackMs` (60 s) and `snapToBucketTime` rounds every row onto a 60 s lattice — while the observed emission cadence is **90 s**. 90 mod 60 = 30, so the two nodes' phases beat against the lattice and co-land in the same bucket only intermittently.
3. `crossNode: 'sum'` then sums **only the nodes present in that bucket**. A bucket holding just the quiet node renders the cluster total as that node's 1–5 connections instead of ~289 — a one-sample vertical dive to ≈0.

## What changed

Bucket alignment alone can't fix this: core's `> 0` guard guarantees ragged coverage however well we bucket. So gauge-shaped specs now get **per-node last-observation-carry-forward with a bounded staleness horizon** before the cross-node sum.

New module [`pipeline/carryForward.ts`](src/features/instance/status/analytics/pipeline/carryForward.ts) holds the policy; [`pipeline.ts`](src/features/instance/status/analytics/pipeline/pipeline.ts) grows one `aggregateOverTime` helper that replaces the three places which previously looped `aggregateTwoPass` over sorted bucket times (groupBy series, the `Other` bucket, and field-mode series).

A node absent from a bucket contributes its most recent value, but only for **~2 of its own emission intervals** — estimated as the median gap between that node's observation instants, floored at the spec's bucket size. The bound is the point: "no row" is genuinely ambiguous between *"this node's sample landed in the adjacent bucket"* (carry it) and *"this node is idle at 0"* (don't). Unbounded LOCF would overstate a node that has genuinely gone quiet. Median rather than mean so a node that keeps crossing zero is still credited with its active cadence instead of one inflated by the absences.

The cadence is measured from **raw, pre-snap** instants — the estimator has to see the true 90 s cadence, not the 60/120 alternation the lattice snap produces.

### Scope

Keys on `crossNode: 'sum'` with a temporal aggregator of `max`/`last`, i.e. a cross-node sum of per-node *level* snapshots. Today that is exactly:

- `connections` (max/sum) — the reported panel
- `database-size` (last/sum) — **the identical latent bug**, called out in the issue

Additive counters (`sum`/`sum` — `mqtt-traffic-*`, `bytes-sent`/`bytes-received`, `fsWrite`) are deliberately excluded: there a missing row legitimately means zero, and carrying the previous bucket's throughput forward would invent traffic that never happened. There's a test asserting this for `bytes-sent`.

### Invariants preserved

- **Carry-forward never creates bucket times.** A bucket where no node reported stays absent, so the series keeps its original x positions and a genuine cluster-wide gap still reads as a gap.
- **Carried values carry `count: 0`**, so `SeriesPoint.count` — which drives confidence gating and the tooltip's sample count — keeps reflecting real observations only.
- **Per-node mode is untouched.** The chip-selector and "Stack by: Node" views read per-node values directly; carry-forward belongs to the cross-node sum alone.
- **LOCF only looks backwards** — buckets before a node's first sample are not back-filled.

## Verification

**The new tests fail without the fix.** Gating `isGaugeCrossNodeSum` to `false` produces `expected [300, 300, 100, 300] to deeply equal [300, 300, 300, 300]` — the dive to one node's own value, reproduced exactly.

**Replaying the reported row shape** (960 + 228 rows over 24 h, `period: 0`, 90 s cadence, independent phases) reproduces the issue's evidence block and then clears it:

|  | before | after |
| --- | --- | --- |
| minimum y in series | **1** | **283** |
| points below 200 (dives) | **114** | **0** |
| bucket census | 114 both · 846 us-west-only · 114 milan-only | unchanged |

**Live on a real 2-node stage cluster** (`anvils.acme-inc.stage`). I temporarily instrumented `aggregateOverTime` and loaded the Storage tab: `nodes=2 buckets=1440 incompleteBuckets=960 carried=959 expired=0`, horizons ≈ 180 002 ms. Two things worth a reviewer's attention:

- **This bug was live on our own stage cluster too** — 67% of `database-size` buckets held only one node, across all five database bands. It just reads as a plausible-looking wobble rather than an obvious dive, because the bands are large and slow-moving.
- The cadence estimator independently landed on ~90 s there as well, so `fallbackMs: 60000` is systematically wrong for these gauge metrics. That corroborates the issue's secondary finding that core stamping a real `period` would remove the guess entirely.

Probe removed afterwards; the panel renders a clean continuous 24 h stack at the full two-node total, all five bands, no error-boundary fallback.

## Tests

The existing `connections-pipeline.test.ts` / `database-size-pipeline.test.ts` suites only exercise uniform `period: 60000` with every node present at every timestamp, so this class of bug could not surface there. Added:

- `__tests__/pipeline/cross-node-gauge-gaps.test.ts` — staggered 90 s cadence with lattice phase beating (including a guard asserting the setup really does produce single-node buckets, so nothing passes vacuously); horizon-expiry when a node goes genuinely idle; cluster-wide gaps staying gaps; no node resurrected across an outage; point-count and `count` invariants; `database-size` same-shape case; `bytes-sent` counter-untouched case.
- `__tests__/pipeline/carryForward.test.ts` — unit coverage for the shape predicate, the median-gap estimator (order independence, duplicate instants, scattered absences), and horizon construction.
- `__tests__/fixtures/connections/node-drop.json` — minimal hand-checkable node-drop fixture, mirroring the `table-size/node-drop.json` precedent the issue points at.

Full repo gate green: **1881 tests / 264 files**, `tsc -b`, `oxlint`, `dprint check`.

## Deliberately out of scope

- **Bucket alignment.** The issue notes it's insufficient on its own, and changing `snapToBucketTime` would affect every spec for no gain here.
- **A spec-level opt-out knob.** The gauge shape is derived from one source of truth (`isGaugeCrossNodeSum`); easy to add a knob later if reviewers prefer it explicit per spec.
- **`StackedAreaChart`'s render-layer forward-fill** ([lines 98–113](src/features/instance/status/analytics/primitives/StackedAreaChart.tsx#L98-L113)) is *unbounded*. That's why "Stack by: Node" mode never showed these dives — but it also means a genuinely idle node's band persists for the rest of the window, which is now inconsistent with the bounded horizon one layer up. It touches every stacked-area panel, so it wants its own change.
- The issue's other secondary findings (harper-pro ignoring `bucket_ms`; `analytics.aggregatePeriod: 60` vs rows landing 90 s apart) are core-side and want a companion core issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
