### PR TITLE
fix(react-query): stop retrying polls the server deterministically rejects

### DIFF
--- a/src/features/cluster/domains/queries/getChallengeCertificates.ts
+++ b/src/features/cluster/domains/queries/getChallengeCertificates.ts
@@ -1,6 +1,6 @@
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getSearchByValue } from '@/integrations/api/instance/database/getSearchByValue';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
 export interface ChallengeCertificate {
@@ -35,7 +35,7 @@ export function getChallengeCertificatesQueryOptions(clusterId?: string) {
 		// Same always-on shape as the 10s pollers: gated only on `clusterId`, so a
 		// user without access to the cluster's data 403s every 5s until they navigate.
 		refetchInterval: pollUnlessForbidden(5000),
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 	});
 }
 

--- a/src/features/organization/queries/getOrganizationQuery.ts
+++ b/src/features/organization/queries/getOrganizationQuery.ts
@@ -27,7 +27,7 @@ export function getOrganizationQueryOptions(orgId: string | undefined) {
 		queryKey: [orgId],
 		queryFn: () => getOrganization(orgId as string),
 		// `retry: false` already surfaces the error on the first failure, so the poll
-		// wrapper below sees a 403 immediately — no `retryUnlessForbidden` needed.
+		// wrapper below sees a 403 immediately — no `retryUnlessRejected` needed.
 		retry: false,
 		enabled: isValidOrganizationId(orgId),
 		refetchInterval: pollUnlessForbidden(10000),

--- a/src/features/organization/queries/getOrganizationRoleInfo.ts
+++ b/src/features/organization/queries/getOrganizationRoleInfo.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/config/apiClient';
 import { SchemaRole } from '@/integrations/api/api.gen';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export interface GetOrganizationRoleInfoResponse extends SchemaRole {
@@ -19,7 +19,7 @@ export function getOrganizationRoleInfoQueryOptions({
 		queryKey: [organizationId, 'roles', roleId] as const,
 		queryFn: () => getOrganizationRoleInfo(roleId),
 		refetchInterval: pollUnlessForbidden(10 * 1000),
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 	});
 }
 

--- a/src/features/organization/queries/getOrganizationRoles.ts
+++ b/src/features/organization/queries/getOrganizationRoles.ts
@@ -13,7 +13,7 @@ export function getOrganizationRolesQueryOptions(organizationId: string) {
 		queryKey: [organizationId, 'roles'],
 		queryFn: () => getOrganizationRoles(organizationId),
 		// `retry: false` surfaces the error immediately, so the wrapper sees a 403 on
-		// the first failure without a `retryUnlessForbidden` predicate.
+		// the first failure without a `retryUnlessRejected` predicate.
 		retry: false,
 		refetchInterval: pollUnlessForbidden(10 * 1000), // 10 seconds, until a 403
 	});

--- a/src/integrations/api/instance/auth/getListRoles.ts
+++ b/src/integrations/api/instance/auth/getListRoles.ts
@@ -1,6 +1,6 @@
 import { InstanceClientConfig, InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { LocalRole } from '@/integrations/api/api.patch';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export function getListRolesQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
@@ -9,7 +9,7 @@ export function getListRolesQueryOptions({ entityId, instanceClient }: InstanceC
 		queryFn: () => getListRoles({ instanceClient }),
 		// Superuser-only like `list_users` above — the same 403-forever shape.
 		refetchInterval: pollUnlessForbidden(10_000),
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 	});
 }
 

--- a/src/integrations/api/instance/auth/getListUsers.ts
+++ b/src/integrations/api/instance/auth/getListUsers.ts
@@ -1,6 +1,6 @@
 import { InstanceClientConfig, InstanceClientIdConfig } from '@/config/instanceClientConfig';
 import { LocalUser } from '@/integrations/api/api.patch';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export function getListUsersQueryOptions({ entityId, instanceClient }: InstanceClientIdConfig) {
@@ -10,7 +10,7 @@ export function getListUsersQueryOptions({ entityId, instanceClient }: InstanceC
 		// `list_users` is a superuser-only operation, so a read-only member sitting on
 		// the Users tab 403s on every tick — stop rather than poll it forever.
 		refetchInterval: pollUnlessForbidden(10_000),
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 	});
 }
 

