### PR TITLE
fix(errors): surface Harper 5 RFC 9457 problem details in error toasts

### DIFF
--- a/src/features/auth/isEmailNotVerifiedError.test.ts
+++ b/src/features/auth/isEmailNotVerifiedError.test.ts
@@ -25,6 +25,25 @@ describe('isEmailNotVerifiedError', () => {
 			.toBe(true);
 	});
 
+	it('matches a Harper 5 RFC 9457 body (message under data.title)', () => {
+		expect(
+			isEmailNotVerifiedError(
+				axiosError(403, {
+					type: 'error:ClientError',
+					code: 'ClientError',
+					title: 'User has not verified email address',
+					status: 403,
+					instance: '/Login/',
+				}),
+			),
+		).toBe(true);
+	});
+
+	it('does NOT match an RFC 9457 deactivated-account rejection', () => {
+		expect(isEmailNotVerifiedError(axiosError(403, { code: 'ClientError', title: 'User account deactivated' })))
+			.toBe(false);
+	});
+
 	it('does NOT match a 403 deactivated-account rejection (same status, different reason)', () => {
 		expect(isEmailNotVerifiedError(axiosError(403, { error: 'User account deactivated' }))).toBe(false);
 	});

--- a/src/features/auth/isEmailNotVerifiedError.ts
+++ b/src/features/auth/isEmailNotVerifiedError.ts
@@ -18,9 +18,11 @@ export function isEmailNotVerifiedError(error: unknown): boolean {
 	if (!isAxiosError(error) || error.response?.status !== 403) {
 		return false;
 	}
-	const data = error.response.data as string | { error?: unknown; message?: unknown } | undefined;
+	// Harper 5 sends errors as RFC 9457 Problem Details, with the message in `title`;
+	// Harper 4 used `error`/`message`. Check all three so the flow works against either.
+	const data = error.response.data as string | { error?: unknown; message?: unknown; title?: unknown } | undefined;
 	const message = typeof data === 'string'
 		? data
-		: errorText(data?.error) ?? errorText(data?.message) ?? '';
+		: errorText(data?.error) ?? errorText(data?.message) ?? errorText(data?.title) ?? '';
 	return /verif/i.test(message);
 }

--- a/src/react-query/queryClient.test.ts
+++ b/src/react-query/queryClient.test.ts
@@ -207,4 +207,81 @@ describe('errorHandler', () => {
 			expect.objectContaining({ id: undefined }),
 		);
 	});
+
+	// Harper 5 REST errors are RFC 9457 Problem Details objects; before these mappings every
+	// v5 error toasted the generic "We had some trouble!".
+	type ProblemDetails = {
+		type?: string;
+		code?: unknown;
+		title?: string;
+		status?: number;
+		detail?: string;
+		instance?: string;
+	};
+
+	it('maps an RFC 9457 body (Harper 5) to code → title, title → description', () => {
+		const axiosError = {
+			response: {
+				data: {
+					type: 'error:ClientError',
+					code: 'ClientError',
+					title: 'Not allowed',
+					status: 403,
+					instance: '/Cluster/clu-123',
+				},
+			},
+		} as AxiosError<ProblemDetails>;
+
+		errorHandler(axiosError);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			'ClientError',
+			expect.objectContaining({ description: 'Not allowed' }),
+		);
+	});
+
+	it('does not colon-split an RFC 9457 title that contains a colon', () => {
+		const axiosError = {
+			response: {
+				data: { code: 'ClientError', title: 'Plan not found: plan-123', status: 400 },
+			},
+		} as AxiosError<ProblemDetails>;
+
+		errorHandler(axiosError);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			'ClientError',
+			expect.objectContaining({ description: 'Plan not found: plan-123' }),
+		);
+	});
+
+	it('appends the RFC 9457 detail to the description when present', () => {
+		const axiosError = {
+			response: {
+				data: { code: 'AccessViolation', title: 'Not authorized', detail: 'Requires the org admin role', status: 403 },
+			},
+		} as AxiosError<ProblemDetails>;
+
+		errorHandler(axiosError);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			'AccessViolation',
+			expect.objectContaining({ description: 'Not authorized: Requires the org admin role' }),
+		);
+	});
+
+	it('falls back to the generic title when an RFC 9457 body has no usable code', () => {
+		const axiosError = {
+			response: {
+				data: { code: 500, title: 'Internal error', status: 500 },
+			},
+		} as AxiosError<ProblemDetails>;
+
+		errorHandler(axiosError);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			'Error',
+			expect.objectContaining({ description: 'Internal error' }),
+		);
+	});
 });

