### PR TITLE
fix(rum): drop private-repo SSH deploy failures from Error Tracking, redact repo URLs

### DIFF
--- a/src/features/instance/applications/components/DeployProgress/DeployProgress.test.tsx
+++ b/src/features/instance/applications/components/DeployProgress/DeployProgress.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { DeployProgress } from '@/features/instance/applications/components/DeployProgress/DeployProgress';
+import { DeploymentStreamState } from '@/features/instance/applications/components/DeployProgress/useDeploymentStream';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Only routing is stubbed (no RouterProvider in this unit test); the link target is built by the
+// real `buildAbsoluteLinkToPage` from these params.
+vi.mock('@tanstack/react-router', () => ({
+	Link: ({ children, to, onClick }: { children?: ReactNode; to?: string; onClick?: () => void }) => (
+		<a href={to} onClick={onClick}>{children}</a>
+	),
+	useParams: () => ({ organizationId: 'org-1', instanceId: 'ins-1' }),
+}));
+
+const SSH_FAILURE = 'Failed to deploy private repository git@github.com:acme-corp/billing-service.git: SSH access '
+	+ 'failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to '
+	+ 'the target repository, and confirm the host is present in the ssh/known_hosts file.';
+
+function failedState(error: string): DeploymentStreamState {
+	return { lifecycle: 'error', phases: { prepare: 'error' }, installLog: [], peers: [], error };
+}
+
+afterEach(cleanup);
+
+describe('DeployProgress', () => {
+	it("shows Harper's guidance and a link to SSH keys when a private repo deploy fails on SSH", () => {
+		render(<DeployProgress state={failedState(SSH_FAILURE)} />);
+
+		expect(screen.getByText(SSH_FAILURE)).toBeTruthy();
+		expect(screen.getByRole('link', { name: 'Manage SSH keys' }).getAttribute('href'))
+			.toBe('/org-1/instance/ins-1/config/ssh-keys');
+	});
+
+	it('lets a hosting modal close itself before the guidance link navigates', () => {
+		const onNavigateAway = vi.fn();
+		render(<DeployProgress state={failedState(SSH_FAILURE)} onNavigateAway={onNavigateAway} />);
+
+		fireEvent.click(screen.getByRole('link', { name: 'Manage SSH keys' }));
+		expect(onNavigateAway).toHaveBeenCalledOnce();
+	});
+
+	it('does not offer SSH guidance for unrelated deploy failures', () => {
+		render(<DeployProgress state={failedState('npm install failed with exit code 1')} />);
+
+		expect(screen.getByText('npm install failed with exit code 1')).toBeTruthy();
+		expect(screen.queryByRole('link', { name: 'Manage SSH keys' })).toBeNull();
+	});
+});

--- a/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
+++ b/src/features/instance/applications/components/DeployProgress/DeployProgress.tsx
@@ -4,6 +4,8 @@ import { Separator } from '@/components/ui/separator';
 import { DEPLOY_PHASE_ORDER } from '@/integrations/api/instance/applications/deployComponentStream';
 import { cn } from '@/lib/cn';
 import { errorText } from '@/lib/errorText';
+import { buildAbsoluteLinkToPage } from '@/lib/urls/buildAbsoluteLinkToPage';
+import { Link, useParams } from '@tanstack/react-router';
 import { CheckIcon, CircleDashedIcon, CircleIcon, Loader2Icon, XIcon } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { DeploymentStreamState, PhaseStatus } from './useDeploymentStream';
@@ -15,6 +17,16 @@ const PHASE_LABELS: Record<string, string> = {
 	restart: 'Restart',
 	success: 'Finish',
 };
