### PR TITLE
fix(monaco): keep the config editor from linking Monaco into an eager chunk

### DIFF
--- a/src/features/instance/config/overview/harper-config/configMonaco.ts
+++ b/src/features/instance/config/overview/harper-config/configMonaco.ts
@@ -14,7 +14,6 @@
  * exports map, so we can't import the schema file directly; refresh the copy
  * when the bundled harper version changes its config schema.
  */
-import { json } from '@/lib/monaco/languageServices';
 import configRootSchemaRaw from './configRootSchema.json?raw';
 
 const configRootSchema = JSON.parse(configRootSchemaRaw);
@@ -35,8 +34,22 @@ const SCHEMA_URI = 'harper://schemas/config-root.json';
  * `beforeMount`. By `onMount` the JSON language is initialized, so the
  * registration sticks. The guard keys off the already-registered schema URI,
  * so repeated mounts (and HMR) are no-ops.
+ *
+ * The JSON language-service defaults are reached through a dynamic `import()`
+ * rather than a top-level one, so this module — which the config route imports
+ * eagerly — never links Monaco into an eager chunk. That matters beyond bundle
+ * size: each `monaco-editor/languages/features/<lang>/register` entry has
+ * registration side effects, and evaluating one at boot builds Monaco's service
+ * collection before `monaco-editor/features/register.all` (loaded with the lazy
+ * `@/lib/monaco/setup`) has registered its singletons. Monaco builds that
+ * collection once, so the late registrations are ignored and every editor then
+ * throws "[createInstance] … depends on UNKNOWN service …" for the five
+ * services backing code lens, inlay hints, suggest memory, the code-action
+ * widget, and tree-view DnD (#1592). By `onMount` Monaco is already loaded, so
+ * this resolves from the module cache.
  */
-export function configureHarperConfigEditor(): void {
+export async function configureHarperConfigEditor(): Promise<void> {
+	const { json } = await import('@/lib/monaco/languageServices');
 	const jsonDefaults = json.jsonDefaults;
 	const { schemas = [], ...rest } = jsonDefaults.diagnosticsOptions;
 

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -153,7 +153,9 @@ export function ConfigOverviewIndex() {
 	}, [configurationInfo]);
 
 	const handleEditorDidMount = useCallback<OnMount>(() => {
-		configureHarperConfigEditor();
+		// Registers the config JSON Schema; deliberately not awaited (`OnMount` is
+		// sync, and the editor is usable while the schema lands a microtask later).
+		void configureHarperConfigEditor();
 	}, []);
 
 	const handleSave = useCallback(() => {

--- a/src/features/instance/config/overview/index.tsx
+++ b/src/features/instance/config/overview/index.tsx
@@ -155,7 +155,15 @@ export function ConfigOverviewIndex() {
 	const handleEditorDidMount = useCallback<OnMount>(() => {
 		// Registers the config JSON Schema; deliberately not awaited (`OnMount` is
 		// sync, and the editor is usable while the schema lands a microtask later).
-		void configureHarperConfigEditor();
+		// Catch rather than leave it floating: the dynamic import can reject when a
+		// hashed chunk is gone after a redeploy, and an unhandled rejection would say
+		// nothing about which editor lost its schema. Recovery for that case is
+		// already global (`vite:preloadError` → `reportPossibleStaleDeploy`); this
+		// only reports the degradation — config editing still works, without
+		// validation or key autocomplete.
+		configureHarperConfigEditor().catch((error: unknown) => {
+			console.error('Failed to register the Harper config JSON Schema:', error);
+		});
 	}, []);
 
 	const handleSave = useCallback(() => {


### PR DESCRIPTION
Fixes #1592.

## Problem

Since production moved to v2.156.4 (~2026-07-29 23:04 UTC), **every editor-creating page load
throws five unhandled errors**:

```
[createInstance] um depends on UNKNOWN service actionWidgetService.
[createInstance] Fm depends on UNKNOWN service ICodeLensCache.
[createInstance] tb depends on UNKNOWN service IInlayHintsCache.
[createInstance] Lk depends on UNKNOWN service ISuggestMemories.
[createInstance] _x depends on UNKNOWN service treeViewsDndService.
```

RUM, last 24h, `env:prod`: **195 events** (39 of each — exactly five per load), 13 sessions,
11 distinct users, all `unhandled`. **Zero** in the previous seven days. The five services back
code lens, inlay hints, suggest-memory ranking, the code-action/lightbulb widget, and tree-view
drag-and-drop, so those are silently degraded in the editor.

This is not new code in v2.156.4 (that release only added RUM filtering). Production's previous
version was v2.154.3, and the monaco-editor 0.55.1 → 0.56.0 upgrade first shipped in v2.154.9 —
v2.156.4 is simply the first production release carrying it.

## Root cause

The five `registerSingleton` calls come from `monaco-editor/features/register.all`, reached only
via `@/lib/monaco/setup`, which `MonacoEditor.tsx` loads behind `React.lazy` — so they live in a
lazy chunk.

But `configMonaco.ts` imported `@/lib/monaco/languageServices` at the top level, and the config
route imports `configMonaco` eagerly. `languageServices` re-exports
`monaco-editor/languages/features/{json,typescript}/register`, which have registration side
effects and statically pull in Monaco's core. So the eager entry chunk contained:

```
esm/vs/languages/features/json/register.js
esm/vs/languages/features/typescript/register.js
esm/vs/languages/features/typescript/lib/typescriptServicesMetadata.js
```

Monaco therefore built its standalone service collection at app boot — before `register.all` had
evaluated. It builds that collection **once**, so the later `registerSingleton` calls were ignored,
and every contribution depending on those five services failed to instantiate.

Only production builds were affected: dev does no chunk splitting, so the registrations always ran
in `setup.ts`'s import order. That's why this reached production uncaught.

## Change

Reach the JSON language-service defaults through a dynamic `import()` inside
`configureHarperConfigEditor` rather than at module top level. It is called from the editor's
`onMount`, so Monaco is already loaded and the import resolves from the module cache.

This restores the invariant `MonacoEditor.tsx` documents — *"the bundler never links Monaco into
an eager chunk"* — which is exactly what guarantees `register.all` evaluates before anything
initializes the service collection.

## Verification

Measured on the built output (`npx vite build`), comparing the entry chunk's **static import
closure**:

| | before | after |
|---|---|---|
| `editor.api` in eager closure | **yes** | **no** |
| Monaco modules in eager chunks | 650 | 5 |
| eager critical path | 4423 kB | **1824 kB** |

The pre-fix build reproduces production's exact chunk hash (`editor.api-OBQnf1nL.js`), confirming
it matches what production served. The five Monaco modules still eager afterwards are the
standalone JSON tokenizer used by `workerFreeJsonLanguage.ts` — no DI, and they do not reach
`editor.api`, so they cannot initialize the service collection.

Also green: `npx tsc -b`, `npx oxlint`, `npx dprint check`, and `npx vitest run`
(264 files / 1983 tests passed).

## Follow-up

This regressed silently and only in production builds. Worth a build-time assertion that
`editor.api-*.js` never enters the entry chunk's static import closure — noted in #1592 rather
than bundled into this fix.