--- a/src/integrations/api/instance/ssh/getSSHKey.ts
+++ b/src/integrations/api/instance/ssh/getSSHKey.ts
@@ -1,5 +1,5 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 interface GetSSHKeyFormData extends InstanceClientIdConfig {
@@ -26,6 +26,6 @@ export function getSSHKeyQueryOptions(params: GetSSHKeyFormData) {
 		queryKey: [params.entityId, 'get_ssh_key', params.name] as const,
 		queryFn: () => getSSHKey(params),
 		refetchInterval: pollUnlessForbidden(10_000),
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 	});
 }

--- a/src/integrations/api/instance/status/getStatus.ts
+++ b/src/integrations/api/instance/status/getStatus.ts
@@ -1,5 +1,5 @@
 import { InstanceClientIdConfig } from '@/config/instanceClientConfig';
-import { pollUnlessForbidden, retryUnlessForbidden } from '@/react-query/pollUnlessForbidden';
+import { pollUnlessForbidden, retryUnlessRejected } from '@/react-query/pollUnlessForbidden';
 import { queryOptions } from '@tanstack/react-query';
 
 export interface SystemStatus {
@@ -49,7 +49,7 @@ export function getStatusQueryOptions({ entityId, instanceClient }: InstanceClie
 		// Without this the default `retry: 3` would swallow the first three 403s into
 		// `failureReason`, so the poll above could not stop until ~30s (and 3 more
 		// doomed requests) later, given the 10s retryDelay.
-		retry: retryUnlessForbidden(),
+		retry: retryUnlessRejected(),
 		retryDelay: 10_000,
 		throwOnError: false,
 		enabled,

--- a/src/react-query/pollUnlessForbidden.integration.test.ts
+++ b/src/react-query/pollUnlessForbidden.integration.test.ts
@@ -72,10 +72,41 @@ describe('poll-stops-on-403, end to end', () => {
 
 		await vi.advanceTimersByTimeAsync(60_000);
 
-		// Without `retryUnlessForbidden` the default retry: 3 would fire 3 doomed
+		// Without `retryUnlessRejected` the default retry: 3 would fire 3 doomed
 		// requests before the timer could even see the error; without
 		// `pollUnlessForbidden` it would then poll for as long as the page is open.
 		expect(post).toHaveBeenCalledTimes(1);
+		unsubscribe();
+	});
+
+	it('surfaces a 400 on the first request instead of after three retries', async () => {
+		const post = vi.fn().mockRejectedValue(httpError(400));
+		const { observer, unsubscribe } = observe(post);
+
+		// Past the mount fetch, well before the first retry would land (this query sets
+		// `retryDelay: 10_000`).
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(post).toHaveBeenCalledTimes(1);
+		// React Query parks a failure in `failureReason` and leaves `error` null until the
+		// retry budget is spent. Without `retryUnlessRejected` a 400 would therefore stay
+		// invisible to `refetchInterval`, the error handler, and the UI for ~30s.
+		const { error, isError } = observer.getCurrentResult();
+		expect(isError).toBe(true);
+		expect((error as AxiosError).response?.status).toBe(400);
+		unsubscribe();
+	});
+
+	it('keeps polling on a 400 so a still-settling request recovers', async () => {
+		const post = vi.fn().mockRejectedValue(httpError(400));
+		const { unsubscribe } = observe(post);
+
+		await vi.advanceTimersByTimeAsync(60_000);
+
+		// A 400 is deterministic but can come from state that is still settling, so the
+		// timer deliberately keeps running — halting it would freeze the UI until remount
+		// or refocus. Whether a *sustained* 400 should stop it is open in #1569.
+		expect(post.mock.calls.length).toBeGreaterThan(3);
 		unsubscribe();
 	});
 

--- a/src/react-query/pollUnlessForbidden.test.ts
+++ b/src/react-query/pollUnlessForbidden.test.ts
@@ -1,6 +1,11 @@
 import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
-import { isForbiddenError, pollUnlessForbidden, retryUnlessForbidden } from './pollUnlessForbidden';
+import {
+	isDeterministicRejection,
+	isForbiddenError,
+	pollUnlessForbidden,
+	retryUnlessRejected,
+} from './pollUnlessForbidden';
 
 /** Minimal stand-in for the `query` argument `refetchInterval` receives — the
  *  wrapper only ever reads `state.error`. */
@@ -63,26 +68,57 @@ describe('pollUnlessForbidden', () => {
 	});
 });
 