--- a/src/react-query/queryClient.ts
+++ b/src/react-query/queryClient.ts
@@ -6,27 +6,40 @@ import { toast } from 'sonner';
 export function errorHandler(rawErr: unknown) {
 	let errorTitle = 'Error';
 	let errorMsg = 'We had some trouble!';
+	let splitTitleFromMsg = true;
 	console.error(rawErr);
-	const axiosWrappedErr = rawErr as AxiosError<string | { error?: unknown; message?: unknown }>;
+	const axiosWrappedErr = rawErr as AxiosError<
+		string | { error?: unknown; message?: unknown; code?: unknown; title?: unknown; detail?: unknown }
+	>;
 	const otherErr = rawErr as { message?: unknown };
 	if (typeof rawErr === 'string') {
 		errorMsg = rawErr;
 	} else if (axiosWrappedErr?.response?.data) {
-		if (typeof axiosWrappedErr.response.data === 'string') {
-			errorMsg = axiosWrappedErr.response.data;
+		const data = axiosWrappedErr.response.data;
+		if (typeof data === 'string') {
+			errorMsg = data;
+		} else if (typeof data.title === 'string' && data.title) {
+			// Harper 5 REST errors are RFC 9457 Problem Details: the "Code: message" string
+			// became { code, title, detail? }. Map code → toast title and title (+ detail) →
+			// description. The title is a plain sentence that may itself contain colons
+			// ("Plan not found: plan-123"), so skip the "Title: detail" split below.
+			if (typeof data.code === 'string' && data.code) {
+				errorTitle = data.code;
+			}
+			const detail = errorText(data.detail);
+			errorMsg = detail ? `${data.title}: ${detail}` : data.title;
+			splitTitleFromMsg = false;
 		} else {
 			// `error`/`message` can be a structured object (e.g. Harper's deploy failures) —
 			// extract its nested message (or JSON) rather than showing "[object Object]" (#1426).
-			errorMsg = errorText(axiosWrappedErr.response.data.error)
-				?? errorText(axiosWrappedErr.response.data.message)
-				?? errorMsg;
+			errorMsg = errorText(data.error) ?? errorText(data.message) ?? errorMsg;
 		}
 	} else {
 		errorMsg = errorText(otherErr?.message) ?? errorMsg;
 	}
 	// The JSON fallback from errorText produces messages full of colons that are not
 	// "Title: detail" shaped — don't split those.
-	if (errorMsg.includes(':') && !errorMsg.startsWith('{') && !errorMsg.startsWith('[')) {
+	if (splitTitleFromMsg && errorMsg.includes(':') && !errorMsg.startsWith('{') && !errorMsg.startsWith('[')) {
 		const split = errorMsg.split(':');
 		errorTitle = split.shift()!;
 		errorMsg = split.join(':');


### PR DESCRIPTION
## What

Harper 5 changed REST error responses from `"Code: message"` strings to [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) objects:

```json
{ "type": "error:ClientError", "code": "ClientError", "title": "Not allowed", "status": 403, "instance": "/Cluster/clu-123" }
```

The global `errorHandler` only looked at `data.error` / `data.message`, so against a Harper 5 central-manager **every** error toast fell through to the generic "We had some trouble!".

## Changes

- **`queryClient.ts`** — recognize a Problem Details body: `code` → toast title, `title` (+ `detail` when present) → description. The title is a plain sentence that can itself contain colons ("Plan not found: plan-123"), so the legacy "Title: detail" colon-split is skipped for this shape. v4 string/`error`/`message` handling is unchanged, so stage/prod CMs still on 4.x are unaffected.
- **`isEmailNotVerifiedError.ts`** — same class of bug found by sweeping for other CM error-body parsing: the unverified-email login detection only read `error`/`message`, so on a v5 CM an unverified user would get a dead-end toast instead of the email-verification redirect. Now also checks `title`.

## Verification

- 6 new unit tests (4 errorHandler RFC 9457 cases incl. colon-in-title and detail-append; 2 for the unverified-email matcher) — 25/25 pass across both files, full suite green via the pre-commit hook (2151 passed / 11 skipped).
- Field mapping verified against Harper 5 source (`server/REST.ts` Problem Details construction): `code = error.code ?? constructor.name`, `title = error.message`, `detail` only present when set.

— devain (Claude)