### PR TITLE
fix(browse): explain a record editor's failed save instead of disabling it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,32 @@ To drive a Radix dropdown/menu (e.g. `src/components/ui/dropdownMenu.tsx`) in js
 
 Working example: `src/features/instance/databases/components/PickColumnsDropdown.test.tsx`.
 
+## An always-rendered modal keeps its state; only its _contents_ unmount
+
+Several modals are rendered unconditionally and toggled with `open` (e.g. `EditTableRowModal`
+in `DatabaseTableView`). Radix's `DialogContent` is not force-mounted, so closing the dialog
+unmounts everything inside it — inputs, editors, their DOM — while the modal **component's own
+`useState` survives**, because that component never unmounted.
+
+The two halves then disagree: the re-mounted contents render from props (fresh), and the
+surviving state still describes the session the user abandoned. In #1600 that combination
+disabled `Save Changes` forever — a `isValidJSON=false` from a malformed draft outlived the
+editor that held it, so re-opening the row showed valid JSON above a dead button.
+
+Reach for whichever fits:
+
+- Reset the state when the modal **opens**, not only when its data changes. Tracking the
+  data snapshot as `null` while closed gets both in one comparison (see
+  `EditTableRowModal`'s render-time reset).
+- Or give the modal a `key` that changes per target and render it only while open, which
+  unmounts the component with the dialog (`AddTableRowModal` in `DatabaseActionModals`).
+
+Related `@monaco-editor/react` behaviour, which is what makes this invisible rather than
+merely wrong: it applies a changed `value` prop through `executeEdits` behind an internal
+`preventTriggerChangeEvent` flag, so **programmatic value updates do not fire `onChange`**.
+An editor re-mounted (or re-valued) from props therefore never tells the component that the
+buffer it is validating has been replaced.
+
 ## Live central-manager data — WebSocket works, the load balancer never flushes SSE
 
 Concretely, "the edge" in front of central-manager is a **Linode NodeBalancer**:

--- a/src/features/instance/databases/modals/AddTableRowModal.test.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.test.tsx
@@ -133,4 +133,36 @@ describe('AddTableRowModal', () => {
 		expect(mutate).not.toHaveBeenCalled();
 		expect(toast.error).toHaveBeenCalledTimes(1);
 	});
+
+	// Regression for #1600: Save used to be gated on a validity flag, so a malformed record left a
+	// dead button and — since the worker-free language draws no squiggles — nothing said why.
+	it('keeps Save clickable on a malformed record and reports where the syntax breaks', () => {
+		renderModal();
+
+		fireEvent.change(screen.getByTestId('editor'), {
+			target: { value: '[\n    {\n        "name" "Rex"\n    }\n]' },
+		});
+		const save = screen.getByRole('button', { name: /Save Changes/i });
+		expect(save.hasAttribute('disabled')).toBe(false);
+
+		fireEvent.click(save);
+
+		expect(mutate).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith(
+			"This record isn't valid JSON",
+			{ description: expect.stringContaining('Line 3') },
+		);
+	});
+
+	// The one gate left on this button, and the sample record on screen explains it: there is
+	// nothing to insert until the user edits it.
+	it('disables Save only until the sample record is edited', () => {
+		renderModal();
+
+		expect(screen.getByRole('button', { name: /Save Changes/i }).hasAttribute('disabled')).toBe(true);
+
+		fireEvent.change(screen.getByTestId('editor'), { target: { value: '{"name":"Rex"}' } });
+
+		expect(screen.getByRole('button', { name: /Save Changes/i }).hasAttribute('disabled')).toBe(false);
+	});
 });