-describe('retryUnlessForbidden', () => {
+describe('isDeterministicRejection', () => {
+	it('covers 400 and 403 — the statuses an unchanged retry cannot change', () => {
+		expect(isDeterministicRejection(axiosErrorWithStatus(400))).toBe(true);
+		expect(isDeterministicRejection(axiosErrorWithStatus(403))).toBe(true);
+		expect(isDeterministicRejection({ status: 400 })).toBe(true);
+	});
+
+	it('is narrower than "all 4xx"', () => {
+		// 401 is resolved by the auth layer re-authenticating; 404/409 can reflect a
+		// resource that is still being created.
+		for (const status of [401, 404, 409, 429, 500, 503]) {
+			expect(isDeterministicRejection(axiosErrorWithStatus(status))).toBe(false);
+		}
+	});
+
+	it('is false for non-HTTP errors and nullish input', () => {
+		expect(isDeterministicRejection(new Error('Network Error'))).toBe(false);
+		expect(isDeterministicRejection(null)).toBe(false);
+		expect(isDeterministicRejection(undefined)).toBe(false);
+	});
+});
+
+describe('retryUnlessRejected', () => {
 	it('never retries a 403', () => {
 		// Without this the 403 sits in `failureReason` for three more requests and
 		// `pollUnlessForbidden` cannot see it until ~30s later.
-		expect(retryUnlessForbidden()(1, axiosErrorWithStatus(403))).toBe(false);
+		expect(retryUnlessRejected()(1, axiosErrorWithStatus(403))).toBe(false);
+	});
+
+	it('never retries a 400', () => {
+		// A validator/parser rejection of the request itself: a retry sends the identical
+		// bytes and can only be rejected identically. On the callers left at default
+		// exponential backoff that cost 4 requests per poll tick instead of 1
+		// (RUM 2026-08-07).
+		expect(retryUnlessRejected()(0, axiosErrorWithStatus(400))).toBe(false);
+		expect(retryUnlessRejected()(1, axiosErrorWithStatus(400))).toBe(false);
 	});
 
 	it('matches the default retry: 3 budget for transient failures', () => {
-		const retry = retryUnlessForbidden();
+		const retry = retryUnlessRejected();
 		expect(retry(1, axiosErrorWithStatus(503))).toBe(true);
 		expect(retry(2, axiosErrorWithStatus(503))).toBe(true);
 		expect(retry(3, axiosErrorWithStatus(503))).toBe(false);
 	});
 
 	it('still retries a 401, which the auth layer resolves by re-authenticating', () => {
-		expect(retryUnlessForbidden()(1, axiosErrorWithStatus(401))).toBe(true);
+		expect(retryUnlessRejected()(1, axiosErrorWithStatus(401))).toBe(true);
 	});
 
 	it('honors a custom retry budget', () => {
-		const retry = retryUnlessForbidden(1);
+		const retry = retryUnlessRejected(1);
 		expect(retry(0, new Error('Network Error'))).toBe(true);
 		expect(retry(1, new Error('Network Error'))).toBe(false);
 	});

--- a/src/react-query/pollUnlessForbidden.ts
+++ b/src/react-query/pollUnlessForbidden.ts
@@ -21,6 +21,23 @@ export function isForbiddenError(err: unknown): boolean {
 	return errorStatus(err) === 403;
 }
 
+/** A rejection the server will repeat verbatim for an unchanged request.
+ *
+ *  400 — the request itself was refused by a validator/parser, not work that failed
+ *  partway. Studio sends operations whose shape depends on the target's Harper build
+ *  (unknown metric names, `bucket_ms`, operations a pre-4.6 instance doesn't
+ *  implement), so a poll can 400 on every tick indefinitely.
+ *  403 — authenticated but not permitted; stable until permissions change.
+ *
+ *  Both are deterministic, so an *immediate* retry of the same request can only
+ *  produce the same status. This is deliberately narrower than "all 4xx": a 401 is
+ *  resolved by the auth layer re-authenticating, and 404/409 can reflect a resource
+ *  that is still being created. */
+export function isDeterministicRejection(err: unknown): boolean {
+	const status = errorStatus(err);
+	return status === 400 || status === 403;
+}
+
 /**
  * Wrap a fixed poll interval so polling STOPS once the endpoint answers 403.
  *
@@ -41,24 +58,47 @@ export function isForbiddenError(err: unknown): boolean {
  *
  * Only 403 stops the timer. 5xx, network failures, and timeouts are transient
  * (instance restarting, unreachable) and should keep polling so the UI self-heals.
+ *
+ * A 400 deliberately does NOT stop the timer, even though it is just as
+ * deterministic (`isDeterministicRejection`). Halting on it would freeze a poll
+ * whose 400 came from state that is still settling — a certificate challenge
+ * mid-provision, an argument derived from a not-yet-loaded resource — until the user
+ * remounts or refocuses the tab. `retryUnlessRejected` removes the retry
+ * amplification instead, which is the part that is waste either way. Whether the
+ * timer itself should stop on a *sustained* 400 is open in #1569.
  */
 export function pollUnlessForbidden(interval: number | false | undefined) {
 	return (query: QueryErrorState) => (isForbiddenError(query.state.error) ? false : (interval ?? false));
 }
 
 /**
- * `retry` predicate that gives up immediately on 403 but otherwise keeps React
- * Query's default retry count.
+ * `retry` predicate that gives up immediately on a deterministic rejection (400 /
+ * 403) but otherwise keeps React Query's default retry count.
  *
- * Needed to make `pollUnlessForbidden` engage on the FIRST 403. `state.error` is
- * only populated once retries are exhausted (until then the failure lives in
- * `failureReason`), so on a query left at the default `retry: 3` the poll timer
- * cannot see the 403 until three more doomed requests have gone out — ~30s later
- * on a query that also sets `retryDelay: 10_000`.
+ * For 403 this is what makes `pollUnlessForbidden` engage on the FIRST one.
+ * `state.error` is only populated once retries are exhausted (until then the failure
+ * lives in `failureReason`), so on a query left at the default `retry: 3` the poll
+ * timer cannot see the 403 until three more doomed requests have gone out — ~30s
+ * later on a query that also sets `retryDelay: 10_000`.
+ *
+ * For 400 the poll timer deliberately keeps running (see `pollUnlessForbidden`) —
+ * this only removes the retry amplification, which is worth two distinct things:
+ *
+ *   - On the five callers that leave `retryDelay` at React Query's default
+ *     exponential backoff (1s/2s/4s), a 400ing tick spent 4 requests inside ~7s.
+ *     Those become 1.
+ *   - On `getStatus`, which pins `retryDelay: 10_000`, the request *rate* was already
+ *     one per interval, so nothing is saved there — what changes is latency to
+ *     visibility: the 400 reaches `state.error`, the error handler, and the UI on the
+ *     first request rather than ~30s later.
+ *
+ * RUM (2026-08-07) motivates it: 26 first-party 400s in 24h against a ~1–3/day
+ * baseline, one page re-issuing the same rejected operation every ~60s for half an
+ * hour.
  *
  * `failureCount < maxRetries` is exactly the semantics of the numeric form
  * (`retry: 3`), so transient failures keep the retry behavior they had before.
  */
-export function retryUnlessForbidden(maxRetries = 3) {
-	return (failureCount: number, error: unknown) => !isForbiddenError(error) && failureCount < maxRetries;
+export function retryUnlessRejected(maxRetries = 3) {
+	return (failureCount: number, error: unknown) => !isDeterministicRejection(error) && failureCount < maxRetries;
 }


### PR DESCRIPTION
## Summary

A **400** is a validator/parser rejection of the request *itself* — an immediate retry sends identical bytes and can only be rejected identically. React Query's `retry` predicate treated it as transient and spent the full budget on it.

This broadens the retry predicate from 403-only to **403 + 400** and adds `isDeterministicRejection` as the shared predicate. `retryUnlessForbidden` → `retryUnlessRejected` (the name would otherwise lie); 6 call sites updated mechanically.

Deliberately **narrower than "all 4xx"**: a 401 is resolved by the auth layer re-authenticating, and 404/409 can reflect a resource that is still being created.

## What actually changes, per caller

The benefit is not uniform, and the docstring now says so rather than claiming a blanket 4× win:

| Caller | `retryDelay` | Effect |
| --- | --- | --- |
| `getOrganizationRoleInfo`, `getChallengeCertificates`, `getListUsers`, `getListRoles`, `getSSHKey` | default backoff (1s/2s/4s) | a 400ing tick spent **4 requests inside ~7s → 1** |
| `getStatus` | pinned `10_000` | request **rate unchanged** (retries were already interval-spaced). What changes is **latency to visibility**: the 400 reaches `state.error`, the global error toast, and the UI on the first request instead of **~30s** later |

## What this deliberately does *not* do

`pollUnlessForbidden` is untouched — **a 400 still does not halt the poll timer.** Halting would freeze a poll whose 400 came from state that is still settling (a certificate challenge mid-provision, an argument derived from a not-yet-loaded resource) until the user remounts or refocuses the tab. `getChallengeCertificates` polls at 5s during ACME provisioning and is exactly the case that would regress.

Whether a *sustained* 400 should stop the timer needs a per-call-site judgment and is left open in #1569.

## Motivation (Datadog RUM, 2026-08-07)

Surfaced by the automated daily RUM review. Direct-to-instance operations API returned **400 twenty-six times in 24h against a ~1–3/day baseline**:

| Window | 400s | Sessions |
| --- | --- | --- |
| 24h → now | **26** | 3 |
| 48h → 24h | 2 | 1 |
| 7d → 48h | 6 | 4 |
| 14d → 7d | 14 | 6 |

One page re-issued the same rejected operation **every ~60s for ~30 minutes**, and a burst of 16 landed in 55s. Fast, uniform rejections (median ~122ms) — a validator saying no, not work failing partway. Full write-up in the companion issue.

## Testing

- `isDeterministicRejection` unit tests: covers 400/403, asserts 401/404/409/429/5xx/non-HTTP are excluded.
- `retryUnlessRejected` unit tests: never retries 400 or 403; unchanged `retry: 3` budget for 5xx; still retries 401.
- **Integration test against a real `QueryClient`** driving the real `getStatusQueryOptions`: a 400 surfaces on the **first** request (`isError`, status 400, one call) rather than after three retries, and the poll timer **keeps running**.
- Verified the new tests are not vacuous — reverting the predicate to 403-only fails **3** of them, including the integration test.
- Full suite green: 278 files / 2131 tests. `tsc -b`, `oxlint`, `dprint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)