### PR TITLE
fix(status): bound the stacked-area forward-fill to each series' cadence

### DIFF
--- a/src/features/instance/status/analytics/__tests__/primitives/stacked-row-staleness.test.ts
+++ b/src/features/instance/status/analytics/__tests__/primitives/stacked-row-staleness.test.ts
@@ -1,0 +1,275 @@
+// Regression coverage for the render-layer half of #1576.
+//
+// The pipeline fix bounded carry-forward for cross-node gauge *sums*, which is
+// what "Stack by: Type" renders. "Stack by: Node" never went through that code
+// path at all: the renderer remaps the spec's dimension to 'node', so each
+// series holds exactly one node and the pipeline's carry-forward — which never
+// invents bucket times — is a structural no-op. The only thing stitching those
+// bands across the lattice is StackedAreaChart's own forward-fill, and it was
+// unbounded, so an idle node's band was carried for the rest of the window.
+//
+// The staggered shapes below mirror cross-node-gauge-gaps.test.ts: `period: 0`
+// gauge rows on a 90 s emission cadence, snapped onto the spec's 60 s fallback
+// lattice, two nodes half a cadence out of phase.
+import { describe, expect, it } from 'vitest';
+import { runPipeline } from '../../pipeline/pipeline';
+import { wrapperMetrics } from '../../pipeline/wrapperMetrics';
+import { mergeStackedRows, type StackedRow } from '../../primitives/mergeStackedRows';
+import type { AnalyticsDataPoint, MetricSpec, SeriesData, TimeRange } from '../../types/analytics';
+
+/** `spec.bucket.fallbackMs` — what `period: 0` degrades to, and so the lattice
+ *  every gauge row here is snapped onto. */
+const LATTICE = 60_000;
+/** Emission cadence observed on the reporting instance. 90 mod 60 = 30, which
+ *  is what makes the nodes' snapped buckets beat against the lattice. */
+const CADENCE = 90_000;
+/** Lattice-aligned epoch, so every snapped bucket below is exact. */
+const T0 = 28_333_334 * LATTICE;
+/** Half a cadence — the second node's phase offset. */
+const PHASE = CADENCE / 2;
+
+const BUSY = 285; // us-west-1's steady connection count
+const QUIET = 3; // Milan's, while it had any at all
+
+const WINDOW: TimeRange = { startTime: T0 - LATTICE, endTime: T0 + 100 * CADENCE };
+const NODES = ['busy', 'quiet'];
+
+/** Round-to-nearest, matching the pipeline's `snapToBucketTime`. */
+const snap = (t: number) => Math.round(t / LATTICE) * LATTICE;
+
+/** The dimension remap TrafficByTypeRenderer applies for "Stack by: Node". */
+function stackByNode(spec: MetricSpec): MetricSpec {
+	if (spec.series.kind !== 'groupBy') { throw new Error('expected a groupBy spec'); }
+	return { ...spec, series: { ...spec.series, dimension: 'node' } };
+}
+
+const connectionsByNode = stackByNode(wrapperMetrics['connections'].spec);
+const bytesSentByNode = stackByNode(wrapperMetrics['bytes-sent'].spec);
+
+function connectionRow(node: string, time: number, connections: number): AnalyticsDataPoint {
+	// `period: 0` is what harper-pro stamps on gauge rows.
+	return { metric: 'mqtt-connections', type: 'mqtt', node, time, connections, count: 1, period: 0 };
+}
+
+/** Two nodes on the same cadence, half a period out of phase. `busy` reports for
+ *  every one of `samples`; `quiet` reports for its first `quietSamples` and then
+ *  goes silent, which is what core's `> 0` guard does to an idle node. */
+function staggeredCluster(samples: number, quietSamples: number): AnalyticsDataPoint[] {
+	const rows: AnalyticsDataPoint[] = [];
+	for (let i = 0; i < samples; i++) {
+		rows.push(connectionRow('busy', T0 + i * CADENCE, BUSY));
+	}
+	for (let j = 0; j < quietSamples; j++) {
+		rows.push(connectionRow('quiet', T0 + PHASE + j * CADENCE, QUIET));
+	}
+	return rows;
+}
+
+const byX = (rows: StackedRow[]) => new Map(rows.map((r) => [r.x, r]));
+
+const nodeStack = (spec: MetricSpec, rows: AnalyticsDataPoint[], nodes = NODES): SeriesData =>
+	runPipeline(spec, rows, WINDOW, nodes, { snapToPeriod: true });
+
+describe('stack-by-node — the render-layer fill is the only thing bridging the lattice', () => {
+	const SAMPLES = 40;
+	const data = nodeStack(connectionsByNode, staggeredCluster(SAMPLES, SAMPLES));
+
+	it('leaves each node reporting on only part of the shared lattice', () => {
+		// Guard on the setup: if the lattice/phase arithmetic ever stopped producing
+		// ragged per-node coverage, everything below would pass vacuously.
+		const xs = new Set(data.series.flatMap((s) => s.points.map((p) => p.x)));
+		expect(data.series.length).toBe(2);
+		for (const s of data.series) {
+			expect(s.points.length, `${s.key} covers the full lattice`).toBeLessThan(xs.size);
+		}
+	});
+
+	it('gives the pipeline no cross-node sum to carry — each series holds one node', () => {
+		// This is why the bound has to be reimplemented at the render layer: with
+		// dimension 'node' every bucket of a series has its own node present, so
+		// pipeline carry-forward has nothing to fill.
+		for (const s of data.series) {
+			expect(s.node).toBe(s.key);
+			const expected = s.key === 'busy' ? BUSY : QUIET;
+			expect(s.points.map((p) => p.y)).toEqual(s.points.map(() => expected));
+		}
+	});
+
+	it('fills both bands at every lattice position once each node has been seen', () => {
+		const merged = mergeStackedRows(data);
+		const quietFirst = snap(T0 + PHASE);
+		expect(merged.length).toBeGreaterThan(SAMPLES);
+		for (const row of merged) {
+			expect(row.busy, `busy @ ${row.x}`).toBe(BUSY);
+			// LOCF only looks backwards — the quiet node's first row is half a
+			// cadence after T0, so the opening bucket is legitimately busy alone.
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(row.x! < quietFirst ? null : QUIET);
+		}
+	});
+});
+
+describe('stack-by-node — an idle node stops contributing to the stack', () => {
+	const SAMPLES = 40;
+	const QUIET_SAMPLES = 5;
+	const data = nodeStack(connectionsByNode, staggeredCluster(SAMPLES, QUIET_SAMPLES));
+	const merged = mergeStackedRows(data);
+	const lastQuiet = snap(T0 + PHASE + (QUIET_SAMPLES - 1) * CADENCE);
+
+	it('drops the quiet band to 0 once its last sample is far enough behind', () => {
+		// Pre-fix these positions all read QUIET — the band was carried to the
+		// right-hand edge of the window, overstating the cluster total forever.
+		const stale = merged.filter((r) => r.x! > lastQuiet + 10 * LATTICE);
+		expect(stale.length).toBeGreaterThan(0);
+		for (const row of stale) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(0);
+			expect(row.busy, `busy @ ${row.x}`).toBe(BUSY);
+		}
+	});
+
+	it('still bridges the positions the quiet node skipped while it was reporting', () => {
+		const bridged = merged.filter((r) => r.x! > snap(T0 + PHASE) && r.x! <= lastQuiet);
+		expect(bridged.length).toBeGreaterThan(0);
+		for (const row of bridged) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(QUIET);
+		}
+	});
+
+	it('never brings the band back once it has expired', () => {
+		// A band that flickered 0 → QUIET → 0 would read as a node reconnecting.
+		const firstZero = merged.findIndex((r) => r.quiet === 0);
+		expect(firstZero).toBeGreaterThan(0);
+		for (const row of merged.slice(firstZero)) {
+			expect(row.quiet, `quiet @ ${row.x}`).toBe(0);
+		}
+	});
+});
+
+describe('bounded carry-forward — exact horizon', () => {
+	// Uniform 60 ms lattice so the arithmetic is checkable by hand: 'b' reports
+	// three times and stops. Its median gap is 60 and the lattice step is 60, so
+	// its horizon is STALENESS_INTERVALS × 60 + one step of snap slack = 180.
+	const data: SeriesData = {
+		series: [
+			{ key: 'a', label: 'A', points: Array.from({ length: 11 }, (_, i) => ({ x: i * 60, y: 100 })) },
+			{ key: 'b', label: 'B', points: [0, 60, 120].map((x) => ({ x, y: 10 })) },
+		],
+	};
+	const rows = byX(mergeStackedRows(data));
+
+	it('carries right up to the horizon and no further', () => {
+		expect(rows.get(120)!.b, 'observed').toBe(10);
+		expect(rows.get(240)!.b, '120 stale — inside the horizon').toBe(10);
+		expect(rows.get(300)!.b, '180 stale — exactly at the horizon').toBe(10);
+		expect(rows.get(360)!.b, '240 stale — past the horizon').toBe(0);
+		expect(rows.get(600)!.b).toBe(0);
+	});
+
+	it('leaves the series that kept reporting untouched', () => {
+		for (const row of rows.values()) {
+			expect(row.a, `a @ ${row.x}`).toBe(100);
+		}
+	});
+});
+
+describe('bounded carry-forward — values the fill must not invent', () => {
+	const spine = Array.from({ length: 11 }, (_, i) => ({ x: i * 60, y: 100 }));
+
+	it('passes an observed value through, including a genuine drop to 0', () => {
+		// A real disconnect reports 0 rather than going absent, so the fill must
+		// never round it back up to the previous reading.
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: 0 }, { x: 120, y: 7 }] },
+			],
+		}));
+		expect([rows.get(0)!.b, rows.get(60)!.b, rows.get(120)!.b]).toEqual([10, 0, 7]);
+	});
+
+	it('does not back-fill positions before a series first reported', () => {
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 300, y: 10 }] },
+			],
+		}));
+		expect([rows.get(0)!.b, rows.get(240)!.b]).toEqual([null, null]);
+		expect(rows.get(300)!.b).toBe(10);
+	});
+
+	it('keeps a point that reported no value null, and carries nothing from it', () => {
+		// `y: null` is an aggregate that had no valid inputs — a known unknown,
+		// which is not the same as a series that has gone to zero.
+		const rows = byX(mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: spine },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: null }] },
+			],
+		}));
+		expect([rows.get(60)!.b, rows.get(120)!.b, rows.get(600)!.b]).toEqual([null, null, null]);
+	});
+
+	it('invents no rows when every series stops, so a cluster-wide gap cannot read as 0', () => {
+		// x positions come only from series that actually reported. If everything
+		// goes quiet the rows stop, and the chart shows a gap rather than a stack
+		// of zeros.
+		const merged = mergeStackedRows({
+			series: [
+				{ key: 'a', label: 'A', points: [{ x: 0, y: 100 }, { x: 60, y: 100 }] },
+				{ key: 'b', label: 'B', points: [{ x: 0, y: 10 }, { x: 60, y: 10 }] },
+			],
+		});
+		expect(merged.map((r) => r.x)).toEqual([0, 60]);
+		expect(merged.flatMap((r) => [r.a, r.b])).toEqual([100, 10, 100, 10]);
+	});
+
+	it('carries the ceiling unbounded — it is a reference line, not a band', () => {
+		// A memory-style ceiling that expired to 0 would draw a limit of nothing.
+		const merged = mergeStackedRows({
+			series: [{ key: 'a', label: 'A', points: spine }],
+			ceiling: { key: 'cap', label: 'Max', points: [{ x: 0, y: 4096 }] },
+		});
+		expect(merged.map((r) => r.__ceiling__)).toEqual(merged.map(() => 4096));
+	});
+
+	it('handles a single-point series without expiring it against a zero horizon', () => {
+		const merged = mergeStackedRows({ series: [{ key: 'a', label: 'A', points: [{ x: 0, y: 100 }] }] });
+		expect(merged).toEqual([{ x: 0, a: 100 }]);
+	});
+});
+
+describe('bytes-sent — a node that stops sending reads 0, not its last rate', () => {
+	// sum/sum, so the pipeline deliberately excludes it from carry-forward. The
+	// render layer still has to fill the positions a node skipped, and past the
+	// horizon 0 is the honest value for a rate: carrying the last throughput on
+	// would keep drawing traffic that stopped.
+	const bytesRow = (node: string, time: number, bytes: number): AnalyticsDataPoint =>
+		({
+			metric: 'bytes-sent',
+			type: 'egress',
+			node,
+			time,
+			count: 1,
+			mean: bytes,
+			period: LATTICE,
+		}) as AnalyticsDataPoint;
+	// rate = count × mean / period × 1000 = 60_000 / 60_000 × 1000 = 1000 B/s
+	const RATE = 1_000;
+
+	const rows: AnalyticsDataPoint[] = [];
+	for (let i = 0; i <= 20; i++) { rows.push(bytesRow('n1', T0 + i * LATTICE, 60_000)); }
+	for (let i = 0; i <= 2; i++) { rows.push(bytesRow('n2', T0 + i * LATTICE, 60_000)); }
+
+	const merged = byX(mergeStackedRows(nodeStack(bytesSentByNode, rows, ['n1', 'n2'])));
+
+	it('still bridges a position inside the horizon', () => {
+		// n2's cadence and the lattice are both 60 s → horizon 180 s.
+		expect(merged.get(T0 + 3 * LATTICE)!.n2).toBe(RATE);
+	});
+
+	it('stops drawing the departed node once its last sample ages out', () => {
+		expect(merged.get(T0 + 10 * LATTICE)!.n2).toBe(0);
+		expect(merged.get(T0 + 20 * LATTICE)!.n2).toBe(0);
+		expect(merged.get(T0 + 20 * LATTICE)!.n1).toBe(RATE);
+	});
+});

