### PR TITLE
feat(status): clearer time picker — group refresh, label the resolution

### DIFF
--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -58,8 +58,12 @@ describe('TimeRangePicker', () => {
 				/>
 			</AnalyticsTestWrapper>,
 		);
-		expect(screen.getByText('Last 24 hours')).toBeTruthy();
-		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+		// Scope to the collapsed trigger (first combobox), not the whole document:
+		// a document-wide getByText would also match the option in the dropdown
+		// portal, so it wouldn't prove the *trigger* shows the resolution.
+		const trigger = screen.getAllByRole('combobox')[0];
+		expect(within(trigger).getByText('Last 24 hours')).toBeTruthy();
+		expect(within(trigger).getByText('by 10 minutes')).toBeTruthy();
 	});
 
 	it('groups the auto-refresh interval together with the refresh action', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -82,6 +82,10 @@ describe('TimeRangePicker', () => {
 		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
 		// …and the range picker stays outside it.
 		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
+		// The interval trigger carries a "reload" sub-label, mirroring the range
+		// picker's second line, so the collapsed value reads as a reload cadence.
+		expect(within(group).getByText('reload')).toBeTruthy();
+		expect(within(group).getByText('60s')).toBeTruthy();
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../hooks/useAnalyticsFreshness', () => ({
@@ -42,6 +42,46 @@ describe('TimeRangePicker', () => {
 			// since the integration is covered by StatusTabs URL sync test.
 			expect(triggers[0]).toBeTruthy();
 		}
+	});
+
+	it('shows the render resolution under the selected range on the trigger', () => {
+		// #1588 recalibrated 24h to a 10-minute bucket; the trigger should say so
+		// even while collapsed, so the resolution is visible before opening.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="24h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		expect(screen.getByText('Last 24 hours')).toBeTruthy();
+		expect(screen.getByText('by 10 minutes')).toBeTruthy();
+	});
+
+	it('groups the auto-refresh interval together with the refresh action', () => {
+		// The interval used to sit as a bare Select beside the range picker, at
+		// the same gap and weight, and got read as a chart-granularity setting.
+		// Grouping is the fix, so assert the grouping rather than the classes.
+		render(
+			<AnalyticsTestWrapper>
+				<TimeRangePicker
+					presetId="1h"
+					onPresetChange={vi.fn()}
+					refreshMs={60_000}
+					onRefreshChange={vi.fn()}
+					onManualRefresh={vi.fn()}
+				/>
+			</AnalyticsTestWrapper>,
+		);
+		const group = screen.getByRole('group', { name: /auto-refresh/i });
+		expect(within(group).getByLabelText(/Auto-refresh interval/i)).toBeTruthy();
+		expect(within(group).getByLabelText(/Refresh now/i)).toBeTruthy();
+		// …and the range picker stays outside it.
+		expect(within(group).getAllByRole('combobox')).toHaveLength(1);
 	});
 
 	it('fires onManualRefresh when the refresh icon is clicked', () => {

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -86,21 +86,36 @@ export function TimeRangePicker({
 			<div
 				role="group"
 				aria-label="Auto-refresh"
-				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
+				className="flex items-stretch rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
 				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					{
+						/* Two-line to match the range picker: the interval on top, a
+					    muted "reload" beneath, so the collapsed value reads as a
+					    reload cadence rather than another time setting. The dropdown
+					    options stay single-line — "reload" on each would be noise,
+					    since (unlike the range picker's per-option bucket) it's the
+					    same word every time. */
+					}
 					<SelectTrigger
 						aria-label="Auto-refresh interval"
 						title="Auto-refresh interval"
-						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue />
+						<SelectValue>
+							<span className="flex flex-col items-start leading-tight">
+								<span>
+									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
+								</span>
+								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+							</span>
+						</SelectValue>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
 					</SelectContent>
 				</Select>
-				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<span aria-hidden="true" className="my-1.5 w-px shrink-0 bg-border" />
 				<Button
 					variant="ghost"
 					size="icon"
@@ -109,7 +124,9 @@ export function TimeRangePicker({
 					aria-busy={isFetching}
 					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
 					title={isFetching ? 'Refreshing…' : 'Refresh now'}
-					className="rounded-l-none"
+					// h-auto (overriding size-9's height) so the button fills the
+					// group's now two-line height; width stays square-ish.
+					className="h-auto w-9 rounded-l-none"
 				>
 					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
 				</Button>

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
@@ -57,15 +57,14 @@ export function TimeRangePicker({
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
 				{
-					/* h-auto so the two-line label isn't clipped by the trigger's
-				    default h-9. Explicit children on SelectValue (not a bare
-				    <SelectValue/>) so the collapsed trigger shows the same
-				    window + resolution stack the options do. */
+					/* RangeLabel rendered straight into the trigger — the collapsed
+				    value is driven by `presetId` here, not by Radix reflecting the
+				    selected item, so the two-line stack is guaranteed regardless of
+				    how a given Radix version treats <SelectValue> children. h-auto
+				    keeps both lines from being clipped by the default h-9. */
 				}
 				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
-					<SelectValue>
-						<RangeLabel presetId={presetId} />
-					</SelectValue>
+					<RangeLabel presetId={presetId} />
 				</SelectTrigger>
 				<SelectContent>
 					{TIME_PRESETS.map((p) => (
@@ -102,14 +101,16 @@ export function TimeRangePicker({
 						title="Auto-refresh interval"
 						className="h-auto min-h-9 w-[96px] rounded-r-none border-0 bg-transparent py-1 shadow-none dark:bg-transparent"
 					>
-						<SelectValue>
-							<span className="flex flex-col items-start leading-tight">
-								<span>
-									{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
-								</span>
-								<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						{
+							/* Rendered directly, same as the range trigger — driven by
+						    `refreshMs`, not Radix's selected-item reflection. */
+						}
+						<span className="flex flex-col items-start leading-tight">
+							<span>
+								{REFRESH_OPTIONS.find((o) => o.value === refreshMs)?.label ?? `${Math.round(refreshMs / 1000)}s`}
 							</span>
-						</SelectValue>
+							<span className="text-[11px] font-normal text-muted-foreground">reload</span>
+						</span>
 					</SelectTrigger>
 					<SelectContent>
 						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}

--- a/src/features/instance/status/analytics/components/TimeRangePicker.tsx
+++ b/src/features/instance/status/analytics/components/TimeRangePicker.tsx
@@ -3,8 +3,21 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { cn } from '@/lib/cn';
 import { RefreshCw } from 'lucide-react';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
-import { REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
+import { formatBucketLabel, getPreset, REFRESH_OPTIONS, TIME_PRESETS, type TimePresetId } from '../context/timePresets';
 import { formatRelativeUpdate, useAnalyticsFreshness } from '../hooks/useAnalyticsFreshness';
+
+/** Range label as two stacked lines: the window on top, the resolution it
+ *  renders at ("by 10 minutes") beneath. Shared by the dropdown options and
+ *  the collapsed trigger so both read the same. */
+function RangeLabel({ presetId }: { presetId: TimePresetId }) {
+	const preset = getPreset(presetId);
+	return (
+		<span className="flex flex-col items-start leading-tight">
+			<span>{preset.label}</span>
+			<span className="text-[11px] font-normal text-muted-foreground">by {formatBucketLabel(preset.bucketMs)}</span>
+		</span>
+	);
+}
 
 interface Props {
 	presetId: TimePresetId;
@@ -26,7 +39,10 @@ export function TimeRangePicker({
 	const updatedLabel = formatRelativeUpdate(lastFetchedAt, now);
 
 	return (
-		<div className="flex items-center gap-2">
+		// gap-3 between groups, 0 inside the refresh group — the spacing is what
+		// tells you the interval belongs to the refresh action rather than to the
+		// range picker beside it.
+		<div className="flex items-center gap-3">
 			{updatedLabel && (
 				<span
 					className="text-xs text-muted-foreground tabular-nums"
@@ -40,32 +56,64 @@ export function TimeRangePicker({
 				</span>
 			)}
 			<Select value={presetId} onValueChange={(v) => onPresetChange(v as TimePresetId)}>
-				<SelectTrigger className="w-[180px]">
-					<SelectValue />
+				{
+					/* h-auto so the two-line label isn't clipped by the trigger's
+				    default h-9. Explicit children on SelectValue (not a bare
+				    <SelectValue/>) so the collapsed trigger shows the same
+				    window + resolution stack the options do. */
+				}
+				<SelectTrigger className="h-auto min-h-9 w-[180px] py-1">
+					<SelectValue>
+						<RangeLabel presetId={presetId} />
+					</SelectValue>
 				</SelectTrigger>
 				<SelectContent>
-					{TIME_PRESETS.map((p) => <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>)}
+					{TIME_PRESETS.map((p) => (
+						<SelectItem key={p.id} value={p.id}>
+							<RangeLabel presetId={p.id} />
+						</SelectItem>
+					))}
 				</SelectContent>
 			</Select>
-			<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
-				<SelectTrigger className="w-[100px]">
-					<SelectValue />
-				</SelectTrigger>
-				<SelectContent>
-					{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
-				</SelectContent>
-			</Select>
-			<Button
-				variant="ghost"
-				size="icon"
-				onClick={onManualRefresh}
-				disabled={isFetching}
-				aria-busy={isFetching}
-				aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
-				title={isFetching ? 'Refreshing…' : 'Refresh now'}
+			{
+				/* Auto-refresh interval + refresh-now, joined into one control. Sat as
+			    a bare Select next to the range picker before, at the same gap and
+			    the same weight, so "60s" read as a second time setting — a chart
+			    granularity — rather than "re-fetch every 60s". Attaching it to the
+			    refresh icon is what disambiguates it; the shared border/background
+			    lives on this wrapper and the children opt out of their own. */
+			}
+			<div
+				role="group"
+				aria-label="Auto-refresh"
+				className="flex items-center rounded-md border border-input bg-white shadow-xs dark:bg-grey-700"
 			>
-				<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
-			</Button>
+				<Select value={String(refreshMs)} onValueChange={(v) => onRefreshChange(Number(v))}>
+					<SelectTrigger
+						aria-label="Auto-refresh interval"
+						title="Auto-refresh interval"
+						className="w-[88px] rounded-r-none border-0 bg-transparent shadow-none dark:bg-transparent"
+					>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{REFRESH_OPTIONS.map((o) => <SelectItem key={o.value} value={String(o.value)}>{o.label}</SelectItem>)}
+					</SelectContent>
+				</Select>
+				<span aria-hidden="true" className="h-5 w-px shrink-0 bg-border" />
+				<Button
+					variant="ghost"
+					size="icon"
+					onClick={onManualRefresh}
+					disabled={isFetching}
+					aria-busy={isFetching}
+					aria-label={isFetching ? 'Refreshing…' : 'Refresh now'}
+					title={isFetching ? 'Refreshing…' : 'Refresh now'}
+					className="rounded-l-none"
+				>
+					<RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/src/features/instance/status/analytics/context/timePresets.test.ts
+++ b/src/features/instance/status/analytics/context/timePresets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_PRESET_ID,
 	DEFAULT_REFRESH_MS,
+	formatBucketLabel,
 	getPreset,
 	PANEL_POINT_TARGET,
 	REFRESH_OPTIONS,
@@ -119,6 +120,29 @@ describe('timePresets', () => {
 
 	it('default refresh is at least 30s — the SRE review pushed back on a 15s default', () => {
 		expect(DEFAULT_REFRESH_MS).toBeGreaterThanOrEqual(30_000);
+	});
+});
+
+describe('formatBucketLabel', () => {
+	it('formats minutes and hours, singular vs plural', () => {
+		expect(formatBucketLabel(60_000)).toBe('1 minute');
+		expect(formatBucketLabel(2 * 60_000)).toBe('2 minutes');
+		expect(formatBucketLabel(10 * 60_000)).toBe('10 minutes');
+		expect(formatBucketLabel(60 * 60_000)).toBe('1 hour');
+		expect(formatBucketLabel(4 * 60 * 60_000)).toBe('4 hours');
+	});
+
+	it('renders every shipped preset bucket as a clean minute/hour phrase', () => {
+		// No preset should surface a raw-ms fallback in the picker.
+		for (const p of TIME_PRESETS) {
+			expect(formatBucketLabel(p.bucketMs), p.id).toMatch(/^\d+ (minute|hour)s?$/);
+			expect(formatBucketLabel(p.expandedBucketMs), `${p.id} expanded`).toMatch(/^\d+ (minute|hour)s?$/);
+		}
+	});
+
+	it('falls back to seconds / ms only for odd values', () => {
+		expect(formatBucketLabel(30_000)).toBe('30 seconds');
+		expect(formatBucketLabel(1500)).toBe('1500 ms');
 	});
 });
 

--- a/src/features/instance/status/analytics/context/timePresets.ts
+++ b/src/features/instance/status/analytics/context/timePresets.ts
@@ -45,6 +45,20 @@ export function getPreset(id: TimePresetId): TimePreset {
 	return p;
 }
 
+/** Human phrase for a bucket duration — "1 minute", "10 minutes", "4 hours".
+ *  Drives the "by X" sub-label under each range option so the operator can see
+ *  the resolution a window renders at (the server ignores our `bucket_ms`, so
+ *  the panel resolution is `targetBucketMs`, i.e. the preset's `bucketMs`).
+ *  Every shipped bucket is a whole number of minutes or hours; the seconds /
+ *  raw-ms branches are just defensive for a future odd value. */
+export function formatBucketLabel(bucketMs: number): string {
+	const plural = (n: number, unit: string) => `${n} ${unit}${n === 1 ? '' : 's'}`;
+	if (bucketMs >= HOUR && bucketMs % HOUR === 0) { return plural(bucketMs / HOUR, 'hour'); }
+	if (bucketMs >= MIN && bucketMs % MIN === 0) { return plural(bucketMs / MIN, 'minute'); }
+	if (bucketMs >= 1000 && bucketMs % 1000 === 0) { return plural(bucketMs / 1000, 'second'); }
+	return `${bucketMs} ms`;
+}
+
 /**
  * Densest bucket the charts should *render* for a window of `windowMs`.
  *


### PR DESCRIPTION
**Stacked on #1588** (base is `claude/status-bucket-density`, not `stage`). The resolution labels only make sense with the recalibrated bucket sizes #1588 introduces, so this must land after it. Review #1588 first; the diff here is only this branch's one commit. Retarget to `stage` once #1588 merges.

Two clarity fixes to the Status toolbar, both about the picker being read as something it isn't.

<img width="515" height="323" alt="Screenshot 2026-07-29 at 5 06 52 PM" src="https://github.com/user-attachments/assets/ba31ee56-4ceb-43de-a59b-1a932047f732" />


## 1. Group the auto-refresh interval with the refresh button

The interval dropdown sat as a bare `Select` beside the range picker, at the same gap and the same weight — so `60s` read as a second *time* setting (a chart granularity) rather than "re-fetch every 60s". It's now one bordered control: the interval select and the refresh-now button share a border/background, split by a hairline divider, and the row gap widens (2 → 3) so the grouping reads by spacing too.

Also adds `role="group"` and an `aria-label="Auto-refresh interval"` on the interval select, which was previously unlabeled.

## 2. Show the render resolution under each range

Each option — and the collapsed trigger — now carries a second line, e.g.:

```
Last 24 hours
by 10 minutes
```

After #1588's recalibration the bucket size *is* the resolution you're looking at: the server ignores our `bucket_ms` (harper#1997), so the client folds every series to `targetBucketMs`, which equals the preset's `bucketMs`. Surfacing it answers "how coarse is this line?" without opening anything.

- `formatBucketLabel(bucketMs)` in `timePresets.ts` renders "1 minute" / "10 minutes" / "4 hours" (unit-tested across every shipped preset + expanded bucket, so none surface a raw-ms fallback).
- A shared `RangeLabel` keeps the trigger and the options identical.
- The trigger goes `h-auto min-h-9` so the two lines aren't clipped by the default `h-9`, with explicit `SelectValue` children — a bare `<SelectValue/>` mirrors the selected option's whole subtree into the trigger.

## Verification

Component tests assert the grouping (interval + refresh inside the `group`, range picker outside it) and that the trigger shows `by 10 minutes` for the 24h preset. `formatBucketLabel` is unit-tested.

Layout/theme verified by injecting the exact markup with the app's real compiled CSS and screenshotting light + dark — the two-line trigger doesn't clip and the refresh group reads as one joined control in both. I did this rather than the live authenticated toolbar because the preview browser wasn't signed in, and I don't sign in on anyone's behalf; the injected-DOM repro is the repo's documented fallback for CSS-only changes.

Full gate green: 1929 tests / 266 files, `tsc -b`, `oxlint`, `dprint check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