+
+/**
+ * A deploy that failed because the *instance* couldn't reach a private repository over SSH is
+ * fixed in Config > SSH Keys (install a key, grant it access to the repo, add the git host to
+ * `known_hosts`), so link the user there instead of leaving them to find it. Harper's message
+ * already spells out the remediation, and this UI is now the only place the failure surfaces:
+ * it's an instance configuration state, not a Studio bug, so `shouldKeepEvent` drops the RUM
+ * event (which also kept the customer's private repo URL out of Error Tracking).
+ */
+const SSH_ACCESS_FAILURE = /Failed to deploy private repository\b|SSH access failed/i;
 
 function PhaseIcon({ status, isCurrent }: { status?: PhaseStatus; isCurrent: boolean }) {
 	if (status === 'done') {
@@ -30,8 +42,16 @@ function PhaseIcon({ status, isCurrent }: { status?: PhaseStatus; isCurrent: boo
 }
 
 /** Renders live `deploy_component` progress: phase checklist, install log tail, peer results. */
-export function DeployProgress({ state }: { state: DeploymentStreamState }) {
+export function DeployProgress({
+	state,
+	onNavigateAway,
+}: {
+	state: DeploymentStreamState;
+	/** Called when a guidance link navigates away — lets a hosting modal close itself first. */
+	onNavigateAway?: () => void;
+}) {
 	const logEndRef = useRef<HTMLDivElement>(null);
+	const params: { clusterId?: string; instanceId?: string; organizationId?: string } = useParams({ strict: false });
 
 	useEffect(() => {
 		logEndRef.current?.scrollIntoView({ block: 'end' });
@@ -103,9 +123,20 @@ export function DeployProgress({ state }: { state: DeploymentStreamState }) {
 			)}
 
 			{phasesFailed && state.error && (
-				<div className="flex items-start gap-2 text-sm text-destructive">
-					<CircleIcon className="mt-0.5 size-4 shrink-0" />
-					<span>{state.error}</span>
+				<div className="flex flex-col gap-2 text-sm text-destructive">
+					<div className="flex items-start gap-2">
+						<CircleIcon className="mt-0.5 size-4 shrink-0" />
+						<span>{state.error}</span>
+					</div>
+					{SSH_ACCESS_FAILURE.test(state.error) && (
+						<Link
+							to={buildAbsoluteLinkToPage(params, 'config/ssh-keys')}
+							onClick={onNavigateAway}
+							className="self-start pl-6 underline"
+						>
+							Manage SSH keys
+						</Link>
+					)}
 				</div>
 			)}
 

--- a/src/features/instance/applications/modals/RedeployApplicationModal.tsx
+++ b/src/features/instance/applications/modals/RedeployApplicationModal.tsx
@@ -169,7 +169,7 @@ export function RedeployApplicationModal() {
 				{isStreaming
 					? (
 						<div className="flex flex-col gap-4">
-							<DeployProgress state={stream.state} />
+							<DeployProgress state={stream.state} onNavigateAway={closeModal} />
 							<Button
 								type="button"
 								variant="ghostOutline"

--- a/src/integrations/datadog/beforeSend.test.ts
+++ b/src/integrations/datadog/beforeSend.test.ts
@@ -27,6 +27,25 @@ describe('beforeSend', () => {
 		].join('\n'));
 	});
 
+	it('redacts the repository path from the resource URL of a failed lookup', () => {
+		const event = errorEvent({
+			message: 'Request failed with status code 404',
+			resource: { url: 'https://api.github.com/repos/acme-corp/billing-service' },
+		});
+		expect(beforeSend(event)).toBe(true);
+		expect(event.error?.resource?.url).toBe('https://api.github.com/<redacted>');
+	});
+
+	// The endpoint is the whole point of a kept 5xx/network error, and it is Harper's own host.
+	it('leaves an instance operation endpoint in the resource URL intact', () => {
+		const event = errorEvent({
+			message: 'Request failed with status code 403',
+			resource: { url: 'https://api.harper.fast/HDBInstance/ins-1/operation' },
+		});
+		expect(beforeSend(event)).toBe(true);
+		expect(event.error?.resource?.url).toBe('https://api.harper.fast/HDBInstance/ins-1/operation');
+	});
+
 	// The third-party attribution in `shouldKeepEvent` reads the raw stack, so filtering has to
 	// happen before redaction could rewrite any frame in it.
 	it('filters on the original stack rather than a redacted one', () => {

--- a/src/integrations/datadog/beforeSend.test.ts
+++ b/src/integrations/datadog/beforeSend.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { beforeSend } from './beforeSend';
+import { DatadogErrorEvent } from './shouldKeepEvent';
+
+function errorEvent(error: DatadogErrorEvent['error']): DatadogErrorEvent {
+	return { type: 'error', error };
+}
+
+describe('beforeSend', () => {
+	it('drops the events shouldKeepEvent rejects', () => {
+		expect(beforeSend(errorEvent({ message: 'AxiosError: Request failed with status code 401' }))).toBe(false);
+	});
+
+	it('redacts the repository path from a kept error message and stack', () => {
+		const event = errorEvent({
+			message: 'Failed to deploy git@github.com:acme-corp/billing-service.git: npm install failed',
+			stack: [
+				'Error: Failed to deploy git@github.com:acme-corp/billing-service.git',
+				'  at deployComponentStream @ https://fabric.harper.fast/assets/index-A1b2C3d4.js:5:1234',
+			].join('\n'),
+		});
+		expect(beforeSend(event)).toBe(true);
+		expect(event.error?.message).toBe('Failed to deploy git@github.com:<redacted>: npm install failed');
+		expect(event.error?.stack).toBe([
+			'Error: Failed to deploy git@github.com:<redacted>',
+			'  at deployComponentStream @ https://fabric.harper.fast/assets/index-A1b2C3d4.js:5:1234',
+		].join('\n'));
+	});
+
+	// The third-party attribution in `shouldKeepEvent` reads the raw stack, so filtering has to
+	// happen before redaction could rewrite any frame in it.
+	it('filters on the original stack rather than a redacted one', () => {
+		expect(
+			beforeSend(
+				errorEvent({
+					message: 'Failed to fetch',
+					stack: [
+						'TypeError: Failed to fetch',
+						'  at <anonymous> @ https://static.reo.dev/6565c3e84c377ad/reo.js:2:188638',
+					].join('\n'),
+				}),
+			),
+		).toBe(false);
+	});
+
+	it('passes non-error events through untouched', () => {
+		expect(beforeSend({ type: 'view' })).toBe(true);
+	});
+});

--- a/src/integrations/datadog/beforeSend.ts
+++ b/src/integrations/datadog/beforeSend.ts
@@ -5,10 +5,16 @@ import { DatadogErrorEvent, shouldKeepEvent } from './shouldKeepEvent';
  * Datadog RUM's `beforeSend` hook: decide whether the event is worth reporting
  * (`shouldKeepEvent`), then redact sensitive text from the ones we keep (`redactErrorText`).
  *
- * The order matters — the filter attributes errors by inspecting the raw stack, so it has to
- * run before any URL in that stack is rewritten. Mutating `error.message`/`error.stack` in
- * `beforeSend` is supported by the browser SDK (both are on its editable-property list), and
- * only affects what is reported: the UI renders the error object itself, untouched.
+ * The order matters — the filter attributes errors by inspecting the raw stack and the raw
+ * resource URL, so it has to run before either is rewritten. Mutating `error.message`,
+ * `error.stack` and `error.resource.url` in `beforeSend` is supported by the browser SDK (all
+ * three are on its editable-property list for error events), and only affects what is reported:
+ * the UI renders the error object itself, untouched.
+ *
+ * `error.resource.url` is redacted alongside the text because a failed request carries the same
+ * identity in a different field — `getGitHubRepo` fetches
+ * `https://api.github.com/repos/<owner>/<repo>`, so a 404 on a private repo would otherwise ship
+ * the repo name verbatim while the message beside it is redacted.
  */
 export function beforeSend(event: DatadogErrorEvent) {
 	if (!shouldKeepEvent(event)) {
@@ -21,6 +27,9 @@ export function beforeSend(event: DatadogErrorEvent) {
 		}
 		if (error.stack) {
 			error.stack = redactErrorText(error.stack);
+		}
+		if (error.resource?.url) {
+			error.resource.url = redactErrorText(error.resource.url);
 		}
 	}
 	return true;

--- a/src/integrations/datadog/beforeSend.ts
+++ b/src/integrations/datadog/beforeSend.ts
@@ -1,0 +1,27 @@
+import { redactErrorText } from './redactErrorText';
+import { DatadogErrorEvent, shouldKeepEvent } from './shouldKeepEvent';
+
+/**
+ * Datadog RUM's `beforeSend` hook: decide whether the event is worth reporting
+ * (`shouldKeepEvent`), then redact sensitive text from the ones we keep (`redactErrorText`).
+ *
+ * The order matters — the filter attributes errors by inspecting the raw stack, so it has to
+ * run before any URL in that stack is rewritten. Mutating `error.message`/`error.stack` in
+ * `beforeSend` is supported by the browser SDK (both are on its editable-property list), and
+ * only affects what is reported: the UI renders the error object itself, untouched.
+ */
+export function beforeSend(event: DatadogErrorEvent) {
+	if (!shouldKeepEvent(event)) {
+		return false;
+	}
+	const error = event.error;
+	if (error) {
+		if (error.message) {
+			error.message = redactErrorText(error.message);
+		}
+		if (error.stack) {
+			error.stack = redactErrorText(error.stack);
+		}
+	}
+	return true;
+}

--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -1,6 +1,6 @@
 import { isLocalStudio } from '@/config/constants';
 import { useOverallAuth } from '@/hooks/useAuth';
-import { shouldKeepEvent } from '@/integrations/datadog/shouldKeepEvent';
+import { beforeSend } from '@/integrations/datadog/beforeSend';
 import { translateUrlForDatadog } from '@/integrations/datadog/translateUrlForDatadog';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { isLocalUser } from '@/lib/types/isLocalUser';
@@ -33,7 +33,7 @@ export function useDatadog() {
 				trackViewsManually: true,
 				trackUserInteractions: true,
 
-				beforeSend: shouldKeepEvent,
+				beforeSend,
 
 				sessionSampleRate: 100,
 				sessionReplaySampleRate: 0,

--- a/src/integrations/datadog/redactErrorText.test.ts
+++ b/src/integrations/datadog/redactErrorText.test.ts
@@ -8,6 +8,9 @@ describe('redactErrorText', () => {
 		// Host aliases are how a customer selects between multiple keys (#1318) — keep them.
 		expect(redactErrorText('git@github-work:acme-corp/internal.git not found'))
 			.toBe('git@github-work:<redacted> not found');
+		// A bare SSH server has no owner prefix; the `.git` suffix is the tell.
+		expect(redactErrorText('Failed to deploy git@server.example.com:billing-service.git: exit code 128'))
+			.toBe('Failed to deploy git@server.example.com:<redacted>: exit code 128');
 	});
 
 	it('redacts the path of a repository URL, keeping scheme and host', () => {

--- a/src/integrations/datadog/redactErrorText.test.ts
+++ b/src/integrations/datadog/redactErrorText.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { redactErrorText } from './redactErrorText';
+
+describe('redactErrorText', () => {
+	it('redacts the path of an scp-style git remote, keeping user and host', () => {
+		expect(redactErrorText('Failed to deploy git@github.com:acme-corp/billing-service.git: exit code 128'))
+			.toBe('Failed to deploy git@github.com:<redacted>: exit code 128');
+		// Host aliases are how a customer selects between multiple keys (#1318) — keep them.
+		expect(redactErrorText('git@github-work:acme-corp/internal.git not found'))
+			.toBe('git@github-work:<redacted> not found');
+	});
+
+	it('redacts the path of an https/ssh repository URL, keeping scheme and host', () => {
+		expect(redactErrorText('Cannot clone https://github.com/acme-corp/billing-service'))
+			.toBe('Cannot clone https://github.com/<redacted>');
+		expect(redactErrorText('Cannot clone ssh://git@source.example.com/acme/repo'))
+			.toBe('Cannot clone ssh://source.example.com/<redacted>');
+		// A self-hosted forge under the conventional `git.` prefix, and a `.git` path anywhere.
+		expect(redactErrorText('https://git.acme-corp.com/team/app failed'))
+			.toBe('https://git.acme-corp.com/<redacted> failed');
+		expect(redactErrorText('https://build.example.com/acme/app.git failed'))
+			.toBe('https://build.example.com/<redacted> failed');
+	});
+
+	it('drops the query and fragment of a repository URL, which can name a private branch', () => {
+		expect(redactErrorText('https://github.com/acme-corp/app.git?ref=feature/pricing#v2 failed'))
+			.toBe('https://github.com/<redacted> failed');
+	});
+
+	it('keeps sentence punctuation that follows a URL outside the redaction', () => {
+		expect(
+			redactErrorText(
+				'Failed to deploy private repository https://github.com/acme-corp/app.git: SSH access failed.',
+			),
+		).toBe('Failed to deploy private repository https://github.com/<redacted>: SSH access failed.');
+	});
+
+	it('strips credentials embedded in any URL, repository or not', () => {
+		expect(redactErrorText('POST https://acme:ghp_secret@github.com/acme-corp/app.git failed'))
+			.toBe('POST https://github.com/<redacted> failed');
+		expect(redactErrorText('POST https://user:hunter2@api.harper.fast/HDBInstance/ins-1/operation failed'))
+			.toBe('POST https://api.harper.fast/HDBInstance/ins-1/operation failed');
+	});
+
+	it('leaves Harper API endpoints and Studio asset URLs intact, so errors stay triageable', () => {
+		const message = 'Request failed with status code 500 https://api.harper.fast/HDBInstance/ins-123/operation';
+		expect(redactErrorText(message)).toBe(message);
+		const stack = [
+			'TypeError: x is not a function',
+			'  at getOrganization @ https://fabric.harper.fast/assets/index-A1b2C3d4.js:5:1234',
+			'  at pn @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3396',
+		].join('\n');
+		expect(redactErrorText(stack)).toBe(stack);
+	});
+
+	it('leaves ordinary error text alone', () => {
+		expect(redactErrorText('AxiosError: timeout of 60000ms exceeded'))
+			.toBe('AxiosError: timeout of 60000ms exceeded');
+		// An email followed by a colon must not be mistaken for an scp-style remote.
+		expect(redactErrorText('dawson@harperdb.io: sign-in failed')).toBe('dawson@harperdb.io: sign-in failed');
+		expect(redactErrorText('not-a-url://')).toBe('not-a-url://');
+	});
+});

--- a/src/integrations/datadog/redactErrorText.test.ts
+++ b/src/integrations/datadog/redactErrorText.test.ts
@@ -10,19 +10,40 @@ describe('redactErrorText', () => {
 			.toBe('git@github-work:<redacted> not found');
 	});
 
-	it('redacts the path of an https/ssh repository URL, keeping scheme and host', () => {
+	it('redacts the path of a repository URL, keeping scheme and host', () => {
 		expect(redactErrorText('Cannot clone https://github.com/acme-corp/billing-service'))
 			.toBe('Cannot clone https://github.com/<redacted>');
 		expect(redactErrorText('Cannot clone ssh://git@source.example.com/acme/repo'))
 			.toBe('Cannot clone ssh://source.example.com/<redacted>');
-		// A self-hosted forge under the conventional `git.` prefix, and a `.git` path anywhere.
-		expect(redactErrorText('https://git.acme-corp.com/team/app failed'))
-			.toBe('https://git.acme-corp.com/<redacted> failed');
 		expect(redactErrorText('https://build.example.com/acme/app.git failed'))
 			.toBe('https://build.example.com/<redacted> failed');
+		// npm/pip-style `git+<transport>` remotes parse as their own protocol; keep it in the output.
+		expect(redactErrorText('Cannot clone git+https://custom-forge.com/acme/repo'))
+			.toBe('Cannot clone git+https://custom-forge.com/<redacted>');
+		expect(redactErrorText('Cannot clone git+ssh://git@custom-forge.com/acme/repo.git'))
+			.toBe('Cannot clone git+ssh://custom-forge.com/<redacted>');
 	});
 
-	it('drops the query and fragment of a repository URL, which can name a private branch', () => {
+	// The gap that made "is this a repository?" the wrong question: a self-hosted forge under a
+	// name that says nothing about git, with no `.git` suffix, is exactly the enterprise setup
+	// whose repo names we most need to keep out of Datadog.
+	it('redacts a self-hosted forge under a custom domain, including nested group paths', () => {
+		expect(redactErrorText('Failed to deploy https://scm.acme-corp.com/acme-corp/billing-service: 404 not found'))
+			.toBe('Failed to deploy https://scm.acme-corp.com/<redacted>: 404 not found');
+		expect(redactErrorText('https://code.acme.io/platform/payments/billing-service failed'))
+			.toBe('https://code.acme.io/<redacted> failed');
+	});
+
+	// Studio looks the repo up itself while the deploy form is filled in (`getGitHubRepo`), so
+	// the same owner/name reaches Datadog through a plain API URL, not a git remote.
+	it('redacts the repository lookups Studio makes on the customer’s behalf', () => {
+		expect(redactErrorText('Request failed with status code 404 https://api.github.com/repos/acme-corp/billing'))
+			.toBe('Request failed with status code 404 https://api.github.com/<redacted>');
+		expect(redactErrorText('https://registry.npmjs.org/@acme-corp/internal-component failed'))
+			.toBe('https://registry.npmjs.org/<redacted> failed');
+	});
+
+	it('drops the query and fragment of a redacted URL, which can name a private branch', () => {
 		expect(redactErrorText('https://github.com/acme-corp/app.git?ref=feature/pricing#v2 failed'))
 			.toBe('https://github.com/<redacted> failed');
 	});
@@ -35,7 +56,7 @@ describe('redactErrorText', () => {
 		).toBe('Failed to deploy private repository https://github.com/<redacted>: SSH access failed.');
 	});
 
-	it('strips credentials embedded in any URL, repository or not', () => {
+	it('strips credentials embedded in any URL, Harper-hosted or not', () => {
 		expect(redactErrorText('POST https://acme:ghp_secret@github.com/acme-corp/app.git failed'))
 			.toBe('POST https://github.com/<redacted> failed');
 		expect(redactErrorText('POST https://user:hunter2@api.harper.fast/HDBInstance/ins-1/operation failed'))
@@ -45,12 +66,21 @@ describe('redactErrorText', () => {
 	it('leaves Harper API endpoints and Studio asset URLs intact, so errors stay triageable', () => {
 		const message = 'Request failed with status code 500 https://api.harper.fast/HDBInstance/ins-123/operation';
 		expect(redactErrorText(message)).toBe(message);
+		// Subdomains of a Harper domain count, which is what keeps Datadog's source maps — matched
+		// on the frame's URL — pointing at real Studio code.
 		const stack = [
 			'TypeError: x is not a function',
 			'  at getOrganization @ https://fabric.harper.fast/assets/index-A1b2C3d4.js:5:1234',
-			'  at pn @ https://fabric.harper.fast/assets/vendor-datadog-DBn-aOxh.js:3:3396',
+			'  at pn @ https://stage.studio.harperfabric.com/assets/vendor-datadog-DBn-aOxh.js:3:3396',
 		].join('\n');
 		expect(redactErrorText(stack)).toBe(stack);
+	});
+
+	it('leaves a host with no path alone rather than inventing one', () => {
+		// A self-hosted instance the customer registered by URL: the host is already in the event,
+		// and there is no path to give away.
+		expect(redactErrorText('Network Error https://harper.acme.com:9925/'))
+			.toBe('Network Error https://harper.acme.com:9925/');
 	});
 
 	it('leaves ordinary error text alone', () => {

--- a/src/integrations/datadog/redactErrorText.ts
+++ b/src/integrations/datadog/redactErrorText.ts
@@ -37,11 +37,12 @@ const URL_TOKEN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s'"<>)\]]+/g;
 const TRAILING_PUNCTUATION = /[.,:;!?]+$/;
 
 /**
- * scp-style git remotes: `git@github.com:acme-corp/repo.git`. Requires both userinfo and a
- * `<segment>/<segment>` path, so ordinary "Title: detail" text and stack frames
+ * scp-style git remotes: `git@github.com:acme-corp/repo.git`. Requires userinfo and either a
+ * `<segment>/<segment>` path or a `.git`-suffixed single segment (a bare SSH server has no
+ * owner prefix), so ordinary "Title: detail" text and stack frames
  * (`index-A1b2C3d4.js:5:1234`) can't match.
  */
-const SCP_GIT_REMOTE = /([\w.+-]+@[\w.-]+):[\w.-]+\/[\w./-]+/g;
+const SCP_GIT_REMOTE = /([\w.+-]+@[\w.-]+):[\w.-]+(?:\/[\w./-]+|\.git\b)/g;
 
 function isHarperHost(hostname: string) {
 	return hostname === 'localhost'

--- a/src/integrations/datadog/redactErrorText.ts
+++ b/src/integrations/datadog/redactErrorText.ts
@@ -1,34 +1,34 @@
 /**
- * Strip customer-identifying git repository references — and any credentials embedded in a
- * URL — out of error text before it leaves the browser for Datadog.
+ * Strip customer-identifying URL paths — and any credentials embedded in a URL — out of error
+ * text before it leaves the browser for Datadog.
  *
  * Deploy failures quote the `package` reference the customer entered, so a message like
  * "Failed to deploy git@github.com:acme-corp/billing-service.git: …" carries their private
  * repo's owner and name (and, for an https remote, sometimes a token in the userinfo) into
- * Error Tracking, where it is retained and searchable. The repo identity tells us nothing we
- * can debug with — the host does — so keep the host and drop the path.
+ * Error Tracking, where it is retained and searchable.
  *
- * Applied by `beforeSend` to `error.message` and `error.stack` of every event we keep. Studio's
- * own asset URLs and Harper API endpoints are deliberately left intact: stack frames and
- * `.../HDBInstance/<id>/operation` paths are how these errors get triaged.
+ * Deciding which URLs *are* repositories turned out to be the wrong way round: github.com and
+ * gitlab.com are the easy half, but a GitLab or Gitea self-hosted at `scm.acme-corp.com` looks
+ * like nothing in particular, and neither does the `https://api.github.com/repos/<owner>/<repo>`
+ * lookup Studio itself makes while the deploy form is filled in. No list of forges or hostname
+ * conventions ever finishes. Harper's own domains, by contrast, are a short list we control — so
+ * keep the path only for those, and reduce every other URL to scheme + host + `<redacted>`. The
+ * host is what we debug with; the path is where the customer's identity lives.
+ *
+ * Applied by `beforeSend` to `error.message`, `error.stack`, and `error.resource.url` of every
+ * event we keep. Harper API endpoints (`.../HDBInstance/<id>/operation`) and Studio's own asset
+ * URLs therefore stay intact: the first is how these errors get triaged, the second is what
+ * Datadog source-maps stack frames against.
  */
 
 const REDACTED = '<redacted>';
 
 /**
- * Hosts whose URL path *is* a repository identity. Self-hosted forges are matched by the
- * `git.`/`gitlab.`/`github.` hostname prefix convention instead of being enumerated.
+ * Registrable domains Harper owns. Studio itself, the central-manager API, and Fabric instances
+ * all sit under one of these. Matched by suffix, so a new subdomain or environment is covered
+ * without an edit here; `localhost` covers a locally registered instance.
  */
-const GIT_HOSTS = new Set([
-	'github.com',
-	'gitlab.com',
-	'bitbucket.org',
-	'dev.azure.com',
-	'ssh.dev.azure.com',
-	'codeberg.org',
-	'git.sr.ht',
-	'gitea.com',
-]);
+const HARPER_DOMAINS = ['harper.fast', 'harperfabric.com', 'harperdb.io'];
 
 /** URL-shaped tokens (`scheme://…`), ending at whitespace or enclosing punctuation. */
 const URL_TOKEN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s'"<>)\]]+/g;
@@ -43,12 +43,15 @@ const TRAILING_PUNCTUATION = /[.,:;!?]+$/;
  */
 const SCP_GIT_REMOTE = /([\w.+-]+@[\w.-]+):[\w.-]+\/[\w./-]+/g;
 
-function isRepositoryUrl(url: URL) {
-	return url.protocol === 'git:'
-		|| url.protocol === 'ssh:'
-		|| /\.git\/?$/.test(url.pathname)
-		|| GIT_HOSTS.has(url.hostname)
-		|| /^(?:git|gitlab|github)[.-]/.test(url.hostname);
+function isHarperHost(hostname: string) {
+	return hostname === 'localhost'
+		|| HARPER_DOMAINS.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+}
+
+/** A URL carries customer identity in everything after the host — unless the host is ours. */
+function carriesCustomerPath(url: URL) {
+	const hasPath = url.pathname.length > 1 || !!url.search || !!url.hash;
+	return hasPath && !isHarperHost(url.hostname);
 }
 
 function redactUrl(token: string) {
@@ -60,9 +63,10 @@ function redactUrl(token: string) {
 	} catch {
 		return token;
 	}
-	if (isRepositoryUrl(url)) {
+	if (carriesCustomerPath(url)) {
 		// Rebuild by hand rather than via `toString()`: this drops userinfo, query, and fragment
-		// (a `?ref=`/`#branch` can name a private branch) without normalizing the rest.
+		// (a `?ref=`/`#branch` can name a private branch) without normalizing the rest. `host`
+		// rather than `hostname`, so a non-default port survives.
 		return `${url.protocol}//${url.host}/${REDACTED}${trailing}`;
 	}
 	if (url.username || url.password) {
@@ -73,7 +77,7 @@ function redactUrl(token: string) {
 	return token;
 }
 
-/** Redact repository references and URL credentials in `text`. Returns it unchanged if none. */
+/** Redact non-Harper URL paths and URL credentials in `text`. Returns it unchanged if none. */
 export function redactErrorText(text: string) {
 	return text
 		.replace(URL_TOKEN, redactUrl)

--- a/src/integrations/datadog/redactErrorText.ts
+++ b/src/integrations/datadog/redactErrorText.ts
@@ -1,0 +1,81 @@
+/**
+ * Strip customer-identifying git repository references — and any credentials embedded in a
+ * URL — out of error text before it leaves the browser for Datadog.
+ *
+ * Deploy failures quote the `package` reference the customer entered, so a message like
+ * "Failed to deploy git@github.com:acme-corp/billing-service.git: …" carries their private
+ * repo's owner and name (and, for an https remote, sometimes a token in the userinfo) into
+ * Error Tracking, where it is retained and searchable. The repo identity tells us nothing we
+ * can debug with — the host does — so keep the host and drop the path.
+ *
+ * Applied by `beforeSend` to `error.message` and `error.stack` of every event we keep. Studio's
+ * own asset URLs and Harper API endpoints are deliberately left intact: stack frames and
+ * `.../HDBInstance/<id>/operation` paths are how these errors get triaged.
+ */
+
+const REDACTED = '<redacted>';
+
+/**
+ * Hosts whose URL path *is* a repository identity. Self-hosted forges are matched by the
+ * `git.`/`gitlab.`/`github.` hostname prefix convention instead of being enumerated.
+ */
+const GIT_HOSTS = new Set([
+	'github.com',
+	'gitlab.com',
+	'bitbucket.org',
+	'dev.azure.com',
+	'ssh.dev.azure.com',
+	'codeberg.org',
+	'git.sr.ht',
+	'gitea.com',
+]);
+
+/** URL-shaped tokens (`scheme://…`), ending at whitespace or enclosing punctuation. */
+const URL_TOKEN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s'"<>)\]]+/g;
+
+/** Sentence punctuation the token regex swallows when a URL ends a clause. */
+const TRAILING_PUNCTUATION = /[.,:;!?]+$/;
+
+/**
+ * scp-style git remotes: `git@github.com:acme-corp/repo.git`. Requires both userinfo and a
+ * `<segment>/<segment>` path, so ordinary "Title: detail" text and stack frames
+ * (`index-A1b2C3d4.js:5:1234`) can't match.
+ */
+const SCP_GIT_REMOTE = /([\w.+-]+@[\w.-]+):[\w.-]+\/[\w./-]+/g;
+
+function isRepositoryUrl(url: URL) {
+	return url.protocol === 'git:'
+		|| url.protocol === 'ssh:'
+		|| /\.git\/?$/.test(url.pathname)
+		|| GIT_HOSTS.has(url.hostname)
+		|| /^(?:git|gitlab|github)[.-]/.test(url.hostname);
+}
+
+function redactUrl(token: string) {
+	const trailing = TRAILING_PUNCTUATION.exec(token)?.[0] ?? '';
+	const bare = trailing ? token.slice(0, -trailing.length) : token;
+	let url: URL;
+	try {
+		url = new URL(bare);
+	} catch {
+		return token;
+	}
+	if (isRepositoryUrl(url)) {
+		// Rebuild by hand rather than via `toString()`: this drops userinfo, query, and fragment
+		// (a `?ref=`/`#branch` can name a private branch) without normalizing the rest.
+		return `${url.protocol}//${url.host}/${REDACTED}${trailing}`;
+	}
+	if (url.username || url.password) {
+		url.username = '';
+		url.password = '';
+		return `${url.toString()}${trailing}`;
+	}
+	return token;
+}
+
+/** Redact repository references and URL credentials in `text`. Returns it unchanged if none. */
+export function redactErrorText(text: string) {
+	return text
+		.replace(URL_TOKEN, redactUrl)
+		.replace(SCP_GIT_REMOTE, `$1:${REDACTED}`);
+}

--- a/src/integrations/datadog/shouldKeepEvent.test.ts
+++ b/src/integrations/datadog/shouldKeepEvent.test.ts
@@ -97,6 +97,32 @@ describe('shouldKeepEvent', () => {
 		expect(shouldKeepEvent(errorEvent({ message: 'Request failed with status code 4010' }))).toBe(true);
 	});
 
+	// The instance couldn't authenticate to the customer's private repo over SSH — an instance
+	// configuration state (no key, key without access, host missing from known_hosts), not a
+	// Studio bug. 8 events from one session in the 24h to 2026-07-30 opened an Error Tracking
+	// issue for it; the deploy UI already shows Harper's remediation text plus a link to
+	// Config > SSH Keys. Dropping it also keeps the embedded private repo URL out of Datadog.
+	it('discards private-repository deploy failures', () => {
+		expect(
+			shouldKeepEvent(
+				errorEvent({
+					message:
+						'Failed to deploy private repository git@github.com:acme-corp/billing-service.git: SSH access failed. '
+						+ 'Verify the repository URL, configure an SSH key on this Harper instance, ensure the key has access to '
+						+ 'the target repository, and confirm the host is present in the ssh/known_hosts file.',
+				}),
+			),
+		).toBe(false);
+		// Matched on the prefix, so a reworded remediation sentence still drops.
+		expect(
+			shouldKeepEvent(
+				errorEvent({ message: 'Failed to deploy private repository https://github.com/acme-corp/app: auth rejected' }),
+			),
+		).toBe(false);
+		// A public-package deploy failure is a different animal — keep it.
+		expect(shouldKeepEvent(errorEvent({ message: 'Failed to deploy component: invalid package' }))).toBe(true);
+	});
+
 	it('discards 5xx errors against an instance/cluster operation endpoint', () => {
 		expect(
 			shouldKeepEvent(

--- a/src/integrations/datadog/shouldKeepEvent.ts
+++ b/src/integrations/datadog/shouldKeepEvent.ts
@@ -141,6 +141,22 @@ export function shouldKeepEvent(event: DatadogErrorEvent) {
 		return false;
 	}
 
+	// Deploying a component from a private git repository fails when the *instance* can't
+	// authenticate to that repository over SSH: no key installed, a key without access to the
+	// repo, or a git host missing from the instance's `ssh/known_hosts`. Harper reports it as a
+	// terminal deploy error whose message is already pure remediation guidance ("configure an
+	// SSH key on this Harper instance, ensure the key has access to the target repository, …"),
+	// which the deploy UI surfaces verbatim — `DeployProgress` also links to Config > SSH Keys.
+	// Nothing in Studio can be fixed in response; like the 401s above it's an expected state of
+	// an instance the customer still has to configure, and it created an Error Tracking issue
+	// off 8 events from a single session in the 24h to 2026-07-30. Dropping it also keeps the
+	// private repo URL the message embeds (owner + repo name) out of Error Tracking entirely;
+	// `redactErrorText` is the backstop for repo URLs in deploy errors we do keep. Match on the
+	// prefix rather than the SSH sentence, so a reworded remediation still matches.
+	if (/Failed to deploy private repository\b/i.test(message)) {
+		return false;
+	}
+
 	const url = event.error?.resource?.url ?? '';
 	const isInstanceEndpoint = /\/(HDBInstance|Cluster)\/[^/]+\/operation/.test(url);
 


### PR DESCRIPTION
No linked issue: the RUM signal embeds a customer's private repository URL, so it was
deliberately not filed publicly. Details below use `acme-corp/billing-service` in place of
the real one.

## Problem

Deploying a component from a private git repository surfaces an `SSEOperationError` whose
message is Harper's:

```
Failed to deploy private repository git@github.com:acme-corp/billing-service.git: SSH access
failed. Verify the repository URL, configure an SSH key on this Harper instance, ensure the
key has access to the target repository, and confirm the host is present in the
ssh/known_hosts file.
```

RUM recorded **8 of these in the 24h to 2026-07-30** (`env:prod`, one customer, one session),
and Error Tracking opened an issue for them. Two things are wrong with that:

1. **It isn't a Studio bug.** Every remediation step in the message is on the *instance* —
   install an SSH key, grant it access to the repo, add the git host to the instance's
   `ssh/known_hosts`. Nothing in Studio changes in response, so the issue can only ever be
   closed as customer configuration.
2. **It carries customer-identifying data.** The message embeds the private repo's owner and
   name, which Error Tracking then retains and makes searchable.

## Treatment

**Drop the event** (`shouldKeepEvent`). This is the same class as the expected states already
dropped there — 401s, timeouts, instance-endpoint 5xx. Matched on the
`Failed to deploy private repository` prefix rather than the SSH remediation sentence, so a
reworded message still drops; a generic `Failed to deploy component: …` is still kept.

**Redact customer URL paths anyway** (`redactErrorText`, new). Dropping this message keeps
*this* URL out of Datadog, but other deploy failures that stay kept — a repo 404, a bad ref,
npm auth output — quote the same `package` reference, and the drop rule depends on Harper's
wording. So redaction is a backstop, not a substitute.

The first cut of it asked "is this URL a repository?" and answered with a forge list, a
`git.`/`gitlab.`/`github.` hostname convention, a `.git` suffix and a git protocol check.
Review found the holes, and they share a root — that list never finishes. A GitLab or Gitea
self-hosted at `scm.acme-corp.com` matches none of it; neither does a `git+https:` remote;
neither does `https://api.github.com/repos/<owner>/<repo>`, which is Studio's own lookup while
the deploy form is being filled in.

So it's inverted: **Harper's domains are the short list we control, so keep the path only for
those and reduce every other URL to scheme + host + `<redacted>`.** Credentials are stripped
from any URL's userinfo (an https private-repo remote can carry a token there — strictly worse
than a repo name), and query/fragment go with the path (a `?ref=` can name a private branch).
scp-style remotes (`git@host:owner/repo.git`) aren't URLs and keep their own rule.

```
Failed to deploy git@github.com:acme-corp/billing-service.git: exit code 128
  -> Failed to deploy git@github.com:<redacted>: exit code 128

Failed to deploy https://scm.acme-corp.com/acme-corp/billing-service: 404 not found
  -> Failed to deploy https://scm.acme-corp.com/<redacted>: 404 not found

Request failed with status code 500 https://api.harper.fast/HDBInstance/ins-123/operation
  -> unchanged
```

Harper API endpoints stay triageable and Studio's asset URLs stay source-mappable — that is
what the allowlist (`harper.fast`, `harperfabric.com`, `harperdb.io` by suffix, plus
`localhost`) is there to protect. Two accepted costs: a stack frame from an embedded
third-party script now reads `https://static.reo.dev/<redacted>`, which still attributes it by
host; and a URL whose path is just `/` is left alone rather than gaining a `<redacted>` that
hides nothing.

**Compose in `beforeSend`** (new module): filter first, then redact `error.message`,
`error.stack` and `error.resource.url`. Order matters — the third-party attribution in
`shouldKeepEvent` inspects the raw stack, so it must run before any frame is rewritten (there's
a test pinning that). `error.resource.url` is in scope because a failed lookup carries the same
identity in a different field: a 404 on a private repo would otherwise ship the repo name
verbatim beside a redacted message. Only the reported copy is rewritten; the UI renders the
error object itself.

**Compensate in the UI.** With RUM now silent on this failure, `DeployProgress` is the only
place it surfaces, so it links to Config > SSH Keys beneath Harper's remediation text.
`onNavigateAway` lets `RedeployApplicationModal` close first — it's controlled by global
watched state, not the route, so it would otherwise sit over the SSH Keys page. The import
flow is unchanged: its toast already shows the full remediation text, and
`ImportAuthorization` links to SSH Keys and warns on key/host mismatch before submit.

## Testing

`npx vitest run` → 267 files / 2003 passing; `tsc -b`, `dprint check`, `oxlint` clean.

New coverage: the drop rule (including the reworded variant and a generic deploy failure that
must stay); redaction of a self-hosted forge under a custom domain (including a nested group
path), `git+https:`/`git+ssh:` remotes, and Studio's own GitHub/npm lookups; what must *not* be
redacted (Harper endpoints, Studio stack frames on a Harper subdomain, a bare host with no
path, an email followed by a colon); `error.resource.url` redacted for a lookup but left intact
for an instance operation endpoint; the filter-before-redact ordering; and the guidance link's
href and dismiss behaviour.

Not browser-verified: reaching that UI needs a real failing private-repo deploy against a
Harper >= 5.1 instance, which the preview can't produce, so the unit tests are the
verification.

## Notes, out of scope

**RUM `resource` events carry the same identity, unredacted.** `beforeSend` only rewrites error
events here. Resource events are a live vector, not a hypothetical one: a 7-day RUM query
returns `resource` events for `github.com` URLs that name a customer's repo path (CI badge
images), and `getGitHubRepo` / `findNpmPackageName` fetch `api.github.com` and
`registry.npmjs.org` with the owner/repo or package the customer typed. Extending redaction to
`resource.url` would close it, but it changes what every third-party resource looks like in the
RUM performance views, so it's a call for the team rather than a quiet addition to this PR.

**The global `errorHandler` splits messages on the first `:`**, so this failure currently toasts
with the title `Failed to deploy private repository git@github.com` and the rest as the
description. That's generic behaviour for any colon-bearing message, not specific to this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