--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -13,7 +13,8 @@ import type { EditorProps, OnMount } from '@monaco-editor/react';
 import { Save, TerminalIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { isRecordJsonProbablyValid, tryParseRecordJson } from './recordEditorJson';
+import { describeRecordJsonError, tryParseRecordJson } from './recordEditorJson';
+import { useRecordJsonErrorMarker } from './recordJsonErrorMarker';
 
 export function AddTableRowModal({
 	isModalOpen,
@@ -32,10 +33,10 @@ export function AddTableRowModal({
 	const { mutate: addTableRecords, isPending: isAddTableRecordsPending } = useInsertTableRecords();
 	const instanceParams = useInstanceClientIdParams();
 
-	const [isValidJSON, setIsValidJSON] = useState(true);
 	const [addTableRecordData, setAddTableRecordData] = useState<string>();
 	const [madeChanges, setMadeChanges] = useState(false);
 	const [skippedHashes, setSkippedHashes] = useState<string[]>([]);
+	const { onEditorMount, showRecordJsonError, clearRecordJsonError } = useRecordJsonErrorMarker();
 
 	const sampleJSON = useMemo(() => {
 		const sample: Record<string, unknown> = {};
@@ -55,15 +56,16 @@ export function AddTableRowModal({
 	}, [instanceTable, databaseTables]);
 
 	const onSubmitClick = useCallback(() => {
-		if (!addTableRecordData) {
+		if (addTableRecordData === undefined) {
 			return;
 		}
-		// Authoritative parse: the live check skips oversized content, so a large,
-		// malformed bulk paste can reach here with isValidJSON still true — parse it
-		// in a catch rather than letting Save throw an uncaught SyntaxError.
+		// The only validation the record editors get. Save is deliberately not gated on it: a
+		// disabled button explained nothing (#1600), so a bad record is reported here instead — the
+		// reason and its location in a toast, plus a marker on the offending line.
 		const parsed = tryParseRecordJson(addTableRecordData);
 		if (!parsed.ok) {
-			toast.error("This record isn't valid JSON — fix the syntax and try again.");
+			toast.error("This record isn't valid JSON", { description: describeRecordJsonError(parsed.error) });
+			showRecordJsonError(parsed.error);
 			return;
 		}
 		const records = (Array.isArray(parsed.value) ? parsed.value : [parsed.value]) as object[];
@@ -107,11 +109,13 @@ export function AddTableRowModal({
 		instanceTable.schema,
 		refreshTable,
 		setIsModalOpen,
+		showRecordJsonError,
 	]);
 
-	const handleEditorDidMount: EditorProps['onMount'] = useCallback<OnMount>((editor) => {
+	const handleEditorDidMount: EditorProps['onMount'] = useCallback<OnMount>((editor, monaco) => {
+		onEditorMount(editor, monaco);
 		editor?.focus();
-	}, []);
+	}, [onEditorMount]);
 
 	return (
 		<Dialog onOpenChange={setIsModalOpen} open={isModalOpen}>
@@ -152,7 +156,8 @@ export function AddTableRowModal({
 						onChange={(updatedValue) => {
 							setAddTableRecordData(updatedValue);
 							setMadeChanges(true);
-							setIsValidJSON(isRecordJsonProbablyValid(updatedValue));
+							// The marker from the last failed save described a buffer that no longer exists.
+							clearRecordJsonError();
 						}}
 						options={{ minimap: { enabled: false }, automaticLayout: true }}
 						onMount={handleEditorDidMount}
@@ -182,7 +187,10 @@ export function AddTableRowModal({
 							variant="submit"
 							onClick={onSubmitClick}
 							accessKey="s"
-							disabled={!addTableRecordData || !isValidJSON || isAddTableRecordsPending}
+							// Only "nothing typed yet" disables Save here, which the untouched sample record on
+							// screen explains on its own; anything the user has actually edited is submittable,
+							// and says why if it can't be inserted.
+							disabled={addTableRecordData === undefined || isAddTableRecordsPending}
 						>
 							<Save />{' '}
 							<span>

--- a/src/features/instance/databases/modals/AddTableRowModal.tsx
+++ b/src/features/instance/databases/modals/AddTableRowModal.tsx
@@ -68,7 +68,7 @@ export function AddTableRowModal({
 			showRecordJsonError(parsed.error);
 			return;
 		}
-		const records = (Array.isArray(parsed.value) ? parsed.value : [parsed.value]) as object[];
+		const records = Array.isArray(parsed.value) ? parsed.value : [parsed.value];
 		const toastId = toast.loading(`Adding ${records.length} records...`);
 		addTableRecords(
 			{

--- a/src/features/instance/databases/modals/EditTableRowModal.test.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.test.tsx
@@ -64,7 +64,7 @@ afterEach(() => {
 const noop = () => {};
 const row = { name: 'Ada Lovelace', city: 'London', id: 'abc-123' };
 
-function renderModal(overrides: Record<string, unknown> = {}) {
+function modal(overrides: Record<string, unknown> = {}) {
 	const props = {
 		canEditRecords: true,
 		canDeleteRecords: true,
@@ -79,7 +79,15 @@ function renderModal(overrides: Record<string, unknown> = {}) {
 		isDeleteTableRecordsPending: false,
 		...overrides,
 	};
-	return render(<EditTableRowModal {...props} />);
+	return <EditTableRowModal {...props} />;
+}
+
+function renderModal(overrides: Record<string, unknown> = {}) {
+	return render(modal(overrides));
+}
+
+function saveButton() {
+	return screen.getByRole('button', { name: /Save Changes/i });
 }
 
 describe('EditTableRowModal', () => {
@@ -147,19 +155,60 @@ describe('EditTableRowModal', () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
-	// Regression for the large-paste path: an oversized edit is not live-validated (the button
-	// stays enabled), so a malformed one reaches Save — which must catch it and surface a toast
-	// rather than throw an uncaught SyntaxError.
+	// Regression for the large-paste path: nothing validates the buffer as it is typed, so a
+	// malformed oversized paste reaches Save — which must catch it and surface a toast rather than
+	// throw an uncaught SyntaxError.
 	it('shows an error and does not save an oversized, malformed record', () => {
 		const onSaveChanges = vi.fn();
 		renderModal({ onSaveChanges });
 
 		const oversizedMalformed = `[{"blob":"${'x'.repeat(MAX_WORKER_MODEL_CHARS)}`; // unterminated
 		fireEvent.change(screen.getByTestId('editor'), { target: { value: oversizedMalformed } });
-		fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+		fireEvent.click(saveButton());
 
 		expect(onSaveChanges).not.toHaveBeenCalled();
 		expect(toast.error).toHaveBeenCalledTimes(1);
+	});
+
+	// Regression for #1600: Save used to be gated on a validity flag, so a malformed edit left a
+	// dead button and — since the worker-free language draws no squiggles — nothing said why.
+	it('keeps Save clickable on a malformed record and reports where the syntax breaks', () => {
+		const onSaveChanges = vi.fn();
+		renderModal({ onSaveChanges });
+
+		fireEvent.change(screen.getByTestId('editor'), {
+			target: { value: '[\n    {\n        "name" "Grace"\n    }\n]' },
+		});
+
+		expect(saveButton().hasAttribute('disabled')).toBe(false);
+
+		fireEvent.click(saveButton());
+
+		expect(onSaveChanges).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith(
+			"This record isn't valid JSON",
+			{ description: expect.stringContaining('Line 3') },
+		);
+	});
+
+	// The reported symptom: the flag lived outside the dialog's contents, so an abandoned malformed
+	// draft kept Save disabled after the modal was closed and re-opened on the same row — with the
+	// stored record, which looks perfectly valid, back on screen.
+	it('does not carry an abandoned draft into the next open of the same row', () => {
+		const onSaveChanges = vi.fn();
+		const setIsModalOpen = vi.fn();
+		const { rerender } = renderModal({ onSaveChanges, setIsModalOpen });
+
+		fireEvent.change(screen.getByTestId('editor'), { target: { value: '[{"name": "Grace' } }); // unterminated
+		rerender(modal({ onSaveChanges, setIsModalOpen, isModalOpen: false }));
+		rerender(modal({ onSaveChanges, setIsModalOpen }));
+
+		expect(saveButton().hasAttribute('disabled')).toBe(false);
+		// The draft went with the dialog, so Save has nothing of the user's to persist.
+		fireEvent.click(saveButton());
+		expect(onSaveChanges).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
+		expect(setIsModalOpen).toHaveBeenCalledWith(false);
 	});
 
 	// The modal instance is reused across rows; opening a different record must not carry the
@@ -171,25 +220,36 @@ describe('EditTableRowModal', () => {
 
 		// Edit the first row, then open a different row without touching it.
 		fireEvent.change(screen.getByTestId('editor'), { target: { value: '[{"name":"edited A"}]' } });
-		rerender(
-			<EditTableRowModal
-				canEditRecords
-				canDeleteRecords
-				setIsModalOpen={setIsModalOpen}
-				isModalOpen
-				primaryKey="email"
-				syntheticAttributes={[]}
-				data={[{ id: 'b', name: 'B' }]}
-				onSaveChanges={onSaveChanges}
-				onDeleteRecord={noop}
-				isUpdateTableRecordsPending={false}
-				isDeleteTableRecordsPending={false}
-			/>,
-		);
-		fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+		rerender(modal({ onSaveChanges, setIsModalOpen, data: [{ id: 'b', name: 'B' }] }));
+		fireEvent.click(saveButton());
 
 		// The stale "edited A" draft was discarded, so Save just closes rather than persisting it.
 		expect(onSaveChanges).not.toHaveBeenCalled();
 		expect(setIsModalOpen).toHaveBeenCalledWith(false);
+	});
+
+	// Same reset, but from a refetch under an open editor: it used to take the unsaved edits with
+	// it, and Save then just closed the modal — no save, no warning, edits gone.
+	it('warns when a record that changed on the server discards unsaved edits', () => {
+		const onSaveChanges = vi.fn();
+		const { rerender } = renderModal({ onSaveChanges, data: [{ id: 'a', name: 'A' }] });
+
+		fireEvent.change(screen.getByTestId('editor'), { target: { value: '[{"id":"a","name":"edited A"}]' } });
+		rerender(modal({ onSaveChanges, data: [{ id: 'a', name: 'A (changed elsewhere)' }] }));
+
+		expect(screen.getByText('This record changed while you were editing it')).toBeTruthy();
+	});
+
+	it('explains an emptied editor rather than closing as if there were nothing to save', () => {
+		const onSaveChanges = vi.fn();
+		const setIsModalOpen = vi.fn();
+		renderModal({ onSaveChanges, setIsModalOpen });
+
+		fireEvent.change(screen.getByTestId('editor'), { target: { value: '' } });
+		fireEvent.click(saveButton());
+
+		expect(onSaveChanges).not.toHaveBeenCalled();
+		expect(setIsModalOpen).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/features/instance/databases/modals/EditTableRowModal.test.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.test.tsx
@@ -155,6 +155,18 @@ describe('EditTableRowModal', () => {
 		expect(toast.error).not.toHaveBeenCalled();
 	});
 
+	// `update` only takes a list of records, and the editor opens on an array of one — but an edit
+	// that drops the brackets still means that record, so it must not go out as a bare object.
+	it('saves a de-bracketed record as the one-record list the operation expects', () => {
+		const onSaveChanges = vi.fn();
+		renderModal({ onSaveChanges });
+
+		fireEvent.change(screen.getByTestId('editor'), { target: { value: '{"name":"Grace"}' } });
+		fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+		expect(onSaveChanges).toHaveBeenCalledWith([{ name: 'Grace' }]);
+	});
+
 	// Regression for the large-paste path: nothing validates the buffer as it is typed, so a
 	// malformed oversized paste reaches Save — which must catch it and surface a toast rather than
 	// throw an uncaught SyntaxError.

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -221,7 +221,9 @@ export function EditTableRowModal({
 										showRecordJsonError(parsed.error);
 										return;
 									}
-									onSaveChanges(parsed.value as Record<string, unknown>[]);
+									// The editor opens on an array of one, but an edit that drops the brackets still
+									// means that record — `update` only takes a list, so send one either way.
+									onSaveChanges(Array.isArray(parsed.value) ? parsed.value : [parsed.value]);
 								}}
 								disabled={isUpdateTableRecordsPending}
 							>

--- a/src/features/instance/databases/modals/EditTableRowModal.tsx
+++ b/src/features/instance/databases/modals/EditTableRowModal.tsx
@@ -8,7 +8,8 @@ import { WORKER_FREE_JSON_LANGUAGE_ID } from '@/lib/monaco/workerFreeJsonLanguag
 import { Save, Trash, TriangleAlert } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { isRecordJsonProbablyValid, tryParseRecordJson } from './recordEditorJson';
+import { describeRecordJsonError, tryParseRecordJson } from './recordEditorJson';
+import { useRecordJsonErrorMarker } from './recordJsonErrorMarker';
 
 export function EditTableRowModal({
 	canEditRecords,
@@ -54,9 +55,9 @@ export function EditTableRowModal({
 	// user's permissions.
 	const unaddressable = Boolean(missingPrimaryKey) || Boolean(recordUnavailable);
 	const isReadOnly = !canEditRecords || unaddressable;
-	const [isValidJSON, setIsValidJSON] = useState(true);
 	const [madeChanges, setMadeChanges] = useState(false);
 	const [updatedTableRecordData, setUpdatedTableRecordData] = useState<string>();
+	const { onEditorMount, showRecordJsonError, clearRecordJsonError } = useRecordJsonErrorMarker();
 
 	const value = useMemo(() => {
 		const dataWithoutTimes = data?.map(({ __createdtime__, __updatedtime__, ...rowWithoutTime }) => {
@@ -68,16 +69,23 @@ export function EditTableRowModal({
 		return JSON.stringify(dataWithoutTimes, null, 4);
 	}, [data, syntheticAttributes]);
 
-	// This modal instance is reused across rows (it stays mounted; only `open`
-	// toggles), so the draft/validity have to be reset when a different record is
-	// loaded — otherwise a previous row's edit could be saved for, or classify, the
-	// newly opened row. Resetting during render (not in an effect) avoids a frame
+	// This modal instance is reused across rows (it stays mounted; only `open` toggles), so the
+	// draft has to be reset both when a different record is loaded — otherwise a previous row's
+	// edit could be saved for the newly opened row — and when the modal is re-opened, since the
+	// dialog's contents unmount while it is closed and an abandoned draft would otherwise outlive
+	// the editor it was typed in (#1600). Tracking `null` while closed gives both: re-opening the
+	// same row is a change of snapshot. Resetting during render (not in an effect) avoids a frame
 	// where the stale draft is still live.
-	const [recordSnapshot, setRecordSnapshot] = useState(value);
-	if (value !== recordSnapshot) {
-		setRecordSnapshot(value);
+	const openRecord = isModalOpen ? value : null;
+	const [recordSnapshot, setRecordSnapshot] = useState(openRecord);
+	const [discardedUnsavedEdits, setDiscardedUnsavedEdits] = useState(false);
+	if (openRecord !== recordSnapshot) {
+		// A record that changes under an open editor is a refetch, not a different row (the dialog
+		// is modal, so no other row can be clicked): the user's edits are about to be replaced by
+		// the stored record, and a Save that silently closed instead of saving was the only sign.
+		setDiscardedUnsavedEdits(isModalOpen && recordSnapshot !== null && madeChanges);
+		setRecordSnapshot(openRecord);
 		setUpdatedTableRecordData(undefined);
-		setIsValidJSON(true);
 		setMadeChanges(false);
 	}
 
@@ -133,6 +141,16 @@ export function EditTableRowModal({
 						</AlertDescription>
 					</Alert>
 				)}
+				{discardedUnsavedEdits && (
+					<Alert variant="warning">
+						<TriangleAlert />
+						<AlertTitle>This record changed while you were editing it</AlertTitle>
+						<AlertDescription>
+							The editor was refreshed with the stored record, so the unsaved changes were discarded. Make them again
+							and save.
+						</AlertDescription>
+					</Alert>
+				)}
 				{data
 					? (
 						// Wrapper owns the flex sizing: @monaco-editor/react applies `className` to its inner
@@ -147,10 +165,13 @@ export function EditTableRowModal({
 								theme={monacoTheme}
 								options={{ readOnly: isReadOnly, automaticLayout: true }}
 								value={value}
+								onMount={onEditorMount}
 								onChange={(updatedValue) => {
 									setUpdatedTableRecordData(updatedValue);
 									setMadeChanges(true);
-									setIsValidJSON(isRecordJsonProbablyValid(updatedValue));
+									setDiscardedUnsavedEdits(false);
+									// The marker from the last failed save described a buffer that no longer exists.
+									clearRecordJsonError();
 								}}
 							/>
 						</div>
@@ -180,21 +201,29 @@ export function EditTableRowModal({
 								autoFocus={true}
 								accessKey="s"
 								onClick={() => {
-									if (!updatedTableRecordData) {
+									// Undefined means the editor was never touched (or the draft was reset because
+									// the stored record changed), so there is nothing of the user's to save. An
+									// *emptied* editor is a real edit, and falls through to the parse below, which
+									// says why it can't be saved.
+									if (updatedTableRecordData === undefined) {
 										setIsModalOpen(false);
 										return;
 									}
-									// Authoritative parse: the live check skips oversized content, so a large,
-									// malformed edit can reach here with isValidJSON still true — parse it in a
-									// catch rather than letting Save throw an uncaught SyntaxError.
+									// The only validation the record editors get. Save is deliberately not gated on
+									// it: a disabled button explained nothing and could outlive the edit that
+									// disabled it (#1600), so a bad record is reported here instead — the reason and
+									// its location in a toast, plus a marker on the offending line.
 									const parsed = tryParseRecordJson(updatedTableRecordData);
 									if (!parsed.ok) {
-										toast.error("This record isn't valid JSON — fix the syntax and try again.");
+										toast.error("This record isn't valid JSON", {
+											description: describeRecordJsonError(parsed.error),
+										});
+										showRecordJsonError(parsed.error);
 										return;
 									}
 									onSaveChanges(parsed.value as Record<string, unknown>[]);
 								}}
-								disabled={!isValidJSON || isUpdateTableRecordsPending}
+								disabled={isUpdateTableRecordsPending}
 							>
 								<Save />{' '}
 								<span>

--- a/src/features/instance/databases/modals/recordEditorJson.test.ts
+++ b/src/features/instance/databases/modals/recordEditorJson.test.ts
@@ -3,11 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { describeRecordJsonError, tryParseRecordJson } from './recordEditorJson';
 
 describe('tryParseRecordJson', () => {
-	it('returns the parsed value for well-formed JSON', () => {
-		expect(tryParseRecordJson('{"id":1}')).toEqual({ ok: true, value: { id: 1 } });
-		expect(tryParseRecordJson('[1,2,3]')).toEqual({ ok: true, value: [1, 2, 3] });
-	});
-
 	it('returns an error rather than throwing for malformed JSON', () => {
 		const parsed = tryParseRecordJson('{"id":1,}');
 		expect(parsed.ok).toBe(false);
@@ -37,6 +32,30 @@ describe('tryParseRecordJson', () => {
 
 		expect(parsed.ok).toBe(false);
 		expect(parsed.ok === false && parsed.error.message).not.toMatch(/position|line \d+ column/i);
+	});
+
+	// These go to the ops API as `records`, so a primitive parses cleanly and then fails on the
+	// wire in the server's wording. Say it here, where the user can act on it.
+	it('rejects JSON that is well-formed but could never be a record', () => {
+		for (const notARecord of ['42', 'true', 'null', '"a string"']) {
+			const parsed = tryParseRecordJson(notARecord);
+			expect(parsed.ok).toBe(false);
+			expect(parsed.ok === false && parsed.error.message).toContain('JSON object');
+		}
+	});
+
+	it('names which item of an array is not a record', () => {
+		const parsed = tryParseRecordJson('[{"id":1},7]');
+
+		expect(parsed.ok).toBe(false);
+		expect(parsed.ok === false && parsed.error.message).toContain('Item 2');
+	});
+
+	it('takes a lone record as well as a list of them', () => {
+		expect(tryParseRecordJson('{"id":1}')).toEqual({ ok: true, value: { id: 1 } });
+		expect(tryParseRecordJson('[{"id":1},{"id":2}]')).toEqual({ ok: true, value: [{ id: 1 }, { id: 2 }] });
+		// Nothing to update, but nothing malformed either.
+		expect(tryParseRecordJson('[]')).toEqual({ ok: true, value: [] });
 	});
 
 	it('explains an emptied editor instead of reporting truncated JSON', () => {

--- a/src/features/instance/databases/modals/recordEditorJson.test.ts
+++ b/src/features/instance/databases/modals/recordEditorJson.test.ts
@@ -1,32 +1,6 @@
 import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { describe, expect, it } from 'vitest';
-import { isRecordJsonProbablyValid, tryParseRecordJson } from './recordEditorJson';
-
-describe('isRecordJsonProbablyValid', () => {
-	it('is true for well-formed JSON', () => {
-		expect(isRecordJsonProbablyValid('{"id":1,"name":"widget"}')).toBe(true);
-		expect(isRecordJsonProbablyValid('[{"id":1},{"id":2}]')).toBe(true);
-	});
-
-	it('is false for malformed JSON', () => {
-		expect(isRecordJsonProbablyValid('{"id":1,}')).toBe(false);
-		expect(isRecordJsonProbablyValid('not json')).toBe(false);
-	});
-
-	it('is false for empty or nullish content (nothing to save)', () => {
-		expect(isRecordJsonProbablyValid('')).toBe(false);
-		expect(isRecordJsonProbablyValid(undefined)).toBe(false);
-		expect(isRecordJsonProbablyValid(null)).toBe(false);
-	});
-
-	it('does not parse oversized content — defers to the submit-time parse', () => {
-		// A malformed buffer past the size limit: parsing it on every keystroke is the
-		// cost we avoid, so it is optimistically valid here and left to submit time.
-		const huge = `{"blob":"${'x'.repeat(MAX_WORKER_MODEL_CHARS)}`; // deliberately unterminated
-		expect(huge.length).toBeGreaterThan(MAX_WORKER_MODEL_CHARS);
-		expect(isRecordJsonProbablyValid(huge)).toBe(true);
-	});
-});
+import { describeRecordJsonError, tryParseRecordJson } from './recordEditorJson';
 
 describe('tryParseRecordJson', () => {
 	it('returns the parsed value for well-formed JSON', () => {
@@ -34,13 +8,56 @@ describe('tryParseRecordJson', () => {
 		expect(tryParseRecordJson('[1,2,3]')).toEqual({ ok: true, value: [1, 2, 3] });
 	});
 
-	it('returns { ok: false } for malformed JSON rather than throwing', () => {
-		expect(tryParseRecordJson('{"id":1,}')).toEqual({ ok: false });
-		expect(tryParseRecordJson('')).toEqual({ ok: false });
+	it('returns an error rather than throwing for malformed JSON', () => {
+		const parsed = tryParseRecordJson('{"id":1,}');
+		expect(parsed.ok).toBe(false);
+		expect(parsed.ok === false && parsed.error.message).toBeTruthy();
 	});
 
 	it('rejects an oversized malformed buffer without throwing', () => {
+		// Nothing validates the buffer as it is typed, so a large malformed paste reaches the
+		// submit-time parse — which has to catch it rather than throw an uncaught SyntaxError.
 		const huge = `{"blob":"${'x'.repeat(MAX_WORKER_MODEL_CHARS)}`; // unterminated
-		expect(tryParseRecordJson(huge)).toEqual({ ok: false });
+		expect(huge.length).toBeGreaterThan(MAX_WORKER_MODEL_CHARS);
+		expect(tryParseRecordJson(huge).ok).toBe(false);
+	});
+
+	it('locates the syntax error, so the editor can mark it', () => {
+		const record = '[\n    {\n        "name": "Ada",\n        "city" "London"\n    }\n]';
+		const parsed = tryParseRecordJson(record);
+
+		expect(parsed.ok).toBe(false);
+		// The offending `"London"` is on line 4; the engine may report the spot as a line/column
+		// pair or as a character offset, and both must land on the same line.
+		expect(parsed.ok === false && parsed.error.location?.lineNumber).toBe(4);
+	});
+
+	it('drops the position the engine already put in its message, so it is not said twice', () => {
+		const parsed = tryParseRecordJson('[\n    {\n        "a": 1,\n    }\n]');
+
+		expect(parsed.ok).toBe(false);
+		expect(parsed.ok === false && parsed.error.message).not.toMatch(/position|line \d+ column/i);
+	});
+
+	it('explains an emptied editor instead of reporting truncated JSON', () => {
+		// `JSON.parse('')` says "Unexpected end of JSON input", which reads like a cut-off record.
+		for (const empty of ['', '   \n  ']) {
+			const parsed = tryParseRecordJson(empty);
+			expect(parsed.ok).toBe(false);
+			expect(parsed.ok === false && parsed.error.message).toContain('empty');
+			expect(parsed.ok === false && parsed.error.location).toBeUndefined();
+		}
+	});
+});
+
+describe('describeRecordJsonError', () => {
+	it('names the location when there is one', () => {
+		expect(describeRecordJsonError({ message: 'Unterminated string', location: { lineNumber: 4, column: 12 } }))
+			.toBe('Line 4, column 12: Unterminated string');
+	});
+
+	it('falls back to the reason alone when the engine reported no position', () => {
+		expect(describeRecordJsonError({ message: 'Unexpected end of JSON input' }))
+			.toBe('Unexpected end of JSON input');
 	});
 });

--- a/src/features/instance/databases/modals/recordEditorJson.ts
+++ b/src/features/instance/databases/modals/recordEditorJson.ts
@@ -20,21 +20,27 @@ export type RecordJsonError = {
 	location?: RecordJsonLocation;
 };
 
-export type ParsedRecordJson = { ok: true; value: unknown } | { ok: false; error: RecordJsonError };
+/** A record, or a list of them — the shapes the ops API takes as `records`. */
+export type RecordJsonValue = Record<string, unknown> | Record<string, unknown>[];
 
-/** Parse `content` as JSON, returning a result object rather than throwing. */
+export type ParsedRecordJson = { ok: true; value: RecordJsonValue } | { ok: false; error: RecordJsonError };
+
+/** Parse `content` as one or more records, returning a result object rather than throwing. */
 export function tryParseRecordJson(content: string): ParsedRecordJson {
 	if (!content.trim()) {
 		// `JSON.parse('')` reports "Unexpected end of JSON input", which reads like a truncated
 		// record rather than an editor the user emptied.
 		return { ok: false, error: { message: 'The editor is empty, so there is nothing to save.' } };
 	}
+	let value: unknown;
 	try {
-		return { ok: true, value: JSON.parse(content) };
+		value = JSON.parse(content);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		return { ok: false, error: { message: withoutEngineLocation(message), location: locate(message, content) } };
 	}
+	const shapeError = recordShapeError(value);
+	return shapeError ? { ok: false, error: { message: shapeError } } : { ok: true, value: value as RecordJsonValue };
 }
 
 /** One-line rendering of a {@link RecordJsonError}, for a toast description. */
@@ -56,10 +62,36 @@ function locate(message: string, content: string): RecordJsonLocation | undefine
 	return characterOffset ? locationOfOffset(content, Number(characterOffset[1])) : undefined;
 }
 
+/** Walked rather than sliced/split: these buffers run to hundreds of KB, and neither a copy of
+ * the prefix nor an array of its lines is worth allocating to count two numbers. */
 function locationOfOffset(content: string, offset: number): RecordJsonLocation {
-	const upToOffset = content.slice(0, Math.max(0, Math.min(offset, content.length)));
-	const lastLineBreak = upToOffset.lastIndexOf('\n');
-	return { lineNumber: upToOffset.split('\n').length, column: upToOffset.length - lastLineBreak };
+	const end = Math.max(0, Math.min(offset, content.length));
+	let lineNumber = 1;
+	let lineStart = 0;
+	for (
+		let lineBreak = content.indexOf('\n');
+		lineBreak !== -1 && lineBreak < end;
+		lineBreak = content.indexOf('\n', lineBreak + 1)
+	) {
+		lineNumber++;
+		lineStart = lineBreak + 1;
+	}
+	return { lineNumber, column: end - lineStart + 1 };
+}
+
+/** Records reach the ops API as `records`, which holds objects. A primitive, a `null`, or a
+ * nested array parses cleanly and then fails on the wire in the server's wording (or, for the
+ * edit modal, as a lone object the `update` operation won't take), so name it here instead. */
+function recordShapeError(value: unknown): string | undefined {
+	if (Array.isArray(value)) {
+		const notARecord = value.findIndex(entry => !isRecord(entry));
+		return notARecord === -1 ? undefined : `Item ${notARecord + 1} of the array isn't a JSON object.`;
+	}
+	return isRecord(value) ? undefined : 'A record has to be a JSON object, or an array of them.';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /** Strip the engine's own position clause: {@link describeRecordJsonError} renders the location

--- a/src/features/instance/databases/modals/recordEditorJson.ts
+++ b/src/features/instance/databases/modals/recordEditorJson.ts
@@ -1,43 +1,73 @@
-import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
-
 /**
  * The record editors highlight JSON with a worker-free language (see
- * `workerFreeJsonLanguage.ts`), so there are no inline validation markers to
- * gate the Save button on. These helpers replace that signal:
- *
- * - {@link isRecordJsonProbablyValid} is a cheap, main-thread check for the Save
- *   button, run on every change but only *parsing* content small enough to be
- *   safe to parse repeatedly.
- * - {@link tryParseRecordJson} is the authoritative, caught parse the submit
- *   handlers run once, so an oversized/never-live-checked buffer that turns out
- *   to be malformed surfaces a toast instead of throwing an uncaught
- *   `SyntaxError`.
+ * `workerFreeJsonLanguage.ts`), so nothing validates the buffer as it is typed —
+ * that is the point of it. This is the replacement signal, and it runs at submit
+ * time: {@link tryParseRecordJson} is the authoritative, caught parse the submit
+ * handlers run once, and a failure carries the parser's reason plus a 1-based
+ * location, so Save can explain itself (a toast, and a marker on the offending
+ * line — see `recordJsonErrorMarker.ts`) instead of going quietly dead.
  */
 
-export type ParsedRecordJson = { ok: true; value: unknown } | { ok: false };
+/** Where a record buffer stopped parsing, 1-based, as Monaco counts lines and columns. */
+export type RecordJsonLocation = { lineNumber: number; column: number };
 
-/**
- * Whether `content` is worth enabling Save for. Empty content is nothing to
- * save. Content over {@link MAX_WORKER_MODEL_CHARS} is not parsed here — parsing
- * a multi-hundred-KB buffer on every keystroke is the cost we are avoiding — so
- * it is treated as valid and left to {@link tryParseRecordJson} at submit time.
- * Everything else is validated with a real parse.
- */
-export function isRecordJsonProbablyValid(content: string | undefined | null): boolean {
-	if (!content) {
-		return false;
-	}
-	if (content.length > MAX_WORKER_MODEL_CHARS) {
-		return true;
-	}
-	return tryParseRecordJson(content).ok;
-}
+/** Why a record buffer could not be parsed, and — when the engine says — where. */
+export type RecordJsonError = {
+	/** The parser's reason, e.g. `Unterminated string`. */
+	message: string;
+	/** Absent when the engine reported no position: V8 omits it for very short inputs, and
+	 * JavaScriptCore never reports one. */
+	location?: RecordJsonLocation;
+};
+
+export type ParsedRecordJson = { ok: true; value: unknown } | { ok: false; error: RecordJsonError };
 
 /** Parse `content` as JSON, returning a result object rather than throwing. */
 export function tryParseRecordJson(content: string): ParsedRecordJson {
+	if (!content.trim()) {
+		// `JSON.parse('')` reports "Unexpected end of JSON input", which reads like a truncated
+		// record rather than an editor the user emptied.
+		return { ok: false, error: { message: 'The editor is empty, so there is nothing to save.' } };
+	}
 	try {
 		return { ok: true, value: JSON.parse(content) };
-	} catch {
-		return { ok: false };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return { ok: false, error: { message: withoutEngineLocation(message), location: locate(message, content) } };
 	}
+}
+
+/** One-line rendering of a {@link RecordJsonError}, for a toast description. */
+export function describeRecordJsonError({ message, location }: RecordJsonError): string {
+	return location ? `Line ${location.lineNumber}, column ${location.column}: ${message}` : message;
+}
+
+/** V8 (`… in JSON at position 30 (line 3 column 5)`) and SpiderMonkey (`… at line 3 column 5 of the
+ * JSON data`) both name the spot; older V8 gave only the character offset. */
+const LINE_AND_COLUMN = /\bline (\d+) column (\d+)/i;
+const CHARACTER_OFFSET = /\bposition (\d+)/i;
+
+function locate(message: string, content: string): RecordJsonLocation | undefined {
+	const lineAndColumn = LINE_AND_COLUMN.exec(message);
+	if (lineAndColumn) {
+		return { lineNumber: Number(lineAndColumn[1]), column: Number(lineAndColumn[2]) };
+	}
+	const characterOffset = CHARACTER_OFFSET.exec(message);
+	return characterOffset ? locationOfOffset(content, Number(characterOffset[1])) : undefined;
+}
+
+function locationOfOffset(content: string, offset: number): RecordJsonLocation {
+	const upToOffset = content.slice(0, Math.max(0, Math.min(offset, content.length)));
+	const lastLineBreak = upToOffset.lastIndexOf('\n');
+	return { lineNumber: upToOffset.split('\n').length, column: upToOffset.length - lastLineBreak };
+}
+
+/** Strip the engine's own position clause: {@link describeRecordJsonError} renders the location
+ * itself, in one wording across engines, so leaving it in reads as a stutter. */
+function withoutEngineLocation(message: string): string {
+	return message
+		.replace(/^JSON\.parse:\s*/, '')
+		.replace(/\s*in JSON at position \d+.*$/i, '')
+		.replace(/\s*at line \d+ column \d+ of the JSON data\.?$/i, '')
+		.trim();
 }

--- a/src/features/instance/databases/modals/recordJsonErrorMarker.test.ts
+++ b/src/features/instance/databases/modals/recordJsonErrorMarker.test.ts
@@ -1,0 +1,110 @@
+import type { Monaco, OnMount } from '@monaco-editor/react';
+import { describe, expect, it, vi } from 'vitest';
+import { clearRecordJsonErrorMarker, setRecordJsonErrorMarker } from './recordJsonErrorMarker';
+
+type RecordEditor = Parameters<OnMount>[0];
+
+/** A model of `lines`, plus the editor/monaco surface the marker helpers actually touch. */
+function fakeEditor(lines: string[]) {
+	const model = {
+		getLineCount: () => lines.length,
+		// Monaco columns are 1-based and one past the last character is a valid position.
+		getLineMaxColumn: (lineNumber: number) => (lines[lineNumber - 1]?.length ?? 0) + 1,
+	};
+	const editor = {
+		getModel: () => model,
+		revealLineInCenter: vi.fn(),
+		setPosition: vi.fn(),
+		focus: vi.fn(),
+	};
+	const monaco = {
+		MarkerSeverity: { Error: 8 },
+		editor: { setModelMarkers: vi.fn() },
+	};
+	return {
+		model,
+		editor: editor as unknown as RecordEditor,
+		monaco: monaco as unknown as Monaco,
+		setModelMarkers: monaco.editor.setModelMarkers,
+		revealLineInCenter: editor.revealLineInCenter,
+		setPosition: editor.setPosition,
+	};
+}
+
+describe('setRecordJsonErrorMarker', () => {
+	it('marks the reported spot through the end of its line and scrolls to it', () => {
+		const { editor, monaco, model, setModelMarkers, revealLineInCenter, setPosition } = fakeEditor([
+			'[',
+			'    {',
+			'        "city" "London"',
+			'    }',
+			']',
+		]);
+
+		setRecordJsonErrorMarker(editor, monaco, {
+			message: "Expected ':' after property name",
+			location: { lineNumber: 3, column: 16 },
+		});
+
+		expect(setModelMarkers).toHaveBeenCalledTimes(1);
+		const [markedModel, owner, markers] = setModelMarkers.mock.calls[0];
+		expect(markedModel).toBe(model);
+		expect(owner).toBe('record-json');
+		expect(markers).toEqual([{
+			severity: 8,
+			message: "Expected ':' after property name",
+			startLineNumber: 3,
+			startColumn: 16,
+			endLineNumber: 3,
+			endColumn: 24, // through the end of the line, so the squiggle has width
+		}]);
+		expect(revealLineInCenter).toHaveBeenCalledWith(3);
+		expect(setPosition).toHaveBeenCalledWith({ lineNumber: 3, column: 16 });
+	});
+
+	it('clamps a location past the end of the buffer, which would drop the marker silently', () => {
+		const { editor, monaco, setModelMarkers, setPosition } = fakeEditor(['{}']);
+
+		setRecordJsonErrorMarker(editor, monaco, {
+			message: 'Unexpected end of JSON input',
+			location: { lineNumber: 99, column: 99 },
+		});
+
+		expect(setModelMarkers.mock.calls[0][2]).toMatchObject([{ startLineNumber: 1, startColumn: 3 }]);
+		expect(setPosition).toHaveBeenCalledWith({ lineNumber: 1, column: 3 });
+	});
+
+	// Some engines report no position at all (V8 for very short inputs, JavaScriptCore always).
+	it('clears the previous marker, and leaves the cursor alone, when the error has no location', () => {
+		const { editor, monaco, setModelMarkers, revealLineInCenter, setPosition } = fakeEditor(['not json']);
+
+		setRecordJsonErrorMarker(editor, monaco, { message: 'Unexpected token' });
+
+		expect(setModelMarkers.mock.calls[0][2]).toEqual([]);
+		expect(revealLineInCenter).not.toHaveBeenCalled();
+		expect(setPosition).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when the editor has no model', () => {
+		const editor = { getModel: () => null } as unknown as RecordEditor;
+		const monaco = { MarkerSeverity: { Error: 8 }, editor: { setModelMarkers: vi.fn() } };
+
+		expect(() =>
+			setRecordJsonErrorMarker(editor, monaco as unknown as Monaco, {
+				message: 'Unterminated string',
+				location: { lineNumber: 1, column: 1 },
+			})
+		).not.toThrow();
+		expect(monaco.editor.setModelMarkers).not.toHaveBeenCalled();
+	});
+});
+
+describe('clearRecordJsonErrorMarker', () => {
+	it('clears only this owner, so no other provider loses its diagnostics', () => {
+		const { editor, monaco, model, setModelMarkers } = fakeEditor(['{}']);
+
+		clearRecordJsonErrorMarker(editor, monaco);
+
+		expect(setModelMarkers).toHaveBeenCalledWith(model, 'record-json', []);
+	});
+});

--- a/src/features/instance/databases/modals/recordJsonErrorMarker.ts
+++ b/src/features/instance/databases/modals/recordJsonErrorMarker.ts
@@ -1,0 +1,97 @@
+import type { Monaco, OnMount } from '@monaco-editor/react';
+import { useCallback, useRef } from 'react';
+import type { RecordJsonError } from './recordEditorJson';
+
+/**
+ * A failed save is the only diagnostic the record editors get: their language
+ * registers no worker, so nothing draws squiggles as the buffer is typed (see
+ * `workerFreeJsonLanguage.ts`). When the submit-time parse fails somewhere the
+ * engine can name, mark that spot by hand and scroll to it — a toast alone
+ * leaves the user hunting for "line 4,213" in a record that doesn't fit on
+ * screen.
+ */
+
+type RecordEditor = Parameters<OnMount>[0];
+type RecordEditorModel = NonNullable<ReturnType<RecordEditor['getModel']>>;
+
+/** Marker owner. Nothing else writes markers for these editors, so clearing by owner can't wipe
+ * another provider's diagnostics. */
+const MARKER_OWNER = 'record-json';
+
+/** Wires an editor's `onMount` to the marker helpers below, so a modal can report a parse failure
+ * without holding the editor instance itself. */
+export function useRecordJsonErrorMarker() {
+	const editorRef = useRef<RecordEditor | null>(null);
+	const monacoRef = useRef<Monaco | null>(null);
+
+	const onEditorMount = useCallback<OnMount>((editor, monaco) => {
+		editorRef.current = editor;
+		monacoRef.current = monaco;
+	}, []);
+
+	const showRecordJsonError = useCallback((error: RecordJsonError) => {
+		if (editorRef.current && monacoRef.current) {
+			setRecordJsonErrorMarker(editorRef.current, monacoRef.current, error);
+		}
+	}, []);
+
+	const clearRecordJsonError = useCallback(() => {
+		if (editorRef.current && monacoRef.current) {
+			clearRecordJsonErrorMarker(editorRef.current, monacoRef.current);
+		}
+	}, []);
+
+	return { onEditorMount, showRecordJsonError, clearRecordJsonError };
+}
+
+/**
+ * Mark `error` on its line, scroll it into view, and put the cursor on it. An error the engine
+ * couldn't place only clears the previous marker — the toast still carries the reason.
+ */
+export function setRecordJsonErrorMarker(editor: RecordEditor, monaco: Monaco, error: RecordJsonError): void {
+	const model = editor.getModel();
+	if (!model) {
+		return;
+	}
+	// The location comes from a parse of the *submitted* text, which is the model's text, but clamp
+	// anyway: an out-of-range marker is dropped silently and `setPosition` would move the cursor
+	// somewhere the error isn't.
+	const location = error.location && clampToModel(model, error.location);
+	monaco.editor.setModelMarkers(
+		model,
+		MARKER_OWNER,
+		location
+			? [{
+				severity: monaco.MarkerSeverity.Error,
+				message: error.message,
+				startLineNumber: location.lineNumber,
+				startColumn: location.column,
+				endLineNumber: location.lineNumber,
+				// Through the end of the line: a zero-width marker draws no squiggle.
+				endColumn: Math.max(model.getLineMaxColumn(location.lineNumber), location.column + 1),
+			}]
+			: [],
+	);
+	if (!location) {
+		return;
+	}
+	editor.revealLineInCenter(location.lineNumber);
+	editor.setPosition(location);
+	editor.focus();
+}
+
+/** Drop the marker left by the last failed save — the buffer it described has changed. */
+export function clearRecordJsonErrorMarker(editor: RecordEditor, monaco: Monaco): void {
+	const model = editor.getModel();
+	if (model) {
+		monaco.editor.setModelMarkers(model, MARKER_OWNER, []);
+	}
+}
+
+function clampToModel(model: RecordEditorModel, { lineNumber, column }: { lineNumber: number; column: number }) {
+	const clampedLine = Math.min(Math.max(lineNumber, 1), model.getLineCount());
+	return {
+		lineNumber: clampedLine,
+		column: Math.min(Math.max(column, 1), model.getLineMaxColumn(clampedLine)),
+	};
+}

--- a/src/lib/monaco/workerFreeJsonLanguage.ts
+++ b/src/lib/monaco/workerFreeJsonLanguage.ts
@@ -23,8 +23,11 @@ import { createTokenizationSupport } from 'monaco-editor/languages/features/json
  * entirely: it registers only the main-thread JSON tokenizer plus the standard
  * JSON language configuration (brackets, auto-closing pairs), and no
  * worker-backed providers — so there is no language worker to overflow, at any
- * size. Records lose worker-only affordances (inline validation squiggles,
- * folding, format-on-type); highlighting and bracket handling are unchanged.
+ * size. Records lose worker-only affordances (live validation squiggles as the
+ * buffer is typed, folding, format-on-type); highlighting and bracket handling
+ * are unchanged. Nothing else validates the buffer, so the record editors mark
+ * the offending line themselves when a save fails to parse — see
+ * `databases/modals/recordJsonErrorMarker.ts`.
  */
 export const WORKER_FREE_JSON_LANGUAGE_ID = 'json-worker-free';
 


### PR DESCRIPTION
Closes #1600.

## What was wrong

`Save Changes` in the browse record editors was gated on an `isValidJSON` flag that only a keystroke or a changed server record could clear. Two consequences:

- **No explanation.** These editors moved to the worker-free JSON language (#1370/#1499), which registers no validation markers by design — so a disabled Save lost the red squiggle that used to accompany it, and kept the disable.
- **The flag outlived the edit.** `EditTableRowModal` stays mounted (only `open` toggles), but the dialog's *contents* unmount when it closes. So an abandoned malformed draft left Save disabled while the editor, re-created from the stored record, showed perfectly valid JSON — the reported symptom.

## What changed

Save is gated only on the pending mutation. A record that won't parse is reported at submit: a toast carrying the parser's reason and location, plus a manual Monaco marker on the offending line, revealed and focused — the squiggle the JSON worker used to draw, without bringing the worker back. The live `isRecordJsonProbablyValid` check is gone (it only fed the disable).

Three smaller fixes in the same path:

- The edit draft resets when the modal **opens**, not only when the record changes.
- An **emptied** editor is a real edit that says why it can't be saved, rather than being indistinguishable from "never touched" and closing the modal silently (`updatedTableRecordData === undefined` instead of falsy).
- A refetch that replaces unsaved edits now warns, instead of turning the next Save into a silent close (the latent bug noted in the issue).
- Well-formed JSON that could never be a record is rejected with a reason rather than failing later in the server's wording: a primitive, `null`, or an array holding one. `tryParseRecordJson` now returns the shape it guarantees (`Record<string, unknown> | Record<string, unknown>[]`), so both call sites drop their `as` casts, and an edit that drops the outer brackets is wrapped back into the one-record list `update` expects. (From review — see the resolved threads.)

## Worth a look

- **`recordJsonErrorMarker.ts`** is the only genuinely new surface. jsdom can't run Monaco, so its unit tests use a fake editor/model; the real integration (marker owner, squiggle width, `revealLineInCenter`, cursor) was verified in the browser against real Monaco on the worker-free language — a 18-line record with the syntax broken on line 15, off-screen at that editor height: marker landed at 15:17–15:39, the view scrolled from lines 1–10 to 10–18, and the marker cleared on the next edit.
- **`AddTableRowModal` keeps one gate**: Save is disabled until the sample record is edited at all (`addTableRecordData === undefined`). That state isn't stuck-able and the untouched sample explains it, but it is a deliberate asymmetry with the edit modal — say if you'd rather it always be clickable.
- **Discarding vs. preserving edits on a refetch.** I kept the existing clobber (stored record wins) and added the warning banner, rather than keeping the user's draft over newer server data. Preserving it would mean a save that silently overwrites someone else's change, so the banner seemed the honest option — but it is a UX call, not a forced one.
- Parser-message handling in `recordEditorJson.ts` normalizes V8/SpiderMonkey wording and strips the engine's own position clause so the location isn't stated twice. JavaScriptCore (Safari) reports no position at all; that path degrades to reason-only, and clears the marker rather than pointing at the wrong line.

🤖 Generated by an LLM (Claude Opus 5).