--- a/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
+++ b/src/features/instance/status/analytics/primitives/StackedAreaChart.tsx
@@ -8,6 +8,7 @@ import { getChartColors } from '../lib/theme';
 import { formatAxisTick } from '../lib/time';
 import type { AxisSpec, SeriesData } from '../types/analytics';
 import { ChartTooltip, useTooltipGate } from './ChartTooltip';
+import { CEILING_KEY, mergeStackedRows } from './mergeStackedRows';
 import { sortByMagnitude } from './sortByMagnitude';
 
 interface Props {
@@ -65,6 +66,14 @@ export function StackedAreaChart(
 		[data.series],
 	);
 
+	// Merge points by x across series, forward-filling each series across the
+	// positions it did not report, bounded by its own reporting cadence. See
+	// mergeStackedRows for why the fill exists and why the bound matters (#1576).
+	// Memoized for the same reason as `nodeNames` above — this chart re-renders
+	// on every hover tick, and the merge walks every point of every series. Kept
+	// above the early return so the hook order stays stable when data is empty.
+	const merged = useMemo(() => mergeStackedRows(data), [data]);
+
 	if (data.series.length === 0) {
 		return (
 			<div role="status" aria-live="polite" className="text-(--color-text-secondary) text-sm p-4">
@@ -74,43 +83,6 @@ export function StackedAreaChart(
 	}
 
 	const chartColors = getChartColors();
-
-	// Merge points by x across series. Series often emit at slightly
-	// staggered timestamps (e.g. Harper emits per-node records at different
-	// instants within the period), so a strict equality merge produces rows
-	// with one populated cell and N-1 nulls — which renders as a sparse,
-	// mostly-empty stack. Forward-fill carries the last-known value across
-	// staggered rows so the stack stays continuous.
-	const xs = new Set<number>();
-	for (const s of data.series) { for (const p of s.points) { xs.add(p.x); } }
-	if (data.ceiling) { for (const p of data.ceiling.points) { xs.add(p.x); } }
-
-	// Pre-build x → index lookup per series for O(1) access during forward-fill.
-	const seriesPointMaps = data.series.map((s) => {
-		const m = new Map<number, number | null>();
-		for (const p of s.points) { m.set(p.x, p.y); }
-		return m;
-	});
-	const ceilingMap = data.ceiling
-		? new Map<number, number | null>(data.ceiling.points.map((p) => [p.x, p.y]))
-		: null;
-
-	const lastSeen: (number | null)[] = data.series.map(() => null);
-	let lastCeiling: number | null = null;
-
-	const merged: Record<string, number | null>[] = [...xs].sort((a, b) => a - b).map((x) => {
-		const row: Record<string, number | null> = { x };
-		data.series.forEach((s, i) => {
-			const m = seriesPointMaps[i];
-			if (m.has(x)) { lastSeen[i] = m.get(x) ?? null; }
-			row[s.key] = lastSeen[i];
-		});
-		if (ceilingMap && data.ceiling) {
-			if (ceilingMap.has(x)) { lastCeiling = ceilingMap.get(x) ?? null; }
-			row.__ceiling__ = lastCeiling;
-		}
-		return row;
-	});
 
 	const resolvedFormatter = yAxis?.formatter;
 	const resolvedUnit = yAxis?.unit;
@@ -177,7 +149,7 @@ export function StackedAreaChart(
 							? (
 								<Line
 									type="monotone"
-									dataKey="__ceiling__"
+									dataKey={CEILING_KEY}
 									name={data.ceiling.label}
 									stroke={chartColors.axisColor}
 									strokeWidth={2}

--- a/src/features/instance/status/analytics/primitives/mergeStackedRows.ts
+++ b/src/features/instance/status/analytics/primitives/mergeStackedRows.ts
@@ -1,0 +1,131 @@
+// Row builder for StackedAreaChart: merges every series onto the union of x
+// positions, forward-filling each across the positions it did not report —
+// bounded by the same staleness horizon the pipeline applies to cross-node
+// gauge sums (#1576, pipeline/carryForward.ts).
+//
+// Why a fill is needed at all: Harper emits per-node analytics records at
+// staggered instants, and gauge rows carry `period: 0`, so the pipeline snaps
+// them onto the spec's `bucket.fallbackMs` lattice — a 90 s cadence on a 60 s
+// lattice lands on some buckets and skips others. A strict equality merge then
+// yields rows with one populated cell and N-1 nulls, which a stacked area
+// renders as a shredded, mostly-empty stack.
+//
+// The fill is most load-bearing in "Stack by: Node" mode. There the renderer
+// remaps the spec's dimension to 'node', so a series' buckets are exactly the
+// instants that one node reported and that node is present in every one of
+// them: the pipeline's own carry-forward (which never invents bucket times) is a
+// structural no-op, and this merge is the only thing holding the bands together.
+// In "Stack by: Type" mode the cross-node fold has already put every type on the
+// shared lattice, so the fill only bridges types that genuinely report at
+// different cadences.
+//
+// Why it has to be bounded: unbounded LOCF carries a band for the rest of the
+// window, so a node that has genuinely gone idle keeps contributing its last
+// value to the stacked total forever. That is exactly the #1576 overstatement,
+// one layer up — core emits `mqtt-connections` only while the count is nonzero
+// (`if (numberOfConnections > 0)` in server/mqtt.ts), so "no row" is what an
+// idle node looks like.
+//
+// Past the horizon a band fills 0, not null:
+//   - It mirrors the pipeline. Dropping an expired node from a `crossNode: 'sum'`
+//     *is* contributing 0 to that sum.
+//   - It is what a stacked chart means. Bands add, so 0 is the neutral element;
+//     a null punches a hole through the stack and drops every band above it.
+//   - It is right for the additive counters too (`mqtt-traffic-*`,
+//     bytes-sent/received): no row for a rate series means no traffic, so 0 is
+//     the honest value — strictly better than carrying the last throughput on
+//     forever.
+// A cluster-wide gap cannot turn into spurious zeros, because the x positions
+// come only from series that actually reported: if everything stops, the rows
+// stop too.
+import { estimateEmissionIntervalMs, STALENESS_INTERVALS } from '../pipeline/carryForward';
+import type { SeriesData } from '../types/analytics';
+
+/** Recharts `dataKey` for the optional ceiling / reference line. Distinct from
+ *  any series key, which is a dimension value or a `dim|node` composite. */
+export const CEILING_KEY = '__ceiling__';
+
+/** One Recharts datum: `x` plus one entry per series key (and the ceiling). */
+export type StackedRow = Record<string, number | null>;
+
+/** Last reading a series produced, and the x position it produced it at. */
+interface LastReading {
+	at: number;
+	y: number | null;
+}
+
+export function mergeStackedRows(data: SeriesData): StackedRow[] {
+	const xs = new Set<number>();
+	for (const s of data.series) { for (const p of s.points) { xs.add(p.x); } }
+	if (data.ceiling) { for (const p of data.ceiling.points) { xs.add(p.x); } }
+	const sortedXs = [...xs].sort((a, b) => a - b);
+
+	// Pre-build x → y lookup per series for O(1) access during the fill.
+	const pointMaps = data.series.map((s) => {
+		const m = new Map<number, number | null>();
+		for (const p of s.points) { m.set(p.x, p.y); }
+		return m;
+	});
+	const horizons = buildHorizons(data, sortedXs);
+	const ceilingMap = data.ceiling
+		? new Map<number, number | null>(data.ceiling.points.map((p) => [p.x, p.y]))
+		: null;
+
+	const last: (LastReading | null)[] = data.series.map(() => null);
+	let lastCeiling: number | null = null;
+
+	return sortedXs.map((x) => {
+		const row: StackedRow = { x };
+		data.series.forEach((s, i) => {
+			// `undefined` is "no point here"; a point whose y is null reported
+			// without a value, and must not be confused with the former.
+			const observed = pointMaps[i].get(x);
+			if (observed !== undefined) { last[i] = { at: x, y: observed }; }
+			row[s.key] = fillAt(last[i], x, horizons[i]);
+		});
+		if (ceilingMap) {
+			// The ceiling is a reference line drawn over the stack, not a band in
+			// it: it adds to no total and has no zero to expire to (a ceiling that
+			// drops to 0 reads as a limit of nothing). Carried unbounded, as before.
+			const observed = ceilingMap.get(x);
+			if (observed !== undefined) { lastCeiling = observed; }
+			row[CEILING_KEY] = lastCeiling;
+		}
+		return row;
+	});
+}
+
+/** What a series contributes at `x`: its own reading where it reported, its most
+ *  recent one while that is still inside the horizon, 0 once it is not. `null`
+ *  before the series' first point — there is nothing to carry, and LOCF never
+ *  back-fills — and for a point that reported no value. */
+function fillAt(last: LastReading | null, x: number, horizonMs: number): number | null {
+	if (last === null || last.y === null) { return null; }
+	return x - last.at > horizonMs ? 0 : last.y;
+}
+
+/**
+ * Per-series staleness horizon (ms), mirroring the pipeline's
+ * `buildStalenessHorizons`: `STALENESS_INTERVALS` × the series' own median
+ * reporting gap, floored at the rendered lattice step so a horizon always spans
+ * at least two x positions (that floor is what covers a series reporting faster
+ * than the lattice, or having reported only once).
+ *
+ * Plus one lattice step of slack, which the pipeline does not need. The pipeline
+ * estimates cadence from raw emission instants; by the time a series reaches a
+ * primitive those have been snapped onto the lattice, and snapping *compresses*
+ * alternate gaps — a 90 s cadence on a 60 s lattice reports at 0/120/180/300…,
+ * so its gaps alternate 120/60 and their median reads 60 or 90 depending on how
+ * many samples the window caught, while the widest gap is 120. Absent the slack,
+ * a series could expire on the very beat pattern the snap induced. One step is
+ * the most the snap can stretch a gap by, so adding it keeps this horizon at
+ * least as generous as the pipeline's — the safe direction, since expiring a
+ * series that is merely out of phase is the artifact we are trying not to draw.
+ */
+function buildHorizons(data: SeriesData, sortedXs: readonly number[]): number[] {
+	const latticeMs = estimateEmissionIntervalMs(sortedXs) ?? 0;
+	return data.series.map((s) => {
+		const cadenceMs = estimateEmissionIntervalMs(s.points.map((p) => p.x)) ?? 0;
+		return STALENESS_INTERVALS * Math.max(cadenceMs, latticeMs) + latticeMs;
+	});
+}


### PR DESCRIPTION
Stacked on #1587 — review that one first. Base auto-retargets to `stage` when it merges.

#1587 bounded last-observation-carry-forward for cross-node gauge sums in the pipeline. `StackedAreaChart` has a **second, independent forward-fill** at the render layer, and it was unbounded: it merges every series onto the union of x positions and carries each series' last-seen value across the positions it did not report, with no staleness limit.

## Why #1587's bound can't reach this

In **Stack by: Node**, `TrafficByTypeRenderer` remaps the spec's dimension to `'node'`, so each series holds exactly one node and that node is present in every bucket the series has. Since pipeline carry-forward never invents bucket times, it is a *structural no-op* in that mode — nothing but this merge bridges those bands.

That is both why node mode never showed the #1576 dives, and why an idle node's band was carried to the right-hand edge of the window. Core emits `mqtt-connections` only while the count is nonzero (`if (numberOfConnections > 0)` in `server/mqtt.ts`), so "no row" is exactly what an idle node looks like — the same overstatement #1587 fixed, one layer up.

## What changed

The fill stays; it is load-bearing. `period: 0` gauge rows snap onto the spec's 60 s fallback lattice, which a 90 s emission cadence beats against, so per-node lattice coverage is ragged and a strict merge draws a shredded stack. What changes is that a band now **expires**:

```
STALENESS_INTERVALS × max(median reporting gap, lattice step) + one lattice step
```

That trailing lattice step is slack the pipeline does not need. The pipeline estimates cadence from *raw* emission instants; a primitive only ever sees times already snapped onto the lattice, and snapping **compresses alternate gaps** — a 90 s cadence on a 60 s lattice reports at 0/120/180/300…, so its gaps alternate 120/60 and their median reads 60 or 90 depending on how many samples the window caught, while the widest gap is 120. Without the slack a series can expire on the very beat pattern the snap induced (I hit a zero-margin case before adding it). One step is the most the snap can stretch a gap by, which keeps this horizon at least as generous as the pipeline's.

Cadence is derived from the series' own point spacing rather than threaded through `SeriesData`: derived metrics (`mqtt-traffic-*`) and hand-built `SeriesData` reach this primitive too, so a threaded field would be absent often enough that this derivation would remain the live path anyway.

### Past the horizon a band fills 0, not null

- It mirrors the pipeline — dropping an expired node from a `crossNode: 'sum'` *is* contributing 0 to that sum.
- It is what a stacked chart means: bands add, so 0 is the neutral element, while a null punches a hole through the stack and drops every band above it.
- A cluster-wide gap still reads as a gap. X positions come only from series that actually reported, so when everything stops the rows stop rather than filling with zeros.

## Regression check across every stacked-area panel

| Panel | Aggregator | Effect |
|---|---|---|
| `connections` | max / sum | the motivating fix — gauge |
| `database-size` | last / sum | same gauge shape |
| `bytes-sent` / `bytes-received` | sum / sum | improves |
| `mqtt-traffic-sent` / `-received` | sum / sum | improves |

The additive counters improve for the same reason #1587 excluded them from pipeline carry-forward: a missing bucket for a rate series means *no traffic*, so expiring to 0 is the honest value where carrying the last throughput forward invented traffic indefinitely.

Observed values are never rewritten — including a genuine drop to 0 — and nothing is back-filled before a series' first point. The ceiling series stays unbounded deliberately: it is a reference line drawn over the stack, not a band in it, with no zero to expire to (a ceiling at 0 reads as a limit of nothing).

`csvExport` is untouched. It exports raw points with empty cells for gaps and never shared this fill — the export is the data, not the drawing.

## Testing

Extracted the merge to `mergeStackedRows` so it is unit-testable at all: every assertion about rendered geometry in the existing `stacked-area` suite is `it.skip`, because neither jsdom nor happy-dom lays Recharts out. Also memoized it in the component, which re-renders on every hover tick.

16 cases in `__tests__/primitives/stacked-row-staleness.test.ts`, shaped after `cross-node-gauge-gaps.test.ts` and driven through the real `connections` / `bytes-sent` specs and the real pipeline: the staggered-cadence shape actually producing ragged coverage, the pipeline no-op in node mode, horizon expiry, still-bridged-inside-the-horizon, no flicker back, the exact horizon boundary on hand-checkable numbers, observed-value passthrough, no back-fill, `y: null` handling, no invented rows, and the ceiling exception.

Verified the coverage is not vacuous by reverting the horizon to `Infinity` — 4 cases fail, then restored.

Gate: 265 files / 1898 tests pass, `tsc -b`, oxlint, and dprint all clean.

**Not browser-verified.** Reproducing the artifact needs a genuinely idle node in a live cluster, which can't be summoned on demand, and port 5173 was held by another checkout. Verification is mechanism-level, through the real specs and pipeline.

Refs #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)