### PR TITLE
perf(status): render charts at the selected window's resolution

### DIFF
--- a/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/bytes-sent-tolerance.test.ts
@@ -59,7 +59,17 @@ describe('bytes-sent tolerance', () => {
 
 	it('mqtt-traffic-sent (msg/sec) total ≈ Σ count/period × 1000 within 0.5%', () => {
 		const records = JSON.parse(readFileSync(join(import.meta.dirname, '../fixtures/bytes/bytes-sent.json'), 'utf8'));
-		const out = mqttTrafficSentDerived.recompute(records, { startTime: 0, endTime: Number.MAX_SAFE_INTEGER }, []);
+		// The window is load-bearing here, unlike the two cases above: this goes
+		// through `recompute`, which opts into `downsampleToWindow`, so the range
+		// decides the render lattice. The old `0 → MAX_SAFE_INTEGER` sentinel
+		// (harmless while runPipeline ignored `window`) now reads as a ~285-century
+		// window and folds every point into one bucket, which would collapse the
+		// Σ-of-rates this test is actually checking. Use the fixture's own span —
+		// ~59 min, so the 1 h preset's 1 min lattice, and the samples sit ~115 s
+		// apart and stay one-per-bucket.
+		const times = (records as { time: number }[]).map((r) => r.time).filter(Number.isFinite);
+		const window = { startTime: Math.min(...times), endTime: Math.max(...times) };
+		const out = mqttTrafficSentDerived.recompute(records, window, []);
 
 		const refTotal = records.reduce((s: number, r: any) => {
 			if (typeof r.count !== 'number' || typeof r.period !== 'number' || r.period <= 0) { return s; }

--- a/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+	downsampleAggregator,
+	downsampleDerivedSeriesData,
+	downsamplePoints,
+	isRateTransform,
+} from '../../pipeline/downsample';
+import type { SeriesData, SeriesPoint } from '../../types/analytics';
+
+describe('isRateTransform', () => {
+	it('detects a direct rate transform', () => {
+		expect(isRateTransform({ kind: 'rate' })).toBe(true);
+	});
+
+	it('detects a rate nested in a compose', () => {
+		expect(isRateTransform({ kind: 'compose', steps: [{ kind: 'scale', factor: 2 }, { kind: 'rate' }] })).toBe(true);
+	});
+
+	it('is false for undefined and for non-rate transforms', () => {
+		expect(isRateTransform(undefined)).toBe(false);
+		expect(isRateTransform({ kind: 'raw' })).toBe(false);
+		expect(isRateTransform({ kind: 'ratio' })).toBe(false);
+		expect(isRateTransform({ kind: 'scale', factor: 1000 })).toBe(false);
+		expect(isRateTransform({ kind: 'compose', steps: [{ kind: 'raw' }, { kind: 'ratio' }] })).toBe(false);
+	});
+});
+
+describe('downsampleAggregator', () => {
+	it('collapses rate fields with mean whatever the spec says temporally', () => {
+		// The whole point: a `sum` over per-second values must not re-sum across
+		// time, or bytes-sent reads 3x high on a 5 min lattice.
+		expect(downsampleAggregator('sum', { kind: 'rate' })).toBe('mean');
+		expect(downsampleAggregator('max', { kind: 'rate' })).toBe('mean');
+	});
+
+	it('keeps sum for extensive (non-rate) quantities', () => {
+		expect(downsampleAggregator('sum', undefined)).toBe('sum');
+		expect(downsampleAggregator('sum', { kind: 'raw' })).toBe('sum');
+	});
+
+	it('preserves gauge aggregators', () => {
+		expect(downsampleAggregator('max', undefined)).toBe('max');
+		expect(downsampleAggregator('last', undefined)).toBe('last');
+	});
+
+	it('collapses percentiles with max so spikes survive a wide window', () => {
+		// A p95-of-p95s is not a p95; of the two approximations, keep the worst
+		// case rather than smoothing it away.
+		expect(downsampleAggregator('p50', undefined)).toBe('max');
+		expect(downsampleAggregator('p95', undefined)).toBe('max');
+		expect(downsampleAggregator('p99', undefined)).toBe('max');
+	});
+
+	it('keeps count-weighted-mean count-weighted', () => {
+		expect(downsampleAggregator('count-weighted-mean', undefined)).toBe('count-weighted-mean');
+	});
+});
+
+describe('downsamplePoints', () => {
+	const pts = (xs: number[], ys: number[], counts?: number[]): SeriesPoint[] =>
+		xs.map((x, i) => ({ x, y: ys[i], ...(counts ? { count: counts[i] } : {}) }));
+
+	it('folds 60s points onto a 300s lattice, round-to-nearest', () => {
+		// Round-to-nearest, not floor — the same convention `snapToBucketTime`
+		// uses, so coarse bucket times stay on a grid the other panels share.
+		// 0/60k/120k round to 0; 180k/240k round up to 300k.
+		const out = downsamplePoints(pts([0, 60_000, 120_000, 180_000, 240_000], [10, 20, 30, 40, 50]), 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([0, 300_000]);
+		expect(out.map((p) => p.y)).toEqual([20, 45]);
+	});
+
+	it('sums observation counts so confidence gating still sees the real total', () => {
+		const out = downsamplePoints(pts([0, 60_000, 120_000], [1, 2, 3], [4, 5, 6]), 300_000, 'sum');
+		expect(out.length).toBe(1);
+		expect(out[0].count).toBe(15);
+	});
+
+	it('returns the original array untouched when nothing would fold', () => {
+		// The 1h/6h presets already sit on the target lattice — identity, and
+		// referentially so, to keep downstream memos stable.
+		const input = pts([0, 60_000, 120_000], [1, 2, 3]);
+		expect(downsamplePoints(input, 60_000, 'mean')).toBe(input);
+	});
+
+	it('is a no-op for a non-positive target or empty input', () => {
+		const input = pts([0, 60_000], [1, 2]);
+		expect(downsamplePoints(input, 0, 'mean')).toBe(input);
+		expect(downsamplePoints([], 300_000, 'mean')).toEqual([]);
+	});
+
+	it('keeps an all-null coarse bucket as an explicit null gap', () => {
+		const input: SeriesPoint[] = [
+			{ x: 0, y: null },
+			{ x: 60_000, y: null },
+			{ x: 600_000, y: 5 },
+		];
+		const out = downsamplePoints(input, 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([0, 600_000]);
+		expect(out[0].y).toBeNull();
+		expect(out[1].y).toBe(5);
+	});
+
+	it('ignores nulls when the bucket also holds real values', () => {
+		const out = downsamplePoints([{ x: 0, y: null }, { x: 60_000, y: 10 }], 300_000, 'mean');
+		expect(out[0].y).toBe(10);
+	});
+
+	it('lands coarse buckets on the same epoch-aligned grid as the fine snap', () => {
+		const out = downsamplePoints(pts([300_000, 360_000, 600_000], [1, 2, 3]), 300_000, 'mean');
+		expect(out.map((p) => p.x)).toEqual([300_000, 600_000]);
+	});
+});
+
+describe('downsampleDerivedSeriesData', () => {
+	const data: SeriesData = {
+		series: [{ key: 'a', label: 'a', points: [{ x: 0, y: 10 }, { x: 60_000, y: 20 }] }],
+	};
+
+	it('defaults to mean — the shipped derived metrics are rates and ratios', () => {
+		const out = downsampleDerivedSeriesData(data, 300_000);
+		expect(out.series[0].points).toEqual([{ x: 0, y: 15 }]);
+	});
+
+	it('honors an explicit aggregator', () => {
+		expect(downsampleDerivedSeriesData(data, 300_000, 'sum').series[0].points[0].y).toBe(30);
+	});
+
+	it('is idempotent — re-folding an already-coarse series changes nothing', () => {
+		// MetricRenderer folds every derived recompute, including mqtt-traffic's
+		// which already downsampled internally. That must not double-average.
+		const once = downsampleDerivedSeriesData(data, 300_000);
+		const twice = downsampleDerivedSeriesData(once, 300_000);
+		expect(twice.series[0].points).toEqual(once.series[0].points);
+	});
+
+	it('folds the ceiling series too', () => {
+		const withCeiling: SeriesData = {
+			...data,
+			ceiling: { key: 'rss', label: 'rss', points: [{ x: 0, y: 100 }, { x: 60_000, y: 200 }] },
+		};
+		const out = downsampleDerivedSeriesData(withCeiling, 300_000);
+		expect(out.ceiling!.points).toEqual([{ x: 0, y: 150 }]);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/downsample.test.ts
@@ -75,6 +75,23 @@ describe('downsamplePoints', () => {
 		expect(out[0].count).toBe(15);
 	});
 
+	it('re-aligns points that map one-to-one but still move', () => {
+		// The dangerous shape: a 90 s lattice folded onto a 60 s target. Every
+		// point lands in a bucket of its own, so a size comparison alone reads as
+		// "nothing to do" — but k*90_000 -> round(1.5k)*60_000 moves all but the
+		// even-k ones. Leaving them put would drop the series off the target grid
+		// and break the StorageTab crosshair match (#1514).
+		const xs = [0, 90_000, 180_000, 270_000, 360_000];
+		const out = downsamplePoints(pts(xs, [1, 2, 3, 4, 5]), 60_000, 'mean');
+		expect(out.length).toBe(xs.length);
+		expect(out.map((p) => p.x)).toEqual([0, 120_000, 180_000, 300_000, 360_000]);
+		for (const p of out) {
+			expect(p.x % 60_000, `x=${p.x} off the target lattice`).toBe(0);
+		}
+		// One point per bucket, so the values pass through untouched.
+		expect(out.map((p) => p.y)).toEqual([1, 2, 3, 4, 5]);
+	});
+
 	it('returns the original array untouched when nothing would fold', () => {
 		// The 1h/6h presets already sit on the target lattice — identity, and
 		// referentially so, to keep downstream memos stable.

--- a/src/features/instance/status/analytics/__tests__/pipeline/error-rate-downsample.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/error-rate-downsample.test.ts
@@ -1,0 +1,50 @@
+// error-rate is a ratio (1 − Σtotal/Σcount), so folding several fine buckets
+// into one coarse bucket at 7 d / 30 d must recombine Σ-correctly, not average
+// the per-bucket ratios. The spec pins `downsampleAggregator:
+// 'count-weighted-mean'` for exactly this; these lock it against the
+// ratio-of-ratios regression (#1588 review).
+import { describe, expect, it } from 'vitest';
+import { getPreset, targetBucketMs } from '../../context/timePresets';
+import { errorRateDerived, recomputeErrorRate } from '../../pipeline/derived/error-rate';
+import { downsampleDerivedSeriesData } from '../../pipeline/downsample';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const T0 = 28_333_334 * 60_000;
+const WINDOW: TimeRange = { startTime: 0, endTime: Number.MAX_SAFE_INTEGER };
+
+// Two buckets of very different request volume on one path:
+//   1000 reqs, 990 ok → ratio 0.010   (10 errors)
+//     10 reqs,   1 ok → ratio 0.900   (9 errors)
+// Σ-correct combined error rate = 19 / 1010 ≈ 0.018812.
+// Mean-of-ratios (the bug) = (0.01 + 0.9) / 2 = 0.455.
+const records: AnalyticsDataPoint[] = [
+	{ node: 'n1', path: '/a', time: T0, count: 1000, total: 990 },
+	{ node: 'n1', path: '/a', time: T0 + 60_000, count: 10, total: 1 },
+];
+
+describe('error-rate downsample fold', () => {
+	it('the spec folds with count-weighted-mean', () => {
+		expect(errorRateDerived.downsampleAggregator).toBe('count-weighted-mean');
+	});
+
+	it('folds disparate-volume buckets Σ-correctly, not as a mean of ratios', () => {
+		const raw = recomputeErrorRate(records, WINDOW, []);
+		// 30d preset → 4h bucket, so both samples (60 s apart) fold into one.
+		const target = targetBucketMs(getPreset('30d').durationMs);
+		const folded = downsampleDerivedSeriesData(raw, target, errorRateDerived.downsampleAggregator);
+		const points = folded.series.find((s) => s.key === '/a')!.points;
+		expect(points).toHaveLength(1);
+		expect(points[0].y).toBeCloseTo(19 / 1010, 6); // ≈ 0.018812, Σ-correct
+		expect(points[0].y).not.toBeCloseTo(0.455, 2); // NOT mean-of-ratios
+		// Folded count is the summed request volume, so confidence gating and
+		// the SLO threshold's minCount still see the real traffic.
+		expect(points[0].count).toBe(1010);
+	});
+
+	it('an unweighted mean fold WOULD reproduce the ratio-of-ratios bug (guard rails the choice)', () => {
+		const raw = recomputeErrorRate(records, WINDOW, []);
+		const target = targetBucketMs(getPreset('30d').durationMs);
+		const wrong = downsampleDerivedSeriesData(raw, target, 'mean');
+		expect(wrong.series.find((s) => s.key === '/a')!.points[0].y).toBeCloseTo(0.455, 3);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
@@ -81,24 +81,45 @@ describe('rendered point count per preset', () => {
 			// Never coarser than asked, and within one bucket of the target.
 			expect(after.length).toBeLessThanOrEqual(intended + 1);
 			expect(after.length).toBeLessThanOrEqual(before.length);
-			// The wide presets are the ones that were over-dense; the 1h/6h
-			// presets already sit on their own lattice and must come through
+			// `period: 0` rows bucket onto the 60 s fallback, so any preset asking
+			// for a coarser bucket than that must come out strictly shorter. The
+			// 1h preset already sits on the 60 s lattice and must come through
 			// unchanged. (Value equality, not reference — these are two separate
 			// runPipeline calls, so the arrays are distinct instances either way.)
 			if (preset.bucketMs > 60_000) {
-				expect(before.length).toBeGreaterThan(intended * 2);
+				expect(after.length).toBeLessThan(before.length);
 			} else {
 				expect(after).toEqual(before);
 			}
 		});
 	}
 
-	it('30d drops from ~43k points to ~720', () => {
+	it('30d drops from ~43k points to ~180', () => {
 		const preset = getPreset('30d');
 		const rows = gaugeRows(preset.durationMs);
 		const w = windowFor(preset.durationMs);
 		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
-		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(721);
+		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(181);
+	});
+
+	it('expanding a chart buys back detail without returning to raw density', () => {
+		// The dialog is ~4x wider, so it resolves to the preset's expanded
+		// bucket: more detail than the panel, still nowhere near one point/60 s.
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		const panel = runPipeline(connectionsSpec, rows, w, [], {
+			snapToPeriod: true,
+			downsampleToWindow: true,
+		}).series.find((s) => s.key === 'mqtt')!.points;
+		const dialog = runPipeline(connectionsSpec, rows, w, [], {
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: true,
+		}).series.find((s) => s.key === 'mqtt')!.points;
+
+		expect(dialog.length).toBeGreaterThan(panel.length);
+		expect(dialog.length).toBeLessThanOrEqual(Math.round(preset.durationMs / preset.expandedBucketMs) + 1);
 	});
 });
 

--- a/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
+++ b/src/features/instance/status/analytics/__tests__/pipeline/render-density.test.ts
@@ -1,0 +1,168 @@
+// Chart point density per time preset.
+//
+// Studio asks Harper for `bucket_ms` sized to the selected window, but builds
+// that ignore the hint (harper-pro 5.1.22) return rows at raw emission cadence.
+// The pipeline then buckets on `spec.bucket.fallbackMs` — 60 s no matter how
+// wide the window — so a 30 d view rendered 43 200 points per series instead of
+// the 720 its preset asks for. `downsampleToWindow` folds the finished series
+// onto the preset's lattice.
+import { describe, expect, it } from 'vitest';
+import { getPreset, targetBucketMs, TIME_PRESETS } from '../../context/timePresets';
+import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import type { AnalyticsDataPoint, TimeRange } from '../../types/analytics';
+
+const connectionsSpec = wrapperMetrics['connections'].spec;
+const bytesSentSpec = wrapperMetrics['bytes-sent'].spec;
+
+/** Observed emission cadence on the reporting instance — not a divisor of the
+ *  60 s fallback lattice, which is what made the counts ragged. */
+const CADENCE = 90_000;
+const T0 = 28_333_334 * 60_000;
+
+const windowFor = (durationMs: number): TimeRange => ({ startTime: T0, endTime: T0 + durationMs });
+
+/** Two nodes reporting a steady gauge for `durationMs`, `period: 0`. */
+function gaugeRows(durationMs: number): AnalyticsDataPoint[] {
+	const rows: AnalyticsDataPoint[] = [];
+	for (let t = 0; t < durationMs; t += CADENCE) {
+		rows.push({ type: 'mqtt', node: 'a', time: T0 + t, connections: 100, count: 1, period: 0 });
+		rows.push({ type: 'mqtt', node: 'b', time: T0 + t + CADENCE / 2, connections: 100, count: 1, period: 0 });
+	}
+	return rows;
+}
+
+const mqttPoints = (rows: AnalyticsDataPoint[], w: TimeRange, downsample: boolean) =>
+	runPipeline(connectionsSpec, rows, w, [], { snapToPeriod: true, downsampleToWindow: downsample })
+		.series.find((s) => s.key === 'mqtt')!.points;
+
+describe('targetBucketMs', () => {
+	it('resolves every preset-sized window to exactly that preset bucketMs', () => {
+		// Load-bearing: StorageTab aligns its trend grid to the context bucketMs
+		// (#1514). If these two ever disagree, crosshair sync silently breaks.
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs), p.id).toBe(p.bucketMs);
+		}
+	});
+
+	it('tolerates the sub-second drift of a live now() end bound', () => {
+		const p = getPreset('24h');
+		expect(targetBucketMs(p.durationMs + 400)).toBe(p.bucketMs);
+		expect(targetBucketMs(p.durationMs - 400)).toBe(p.bucketMs);
+	});
+
+	it('falls to the finest bucket for a degenerate window', () => {
+		const finest = TIME_PRESETS[0].bucketMs;
+		expect(targetBucketMs(0)).toBe(finest);
+		expect(targetBucketMs(-1)).toBe(finest);
+		expect(targetBucketMs(Number.NaN)).toBe(finest);
+	});
+
+	it('holds the widest preset ratio beyond 30d instead of reverting to 60s', () => {
+		const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
+		const ratio = widest.durationMs / widest.bucketMs;
+		const twice = widest.durationMs * 2;
+		expect(targetBucketMs(twice)).toBe(Math.ceil(twice / ratio));
+		// A 285-century sentinel window must not silently produce a 60s lattice.
+		expect(targetBucketMs(Number.MAX_SAFE_INTEGER)).toBeGreaterThan(widest.bucketMs);
+	});
+});
+
+describe('rendered point count per preset', () => {
+	for (const preset of TIME_PRESETS) {
+		it(`${preset.id}: folds to the preset's own resolution`, () => {
+			const rows = gaugeRows(preset.durationMs);
+			const w = windowFor(preset.durationMs);
+			const intended = Math.round(preset.durationMs / preset.bucketMs);
+
+			const before = mqttPoints(rows, w, false);
+			const after = mqttPoints(rows, w, true);
+
+			// Never coarser than asked, and within one bucket of the target.
+			expect(after.length).toBeLessThanOrEqual(intended + 1);
+			expect(after.length).toBeLessThanOrEqual(before.length);
+			// The wide presets are the ones that were over-dense; the 1h/6h
+			// presets already sit on their own lattice and must come through
+			// unchanged. (Value equality, not reference — these are two separate
+			// runPipeline calls, so the arrays are distinct instances either way.)
+			if (preset.bucketMs > 60_000) {
+				expect(before.length).toBeGreaterThan(intended * 2);
+			} else {
+				expect(after).toEqual(before);
+			}
+		});
+	}
+
+	it('30d drops from ~43k points to ~720', () => {
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
+		expect(mqttPoints(rows, w, true).length).toBeLessThanOrEqual(721);
+	});
+});
+
+describe('gauge values survive the fold', () => {
+	it('keeps the cluster total, not a fraction of it', () => {
+		// connections is max/sum with the #1576 carry-forward; folding must not
+		// reintroduce a dip. Both nodes hold 100, so the total is 200 throughout.
+		const preset = getPreset('7d');
+		const points = mqttPoints(gaugeRows(preset.durationMs), windowFor(preset.durationMs), true);
+		for (const p of points) {
+			expect(p.y, `bucket ${p.x}`).toBe(200);
+		}
+	});
+});
+
+describe('rate-transformed counters are NOT inflated', () => {
+	// The regression this design exists to avoid. bytes-sent is temporal 'sum'
+	// over a `rate`-transformed field: widening the *record* bucketing would sum
+	// per-second rates from different periods (measured 1000 B/s -> 3000 B/s on a
+	// 5 min lattice, and 60x at 30 d). Folding after aggregation must not.
+	const rateRows = (durationMs: number): AnalyticsDataPoint[] => {
+		const rows: AnalyticsDataPoint[] = [];
+		for (let t = 0; t < durationMs; t += CADENCE) {
+			// count x mean = 60_000 bytes over a 60 s period => 1000 B/s.
+			rows.push({ type: 'egress', node: 'a', time: T0 + t, count: 1, mean: 60_000, period: 60_000 });
+		}
+		return rows;
+	};
+
+	const egressPoints = (durationMs: number, downsample: boolean) =>
+		runPipeline(bytesSentSpec, rateRows(durationMs), windowFor(durationMs), [], {
+			snapToPeriod: true,
+			downsampleToWindow: downsample,
+		}).series.find((s) => s.key === 'egress')!.points;
+
+	for (const id of ['24h', '7d', '30d'] as const) {
+		it(`${id}: every bucket still reads 1000 B/s`, () => {
+			const preset = getPreset(id);
+			const points = egressPoints(preset.durationMs, true);
+			expect(points.length).toBeGreaterThan(0);
+			for (const p of points) {
+				expect(p.y, `bucket ${p.x}`).toBeCloseTo(1000, 6);
+			}
+		});
+	}
+
+	it('24h: fold reduces the point count without moving the value', () => {
+		const preset = getPreset('24h');
+		const before = egressPoints(preset.durationMs, false);
+		const after = egressPoints(preset.durationMs, true);
+		// One node at 90 s over 24 h is 960 snapped points; the 5 min preset asks
+		// for 288 (+1 for the inclusive end bound).
+		expect(before.length).toBeGreaterThan(900);
+		expect(after.length).toBeLessThanOrEqual(289);
+		expect(before.every((p) => Math.abs((p.y ?? 0) - 1000) < 1e-6)).toBe(true);
+		expect(after.every((p) => Math.abs((p.y ?? 0) - 1000) < 1e-6)).toBe(true);
+	});
+});
+
+describe('opting out keeps full resolution', () => {
+	it('omitting downsampleToWindow leaves the series untouched (KPI tile path)', () => {
+		const preset = getPreset('30d');
+		const rows = gaugeRows(preset.durationMs);
+		const w = windowFor(preset.durationMs);
+		expect(mqttPoints(rows, w, false).length).toBeGreaterThan(40_000);
+	});
+});

--- a/src/features/instance/status/analytics/__tests__/primitives/per-path-rate-renderer.test.tsx
+++ b/src/features/instance/status/analytics/__tests__/primitives/per-path-rate-renderer.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+// PerPathRateRenderer (request-rate) reaches the chart through a custom
+// Renderer, so it skips runPipeline's downsample pass and MetricRenderer's
+// derived-fold. It must fold its own computed series or a wide window renders
+// one point per 60 s next to panels capped at ~180 (#1588 review). Rendering
+// the real recharts LineChart gives no point-count signal, so swap it for a
+// prop recorder and read the series it receives.
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPreset } from '../../context/timePresets';
+import type { SeriesData, TimeRange } from '../../types/analytics';
+
+const lineChartCalls: { data: SeriesData }[] = [];
+vi.mock('../../primitives/LineChart', () => ({
+	LineChart: (props: { data: SeriesData }) => {
+		lineChartCalls.push(props);
+		return null;
+	},
+}));
+
+const { PerPathRateRenderer } = await import('../../primitives/PerPathRateRenderer');
+
+afterEach(() => {
+	cleanup();
+	lineChartCalls.length = 0;
+});
+
+const preset = getPreset('30d');
+const WINDOW: TimeRange = { startTime: 0, endTime: preset.durationMs };
+// A dense computed series — one point every 10 min across 30 d = 4320 points.
+const RAW_POINTS = Math.round(preset.durationMs / (10 * 60_000));
+const denseSeries: SeriesData = {
+	series: [{
+		key: '/a',
+		label: '/a',
+		points: Array.from({ length: RAW_POINTS }, (_, i) => ({ x: i * 10 * 60_000, y: 100, count: 5 })),
+	}],
+};
+const compute = () => denseSeries;
+
+const lastData = () => lineChartCalls.at(-1)!.data;
+
+describe('PerPathRateRenderer downsample wiring', () => {
+	it('folds the computed series to the window resolution before charting', () => {
+		render(
+			<PerPathRateRenderer records={[]} timeRange={WINDOW} nodes={[]} viewMode="aggregate" compute={compute} />,
+		);
+		const points = lastData().series.find((s) => s.key === '/a')!.points;
+		// 30d preset → 4h bucket → ~180 points, not the 4320 raw.
+		const intended = Math.round(preset.durationMs / preset.bucketMs);
+		expect(RAW_POINTS).toBeGreaterThan(4000); // sanity: the raw series really is dense
+		expect(points.length).toBeLessThanOrEqual(intended + 1);
+		expect(points.length).toBeLessThan(RAW_POINTS);
+	});
+
+	it('leaves the series at full resolution when no window is supplied', () => {
+		// Guards that the fold is driven by timeRange, not applied blindly.
+		render(<PerPathRateRenderer records={[]} nodes={[]} viewMode="aggregate" compute={compute} />);
+		expect(lastData().series.find((s) => s.key === '/a')!.points).toHaveLength(RAW_POINTS);
+	});
+});

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -58,8 +58,12 @@ describe('TimeRangePicker', () => {
 				/>
 			</AnalyticsTestWrapper>,
 		);
-		expect(screen.getByText('Last 24 hours')).toBeTruthy();
-		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+		// Scope to the collapsed trigger (first combobox), not the whole document:
+		// a document-wide getByText would also match the option in the dropdown
+		// portal, so it wouldn't prove the *trigger* shows the resolution.
+		const trigger = screen.getAllByRole('combobox')[0];
+		expect(within(trigger).getByText('Last 24 hours')).toBeTruthy();
+		expect(within(trigger).getByText('by 10 minutes')).toBeTruthy();
 	});
 
 	it('groups the auto-refresh interval together with the refresh action', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -82,6 +82,10 @@ describe('TimeRangePicker', () => {
 		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
 		// …and the range picker stays outside it.
 		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
+		// The interval trigger carries a "reload" sub-label, mirroring the range
+		// picker's second line, so the collapsed value reads as a reload cadence.
+		expect(within(group).getByText('reload')).toBeTruthy();
+		expect(within(group).getByText('60s')).toBeTruthy();
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../hooks/useAnalyticsFreshness', () => ({
@@ -42,6 +42,46 @@ describe('TimeRangePicker', () => {
 			// since the integration is covered by StatusTabs URL sync test.
 			expect(triggers[0]).toBeTruthy();
 		}
+	});
+
+	it('shows the render resolution under the selected range on the trigger', () => {
+		// #1588 recalibrated 24h to a 10-minute bucket; the trigger should say so
+		// even while collapsed, so the resolution is visible before opening.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="24h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText('Last 24 hours')).toBeTruthy();
+		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+	});
+
+	it('groups the auto-refresh interval together with the refresh action', () => {
+		// The interval used to sit as a bare Select beside the range picker, at
+		// the same gap and weight, and got read as a chart-granularity setting.
+		// Grouping is the fix, so assert the grouping rather than the classes.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="1h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		const group = screen.getByRole('group', { name: /auto-refresh/i });
+		expect(within(group).getByLabelText(/Auto-refresh interval/i)).toBeTruthy();
+		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
+		// …and the range picker stays outside it.
+		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -86,21 +86,36 @@ export function TimeRangePicker({
 			<div
 				role="group"
 				aria-label="Auto-refresh"
-				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
+				className="flex items-stretch rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
 				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					{
+						/* Two-line to match the range picker: the interval on top, a
+					    muted "reload" beneath, so the collapsed value reads as a
+					    reload cadence rather than another time setting. The dropdown
+					    options stay single-line — "reload" on each would be noise,
+					    since (unlike the range picker's per-option bucket) it's the
+					    same word every time. */
+					}
 					<SelectTrigger
 						aria-label="Auto-refresh interval"
 						title="Auto-refresh interval"
-						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue />
+						<SelectValue>
+							<span className="flex flex-col items-start leading-tight">
+								<span>
+									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
+								</span>
+								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+							</span>
+						</SelectValue>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
 					</SelectContent>
 				</Select>
-				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<span aria-hidden="true" className="my-1.5 w-px shrink-0 bg-border" />
 				<Button
 					variant="ghost"
 					size="icon"
@@ -109,7 +124,9 @@ export function TimeRangePicker({
 					aria-busy={isFetching}
 					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
 					title={isFetching ? 'Refreshing…' : 'Refresh now'}
-					className="rounded-l-none"
+					// h-auto (overriding size-9's height) so the button fills the
+					// group's now two-line height; width stays square-ish.
+					className="h-auto w-9 rounded-l-none"
 				>
 					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
 				</Button>

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
@@ -57,15 +57,14 @@ export function TimeRangePicker({
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
 				{
-					/* h-auto so the two-line label isn't clipped by the trigger's
-				    default h-9. Explicit children on SelectValue (not a bare
-				    <SelectValue/>) so the collapsed trigger shows the same
-				    window + resolution stack the options do. */
+					/* RangeLabel rendered straight into the trigger — the collapsed
+				    value is driven by `presetId` here, not by Radix reflecting the
+				    selected item, so the two-line stack is guaranteed regardless of
+				    how a given Radix version treats <SelectValue> children. h-auto
+				    keeps both lines from being clipped by the default h-9. */
 				}
 				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
-					<SelectValue>
-						<RangeLabel presetId={presetId} />
-					</SelectValue>
+					<RangeLabel presetId={presetId} />
 				</SelectTrigger>
 				<SelectContent>
 					{TIME_PRESETS.map((p) => (
@@ -102,14 +101,16 @@ export function TimeRangePicker({
 						title="Auto-refresh interval"
 						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue>
-							<span className="flex flex-col items-start leading-tight">
-								<span>
-									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
-								</span>
-								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						{
+							/* Rendered directly, same as the range trigger — driven by
+						    `refreshMs`, not Radix's selected-item reflection. */
+						}
+						<span className="flex flex-col items-start leading-tight">
+							<span>
+								{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
 							</span>
-						</SelectValue>
+							<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						</span>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -3,8 +3,21 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
-import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
+import { formatBucketLabel, getPreset, REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
 import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness';
+
+/** Range label as two stacked lines: the window on top, the resolution it
+ *  renders at ("by 10 minutes") beneath. Shared by the dropdown options and
+ *  the collapsed trigger so both read the same. */
+function RangeLabel({ presetId }: { presetId: TimePresetId }) {
+	const preset = getPreset(presetId);
+	return (
+		<span className="flex flex-col items-start leading-tight">
+			<span>{preset.label}</span>
+			<span className="text-[11px] font-normal text-muted-foreground">by {formatBucketLabel(preset.bucketMs)}</span>
+		</span>
+	);
+}
 
 interface Props {
 	presetId: TimePresetId;
@@ -26,7 +39,10 @@ export function TimeRangePicker({
 	const updatedLabel = formatRelativeUpdate(lastFetchedAt, now);
 
 	return (
-		<div className="flex items-center gap-2">
+		// gap-3 between groups, 0 inside the refresh group — the spacing is what
+		// tells you the interval belongs to the refresh action rather than to the
+		// range picker beside it.
+		<div className="flex items-center gap-3">
 			{updatedLabel && (
 				<span
 					className="text-xs text-muted-foreground tabular-nums"
@@ -40,32 +56,64 @@ export function TimeRangePicker({
 				</span>
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
-				<SelectTrigger className="w-[180px]">
-					<SelectValue />
+				{
+					/* h-auto so the two-line label isn't clipped by the trigger's
+				    default h-9. Explicit children on SelectValue (not a bare
+				    <SelectValue/>) so the collapsed trigger shows the same
+				    window + resolution stack the options do. */
+				}
+				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
+					<SelectValue>
+						<RangeLabel presetId={presetId} />
+					</SelectValue>
 				</SelectTrigger>
 				<SelectContent>
-					{TIME_PRESETS.map((p) => <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>)}
+					{TIME_PRESETS.map((p) => (
+						<SelectItem key={p.id} value={p.id}>
+							<RangeLabel presetId={p.id} />
+						</SelectItem>
+					))}
 				</SelectContent>
 			</Select>
-			<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
-				<SelectTrigger className="w-[100px]">
-					<SelectValue />
-				</SelectTrigger>
-				<SelectContent>
-					{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
-				</SelectContent>
-			</Select>
-			<Button
-				variant="ghost"
-				size="icon"
-				onClick={onManualRefresh}
-				disabled={isFetching}
-				aria-busy={isFetching}
-				aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
-				title={isFetching ? 'Refreshing…' : 'Refresh now'}
+			{
+				/* Auto-refresh interval + refresh-now, joined into one control. Sat as
+			    a bare Select next to the range picker before, at the same gap and
+			    the same weight, so "60s" read as a second time setting — a chart
+			    granularity — rather than "re-fetch every 60s". Attaching it to the
+			    refresh icon is what disambiguates it; the shared border/background
+			    lives on this wrapper and the children opt out of their own. */
+			}
+			<div
+				role="group"
+				aria-label="Auto-refresh"
+				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
-				<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
-			</Button>
+				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					<SelectTrigger
+						aria-label="Auto-refresh interval"
+						title="Auto-refresh interval"
+						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
+					</SelectContent>
+				</Select>
+				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onManualRefresh}
+					disabled={isFetching}
+					aria-busy={isFetching}
+					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
+					title={isFetching ? 'Refreshing…' : 'Refresh now'}
+					className="rounded-l-none"
+				>
+					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_PRESET_ID,
 	DEFAULT_REFRESH_MS,
 	getPreset,
+	PANEL_POINT_TARGET,
 	REFRESH_OPTIONS,
 	targetBucketMs,
 	TIME_PRESETS,
@@ -42,6 +43,34 @@ describe('timePresets', () => {
 		// exceed ~1500 buckets — the SRE review's payload-blow-up mitigation.
 		for (const p of TIME_PRESETS) {
 			expect(p.durationMs / p.bucketMs).toBeLessThanOrEqual(1500);
+		}
+	});
+
+	it('every preset lands a panel chart inside the point target', () => {
+		// Above PANEL_POINT_TARGET.max the line is denser than the panel has
+		// pixels — payload and render cost for nothing.
+		for (const p of TIME_PRESETS) {
+			const points = p.durationMs / p.bucketMs;
+			expect(points, `${p.id} points`).toBeLessThanOrEqual(PANEL_POINT_TARGET.max);
+			// 1h is the documented exception: Harper's own aggregate period is
+			// 60 s, so there is no finer data to ask for and it undershoots.
+			if (p.id !== '1h') {
+				expect(points, `${p.id} points`).toBeGreaterThanOrEqual(PANEL_POINT_TARGET.min);
+			}
+		}
+	});
+
+	it('expanded buckets are finer than (or equal to) panel buckets', () => {
+		for (const p of TIME_PRESETS) {
+			expect(p.expandedBucketMs, p.id).toBeLessThanOrEqual(p.bucketMs);
+			expect(p.expandedBucketMs, p.id).toBeGreaterThan(0);
+		}
+	});
+
+	it('targetBucketMs reads the expanded column when asked', () => {
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs, { expanded: true }), p.id).toBe(p.expandedBucketMs);
+			expect(targetBucketMs(p.durationMs, { expanded: false }), p.id).toBe(p.bucketMs);
 		}
 	});
 

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_REFRESH_MS,
 	getPreset,
 	REFRESH_OPTIONS,
+	targetBucketMs,
 	TIME_PRESETS,
 	type TimePresetId,
 } from './timePresets';
@@ -41,6 +42,26 @@ describe('timePresets', () => {
 		// exceed ~1500 buckets — the SRE review's payload-blow-up mitigation.
 		for (const p of TIME_PRESETS) {
 			expect(p.durationMs / p.bucketMs).toBeLessThanOrEqual(1500);
+		}
+	});
+
+	it('targetBucketMs agrees with the table it is derived from', () => {
+		// The render lattice (targetBucketMs, looked up by duration) and the
+		// server hint / StorageTab trend grid (preset.bucketMs, looked up by id)
+		// must be the same number for a preset-sized window, or the Storage tab's
+		// trend timestamps stop landing on the metric panels' and syncMethod
+		// "value" crosshair sync silently breaks (#1514).
+		for (const p of TIME_PRESETS) {
+			expect(targetBucketMs(p.durationMs), p.id).toBe(p.bucketMs);
+		}
+	});
+
+	it('targetBucketMs is monotonic in the window width', () => {
+		let prev = 0;
+		for (const p of TIME_PRESETS) {
+			const cur = targetBucketMs(p.durationMs);
+			expect(cur).toBeGreaterThanOrEqual(prev);
+			prev = cur;
 		}
 	});
 

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_PRESET_ID,
 	DEFAULT_REFRESH_MS,
+	formatBucketLabel,
 	getPreset,
 	PANEL_POINT_TARGET,
 	REFRESH_OPTIONS,
@@ -119,6 +120,29 @@ describe('timePresets', () => {
 
 	it('default refresh is at least 30s — the SRE review pushed back on a 15s default', () => {
 		expect(DEFAULT_REFRESH_MS).toBeGreaterThanOrEqual(30_000);
+	});
+});
+
+describe('formatBucketLabel', () => {
+	it('formats minutes and hours, singular vs plural', () => {
+		expect(formatBucketLabel(60_000)).toBe('1 minute');
+		expect(formatBucketLabel(2 * 60_000)).toBe('2 minutes');
+		expect(formatBucketLabel(10 * 60_000)).toBe('10 minutes');
+		expect(formatBucketLabel(60 * 60_000)).toBe('1 hour');
+		expect(formatBucketLabel(4 * 60 * 60_000)).toBe('4 hours');
+	});
+
+	it('renders every shipped preset bucket as a clean minute/hour phrase', () => {
+		// No preset should surface a raw-ms fallback in the picker.
+		for (const p of TIME_PRESETS) {
+			expect(formatBucketLabel(p.bucketMs), p.id).toMatch(/^\d+ (minute|hour)s?$/);
+			expect(formatBucketLabel(p.expandedBucketMs), `${p.id} expanded`).toMatch(/^\d+ (minute|hour)s?$/);
+		}
+	});
+
+	it('falls back to seconds / ms only for odd values', () => {
+		expect(formatBucketLabel(30_000)).toBe('30 seconds');
+		expect(formatBucketLabel(1500)).toBe('1500 ms');
 	});
 });
 

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -31,6 +31,35 @@ export function getPreset(id: TimePresetId): TimePreset {
 	return p;
 }
 
+/**
+ * Densest bucket the charts should *render* for a window of `windowMs`.
+ *
+ * The same numbers the presets declare, looked up by duration instead of id.
+ * That matters because `bucketMs` reaches the server as `bucket_ms` but is
+ * otherwise unused client-side: builds that ignore the hint (harper-pro 5.1.22)
+ * return rows at raw emission cadence, and the pipeline then buckets them onto
+ * `spec.bucket.fallbackMs` — 60 s regardless of the selected window. A 30 d
+ * window rendered 43 200 points instead of 720 (#1576 follow-up).
+ *
+ * Reading the same table by duration keeps one source of truth: StorageTab
+ * aligns its trend grid to the context's `bucketMs` (#1514), so a preset-sized
+ * window MUST resolve to exactly that preset's value or the two grids diverge
+ * and crosshair sync breaks. `targetBucketMs` locks that (see timePresets.test).
+ */
+export function targetBucketMs(windowMs: number): number {
+	const finest = TIME_PRESETS[0].bucketMs;
+	if (!Number.isFinite(windowMs) || windowMs <= 0) { return finest; }
+	for (const p of TIME_PRESETS) {
+		// 1% slack: a live `endTime = Date.now()` bound makes the computed
+		// window drift a few ms off the preset's exact duration.
+		if (windowMs <= p.durationMs * 1.01) { return p.bucketMs; }
+	}
+	// Past the widest preset, hold its points-per-window ratio rather than
+	// falling back to the finest bucket and re-creating the density problem.
+	const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
+	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / widest.bucketMs)));
+}
+
 export interface RefreshOption {
 	label: string;
 	value: number;

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -45,6 +45,20 @@ export function getPreset(id: TimePresetId): TimePreset {
 	return p;
 }
 
+/** Human phrase for a bucket duration — "1 minute", "10 minutes", "4 hours".
+ *  Drives the "by X" sub-label under each range option so the operator can see
+ *  the resolution a window renders at (the server ignores our `bucket_ms`, so
+ *  the panel resolution is `targetBucketMs`, i.e. the preset's `bucketMs`).
+ *  Every shipped bucket is a whole number of minutes or hours; the seconds /
+ *  raw-ms branches are just defensive for a future odd value. */
+export function formatBucketLabel(bucketMs: number): string {
+	const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? '' : 's'}`;
+	if (bucketMs >= HOUR && bucketMs % HOUR === 0) { return plural(bucketMs / HOUR, 'hour'); }
+	if (bucketMs >= MIN && bucketMs % MIN === 0) { return plural(bucketMs / MIN, 'minute'); }
+	if (bucketMs >= 1000 && bucketMs % 1000 === 0) { return plural(bucketMs / 1000, 'second'); }
+	return `${bucketMs} ms`;
+}
+
 /**
  * Densest bucket the charts should *render* for a window of `windowMs`.
  *

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -6,7 +6,12 @@ export interface TimePreset {
 	id: TimePresetId;
 	label: string;
 	durationMs: number;
+	/** Bucket for a panel-sized chart — sized so the window lands in
+	 *  `PANEL_POINT_TARGET`. Also the `bucket_ms` hint sent to Harper. */
 	bucketMs: number;
+	/** Bucket when the chart is expanded to the near-fullscreen dialog, where
+	 *  there is roughly 4x the horizontal room. Always ≤ `bucketMs`. */
+	expandedBucketMs: number;
 }
 
 export type TimePresetId = '1h' | '6h' | '24h' | '7d' | '30d';
@@ -15,12 +20,21 @@ const MIN = 60_000;
 const HOUR = 60 * MIN;
 const DAY = 24 * HOUR;
 
+/** Points a panel-sized chart aims for. Above this the line is denser than the
+ *  panel has pixels, so the extra samples cost payload and render time and buy
+ *  nothing; the 1h preset undershoots because Harper's own aggregate period is
+ *  60 s and there is no finer data to ask for. */
+export const PANEL_POINT_TARGET = { min: 100, max: 200 } as const;
+
 export const TIME_PRESETS: readonly TimePreset[] = [
-	{ id: '1h', label: 'Last 1 hour', durationMs: HOUR, bucketMs: 1 * MIN },
-	{ id: '6h', label: 'Last 6 hours', durationMs: 6 * HOUR, bucketMs: 1 * MIN },
-	{ id: '24h', label: 'Last 24 hours', durationMs: DAY, bucketMs: 5 * MIN },
-	{ id: '7d', label: 'Last 7 days', durationMs: 7 * DAY, bucketMs: 15 * MIN },
-	{ id: '30d', label: 'Last 30 days', durationMs: 30 * DAY, bucketMs: HOUR },
+	// bucketMs is chosen to land `durationMs / bucketMs` inside
+	// PANEL_POINT_TARGET; expandedBucketMs gives the dialog ~3-4x the detail.
+	//                                                              panel  expanded
+	{ id: '1h', label: 'Last 1 hour', durationMs: HOUR, bucketMs: 1 * MIN, expandedBucketMs: 1 * MIN }, //   60    60
+	{ id: '6h', label: 'Last 6 hours', durationMs: 6 * HOUR, bucketMs: 2 * MIN, expandedBucketMs: 1 * MIN }, // 180   360
+	{ id: '24h', label: 'Last 24 hours', durationMs: DAY, bucketMs: 10 * MIN, expandedBucketMs: 5 * MIN }, // 144   288
+	{ id: '7d', label: 'Last 7 days', durationMs: 7 * DAY, bucketMs: HOUR, expandedBucketMs: 15 * MIN }, // 168   672
+	{ id: '30d', label: 'Last 30 days', durationMs: 30 * DAY, bucketMs: 4 * HOUR, expandedBucketMs: HOUR }, // 180   720
 ];
 
 export const DEFAULT_PRESET_ID: TimePresetId = '1h';
@@ -46,18 +60,19 @@ export function getPreset(id: TimePresetId): TimePreset {
  * window MUST resolve to exactly that preset's value or the two grids diverge
  * and crosshair sync breaks. `targetBucketMs` locks that (see timePresets.test).
  */
-export function targetBucketMs(windowMs: number): number {
-	const finest = TIME_PRESETS[0].bucketMs;
+export function targetBucketMs(windowMs: number, opts?: { expanded?: boolean }): number {
+	const pick = (p: TimePreset) => (opts?.expanded ? p.expandedBucketMs : p.bucketMs);
+	const finest = pick(TIME_PRESETS[0]);
 	if (!Number.isFinite(windowMs) || windowMs <= 0) { return finest; }
 	for (const p of TIME_PRESETS) {
 		// 1% slack: a live `endTime = Date.now()` bound makes the computed
 		// window drift a few ms off the preset's exact duration.
-		if (windowMs <= p.durationMs * 1.01) { return p.bucketMs; }
+		if (windowMs <= p.durationMs * 1.01) { return pick(p); }
 	}
 	// Past the widest preset, hold its points-per-window ratio rather than
 	// falling back to the finest bucket and re-creating the density problem.
 	const widest = TIME_PRESETS[TIME_PRESETS.length - 1];
-	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / widest.bucketMs)));
+	return Math.max(finest, Math.ceil(windowMs / (widest.durationMs / pick(widest))));
 }
 
 export interface RefreshOption {

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -9,8 +9,10 @@
 // consumer can filter. No network calls: everything recomputes from the
 // records the panel already fetched.
 
+import { targetBucketMs } from '../context/timePresets';
 import { preprocessConnectionRecords } from '../pipeline/connection';
 import { derivedRegistry } from '../pipeline/derived/index';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
 import { specRegistry } from '../pipeline/index';
 import { runPipeline } from '../pipeline/pipeline';
 import { aggregateReplicationMatrix, type ReplicationQuantileField } from '../pipeline/replication-latency';
@@ -181,7 +183,16 @@ export function computeMetricCsvData(
 
 	const derived = derivedRegistry[metric];
 	if (derived) {
-		return { kind: 'series', data: derived.recompute(records, timeRange, nodes, viewMode) };
+		// Folded to the same lattice MetricRenderer draws, so a download matches
+		// the chart it was taken from rather than being 60x longer at 30 d.
+		return {
+			kind: 'series',
+			data: downsampleDerivedSeriesData(
+				derived.recompute(records, timeRange, nodes, viewMode),
+				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				derived.downsampleAggregator,
+			),
+		};
 	}
 
 	const entry = specRegistry[metric];
@@ -207,7 +218,10 @@ export function computeMetricCsvData(
 		// `connection` groups on the synthetic pathMethod field, so it needs
 		// the renderer's own preprocessing first.
 		const rows = metric === 'connection' ? preprocessConnectionRecords(records).records : records;
-		return { kind: 'series', data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(spec, rows, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 
 	const isPerNodeMode = (viewMode ?? 'per-node') === 'per-node';
@@ -224,7 +238,11 @@ export function computeMetricCsvData(
 					crossNode: field.aggregator?.crossNode ?? spec.aggregator.crossNode,
 				},
 			};
-			const out = runPipeline(innerSpec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true });
+			const out = runPipeline(innerSpec, records, timeRange, nodes, {
+				perNode: isPerNodeMode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			});
 			series.push(...out.series);
 			// Each panel's ceiling (if any) becomes a regular column — SeriesData
 			// has a single ceiling slot, which can't carry one per panel.
@@ -235,23 +253,37 @@ export function computeMetricCsvData(
 
 	if (wantsStackedAreaNodeRemap(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const remapped: MetricSpec = { ...spec, series: { ...spec.series, dimension: 'node' } };
-		return { kind: 'series', data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 	if (wantsClusterLineFold(spec, isPerNodeMode) && spec.series.kind === 'groupBy') {
 		const inner: MetricSpec = {
 			...spec,
 			series: { kind: 'field', fields: [{ ...spec.series.field, label: 'cluster' }] },
 		};
-		return { kind: 'series', data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true }) };
+		return {
+			kind: 'series',
+			data: runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
+		};
 	}
 	if (wantsDimensionLineSplit(spec)) {
 		return {
 			kind: 'series',
-			data: runPipeline(spec, records, timeRange, nodes, { perNode: false, snapToPeriod: true }),
+			data: runPipeline(spec, records, timeRange, nodes, {
+				perNode: false,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			}),
 		};
 	}
 	return {
 		kind: 'series',
-		data: runPipeline(spec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true }),
+		data: runPipeline(spec, records, timeRange, nodes, {
+			perNode: isPerNodeMode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+		}),
 	};
 }

--- a/src/features/instance/status/analytics/lib/csvExport.ts
+++ b/src/features/instance/status/analytics/lib/csvExport.ts
@@ -183,8 +183,11 @@ export function computeMetricCsvData(
 
 	const derived = derivedRegistry[metric];
 	if (derived) {
-		// Folded to the same lattice MetricRenderer draws, so a download matches
-		// the chart it was taken from rather than being 60x longer at 30 d.
+		// Folded to the same lattice MetricRenderer draws for a panel, so a
+		// download matches the chart it was taken from rather than being 60x
+		// longer at 30 d. Deliberately panel resolution even when the export is
+		// triggered from the expand dialog — an exported file should be a stable
+		// artifact of (metric, window), not of transient dialog state.
 		return {
 			kind: 'series',
 			data: downsampleDerivedSeriesData(

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -105,8 +105,9 @@ export function ConnectionRenderer(
 				perNode,
 				snapToPeriod: true,
 				downsampleToWindow: true,
+				expanded: !!fillParent,
 			}),
-		[processed, timeRange, nodes, perNode],
+		[processed, timeRange, nodes, perNode, fillParent],
 	);
 
 	// The chip selector picks one composite (pathMethod) dimension value;

--- a/src/features/instance/status/analytics/pipeline/connection.tsx
+++ b/src/features/instance/status/analytics/pipeline/connection.tsx
@@ -100,7 +100,12 @@ export function ConnectionRenderer(
 	const { records: processed, dimParts } = useMemo(() => preprocessConnectionRecords(records), [records]);
 
 	const fullData = useMemo<SeriesData>(
-		() => runPipeline(connectionSpec, processed, timeRange, nodes, { perNode, snapToPeriod: true }),
+		() =>
+			runPipeline(connectionSpec, processed, timeRange, nodes, {
+				perNode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			}),
 		[processed, timeRange, nodes, perNode],
 	);
 

--- a/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
+++ b/src/features/instance/status/analytics/pipeline/derived/error-rate.ts
@@ -60,6 +60,16 @@ export const errorRateDerived: DerivedMetricSpec = {
 	tab: 'requests',
 	sourceMetric: 'success',
 	recompute: recomputeErrorRate,
+	// Wide-window downsampling folds several fine buckets into one; a ratio must
+	// be recombined Σ-correctly, not averaged. Each point carries count=sumCount,
+	// and ratio·count = count − total = the bucket's error count, so
+	// count-weighted-mean = Σerrors/Σcount = 1 − Σtotal/Σcount — the same
+	// Σ-arithmetic recomputeErrorRate does per bucket. Plain 'mean' here would be
+	// the ratio-of-ratios bug this file's docstring warns against (a low-traffic,
+	// high-error bucket weighted equally with a high-traffic, low-error one).
+	// error-rate has no custom Renderer, so this drives both the on-screen fold
+	// (MetricRenderer) and the CSV fold (csvExport).
+	downsampleAggregator: 'count-weighted-mean',
 	primitive: 'line',
 	yAxis: { unit: '', formatter: 'percent' },
 	// Threshold lives on the SeriesData returned by `recomputeErrorRate` — the

--- a/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/mqtt-traffic.tsx
@@ -56,7 +56,7 @@ function makeMqttTrafficDerived(
 			if (isPerNode && baseSpec.series.kind === 'groupBy') {
 				spec = { ...baseSpec, series: { ...baseSpec.series, dimension: 'node' } };
 			}
-			return runPipeline(spec, records, window, nodes, { snapToPeriod: true });
+			return runPipeline(spec, records, window, nodes, { snapToPeriod: true, downsampleToWindow: true });
 		},
 		Renderer: (props) => <TrafficByTypeRenderer spec={baseSpec} typeField="type" {...props} />,
 		primitive: 'stacked-area',

--- a/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
+++ b/src/features/instance/status/analytics/pipeline/derived/request-rate.tsx
@@ -104,7 +104,10 @@ export const requestRateDerived: DerivedMetricSpec = {
 	tab: 'requests',
 	sourceMetric: 'duration',
 	recompute: recomputeRequestRate,
-	Renderer: ({ records, timeRange, nodes, viewMode }) => (
+	// req/s is a rate, so the fold's default 'mean' is correct — no
+	// downsampleAggregator needed. fillParent is forwarded so the expand dialog
+	// both fills the canvas and folds at the finer expanded resolution.
+	Renderer: ({ records, timeRange, nodes, viewMode, fillParent }) => (
 		<PerPathRateRenderer
 			records={records}
 			timeRange={timeRange}
@@ -112,6 +115,7 @@ export const requestRateDerived: DerivedMetricSpec = {
 			viewMode={viewMode}
 			yAxis={{ unit: '/s', formatter: 'count-si' }}
 			compute={computeForRenderer}
+			fillParent={fillParent}
 		/>
 	),
 	primitive: 'line',

--- a/src/features/instance/status/analytics/pipeline/downsample.ts
+++ b/src/features/instance/status/analytics/pipeline/downsample.ts
@@ -59,8 +59,12 @@ export function downsampleAggregator(temporal: Aggregator, transform: Transform 
 export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: Aggregator): SeriesPoint[] {
 	if (targetMs <= 0 || points.length === 0) { return points; }
 	const byBucket = new Map<number, { items: { value: number | null; count?: number }[]; count: number }>();
+	let shifted = false;
 	for (const p of points) {
 		const bucket = Math.round(p.x / targetMs) * targetMs;
+		// A point can land in a bucket of its own and *still* need moving —
+		// see the early-return note below.
+		if (bucket !== p.x) { shifted = true; }
 		let entry = byBucket.get(bucket);
 		if (!entry) {
 			entry = { items: [], count: 0 };
@@ -70,9 +74,20 @@ export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: A
 		// Sum observation counts so confidence gating still sees the real total.
 		entry.count += p.count ?? 0;
 	}
-	// Nothing to gain (and a needless copy) when every point already sits in
-	// its own coarse bucket — the common case for the 1 h / 6 h presets.
-	if (byBucket.size === points.length) { return points; }
+	// Nothing to gain (and a needless copy) when every point already sits ON its
+	// own coarse bucket boundary — the common case for the 1 h preset, whose
+	// target equals the snap lattice.
+	//
+	// `byBucket.size === points.length` alone is NOT sufficient: points can map
+	// one-to-one onto buckets while every one of them still moves. Records
+	// carrying a real 90 s `period` snap onto a 90 s lattice, and folding that
+	// onto the 1 h preset's 60 s target sends k*90 000 to round(1.5k)*60 000 —
+	// 0, 120 000, 180 000, 300 000 … all distinct, none equal to their input.
+	// Returning the input there would leave the series off the target grid and
+	// break the StorageTab trend's `syncMethod="value"` crosshair match (#1514).
+	// Reachable as soon as core stops stamping `period: 0`
+	// (HarperFast/harper#1997), which is exactly what we asked it to do.
+	if (!shifted && byBucket.size === points.length) { return points; }
 	const out: SeriesPoint[] = [];
 	for (const bucket of [...byBucket.keys()].sort((a, b) => a - b)) {
 		const { items, count } = byBucket.get(bucket)!;

--- a/src/features/instance/status/analytics/pipeline/downsample.ts
+++ b/src/features/instance/status/analytics/pipeline/downsample.ts
@@ -1,0 +1,135 @@
+// Post-aggregation downsampling: fold a series' points onto the window's
+// target bucket lattice.
+//
+// Why this is a *post* pass rather than a coarser snap in `snapToBucketTime`
+// (#1576 follow-up): the pipeline's per-record bucketing assumes roughly one
+// record per (node, bucket) and folds anything more with the spec's temporal
+// aggregator. Widening that lattice therefore changes what the temporal
+// aggregator sees, and for a `rate`-transformed field with `temporal: 'sum'`
+// (bytes-sent/received, mqtt-traffic-*, fsWrite) it sums per-second rates that
+// belong to *different* time periods — measured 1000 B/s becoming 3000 B/s on a
+// 5 min lattice, and it would have been 60x at 30 d.
+//
+// Downsampling after the fact leaves every existing aggregation path — temporal,
+// cross-node, and the bounded carry-forward from #1576 — operating on exactly
+// the buckets it does today, and only reduces what the primitives have to draw.
+import type { Aggregator, FieldSpec, MetricSpec, Series, SeriesData, SeriesPoint, Transform } from '../types/analytics';
+import { aggregate } from './aggregators';
+
+/** True when a field's value has already been divided by its period, i.e. it is
+ *  an *intensive* per-second quantity. Such values must never be re-summed
+ *  across time — two consecutive 1000 B/s samples are 1000 B/s, not 2000. */
+export function isRateTransform(transform: Transform | undefined): boolean {
+	if (!transform) { return false; }
+	if (transform.kind === 'rate') { return true; }
+	if (transform.kind === 'compose') { return transform.steps.some(isRateTransform); }
+	return false;
+}
+
+/**
+ * How to fold several fine-grained points into one coarse bucket.
+ *
+ * The guiding rule is "aggregate over time the same way the spec already
+ * does", with two corrections:
+ *
+ * - **rate fields** collapse with `mean`, never `sum` (see `isRateTransform`).
+ *   Equal-weighted because Harper emits one row per node per period at a fixed
+ *   cadence, so every point in a coarse bucket covers the same span.
+ * - **percentiles** collapse with `max`. A p95-of-p95s is not a p95, and of the
+ *   two defensible approximations an operator wants the one that keeps spikes
+ *   visible rather than smoothing them away at 7 d / 30 d.
+ *
+ * `count-weighted-mean` stays count-weighted — `SeriesPoint.count` carries the
+ * per-bucket observation total, so the weighting survives the fold.
+ */
+export function downsampleAggregator(temporal: Aggregator, transform: Transform | undefined): Aggregator {
+	if (isRateTransform(transform)) { return 'mean'; }
+	switch (temporal) {
+		case 'p50':
+		case 'p95':
+		case 'p99':
+			return 'max';
+		default:
+			return temporal;
+	}
+}
+
+/** Fold `points` onto a `targetMs` lattice, round-to-nearest so coarse bucket
+ *  times stay on the same epoch-aligned grid the fine snap uses. */
+export function downsamplePoints(points: SeriesPoint[], targetMs: number, agg: Aggregator): SeriesPoint[] {
+	if (targetMs <= 0 || points.length === 0) { return points; }
+	const byBucket = new Map<number, { items: { value: number | null; count?: number }[]; count: number }>();
+	for (const p of points) {
+		const bucket = Math.round(p.x / targetMs) * targetMs;
+		let entry = byBucket.get(bucket);
+		if (!entry) {
+			entry = { items: [], count: 0 };
+			byBucket.set(bucket, entry);
+		}
+		entry.items.push({ value: p.y, count: p.count });
+		// Sum observation counts so confidence gating still sees the real total.
+		entry.count += p.count ?? 0;
+	}
+	// Nothing to gain (and a needless copy) when every point already sits in
+	// its own coarse bucket — the common case for the 1 h / 6 h presets.
+	if (byBucket.size === points.length) { return points; }
+	const out: SeriesPoint[] = [];
+	for (const bucket of [...byBucket.keys()].sort((a, b) => a - b)) {
+		const { items, count } = byBucket.get(bucket)!;
+		// `aggregate` returns null when every value is null, which preserves an
+		// explicit gap rather than dropping the bucket entirely.
+		out.push({ x: bucket, y: aggregate(agg, items), ...(count > 0 ? { count } : {}) });
+	}
+	return out;
+}
+
+/** Resolve the temporal aggregator + transform a series was built from, so the
+ *  fold matches the spec. Series are keyed by `dim`; for field-mode specs `dim`
+ *  is the field key, for groupBy every series shares the one field. */
+function fieldFor(spec: MetricSpec, series: Series): FieldSpec | undefined {
+	if (spec.series.kind === 'groupBy') { return spec.series.field; }
+	return spec.series.fields.find((f) => (typeof f.field === 'string' ? f.field : f.label) === series.dim)
+		?? spec.series.fields[0];
+}
+
+/** Fold every series (and the ceiling) in a result, choosing the aggregator
+ *  per series via `aggFor`. */
+function foldSeriesData(data: SeriesData, targetMs: number, aggFor: (s: Series) => Aggregator): SeriesData {
+	if (targetMs <= 0) { return data; }
+	const fold = (s: Series): Series => ({ ...s, points: downsamplePoints(s.points, targetMs, aggFor(s)) });
+	return {
+		...data,
+		series: data.series.map(fold),
+		...(data.ceiling ? { ceiling: fold(data.ceiling) } : {}),
+	};
+}
+
+/** Downsample a spec-driven pipeline result, matching each series' own field. */
+export function downsampleSeriesData(data: SeriesData, spec: MetricSpec, targetMs: number): SeriesData {
+	return foldSeriesData(data, targetMs, (s) => {
+		const field = fieldFor(spec, s);
+		const temporal = field?.aggregator?.temporal ?? spec.aggregator.temporal;
+		return downsampleAggregator(temporal, field?.transform);
+	});
+}
+
+/**
+ * Downsample a derived metric's hand-built SeriesData.
+ *
+ * `error-rate`, `request-rate` and `transaction-log-growth` assemble series
+ * from raw columns instead of going through `runPipeline`, so they never see
+ * the spec-driven path above. They are all intensive quantities (a ratio and
+ * two per-second rates), hence the `'mean'` default; a derived metric that
+ * measures something extensive sets `downsampleAggregator` on its spec.
+ *
+ * Idempotent: folding points that already sit on `targetMs` leaves them
+ * untouched, so applying this to a recompute that internally opted into
+ * `downsampleToWindow` (mqtt-traffic) is a no-op rather than a double average.
+ */
+export function downsampleDerivedSeriesData(
+	data: SeriesData,
+	targetMs: number,
+	agg: Aggregator = 'mean',
+): SeriesData {
+	return foldSeriesData(data, targetMs, () => agg);
+}

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -100,8 +100,13 @@ export function MainThreadRenderer(
 			series: { kind: 'field', fields: [{ field: selected.field, label: selected.label }] },
 			yAxis: selected.yAxis,
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
-	}, [selected, records, timeRange, nodes, perNode]);
+		return runPipeline(innerSpec, records, timeRange, nodes, {
+			perNode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: !!fillParent,
+		});
+	}, [selected, records, timeRange, nodes, perNode, fillParent]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 

--- a/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
+++ b/src/features/instance/status/analytics/pipeline/main-thread-utilization.tsx
@@ -100,7 +100,7 @@ export function MainThreadRenderer(
 			series: { kind: 'field', fields: [{ field: selected.field, label: selected.label }] },
 			yAxis: selected.yAxis,
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
+		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
 	}, [selected, records, timeRange, nodes, perNode]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -58,8 +58,13 @@ export function MemoryRenderer(
 			...memorySpec,
 			series: { kind: 'field', fields: [selectedField] },
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
-	}, [selectedField, records, timeRange, nodes, perNode]);
+		return runPipeline(innerSpec, records, timeRange, nodes, {
+			perNode,
+			snapToPeriod: true,
+			downsampleToWindow: true,
+			expanded: !!fillParent,
+		});
+	}, [selectedField, records, timeRange, nodes, perNode, fillParent]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);
 

--- a/src/features/instance/status/analytics/pipeline/memory.tsx
+++ b/src/features/instance/status/analytics/pipeline/memory.tsx
@@ -58,7 +58,7 @@ export function MemoryRenderer(
 			...memorySpec,
 			series: { kind: 'field', fields: [selectedField] },
 		};
-		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true });
+		return runPipeline(innerSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true });
 	}, [selectedField, records, timeRange, nodes, perNode]);
 
 	const { data: filteredData, isActive, handleLegendClick } = useNodeFilteredSeries(data, nodes);

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -18,6 +18,12 @@
 // intervals. Harper omits a gauge row entirely when the value is 0, so absence
 // is not zero — see carryForward.ts for the full rationale (#1576).
 //
+// `downsampleToWindow` adds a final pass that folds the finished series onto
+// the lattice the requested window implies, so a 7 d / 30 d view renders the
+// few hundred points its preset asks for instead of one per 60 s. It runs
+// AFTER every aggregation above precisely so none of them change — see
+// downsample.ts.
+//
 // Known limitation — count-weighted-mean across nodes: the inner pass
 // invokes the temporal aggregator with values that share the per-node
 // bucket's totalCount as their weight. When a single (node, time) bucket
@@ -29,6 +35,7 @@
 // shipped specs this is fine: replication-latency does not flow through
 // this pipeline, mqtt-traffic-* is sum/sum (associative). Revisit if a CWM
 // crossNode spec lands.
+import { targetBucketMs } from '../context/timePresets';
 import type {
 	Aggregator,
 	AnalyticsDataPoint,
@@ -43,6 +50,7 @@ import { type AggInput, aggregate } from './aggregators';
 import { labelWithApprox } from './approxLabel';
 import { buildStalenessHorizons, isGaugeCrossNodeSum } from './carryForward';
 import { classifyConfidence } from './confidence';
+import { downsampleSeriesData } from './downsample';
 import { evalFieldExpr } from './fieldExpr';
 import { runTransform } from './runTransform';
 
@@ -65,6 +73,19 @@ export interface RunPipelineOptions {
 	 *  rendering; pipeline tests that use synthetic small-integer times
 	 *  leave it off so they keep their distinct buckets. */
 	snapToPeriod?: boolean;
+	/** When true, the finished series are folded onto the bucket lattice the
+	 *  requested `window` implies (`targetBucketMs`), after every aggregation
+	 *  pass has run. Harper builds that ignore studio's `bucket_ms` hint return
+	 *  rows at raw cadence, so without this a 30 d window renders 43 200 points
+	 *  per series instead of the 720 the preset asks for.
+	 *
+	 *  Chart render paths (and CSV export, so a download matches what was on
+	 *  screen) opt in. KPI tiles deliberately do NOT: they collapse a series to
+	 *  a single headline number, so there is no density to save, and folding
+	 *  first would change `latestValue` from "the newest bucket" to "an average
+	 *  over the newest coarse bucket". See downsample.ts for the per-aggregator
+	 *  rules. */
+	downsampleToWindow?: boolean;
 }
 
 /** Composite string key for a per-node series — React key / recharts name
@@ -78,14 +99,15 @@ export function makeSeriesKey(dim: string, node: string): string {
 export function runPipeline(
 	spec: MetricSpec,
 	records: AnalyticsDataPoint[],
-	_window: TimeRange,
+	window: TimeRange,
 	_nodes: string[],
 	options?: RunPipelineOptions,
 ): SeriesData {
-	if (spec.series.kind === 'field') {
-		return runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
-	}
-	return runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
+	const data = spec.series.kind === 'field'
+		? runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false)
+		: runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
+	if (!options?.downsampleToWindow) { return data; }
+	return downsampleSeriesData(data, spec, targetBucketMs(window.endTime - window.startTime));
 }
 
 /** Snap a record's time to its period boundary so per-node staggering

--- a/src/features/instance/status/analytics/pipeline/pipeline.ts
+++ b/src/features/instance/status/analytics/pipeline/pipeline.ts
@@ -86,6 +86,11 @@ export interface RunPipelineOptions {
 	 *  over the newest coarse bucket". See downsample.ts for the per-aggregator
 	 *  rules. */
 	downsampleToWindow?: boolean;
+	/** Chart is rendering into the near-fullscreen expand dialog, which has
+	 *  roughly 4x the horizontal room — resolve to the preset's
+	 *  `expandedBucketMs` instead of its panel `bucketMs`. Only meaningful
+	 *  alongside `downsampleToWindow`. */
+	expanded?: boolean;
 }
 
 /** Composite string key for a per-node series — React key / recharts name
@@ -107,7 +112,8 @@ export function runPipeline(
 		? runFieldSpecs(spec, spec.series.fields, records, options?.perNode ?? false, options?.snapToPeriod ?? false)
 		: runGroupBy(spec, spec.series, records, options?.perNode ?? false, options?.snapToPeriod ?? false);
 	if (!options?.downsampleToWindow) { return data; }
-	return downsampleSeriesData(data, spec, targetBucketMs(window.endTime - window.startTime));
+	const target = targetBucketMs(window.endTime - window.startTime, { expanded: options.expanded });
+	return downsampleSeriesData(data, spec, target);
 }
 
 /** Snap a record's time to its period boundary so per-node staggering

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -83,7 +83,8 @@ export function DimensionSelectorRenderer({
 	}, [spec, quantileFields, effectiveQuantile]);
 
 	const fullData = useMemo<SeriesData>(
-		() => runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true }),
+		() =>
+			runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true }),
 		[runtimeSpec, records, timeRange, nodes, perNode],
 	);
 

--- a/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/DimensionSelectorRenderer.tsx
@@ -84,8 +84,13 @@ export function DimensionSelectorRenderer({
 
 	const fullData = useMemo<SeriesData>(
 		() =>
-			runPipeline(runtimeSpec, records, timeRange, nodes, { perNode, snapToPeriod: true, downsampleToWindow: true }),
-		[runtimeSpec, records, timeRange, nodes, perNode],
+			runPipeline(runtimeSpec, records, timeRange, nodes, {
+				perNode,
+				snapToPeriod: true,
+				downsampleToWindow: true,
+				expanded: !!fillParent,
+			}),
+		[runtimeSpec, records, timeRange, nodes, perNode, fillParent],
 	);
 
 	// Build the dimension list (the chip-row values) from each series's

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -1,5 +1,7 @@
 import { Component, type ReactNode } from 'react';
+import { targetBucketMs } from '../context/timePresets';
 import { derivedRegistry } from '../pipeline/derived/index';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
 import { specRegistry } from '../pipeline/index';
 import { runPipeline } from '../pipeline/pipeline';
 import type { AnalyticsDataPoint, AxisSpec, MetricSpec, SeriesData, TimeRange } from '../types/analytics';
@@ -135,7 +137,15 @@ export function MetricRenderer({
 				/>
 			);
 		} else {
-			const seriesData = derived.recompute(records, timeRange, nodes, viewMode);
+			// Derived metrics that assemble series from raw columns never pass
+			// through runPipeline's downsample pass, so fold here instead —
+			// otherwise a 7 d / 30 d view of these panels stays at one point per
+			// 60 s while every spec-driven panel beside it is coarsened.
+			const seriesData = downsampleDerivedSeriesData(
+				derived.recompute(records, timeRange, nodes, viewMode),
+				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				derived.downsampleAggregator,
+			);
 			body = renderPrimitive(derived.primitive, seriesData, derived.yAxis, xDomain, fillParent);
 		}
 	} else {
@@ -169,7 +179,11 @@ export function MetricRenderer({
 					};
 					return {
 						title: field.label,
-						data: runPipeline(innerSpec, records, timeRange, nodes, { perNode: isPerNodeMode, snapToPeriod: true }),
+						data: runPipeline(innerSpec, records, timeRange, nodes, {
+							perNode: isPerNodeMode,
+							snapToPeriod: true,
+							downsampleToWindow: true,
+						}),
 						yAxis: field.yAxis ?? outerSpec.yAxis,
 					};
 				});
@@ -179,7 +193,10 @@ export function MetricRenderer({
 					...entry.spec,
 					series: { ...entry.spec.series, dimension: 'node' },
 				};
-				const seriesData = runPipeline(remapped, records, timeRange, nodes, { snapToPeriod: true });
+				const seriesData = runPipeline(remapped, records, timeRange, nodes, {
+					snapToPeriod: true,
+					downsampleToWindow: true,
+				});
 				body = renderPrimitive('stacked-area', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsClusterLineFold(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
 				const groupSrc = entry.spec.series;
@@ -187,18 +204,23 @@ export function MetricRenderer({
 					...entry.spec,
 					series: { kind: 'field', fields: [{ ...groupSrc.field, label: 'cluster' }] },
 				};
-				const seriesData = runPipeline(inner, records, timeRange, nodes, { snapToPeriod: true });
+				const seriesData = runPipeline(inner, records, timeRange, nodes, {
+					snapToPeriod: true,
+					downsampleToWindow: true,
+				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsDimensionLineSplit(entry.spec)) {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: false,
 					snapToPeriod: true,
+					downsampleToWindow: true,
 				});
 				body = renderPrimitive('line', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else {
 				const seriesData = runPipeline(entry.spec, records, timeRange, nodes, {
 					perNode: isPerNodeMode,
 					snapToPeriod: true,
+					downsampleToWindow: true,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}

--- a/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/MetricRenderer.tsx
@@ -143,7 +143,7 @@ export function MetricRenderer({
 			// 60 s while every spec-driven panel beside it is coarsened.
 			const seriesData = downsampleDerivedSeriesData(
 				derived.recompute(records, timeRange, nodes, viewMode),
-				targetBucketMs(timeRange.endTime - timeRange.startTime),
+				targetBucketMs(timeRange.endTime - timeRange.startTime, { expanded: !!fillParent }),
 				derived.downsampleAggregator,
 			);
 			body = renderPrimitive(derived.primitive, seriesData, derived.yAxis, xDomain, fillParent);
@@ -183,6 +183,7 @@ export function MetricRenderer({
 							perNode: isPerNodeMode,
 							snapToPeriod: true,
 							downsampleToWindow: true,
+							expanded: !!fillParent,
 						}),
 						yAxis: field.yAxis ?? outerSpec.yAxis,
 					};
@@ -196,6 +197,7 @@ export function MetricRenderer({
 				const seriesData = runPipeline(remapped, records, timeRange, nodes, {
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive('stacked-area', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsClusterLineFold(entry.spec, isPerNodeMode) && entry.spec.series.kind === 'groupBy') {
@@ -207,6 +209,7 @@ export function MetricRenderer({
 				const seriesData = runPipeline(inner, records, timeRange, nodes, {
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else if (wantsDimensionLineSplit(entry.spec)) {
@@ -214,6 +217,7 @@ export function MetricRenderer({
 					perNode: false,
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive('line', seriesData, entry.spec.yAxis, xDomain, fillParent);
 			} else {
@@ -221,6 +225,7 @@ export function MetricRenderer({
 					perNode: isPerNodeMode,
 					snapToPeriod: true,
 					downsampleToWindow: true,
+					expanded: !!fillParent,
 				});
 				body = renderPrimitive(entry.spec.primitive, seriesData, entry.spec.yAxis, xDomain, fillParent);
 			}

--- a/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/PerPathRateRenderer.tsx
@@ -7,10 +7,12 @@
 
 import { useMemo, useState } from 'react';
 import { NodeLegend } from '../charts/NodeLegend';
+import { targetBucketMs } from '../context/timePresets';
 import { useNodeSelection } from '../hooks/useNodeSelection';
 import { getNodeColor } from '../lib/nodeColors';
 import { shortenNodeLabel } from '../lib/nodeLabels';
-import type { AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
+import { downsampleDerivedSeriesData } from '../pipeline/downsample';
+import type { Aggregator, AnalyticsDataPoint, AxisSpec, SeriesData, Threshold, TimeRange } from '../types/analytics';
 import { DimensionChipRow } from './DimensionChipRow';
 import { LineChart } from './LineChart';
 
@@ -30,6 +32,11 @@ interface Props {
 		records: AnalyticsDataPoint[],
 		options: { perNode: boolean; selectedPath: string | null },
 	) => SeriesData;
+	/** How to fold points when the window is wider than the render lattice.
+	 *  Defaults to 'mean', correct for a per-second rate (request-rate): equal
+	 *  time buckets, so the coarse rate is the mean of the fine rates. A ratio
+	 *  metric would pass 'count-weighted-mean' to stay Σ-correct. */
+	downsampleAggregator?: Aggregator;
 }
 
 export function PerPathRateRenderer({
@@ -40,6 +47,7 @@ export function PerPathRateRenderer({
 	yAxis,
 	thresholds,
 	compute,
+	downsampleAggregator,
 	fillParent,
 }: Props) {
 	const xDomain = timeRange ? [timeRange.startTime, timeRange.endTime] as [number, number] : undefined;
@@ -68,8 +76,21 @@ export function PerPathRateRenderer({
 		: (perNode ? (paths[0] ?? '') : '');
 
 	const data = useMemo<SeriesData>(
-		() => compute(records, { perNode, selectedPath: effective || null }),
-		[records, perNode, effective, compute],
+		() => {
+			const raw = compute(records, { perNode, selectedPath: effective || null });
+			// These derived metrics build series from raw columns and reach the
+			// chart through this custom Renderer, so they skip runPipeline's
+			// downsample pass and MetricRenderer's derived-fold. Fold here or a
+			// 7 d / 30 d view stays at one point per 60 s beside panels capped at
+			// ~180 (#1588). No window (standalone/test) → leave raw.
+			if (!timeRange) { return raw; }
+			return downsampleDerivedSeriesData(
+				raw,
+				targetBucketMs(timeRange.endTime - timeRange.startTime, { expanded: !!fillParent }),
+				downsampleAggregator,
+			);
+		},
+		[records, perNode, effective, compute, timeRange, fillParent, downsampleAggregator],
 	);
 
 	const { isActive, handleLegendClick } = useNodeSelection(nodes);

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -95,8 +95,13 @@ export function TrafficByTypeRenderer({
 	}, [spec, stackBy]);
 
 	const data: SeriesData = useMemo(
-		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
-		[runtimeSpec, filteredRecords, timeRange, nodes],
+		() =>
+			runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, {
+				snapToPeriod: true,
+				downsampleToWindow: true,
+				expanded: !!fillParent,
+			}),
+		[runtimeSpec, filteredRecords, timeRange, nodes, fillParent],
 	);
 
 	// Color each series by its key using the appropriate allocator so the
@@ -122,6 +127,7 @@ export function TrafficByTypeRenderer({
 			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], {
 				snapToPeriod: true,
 				downsampleToWindow: true,
+				expanded: !!fillParent,
 			});
 			return {
 				title: nodeId,

--- a/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
+++ b/src/features/instance/status/analytics/primitives/TrafficByTypeRenderer.tsx
@@ -95,7 +95,7 @@ export function TrafficByTypeRenderer({
 	}, [spec, stackBy]);
 
 	const data: SeriesData = useMemo(
-		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true }),
+		() => runPipeline(runtimeSpec, filteredRecords, timeRange, nodes, { snapToPeriod: true, downsampleToWindow: true }),
 		[runtimeSpec, filteredRecords, timeRange, nodes],
 	);
 
@@ -119,7 +119,10 @@ export function TrafficByTypeRenderer({
 		const activeNodes = nodes.filter(isNodeActive);
 		return activeNodes.map((nodeId) => {
 			const nodeRecords = filteredRecords.filter((r) => r.node === nodeId);
-			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], { snapToPeriod: true });
+			const seriesData = runPipeline(spec, nodeRecords, timeRange, [nodeId], {
+				snapToPeriod: true,
+				downsampleToWindow: true,
+			});
 			return {
 				title: nodeId,
 				data: {

--- a/src/features/instance/status/analytics/tabs/kpi/useKpiTileData.ts
+++ b/src/features/instance/status/analytics/tabs/kpi/useKpiTileData.ts
@@ -68,6 +68,11 @@ export function useKpiTileData(def: KpiTileDef): KpiTileData {
 
 	const sparkPoints = useMemo<KpiPoint[]>(() => {
 		if (current.isError) { return []; }
+		// No `downsampleToWindow` here, unlike the chart panels: these points
+		// collapse to a headline number and a sparkline, so there is no density
+		// to save, and folding onto a coarse lattice first would redefine
+		// `latestValue` from "the newest bucket" to "an average across the
+		// newest coarse bucket".
 		return collapseSeries(
 			runPipeline(def.spec, current.data, timeRange, [], { snapToPeriod: true }),
 			def.combine,
@@ -78,6 +83,8 @@ export function useKpiTileData(def: KpiTileDef): KpiTileData {
 	const previousMean = useMemo<number | null>(() => {
 		if (previous.isLoading || previous.isError) { return null; }
 		const prevRange: TimeRange = { startTime: prevStart, endTime: prevEnd };
+		// Full resolution, matching sparkPoints above — the delta compares two
+		// window means and both sides must be computed the same way.
 		return windowMean(collapseSeries(
 			runPipeline(def.spec, previous.data, prevRange, [], { snapToPeriod: true }),
 			def.combine,

--- a/src/features/instance/status/analytics/types/analytics.ts
+++ b/src/features/instance/status/analytics/types/analytics.ts
@@ -181,6 +181,11 @@ export interface DerivedMetricSpec {
 	yAxis: MetricSpec['yAxis'];
 	thresholds?: Threshold[];
 	layout?: MetricSpec['layout'];
+	/** How to fold this metric's points when the selected window is wider than
+	 *  the render lattice (see pipeline/downsample.ts). Defaults to `'mean'`,
+	 *  which is right for the shipped derived metrics — all rates or ratios.
+	 *  Set `'sum'` for an extensive quantity, or `'max'`/`'last'` for a gauge. */
+	downsampleAggregator?: Aggregator;
 	/** Optional custom React component. When present, MetricRenderer uses
 	 *  it INSTEAD of the recompute → renderPrimitive flow — same role as
 	 *  SpecRegistryEntry.Renderer for spec-driven metrics. Lets derived


### PR DESCRIPTION
**Stacked on #1587** — base branch is `claude/mqtt-status-chart-gaps-ace583`, not `stage`. Review #1587 first; this PR's diff is only its own commit. Retarget to `stage` once #1587 merges.

Follow-up to a secondary finding in #1576.

## The problem

Each time preset declares the densest bucket Harper should serve, and those numbers are sensible:

```
1h → 1m    6h → 1m    24h → 5m    7d → 15m    30d → 1h
```

But that value only ever reached the server, as the `bucket_ms` hint. Client-side, `snapToBucketTime` used `record.period || spec.bucket.fallbackMs` — **60 s regardless of the selected window**. Builds that ignore `bucket_ms` (harper-pro 5.1.22, per #1576) return rows at raw emission cadence, so what actually rendered was:

| preset | intended | rendered | ratio | rows fetched |
| --- | --- | --- | --- | --- |
| 1h | 60 | 60 | 1× | 80 |
| 6h | 360 | 360 | 1× | 480 |
| 24h | 288 | **1 440** | 5× | 1 920 |
| 7d | 672 | **10 080** | 15× | 13 440 |
| 30d | 720 | **43 200** | **60×** | 57 600 |

At 30 d the Storage tab drew ~43 200 points × 5 database bands ≈ 216 000 SVG path coordinates in one chart. (The 1 440 figure matches a live measurement taken on the stage cluster while instrumenting #1576, so this isn't theoretical.)

## What changed

An opt-in `downsampleToWindow` pass folds the **finished** series onto the lattice the requested window implies. `targetBucketMs(windowMs)` reads the same `TIME_PRESETS` table, just keyed by duration instead of id, so there's one source of truth.

Measured on the live 2-node stage cluster at 7 d: each band's path `d` attribute drops from **~110 KB to ~8 KB** (193 curve segments per band).

### Why a post-aggregation fold, not a wider snap

Widening the *record* lattice changes what the temporal aggregator sees. `bytes-sent` is `temporal: 'sum'` over a `rate`-transformed field, so rows from different periods landing in one bucket get summed. Measured before choosing the design:

```
60s lattice:    6 points, y = [1000, 1000, 1000, 1000, 1000, 1000]   ← correct B/s
300s grouping:  2 points, y = [3000, 3000]                            ← 3× inflated
```

That would have silently inflated bytes-sent/received, both `mqtt-traffic-*` panels and `fsWrite` — 60× at 30 d. Folding *after* every aggregation pass leaves temporal, cross-node, and the bounded carry-forward from #1576 operating on exactly the buckets they do today. `render-density.test.ts` pins those counters at 1000 B/s across 24h/7d/30d so it can't regress.

### Fold rules ([downsample.ts](src/features/instance/status/analytics/pipeline/downsample.ts))

- **rate fields → `mean`**, never `sum`. Equal-weighted: Harper emits one row per node per period at fixed cadence, so every point in a coarse bucket covers the same span.
- **percentiles → `max`**. A p95-of-p95s isn't a p95; of the two defensible approximations, an operator would rather keep spikes visible than smooth them away at 30 d.
- **gauges → `max`/`last`** unchanged.
- **`count-weighted-mean` stays count-weighted**, via `SeriesPoint.count`.
- Counts are summed so confidence gating still sees the real observation total; an all-null coarse bucket stays an explicit `null` gap; bucket times use round-to-nearest, matching `snapToBucketTime`'s convention so grids stay aligned.

### Who opts in

18 chart-render sites plus CSV export (so a download matches the chart it came from).

**KPI tiles deliberately opt out** — they collapse to a headline number, so there's no density to save, and folding first would redefine `latestValue` from "the newest bucket" to "an average over the newest coarse bucket".

`error-rate`, `request-rate` and `transaction-log-growth` build series from raw columns without going through `runPipeline`, so MetricRenderer and csvExport fold their output via `downsampleDerivedSeriesData` — otherwise those panels would stay dense right next to coarsened neighbours on the same tab (`transaction-log-growth` sits beside `database-size` on Storage). The fold is idempotent, so applying it to `mqtt-traffic`'s recompute — which opts in internally — is a no-op, not a double average. `DerivedMetricSpec` gains an optional `downsampleAggregator` defaulting to `mean`, correct for all three shipped derived metrics.

## Reviewer notes

**`runPipeline`'s `window` argument is now load-bearing.** It was previously ignored (`_window`), so callers passed whatever. `bytes-sent-tolerance`'s `0 → MAX_SAFE_INTEGER` sentinel read as a ~285-century window and folded the series into a single bucket, collapsing the Σ-of-rates that test checks; it now passes the fixture's own ~59 min span. `recomputeRequestRate` uses the same sentinel but never delegates to `runPipeline`, so it's unaffected. I grepped for other sentinel windows — the remaining ones are in tests that don't opt into downsampling, which is the payoff of making this opt-in rather than default-on.

**`targetBucketMs(preset.durationMs) === preset.bucketMs` is an invariant, not a coincidence.** StorageTab aligns its trend grid to the context's `bucketMs` (#1514); if the render lattice and that value diverge, trend timestamps stop landing on the metric panels' and `syncMethod="value"` crosshair sync silently breaks. Locked by tests in both `timePresets.test.ts` and `render-density.test.ts`.

## This does NOT reduce server load

Worth being explicit, since that was half the original ask. We already send `bucket_ms`; the server ignoring it is what makes the payload 57 600 rows at 30 d. While verifying at 7 d I saw the analytics requests **hit the 60 s axios timeout**, and `getAnalytics`' `MAX_ROWS = 50_000` tail-keep can silently truncate the oldest part of a wide window (at 30 d, `database-size` across 5 databases × 2 nodes is ~288 000 rows, so the chart would show roughly the most recent 5 days of a 30-day window and say nothing about it). Both need core to honor `bucket_ms` — worth a companion core issue, and arguably a client-side banner when the cap trips.

## Tests

- `__tests__/pipeline/render-density.test.ts` — rendered point count per preset (30 d: >40 000 → ≤721); `targetBucketMs` preset agreement, now()-drift tolerance, degenerate windows, beyond-30 d behavior; gauge totals surviving the fold; the rate-inflation guard; opt-out keeping full resolution.
- `__tests__/pipeline/downsample.test.ts` — `isRateTransform` (including nested in `compose`), the aggregator mapping, folding/count-summing/null handling/identity-when-nothing-folds, derived idempotence, ceiling series.
- `context/timePresets.test.ts` — the #1514 alignment invariant and monotonicity.

Full repo gate green: **1918 tests / 266 files**, `tsc -b`, `oxlint`, `dprint check`. Verified in the browser at 24 h and 7 d on the stage cluster — charts render cleanly, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
