### PR TITLE
fix(monaco): register editor features before any service lookup [#1614]

### DIFF
--- a/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
+++ b/src/features/instance/applications/hooks/useApplicationTypeIntelligence.ts
@@ -46,10 +46,10 @@ import {
 	sweepStaleApplicationModels,
 } from '@/features/instance/applications/lib/modelHousekeeping';
 import { getComponentFileQueryOptions } from '@/integrations/api/instance/applications/getComponentFile';
+import * as monaco from '@/lib/monaco/editorApi';
 import { typescript } from '@/lib/monaco/languageServices';
 import { MAX_WORKER_MODEL_CHARS } from '@/lib/monaco/workerLimits';
 import { useQueryClient } from '@tanstack/react-query';
-import * as monaco from 'monaco-editor/editor';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 /** Degradation status the editor surfaces to the user (HarperFast/studio#1504). */

--- a/src/features/instance/applications/hooks/useCodeNavigation.ts
+++ b/src/features/instance/applications/hooks/useCodeNavigation.ts
@@ -26,7 +26,7 @@
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
 import { useListener } from '@/lib/events/listener';
 import { setWatchedValue } from '@/lib/events/watcher';
-import * as monaco from 'monaco-editor/editor';
+import * as monaco from '@/lib/monaco/editorApi';
 import { useEffect, useRef } from 'react';
 
 type Editor = monaco.editor.IStandaloneCodeEditor;

--- a/src/features/instance/config/overview/harper-config/configMonaco.ts
+++ b/src/features/instance/config/overview/harper-config/configMonaco.ts
@@ -37,16 +37,16 @@ const SCHEMA_URI = 'harper://schemas/config-root.json';
  *
  * The JSON language-service defaults are reached through a dynamic `import()`
  * rather than a top-level one, so this module — which the config route imports
- * eagerly — never links Monaco into an eager chunk. That matters beyond bundle
- * size: each `monaco-editor/languages/features/<lang>/register` entry has
- * registration side effects, and evaluating one at boot builds Monaco's service
- * collection before `monaco-editor/features/register.all` (loaded with the lazy
- * `@/lib/monaco/setup`) has registered its singletons. Monaco builds that
- * collection once, so the late registrations are ignored and every editor then
- * throws "[createInstance] … depends on UNKNOWN service …" for the five
- * services backing code lens, inlay hints, suggest memory, the code-action
- * widget, and tree-view DnD (#1592). By `onMount` Monaco is already loaded, so
- * this resolves from the module cache.
+ * eagerly — never links Monaco into an eager chunk (#1592). By `onMount` Monaco
+ * is already loaded, so this resolves from the module cache.
+ *
+ * This comment used to claim that evaluating a `languages/features/<lang>/register`
+ * entry is what builds Monaco's service collection too early. It isn't:
+ * `languages.register` deliberately routes through `ModesRegistry` "to avoid
+ * instantiating services too quickly", and `StandaloneServices.initialize()`
+ * folds in singletons registered after the module loaded. What actually freezes
+ * the collection is the first *service lookup* — see `@/lib/monaco/editorApi`,
+ * which owns that ordering invariant now (#1614).
  */
 export async function configureHarperConfigEditor(): Promise<void> {
 	const { json } = await import('@/lib/monaco/languageServices');

--- a/src/lib/monaco/__tests__/setup.ts
+++ b/src/lib/monaco/__tests__/setup.ts
@@ -18,3 +18,21 @@ if (typeof document !== 'undefined') {
 		document.execCommand = () => false;
 	}
 }
+
+// Monaco's theme service watches the OS light/dark preference via
+// `matchMedia('(forced-colors: active)')` as soon as it is instantiated, and
+// jsdom ships no `matchMedia` at all — so any suite that reaches a Monaco
+// service throws from the service constructor, outside the test's own stack.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+	window.matchMedia = (query: string) =>
+		({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+}

--- a/src/lib/monaco/editorApi.test.ts
+++ b/src/lib/monaco/editorApi.test.ts
@@ -37,9 +37,16 @@ describe('monaco editorApi', () => {
 		// call `useApplicationTypeIntelligence` makes from an effect, which used
 		// to run while the lazy `./setup` chunk (and its `register.all`) was
 		// still loading behind `<MonacoEditor>`'s Suspense boundary.
-		monaco.editor.createModel('{}', 'json', monaco.Uri.parse('file:///editorApi-test/a.json'));
+		const model = monaco.editor.createModel('{}', 'json', monaco.Uri.parse('file:///editorApi-test/a.json'));
 
-		expect(await committedServiceIds()).toEqual(expect.arrayContaining(REGISTER_ALL_SERVICES));
+		// Released even if the assertion throws: Monaco's model registry is
+		// module state, so a leaked model would collide on its URI if this file
+		// re-ran in the same worker (watch mode).
+		try {
+			expect(await committedServiceIds()).toEqual(expect.arrayContaining(REGISTER_ALL_SERVICES));
+		} finally {
+			model.dispose();
+		}
 		// Evaluating Monaco's editor + every feature registration is seconds of
 		// work, well past the 5s default once the suite runs them in parallel.
 	}, 30_000);

--- a/src/lib/monaco/editorApi.test.ts
+++ b/src/lib/monaco/editorApi.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The services `monaco-editor/features/register.all` contributes. They are the
+ * ones that showed up as `[createInstance] … depends on UNKNOWN service …` in
+ * production when an editor-feature registration lost the race against the
+ * first service lookup (HarperFast/studio#1614).
+ */
+const REGISTER_ALL_SERVICES = [
+	'actionWidgetService',
+	'ICodeLensCache',
+	'IInlayHintsCache',
+	'ISuggestMemories',
+	'treeViewsDndService',
+];
+
+/**
+ * Read the service ids Monaco's standalone DI container actually committed to.
+ * `initialize()` is the one-shot that snapshots the singleton registry; calling
+ * it again returns the existing container, so this observes the real collection
+ * rather than building a fresh one.
+ */
+async function committedServiceIds(): Promise<string[]> {
+	const { StandaloneServices } = await import('monaco-editor/editor/standalone/browser/standaloneServices.js');
+	const entries = StandaloneServices.initialize({})._services?._entries;
+	return entries ? [...entries.keys()].map(String) : [];
+}
+
+describe('monaco editorApi', () => {
+	// One test per file: the DI container snapshots once per module registry, so
+	// a second case in this file would observe the first case's container.
+	it('registers the editor features before a service lookup can freeze the collection', async () => {
+		const monaco = await import('./editorApi');
+
+		// Touching a service is what triggers the one-shot snapshot. This is the
+		// call `useApplicationTypeIntelligence` makes from an effect, which used
+		// to run while the lazy `./setup` chunk (and its `register.all`) was
+		// still loading behind `<MonacoEditor>`'s Suspense boundary.
+		monaco.editor.createModel('{}', 'json', monaco.Uri.parse('file:///editorApi-test/a.json'));
+
+		expect(await committedServiceIds()).toEqual(expect.arrayContaining(REGISTER_ALL_SERVICES));
+		// Evaluating Monaco's editor + every feature registration is seconds of
+		// work, well past the 5s default once the suite runs them in parallel.
+	}, 30_000);
+});

--- a/src/lib/monaco/editorApi.ts
+++ b/src/lib/monaco/editorApi.ts
@@ -1,0 +1,32 @@
+/**
+ * The Monaco API namespace, with Monaco's editor features guaranteed to be
+ * registered first. **Import Monaco through this module, never from
+ * `monaco-editor/editor` directly.**
+ *
+ * Monaco's standalone DI container snapshots its service collection exactly
+ * once, the first time anything asks for a service:
+ * `StandaloneServices.get()` calls a one-shot `initialize()`, which copies
+ * `getSingletonServiceDescriptors()` into the collection and then never
+ * re-reads it. Any `registerSingleton` that runs after that point is silently
+ * dropped, and because the container is constructed in strict mode, every
+ * contribution that later asks for a missing service throws
+ * `[createInstance] … depends on UNKNOWN service …`.
+ *
+ * `monaco-editor/features/register.all` is what registers the services backing
+ * code lens, inlay hints, suggest memory, the code-action widget, and tree-view
+ * DnD. It is imported by `./setup`, which `MonacoEditor` loads lazily — so a
+ * module that pulls in `monaco-editor/editor` on its own and touches a service
+ * (`monaco.editor.createModel`, `getModels`, `onDidCreateModel`, … all call
+ * `StandaloneServices.get`) can win that race and freeze an incomplete
+ * collection while the setup chunk is still in flight. That poisons the DI
+ * container for the rest of the session, so every editor opened afterwards —
+ * on any route — throws on hover (HarperFast/studio#1614).
+ *
+ * Re-exporting the namespace from behind the `register.all` side-effect import
+ * makes the ordering a property of the module graph: ES modules evaluate
+ * imports depth-first in source order, so `register.all` has always registered
+ * its singletons before any consumer of this module can run a line of code.
+ */
+import 'monaco-editor/features/register.all';
+
+export * from 'monaco-editor/editor';

--- a/src/lib/monaco/monacoStandaloneServices.d.ts
+++ b/src/lib/monaco/monacoStandaloneServices.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Monaco's standalone DI container. Not one of monaco-editor's declared entry
+ * points, so it ships without type declarations.
+ *
+ * `editorApi.test.ts` reaches in to assert *which* services the container
+ * actually committed to — see `editorApi.ts` for why that set depends on
+ * evaluation order. `initialize` is the one-shot that snapshots the singleton
+ * registry; calling it again returns the existing `InstantiationService`, whose
+ * internal service collection is the only place the committed set is
+ * observable. Typed as loosely as the assertion needs, since these are
+ * Monaco-internal shapes with no compatibility promise.
+ */
+declare module 'monaco-editor/editor/standalone/browser/standaloneServices.js' {
+	export const StandaloneServices: {
+		initialize(overrides: object): { _services?: { _entries?: Map<unknown, unknown> } };
+	};
+}


### PR DESCRIPTION
Fixes the Monaco DI errors tracked in #1614 — **84% of all Studio RUM errors in the last 24h** (480 events across 32 of 128 prod sessions, ~25% of sessions).

## Root cause

Monaco's standalone DI container commits its service collection exactly once. `StandaloneServices.get()` calls a one-shot `initialize()` which copies `getSingletonServiceDescriptors()` into the collection and never re-reads it, and the container is constructed in **strict** mode — so any singleton registered afterwards is silently dropped, and every contribution that later asks for it throws `[createInstance] … depends on UNKNOWN service …`.

`useApplicationTypeIntelligence` and `useCodeNavigation` imported `monaco-editor/editor` **directly**, so the Applications route chunk reached Monaco's API without `monaco-editor/features/register.all` — which only comes in via `@/lib/monaco/setup`, loaded lazily behind `<MonacoEditor>`'s Suspense boundary. Those hooks' effects fire while the setup chunk is still in flight, and `monaco.editor.createModel` / `getModels` / `onDidCreateModel` all call `StandaloneServices.get`.

Whichever won the race froze a collection missing exactly the five services `register.all` contributes — code lens, inlay hints, suggest memory, the code-action widget, tree-view DnD. That poisons the container **for the whole session**, which is why the errors show up on every editor route (`config/` 135, `apps/` 83, `databases/…` 50, `instance/…/config/` 50, and `config/roles/$roleId/` newly this window) and fire on hover rather than at load.

Reproduced in a test before fixing — touching a service before `register.all` freezes the collection at 55 descriptors with none of the five, permanently, even after `register.all` later loads.

## Why the previous fixes didn't take

- **#1592** removed the eager Monaco import from `main.tsx`. Real, but eagerness at *boot* was never the load-bearing part — the race is route-level.
- **#1614's** diagnosis (and the comment in `configMonaco.ts`) attributed it to `editor.api` evaluating before `register.all`, since `register.all` imports `editor.api`. That ordering is normal and harmless: `languages.register` deliberately routes through `ModesRegistry` "to avoid instantiating services too quickly", and `initialize()` explicitly folds in singletons registered after the module loaded. Verified directly — importing `json/register` first still yields a complete 64-service collection. **The first service _lookup_ is what commits the collection**, not module evaluation order. The stale comment is corrected in this PR.

## The fix

A new `@/lib/monaco/editorApi` re-exports the Monaco namespace from behind a `register.all` side-effect import, and both hooks import from it. ES modules evaluate imports depth-first in source order, so the registrations always land before any consumer runs a line of code — the invariant becomes a property of the module graph instead of load timing.

## Verification

Against a real `vite build` (the `editor.api` / `toggleHighContrast` chunk hashes match what production serves today, so it's directly comparable):

| | Applications chunk reaches `register.all` statically? |
| --- | --- |
| before | **No** — only `editor.api` (via `editor-DK9rdQRE.js`, the exact chunk hash prod serves) |
| after | **Yes** — via `editorApi` → `toggleHighContrast-el2uNoWb.js` |

**#1592 is not regressed:** the entry chunk still has no static Monaco import, and `index.html` preloads no Monaco chunk.

- New regression test asserts the committed collection contains all five services; confirmed it **fails** when pointed back at raw `monaco-editor/editor` and passes through `editorApi`.
- Full suite green (284 files / 2179 tests), `tsc -b` clean, `oxlint` + `dprint` clean.
- Added a `matchMedia` polyfill to the shared Monaco test setup — jsdom ships none, and Monaco's theme service throws from its constructor without it.

## Note for reviewers — unrelated, needs a separate look

`pnpm-lock.yaml` pins `@tanstack/react-table` **9.1.2** (migrated in 049baf38), but an environment installed before that lands resolves **8.21.3**, which fails the build outright (`"columnResizingFeature" is not exported`) plus 85 `tsc` errors and 13 uncollectable test suites. If you see that, re-run `pnpm install` — it is not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
