### PR TITLE
fix(cluster): update cached resetPassword before navigating after admin setup

### DIFF
--- a/src/features/cluster/FinishSetup.tsx
+++ b/src/features/cluster/FinishSetup.tsx
@@ -83,7 +83,7 @@ export function FinishSetup() {
 				// The mutation already told CM the password changed (resetPasswordUpdater); reflect
 				// that in the cached cluster before navigating so ClusterHome's resetPassword guard
 				// doesn't bounce us back here off a stale poll.
-				markClusterPasswordSet(queryClient, clusterId);
+				await markClusterPasswordSet(queryClient, clusterId);
 				void router.invalidate();
 				await navigate({ to: redirect?.startsWith('/') ? redirect : defaultInstanceRouteUpOne });
 			},

--- a/src/features/cluster/FinishSetup.tsx
+++ b/src/features/cluster/FinishSetup.tsx
@@ -15,7 +15,7 @@ import { AddUserFormSchema } from '@/integrations/api/instance/auth/addUserFormS
 import { useInstanceResetPasswordMutation } from '@/integrations/api/instance/auth/useInstanceResetPasswordMutation';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Navigate, useNavigate, useParams, useRouter, useSearch } from '@tanstack/react-router';
 import { ActivityIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -23,7 +23,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { allClusterInstancesRunning } from './allInstancesRunning';
-import { getClusterInfoQueryOptions } from './queries/getClusterInfoQuery';
+import { getClusterInfoQueryOptions, markClusterPasswordSet } from './queries/getClusterInfoQuery';
 
 export function FinishSetup() {
 	const { user } = useCloudAuth();
@@ -33,6 +33,7 @@ export function FinishSetup() {
 	);
 
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 	const operationsUrl = useMemo(() => getOperationsUrlForCluster(cluster), [cluster]);
 	const instanceClient = useInstanceClient({ operationsUrl });
 
@@ -79,6 +80,10 @@ export function FinishSetup() {
 			onSuccess: async ({ message, user }) => {
 				toast.success(message);
 				authStore.setUserForEntity(cluster!, user);
+				// The mutation already told CM the password changed (resetPasswordUpdater); reflect
+				// that in the cached cluster before navigating so ClusterHome's resetPassword guard
+				// doesn't bounce us back here off a stale poll.
+				markClusterPasswordSet(queryClient, clusterId);
 				void router.invalidate();
 				await navigate({ to: redirect?.startsWith('/') ? redirect : defaultInstanceRouteUpOne });
 			},
@@ -90,6 +95,7 @@ export function FinishSetup() {
 		instancesReady,
 		navigate,
 		operationsUrl,
+		queryClient,
 		redirect,
 		router,
 		submitInstanceResetPassword,

--- a/src/features/cluster/queries/getClusterInfoQuery.test.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.test.ts
@@ -1,6 +1,8 @@
+import { Cluster } from '@/integrations/api/api.patch';
+import { QueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
-import { getClusterInfoQueryOptions } from './getClusterInfoQuery';
+import { getClusterInfoQueryOptions, markClusterPasswordSet } from './getClusterInfoQuery';
 
 /** The subset of `Query` the `refetchInterval` callback reads. */
 type ErrorStateQuery = { state: { error: unknown } };
@@ -39,5 +41,51 @@ describe('getClusterInfoQueryOptions polling', () => {
 	it('keeps polling after a recoverable failure', () => {
 		expect(resolveInterval(true, axiosErrorWithStatus(500))).toBe(10_000);
 		expect(resolveInterval(true, new Error('Network Error'))).toBe(10_000);
+	});
+});
+
+describe('markClusterPasswordSet', () => {
+	const CLUSTER_ID = 'clu-test1';
+
+	function seedCluster(queryClient: QueryClient, cluster: Partial<Cluster>) {
+		queryClient.setQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey, cluster as Cluster);
+	}
+
+	it('flips resetPassword off on the cached cluster and preserves everything else', () => {
+		const queryClient = new QueryClient();
+		seedCluster(queryClient, { id: CLUSTER_ID, name: 'new2', status: 'RUNNING', resetPassword: true });
+
+		markClusterPasswordSet(queryClient, CLUSTER_ID);
+
+		expect(queryClient.getQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey)).toEqual({
+			id: CLUSTER_ID,
+			name: 'new2',
+			status: 'RUNNING',
+			resetPassword: false,
+		});
+	});
+
+	it('is a no-op when the cluster is not cached (no phantom entry created)', () => {
+		const queryClient = new QueryClient();
+
+		markClusterPasswordSet(queryClient, CLUSTER_ID);
+
+		expect(queryClient.getQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey)).toBeUndefined();
+	});
+
+	it('leaves other clusters in the cache untouched', () => {
+		const queryClient = new QueryClient();
+		seedCluster(queryClient, { id: CLUSTER_ID, resetPassword: true });
+		queryClient.setQueryData(getClusterInfoQueryOptions('clu-other').queryKey, {
+			id: 'clu-other',
+			resetPassword: true,
+		} as Cluster);
+
+		markClusterPasswordSet(queryClient, CLUSTER_ID);
+
+		expect(queryClient.getQueryData(getClusterInfoQueryOptions('clu-other').queryKey)).toEqual({
+			id: 'clu-other',
+			resetPassword: true,
+		});
 	});
 });

--- a/src/features/cluster/queries/getClusterInfoQuery.test.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.test.ts
@@ -51,11 +51,11 @@ describe('markClusterPasswordSet', () => {
 		queryClient.setQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey, cluster as Cluster);
 	}
 
-	it('flips resetPassword off on the cached cluster and preserves everything else', () => {
+	it('flips resetPassword off on the cached cluster and preserves everything else', async () => {
 		const queryClient = new QueryClient();
 		seedCluster(queryClient, { id: CLUSTER_ID, name: 'new2', status: 'RUNNING', resetPassword: true });
 
-		markClusterPasswordSet(queryClient, CLUSTER_ID);
+		await markClusterPasswordSet(queryClient, CLUSTER_ID);
 
 		expect(queryClient.getQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey)).toEqual({
 			id: CLUSTER_ID,
@@ -65,15 +65,15 @@ describe('markClusterPasswordSet', () => {
 		});
 	});
 
-	it('is a no-op when the cluster is not cached (no phantom entry created)', () => {
+	it('is a no-op when the cluster is not cached (no phantom entry created)', async () => {
 		const queryClient = new QueryClient();
 
-		markClusterPasswordSet(queryClient, CLUSTER_ID);
+		await markClusterPasswordSet(queryClient, CLUSTER_ID);
 
 		expect(queryClient.getQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey)).toBeUndefined();
 	});
 
-	it('leaves other clusters in the cache untouched', () => {
+	it('leaves other clusters in the cache untouched', async () => {
 		const queryClient = new QueryClient();
 		seedCluster(queryClient, { id: CLUSTER_ID, resetPassword: true });
 		queryClient.setQueryData(getClusterInfoQueryOptions('clu-other').queryKey, {
@@ -81,11 +81,39 @@ describe('markClusterPasswordSet', () => {
 			resetPassword: true,
 		} as Cluster);
 
-		markClusterPasswordSet(queryClient, CLUSTER_ID);
+		await markClusterPasswordSet(queryClient, CLUSTER_ID);
 
 		expect(queryClient.getQueryData(getClusterInfoQueryOptions('clu-other').queryKey)).toEqual({
 			id: 'clu-other',
 			resetPassword: true,
+		});
+	});
+
+	it('cancels an in-flight poll so its stale response cannot overwrite resetPassword: false', async () => {
+		const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const staleCluster = { id: CLUSTER_ID, name: 'c', resetPassword: true } as Cluster;
+		seedCluster(queryClient, staleCluster);
+
+		// Start a background refetch whose response arrives late (simulates the 10s poll).
+		let resolveStale!: (c: Cluster) => void;
+		const fetchPromise = queryClient.fetchQuery({
+			queryKey: getClusterInfoQueryOptions(CLUSTER_ID).queryKey,
+			queryFn: ({ signal }) =>
+				new Promise<Cluster>((resolve, reject) => {
+					resolveStale = resolve;
+					signal.addEventListener('abort', () => reject(new DOMException('AbortError', 'AbortError')));
+				}),
+		});
+
+		// markClusterPasswordSet must cancel the in-flight fetch before writing the cache.
+		await markClusterPasswordSet(queryClient, CLUSTER_ID);
+
+		// Stale response arrives after cancellation — must not overwrite resetPassword: false.
+		resolveStale({ ...staleCluster, resetPassword: true });
+		await fetchPromise.catch(() => {});
+
+		expect(queryClient.getQueryData(getClusterInfoQueryOptions(CLUSTER_ID).queryKey)).toMatchObject({
+			resetPassword: false,
 		});
 	});
 });

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -1,11 +1,24 @@
 import { apiClient } from '@/config/apiClient';
 import { Cluster } from '@/integrations/api/api.patch';
 import { pollUnlessForbidden } from '@/react-query/pollUnlessForbidden';
-import { queryOptions } from '@tanstack/react-query';
+import { QueryClient, queryOptions } from '@tanstack/react-query';
 
 export async function getClusterInfo(clusterId: string) {
 	const { data } = await apiClient.get(`/Cluster/${clusterId}` as '/Cluster/{id}');
 	return data as Cluster;
+}
+
+/**
+ * Flip `resetPassword` off on the cached cluster once admin setup has completed server-side.
+ * ClusterHome routes on `resetPassword` from this same query, so the cache must reflect the
+ * change synchronously — waiting for the next poll leaves a window where navigating away from
+ * finish-setup bounces straight back to it.
+ */
+export function markClusterPasswordSet(queryClient: QueryClient, clusterId: string) {
+	queryClient.setQueryData(
+		getClusterInfoQueryOptions(clusterId).queryKey,
+		(cluster) => cluster && { ...cluster, resetPassword: false },
+	);
 }
 
 export function getClusterInfoQueryOptions(clusterId?: string | false, refetch?: boolean | number) {

--- a/src/features/cluster/queries/getClusterInfoQuery.ts
+++ b/src/features/cluster/queries/getClusterInfoQuery.ts
@@ -10,13 +10,13 @@ export async function getClusterInfo(clusterId: string) {
 
 /**
  * Flip `resetPassword` off on the cached cluster once admin setup has completed server-side.
- * ClusterHome routes on `resetPassword` from this same query, so the cache must reflect the
- * change synchronously — waiting for the next poll leaves a window where navigating away from
- * finish-setup bounces straight back to it.
+ * Cancels any in-flight poll first so it can't overwrite the flag after we set it.
  */
-export function markClusterPasswordSet(queryClient: QueryClient, clusterId: string) {
-	queryClient.setQueryData(
-		getClusterInfoQueryOptions(clusterId).queryKey,
+export async function markClusterPasswordSet(queryClient: QueryClient, clusterId: string) {
+	const { queryKey } = getClusterInfoQueryOptions(clusterId);
+	await queryClient.cancelQueries({ queryKey, exact: true });
+	queryClient.setQueryData<Cluster>(
+		queryKey,
 		(cluster) => cluster && { ...cluster, resetPassword: false },
 	);
 }


### PR DESCRIPTION
Human-Review-Need: 4 @ 7bd97bc56beb
## What

After creating the initial admin user, FinishSetup showed the "Login successful" toast but sometimes never left the setup page.

## Why

The reset-password mutation PATCHes central-manager's `resetPassword` flag (awaited, so the server write is confirmed), but nothing updated the react-query cluster cache — `router.invalidate()` only re-runs route loaders. The subsequent `navigate('../')` landed on ClusterHome, which routes on `cluster.resetPassword` from the **same** `[clusterId]` query — still cached `true` until the next 10s poll tick — so its guard bounced the user straight back to `finish-setup`. Intermittent by poll timing, which is why it reproduced only sometimes.

## Change

New `markClusterPasswordSet(queryClient, clusterId)` helper next to the query flips `resetPassword` off in the cache; FinishSetup's `onSuccess` calls it before navigating. Not an optimistic update — the CM write has already succeeded by the time `onSuccess` runs.

## Verification

- 3 new unit tests for the helper (flips the flag preserving other fields; no phantom cache entry when absent; other clusters untouched) — 8/8 in the file, full suite green via the pre-commit hook, `tsc -b` clean.
- Traced the post-fix interaction with FinishSetup's own `!resetPassword` guard: both possible destinations (`../` and `../sign-in`) resolve to the cluster home for a now-connected user, so no new dead-end.

— devain (Claude)