### PR TITLE
feat(applications): warn before a download too large for the browser

### DIFF
--- a/src/features/instance/applications/components/ApplicationsSidebar/calculateRootEntries.test.ts
+++ b/src/features/instance/applications/components/ApplicationsSidebar/calculateRootEntries.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `calculateRootEntries` rebuilds every node from scratch rather than spreading the API entry,
+ * so any field it doesn't name explicitly is silently dropped. That already bit once: `size`
+ * was missing, and the download modal reported "At least 0 B across 159 files" against a real
+ * instance that was sending a size on every file (HarperFast/studio#1591). Nothing about that
+ * failure is visible from types — the field is optional — so it needs a test to stay fixed.
+ */
+import { calculateRootEntries } from '@/features/instance/applications/components/ApplicationsSidebar/calculateRootEntries';
+import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
+import { FileEntry } from '@/features/instance/applications/context/fileEntry';
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
+import { APIDirectoryEntry } from '@/integrations/api/instance/applications/getComponents';
+import { describe, expect, it } from 'vitest';
+
+const TREE: APIDirectoryEntry[] = [
+	{
+		name: 'my-app',
+		entries: [
+			{ name: 'package.json', size: 100 },
+			{ name: 'README.md', size: 200 },
+			{
+				name: 'src',
+				entries: [{ name: 'index.js', size: 900 }],
+			} as APIDirectoryEntry,
+		],
+	} as APIDirectoryEntry,
+];
+
+type AnyEntry = DirectoryEntry | FileEntry;
+
+/** Depth-first lookup by the `path` the transformer assigns. */
+function at(entries: AnyEntry[], path: string): AnyEntry | undefined {
+	for (const entry of entries) {
+		if (entry.path === path) {
+			return entry;
+		}
+		if (isDirectory(entry)) {
+			const found = at(entry.entries, path);
+			if (found) {
+				return found;
+			}
+		}
+	}
+	return undefined;
+}
+
+describe('calculateRootEntries', () => {
+	it('carries each file size through to the transformed tree', () => {
+		const { rootEntries } = calculateRootEntries(TREE);
+
+		expect(at(rootEntries, 'my-app/package.json')?.size).toBe(100);
+		// Nested a level down, where the transformer recurses — the case the modal actually sums.
+		expect(at(rootEntries, 'my-app/src/index.js')?.size).toBe(900);
+	});
+
+	it('leaves size undefined when the API entry has none, rather than inventing a zero', () => {
+		const { rootEntries } = calculateRootEntries([
+			{ name: 'my-app', entries: [{ name: 'mystery.bin' }] } as APIDirectoryEntry,
+		]);
+
+		expect(at(rootEntries, 'my-app/mystery.bin')?.size).toBeUndefined();
+	});
+
+	it('builds nested paths and attributes every entry to its top-level project', () => {
+		const { rootEntries, pathsRegistry } = calculateRootEntries(TREE);
+
+		expect(at(rootEntries, 'my-app/src/index.js')?.project).toBe('my-app');
+		expect(pathsRegistry.has('my-app/src/index.js')).toBe(true);
+		expect(pathsRegistry.has('my-app')).toBe(true);
+	});
+
+	it('attaches a directory README as its overview entry', () => {
+		const { rootEntries } = calculateRootEntries(TREE);
+		const root = at(rootEntries, 'my-app');
+
+		expect(isDirectory(root) && root.overviewEntry?.path).toBe('my-app/README.md');
+	});
+});

--- a/src/features/instance/applications/components/ApplicationsSidebar/calculateRootEntries.ts
+++ b/src/features/instance/applications/components/ApplicationsSidebar/calculateRootEntries.ts
@@ -19,6 +19,10 @@ export function calculateRootEntries(entries: Array<APIDirectoryEntry | APIFileE
 			return {
 				name: node.name,
 				path,
+				// Carried through from the API entry rather than dropped: the download modal sizes a
+				// package by summing these off the tree (see measureProjectPackage), and this
+				// transformer rebuilds each node from scratch, so anything not named here is lost.
+				size: node.size,
 				project: (parents[0] || node)?.name,
 				package: (parents[0] || node)?.package,
 				overviewEntry: readMeAPIFile && !isDirectory(readMeAPIFile) && {

--- a/src/features/instance/applications/lib/projectPackageSize.test.ts
+++ b/src/features/instance/applications/lib/projectPackageSize.test.ts
@@ -1,0 +1,71 @@
+import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
+import { FileEntry } from '@/features/instance/applications/context/fileEntry';
+import { LARGE_PACKAGE_BYTES, measureProjectPackage } from '@/features/instance/applications/lib/projectPackageSize';
+import { describe, expect, it } from 'vitest';
+
+function file(name: string, size?: number): FileEntry {
+	return { name, path: `app/${name}`, project: 'app', size } as FileEntry;
+}
+
+function dir(name: string, entries: Array<DirectoryEntry | FileEntry>): DirectoryEntry {
+	return { name, path: name, project: name, entries } as DirectoryEntry;
+}
+
+describe('measureProjectPackage', () => {
+	it('sums every file under the project, at any depth', () => {
+		const tree = [
+			dir('app', [
+				file('package.json', 100),
+				dir('src', [file('index.js', 900), dir('deep', [file('nested.js', 1_000)])]),
+			]),
+		];
+
+		expect(measureProjectPackage(tree, 'app')).toEqual({ bytes: 2_000, fileCount: 3, exact: true });
+	});
+
+	it('ignores other projects in the tree', () => {
+		const tree = [
+			dir('app', [file('index.js', 10)]),
+			dir('other', [file('huge.bin', 999_999)]),
+		];
+
+		expect(measureProjectPackage(tree, 'app')?.bytes).toBe(10);
+	});
+
+	it('reports an inexact total when a file entry carries no size', () => {
+		const tree = [dir('app', [file('sized.js', 40), file('unsized.js', undefined)])];
+
+		expect(measureProjectPackage(tree, 'app')).toEqual({ bytes: 40, fileCount: 2, exact: false });
+	});
+
+	it('counts an empty project as zero rather than undefined', () => {
+		expect(measureProjectPackage([dir('app', [])], 'app')).toEqual({ bytes: 0, fileCount: 0, exact: true });
+	});
+
+	// Undefined is the "say nothing" signal for the modal — distinct from a real zero, which
+	// would otherwise render as a confident "About 0 B".
+	it('returns undefined when the project is absent from the tree', () => {
+		expect(measureProjectPackage([dir('other', [file('a.js', 1)])], 'app')).toBeUndefined();
+	});
+
+	it('returns undefined when no project is opened', () => {
+		expect(measureProjectPackage([dir('app', [file('a.js', 1)])], undefined)).toBeUndefined();
+	});
+
+	it('returns undefined when the named entry is a file, not a project directory', () => {
+		expect(measureProjectPackage([file('app', 10)], 'app')).toBeUndefined();
+	});
+
+	// The case that produced HarperFast/studio#1591: ~800 MB of application, no node_modules.
+	it('puts a #1591-sized application over the warning threshold', () => {
+		const tree = [dir('app', [file('assets.bin', 800_000_000)])];
+
+		expect(measureProjectPackage(tree, 'app')!.bytes).toBeGreaterThan(LARGE_PACKAGE_BYTES);
+	});
+
+	it('leaves an ordinary application under the warning threshold', () => {
+		const tree = [dir('app', [file('index.js', 20_000), file('README.md', 4_000)])];
+
+		expect(measureProjectPackage(tree, 'app')!.bytes).toBeLessThan(LARGE_PACKAGE_BYTES);
+	});
+});

--- a/src/features/instance/applications/lib/projectPackageSize.test.ts
+++ b/src/features/instance/applications/lib/projectPackageSize.test.ts
@@ -1,6 +1,10 @@
 import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
 import { FileEntry } from '@/features/instance/applications/context/fileEntry';
-import { LARGE_PACKAGE_BYTES, measureProjectPackage } from '@/features/instance/applications/lib/projectPackageSize';
+import {
+	LARGE_PACKAGE_BYTES,
+	measureProjectPackage,
+	packageCaution,
+} from '@/features/instance/applications/lib/projectPackageSize';
 import { describe, expect, it } from 'vitest';
 
 function file(name: string, size?: number): FileEntry {
@@ -67,5 +71,44 @@ describe('measureProjectPackage', () => {
 		const tree = [dir('app', [file('index.js', 20_000), file('README.md', 4_000)])];
 
 		expect(measureProjectPackage(tree, 'app')!.bytes).toBeLessThan(LARGE_PACKAGE_BYTES);
+	});
+});
+
+describe('packageCaution', () => {
+	const exact = (bytes: number) => ({ bytes, fileCount: 3, exact: true });
+
+	it('stays quiet for a measured, ordinary application', () => {
+		expect(packageCaution(exact(24_000), false)).toBeUndefined();
+	});
+
+	it('flags a measured application over the threshold as large', () => {
+		expect(packageCaution(exact(800_000_000), false)).toBe('large');
+	});
+
+	it('treats the threshold as exclusive', () => {
+		expect(packageCaution(exact(LARGE_PACKAGE_BYTES), false)).toBeUndefined();
+		expect(packageCaution(exact(LARGE_PACKAGE_BYTES + 1), false)).toBe('large');
+	});
+
+	it('flags including node modules as large, since the measured total is then only a floor', () => {
+		expect(packageCaution(exact(1_000), true)).toBe('large');
+	});
+
+	// The hole this function exists to close. An instance that reports no file sizes yields
+	// { bytes: 0, exact: false }; comparing that against the threshold reads as "safe", so an
+	// 800 MB application would get no warning at all and reproduce the #1591 tab crash.
+	it('flags an inexact measurement even though its partial total is under the threshold', () => {
+		expect(packageCaution({ bytes: 0, fileCount: 4_213, exact: false }, false)).toBe('unmeasured');
+		expect(packageCaution({ bytes: 2_000, fileCount: 4_213, exact: false }, false)).toBe('unmeasured');
+	});
+
+	it('flags a project it could not measure at all', () => {
+		expect(packageCaution(undefined, false)).toBe('unmeasured');
+	});
+
+	// Unmeasured wins over large: the honest message is "we don't know", not a size claim we
+	// can't support.
+	it('reports unmeasured rather than large when an inexact total is itself over the threshold', () => {
+		expect(packageCaution({ bytes: 800_000_000, fileCount: 10, exact: false }, false)).toBe('unmeasured');
 	});
 });

--- a/src/features/instance/applications/lib/projectPackageSize.ts
+++ b/src/features/instance/applications/lib/projectPackageSize.ts
@@ -1,0 +1,84 @@
+/**
+ * Sizing for the Download Application flow, so the modal can say how big a package is
+ * *before* asking the instance to build it.
+ *
+ * The numbers come from the `get_components` tree Studio already has cached — Harper returns
+ * a `size` on every file entry — so this costs no extra request. `get_components` also skips
+ * `node_modules`, which makes the total an exact match for the modal's default
+ * (`skip_node_modules: true`) and a floor for the include-node_modules case.
+ *
+ * Why it matters: `package_component` returns the whole archive as base64 inside JSON, and
+ * decoding that costs roughly 5x the archive size in the renderer (response text, the parsed
+ * string, the `atob` copy, the byte array, the Blob). Past a few hundred MB Chrome kills the
+ * tab mid-download with a generic "Aw, Snap!" and no explanation — HarperFast/studio#1591.
+ * Streaming the archive instead is HarperFast/harper#2150; until that lands (and for older
+ * instances after it does) the honest fix is to tell the user the size up front.
+ */
+import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
+import { FileEntry } from '@/features/instance/applications/context/fileEntry';
+import { isDirectory } from '@/features/instance/applications/context/isDirectory';
+
+type AnyEntry = DirectoryEntry | FileEntry;
+
+export interface ProjectPackageSize {
+	/** Total uncompressed bytes of the files Harper would pack, excluding `node_modules`. */
+	bytes: number;
+	fileCount: number;
+	/**
+	 * False when at least one file entry carried no `size` — Harper has sent one on every file
+	 * for a long time, but an older instance (or a directory the walk failed to stat) would
+	 * make `bytes` an undercount, and the modal should hedge its wording rather than state a
+	 * total it can't stand behind.
+	 */
+	exact: boolean;
+}
+
+/**
+ * Uncompressed bytes above which the modal warns before packaging. Decimal MB, matching
+ * `humanFileSize`.
+ *
+ * 100 MB is well under anything that has actually failed (#1591 was ~800 MB) and well over a
+ * normal application, so it catches the "I didn't realize how big this was" case — the one
+ * that produced #1591 — without nagging about ordinary downloads. It is deliberately the only
+ * tier: a hard ceiling would have to be guessed from an uncompressed total, and a large tree
+ * of compressible source can still download fine, so the decision stays the user's.
+ */
+export const LARGE_PACKAGE_BYTES = 100_000_000;
+
+/**
+ * Total size of the files `package_component` would pack for `project`, or undefined when the
+ * project isn't in the tree (nothing trustworthy to report — say nothing rather than "0 B").
+ */
+export function measureProjectPackage(
+	rootEntries: AnyEntry[],
+	project: string | undefined,
+): ProjectPackageSize | undefined {
+	if (!project) {
+		return undefined;
+	}
+	const root = rootEntries.find(entry => entry.name === project);
+	if (!root || !isDirectory(root)) {
+		return undefined;
+	}
+
+	let bytes = 0;
+	let fileCount = 0;
+	let exact = true;
+	const walk = (entries: AnyEntry[]) => {
+		for (const entry of entries) {
+			if (isDirectory(entry)) {
+				walk(entry.entries);
+				continue;
+			}
+			fileCount++;
+			if (typeof entry.size === 'number') {
+				bytes += entry.size;
+			} else {
+				exact = false;
+			}
+		}
+	};
+	walk(root.entries);
+
+	return { bytes, fileCount, exact };
+}

--- a/src/features/instance/applications/lib/projectPackageSize.ts
+++ b/src/features/instance/applications/lib/projectPackageSize.ts
@@ -45,6 +45,39 @@ export interface ProjectPackageSize {
  */
 export const LARGE_PACKAGE_BYTES = 100_000_000;
 
+/** Why the modal should caution before packaging, or undefined when it shouldn't. */
+export type PackageCaution =
+	/** Measured, and big enough that the browser may not survive decoding it. */
+	| 'large'
+	/** Not measured, or measured short — the size is unknown, which is not the same as small. */
+	| 'unmeasured';
+
+/**
+ * Whether to caution before packaging `measured`, and why.
+ *
+ * The `unmeasured` state is the whole reason this is a function rather than a `>` comparison.
+ * An instance that reports no file sizes yields `{ bytes: 0, exact: false }`, and comparing that
+ * total against the threshold reads as "safe" — so the 800 MB application this warning exists
+ * for (HarperFast/studio#1591) would sail through to the same tab crash, on precisely the older
+ * instances least likely to have the streamed download. Absence of a measurement must never
+ * suppress the warning; it earns one of its own.
+ */
+export function packageCaution(
+	measured: ProjectPackageSize | undefined,
+	includeNodeModules: boolean,
+): PackageCaution | undefined {
+	if (!measured || !measured.exact) {
+		return 'unmeasured';
+	}
+	// node_modules is absent from the tree, so an exact total is still only a floor once it's
+	// included — and usually by a lot. Treat that as large rather than unmeasured: we know the
+	// real package exceeds what we measured, which is the same thing the user needs to hear.
+	if (includeNodeModules || measured.bytes > LARGE_PACKAGE_BYTES) {
+		return 'large';
+	}
+	return undefined;
+}
+
 /**
  * Total size of the files `package_component` would pack for `project`, or undefined when the
  * project isn't in the tree (nothing trustworthy to report — say nothing rather than "0 B").

--- a/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
@@ -1,0 +1,178 @@
+/** @vitest-environment jsdom */
+/**
+ * The download modal's job before HarperFast/harper#2150 lands is to be honest about size:
+ * `package_component` returns the whole archive as base64 in JSON, and past a few hundred MB
+ * decoding it kills the tab with a generic Chrome error and no explanation
+ * (HarperFast/studio#1591). These tests cover the up-front size, the warning that fires for a
+ * #1591-sized application, and the two failure paths that used to leave the "Packaging..."
+ * toast spinning forever.
+ */
+import { DirectoryEntry } from '@/features/instance/applications/context/directoryEntry';
+import { EditorViewContext, EditorViewContextValue } from '@/features/instance/applications/context/EditorViewContext';
+import { FileEntry } from '@/features/instance/applications/context/fileEntry';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	packageComponent: vi.fn(),
+	toast: {
+		loading: vi.fn(() => 'toast-1'),
+		success: vi.fn(),
+		error: vi.fn(),
+		dismiss: vi.fn(),
+	},
+}));
+
+vi.mock('@/config/useInstanceClient', () => ({
+	useInstanceClientIdParams: () => ({ entityId: 'instance-1', entityType: 'instance' }),
+}));
+vi.mock('@/integrations/api/instance/applications/packageComponent', () => ({
+	usePackageComponentMutation: () => ({ mutate: mocks.packageComponent, isPending: false, isSuccess: false }),
+}));
+vi.mock('@/lib/events/watcher', () => ({
+	useWatchedValue: () => ({ value: true, trigger: undefined }),
+	setWatchedValue: () => {},
+}));
+vi.mock('@/lib/attemptToRestoreFocus', () => ({ attemptToRestoreFocus: () => {} }));
+vi.mock('sonner', () => ({ toast: mocks.toast }));
+
+import { DownloadApplicationModal } from './DownloadApplicationModal';
+
+function file(name: string, size: number): FileEntry {
+	return { name, path: `my-app/${name}`, project: 'my-app', size } as FileEntry;
+}
+
+function mount(files: FileEntry[]) {
+	const root: DirectoryEntry = { name: 'my-app', path: 'my-app', project: 'my-app', entries: files };
+	const openedEntry: FileEntry = { name: 'index.js', path: 'my-app/index.js', project: 'my-app' };
+	const value = {
+		rootEntries: [root],
+		reloadRootEntries: () => Promise.resolve({ name: '', entries: [] }),
+		entryExists: () => false,
+		openedEntry,
+		setOpenedEntry: () => {},
+		restrictPackageModification: false,
+		openedEntryContents: undefined,
+		setOpenedEntryContents: () => {},
+		focusedItem: undefined,
+		setFocusedItem: () => {},
+		expandedItems: [],
+		setExpandedItems: () => {},
+		selectedItems: [],
+		setSelectedItems: () => {},
+		saveFile: () => {},
+		isSavingFile: false,
+	} as unknown as EditorViewContextValue;
+	return render(
+		<EditorViewContext.Provider value={value}>
+			<DownloadApplicationModal />
+		</EditorViewContext.Provider>,
+	);
+}
+
+/** Click Download and hand back the callbacks the modal passed to the mutation. */
+function clickDownload() {
+	fireEvent.click(screen.getByRole('button', { name: /Download/ }));
+	const [, options] = mocks.packageComponent.mock.calls.at(-1)!;
+	return options as {
+		onSuccess: (response: { payload: string }) => void;
+		onError: (error: Error) => void;
+	};
+}
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+describe('DownloadApplicationModal size warning', () => {
+	it('states the package size up front, before anything is packaged', () => {
+		mount([file('index.js', 2_000_000), file('README.md', 1_000_000)]);
+
+		expect(screen.getByText(/About 3 MB across 2 files/)).toBeTruthy();
+		expect(mocks.packageComponent).not.toHaveBeenCalled();
+	});
+
+	it('stays quiet for an ordinary application', () => {
+		mount([file('index.js', 2_000_000)]);
+
+		expect(screen.queryByText('This is a large download')).toBeNull();
+		expect(screen.getByRole('button', { name: /Download$/ })).toBeTruthy();
+	});
+
+	it('warns and relabels the button for a #1591-sized application', () => {
+		mount([file('assets.bin', 800_000_000)]);
+
+		expect(screen.getByText('This is a large download')).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Download anyway/ })).toBeTruthy();
+	});
+
+	// node_modules is absent from the get_components tree, so the measured total is only a
+	// floor once the user opts into including it — warn rather than quote a number we know is low.
+	it('warns once node modules are included, even for a small application', () => {
+		mount([file('index.js', 1_000)]);
+		expect(screen.queryByText('This is a large download')).toBeNull();
+
+		fireEvent.click(screen.getByRole('checkbox'));
+
+		expect(screen.getByText('This is a large download')).toBeTruthy();
+		expect(screen.getByText(/plus node modules/)).toBeTruthy();
+	});
+
+	it('downloads with the size known but does not block the request', () => {
+		mount([file('assets.bin', 800_000_000)]);
+
+		clickDownload();
+
+		expect(mocks.packageComponent).toHaveBeenCalledTimes(1);
+		expect(mocks.packageComponent.mock.calls[0][0]).toMatchObject({ project: 'my-app', skipNodeModules: true });
+	});
+});
+
+describe('DownloadApplicationModal failure reporting', () => {
+	it('resolves the loading toast into an error when packaging fails', () => {
+		mount([file('index.js', 1_000)]);
+
+		clickDownload().onError(new Error('ERR_STRING_TOO_LONG'));
+
+		expect(mocks.toast.error).toHaveBeenCalledWith(
+			expect.stringContaining('ERR_STRING_TOO_LONG'),
+			{ id: 'toast-1' },
+		);
+		expect(mocks.toast.success).not.toHaveBeenCalled();
+	});
+
+	it('reports a decode failure instead of letting it escape into react-query', () => {
+		mount([file('index.js', 1_000)]);
+		const options = clickDownload();
+
+		const atobSpy = vi.spyOn(globalThis, 'atob').mockImplementation(() => {
+			throw new RangeError('Invalid string length');
+		});
+		try {
+			expect(() => options.onSuccess({ payload: 'whatever' })).not.toThrow();
+		} finally {
+			atobSpy.mockRestore();
+		}
+
+		expect(mocks.toast.error).toHaveBeenCalledWith(expect.stringContaining('too large'), { id: 'toast-1' });
+		expect(mocks.toast.success).not.toHaveBeenCalled();
+	});
+
+	it('decodes a real payload and reports success', () => {
+		mount([file('index.js', 1_000)]);
+		const createObjectURL = vi.fn((_obj: Blob | MediaSource) => 'blob:mock');
+		const priorCreate = URL.createObjectURL;
+		URL.createObjectURL = createObjectURL;
+		try {
+			clickDownload().onSuccess({ payload: btoa('gzip-bytes') });
+		} finally {
+			URL.createObjectURL = priorCreate;
+		}
+
+		expect(mocks.toast.success).toHaveBeenCalledWith('Download ready!', { id: 'toast-1' });
+		expect(createObjectURL).toHaveBeenCalledTimes(1);
+		const blob = createObjectURL.mock.calls[0]![0] as Blob;
+		expect(blob.size).toBe('gzip-bytes'.length);
+	});
+});

--- a/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
@@ -102,6 +102,24 @@ describe('DownloadApplicationModal size warning', () => {
 		expect(screen.queryByText(/About 2 MB/)).toBeNull();
 	});
 
+	// The regression kriszyp caught: an older instance reporting no sizes at all measures to
+	// { bytes: 0, exact: false }, which a bare threshold comparison reads as safe — so an
+	// 800 MB application would reach the same tab crash #1591 reports, with no warning.
+	it('warns when the instance reports no sizes, instead of reading zero as safe', () => {
+		mount([file('a.js'), file('b.js'), file('assets.bin')]);
+
+		expect(screen.getByText('This download’s size is unknown')).toBeTruthy();
+		expect(screen.getByRole('button', { name: /Download anyway/ })).toBeTruthy();
+	});
+
+	it('never quotes "0 B" for an unmeasured application', () => {
+		mount([file('a.js'), file('b.js'), file('assets.bin')]);
+
+		expect(screen.queryByText(/0 B/)).toBeNull();
+		// The file count is real even when the sizes aren't, so it still gets reported.
+		expect(screen.getByText(/3 files of unreported size/)).toBeTruthy();
+	});
+
 	it('says "file" rather than "files" for a single-file application', () => {
 		mount([file('index.js', 2_000_000)]);
 

--- a/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.test.tsx
@@ -38,7 +38,7 @@ vi.mock('sonner', () => ({ toast: mocks.toast }));
 
 import { DownloadApplicationModal } from './DownloadApplicationModal';
 
-function file(name: string, size: number): FileEntry {
+function file(name: string, size?: number): FileEntry {
 	return { name, path: `my-app/${name}`, project: 'my-app', size } as FileEntry;
 }
 
@@ -91,6 +91,21 @@ describe('DownloadApplicationModal size warning', () => {
 
 		expect(screen.getByText(/About 3 MB across 2 files/)).toBeTruthy();
 		expect(mocks.packageComponent).not.toHaveBeenCalled();
+	});
+
+	// An instance that sends no size makes the sum a floor, not a total — hedge the wording
+	// rather than stating a number we can't stand behind.
+	it('hedges to "At least" when a file carries no size', () => {
+		mount([file('index.js', 2_000_000), file('mystery.bin')]);
+
+		expect(screen.getByText(/At least 2 MB across 2 files/)).toBeTruthy();
+		expect(screen.queryByText(/About 2 MB/)).toBeNull();
+	});
+
+	it('says "file" rather than "files" for a single-file application', () => {
+		mount([file('index.js', 2_000_000)]);
+
+		expect(screen.getByText(/across 1 file\./)).toBeTruthy();
 	});
 
 	it('stays quiet for an ordinary application', () => {

--- a/src/features/instance/applications/modals/DownloadApplicationModal.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.tsx
@@ -1,25 +1,58 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
+import { LARGE_PACKAGE_BYTES, measureProjectPackage } from '@/features/instance/applications/lib/projectPackageSize';
 import { usePackageComponentMutation } from '@/integrations/api/instance/applications/packageComponent';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
-import { DownloadIcon } from 'lucide-react';
-import { ChangeEvent, MouseEvent, useCallback, useState } from 'react';
+import { humanFileSize } from '@/lib/humanFileSize';
+import { AlertTriangleIcon, DownloadIcon } from 'lucide-react';
+import { ChangeEvent, MouseEvent, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+
+/**
+ * Decode the base64 archive Harper returns into bytes.
+ *
+ * Allocates once and fills in a loop rather than `Uint8Array.from(str, c => c.charCodeAt(0))`,
+ * which runs a JS callback per byte — hundreds of millions of them for a large application,
+ * all on the main thread. This is still O(n) memory on top of the `atob` copy; the real fix is
+ * a streamed archive (HarperFast/harper#2150). Until then the modal warns first — see
+ * `measureProjectPackage`.
+ */
+function decodeArchive(payload: string): Uint8Array<ArrayBuffer> {
+	const binary = atob(payload);
+	// Allocated over an explicit ArrayBuffer: a bare `new Uint8Array(n)` widens to
+	// ArrayBufferLike, which TS 5.7+ rejects as a BlobPart.
+	const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+}
 
 export function DownloadApplicationModal() {
 	const { value: isModalOpen, trigger } = useWatchedValue('ShowDownloadApplicationModal', false);
 
 	const instanceParams = useInstanceClientIdParams();
-	const { openedEntry } = useEditorView();
+	const { openedEntry, rootEntries } = useEditorView();
 	const { mutate: packageComponent, isPending, isSuccess } = usePackageComponentMutation();
 	const actionStatus = isSuccess ? `Downloaded` : isPending ? `Downloading` : 'Download';
 
 	const [includeNodeModules, setIncludeNodeModules] = useState(false);
+
+	// Measured from the cached `get_components` tree, so it costs no request and is ready
+	// before the user commits to packaging.
+	const measured = useMemo(
+		() => measureProjectPackage(rootEntries, openedEntry?.project),
+		[rootEntries, openedEntry?.project],
+	);
+	// node_modules is absent from the tree, so with it included the real package is strictly
+	// larger than what we measured — and usually by a lot. Treat that as large regardless.
+	const isLarge = measured !== undefined && (measured.bytes > LARGE_PACKAGE_BYTES || includeNodeModules);
 
 	const includeNodeModulesChanged = useCallback((e: ChangeEvent<HTMLInputElement>) => {
 		setIncludeNodeModules(e.target.checked);
@@ -45,17 +78,34 @@ export function DownloadApplicationModal() {
 			},
 			{
 				onSuccess: (response) => {
+					// Decoding can fail on its own once the archive is big enough — a payload past
+					// V8's ~512 MB string cap throws here rather than in transport. Without this
+					// the throw escapes into react-query and the "Packaging..." toast spins forever.
+					let file: Blob;
+					try {
+						file = new Blob([decodeArchive(response.payload)], { type: 'application/gzip' });
+					} catch (error) {
+						toast.error(
+							`${openedEntry.project} was packaged, but is too large for the browser to save. `
+								+ `Copy it off the host directly instead.`,
+							{ id: toastId },
+						);
+						console.error('[harper] failed to decode downloaded application archive', error);
+						return;
+					}
 					toast.success('Download ready!', { id: toastId });
 
 					const element = document.createElement('a');
 					element.setAttribute('class', 'invisible absolute top-0');
-					const bytes = Uint8Array.from(atob(response.payload), c => c.charCodeAt(0));
-					const file = new Blob([bytes], { type: 'application/gzip' });
 					element.href = URL.createObjectURL(file);
 					element.download = `${openedEntry.project}.gz`;
 					document.body.appendChild(element);
 					element.click();
 					document.body.removeChild(element);
+				},
+				onError: (error) => {
+					// Previously unhandled, which left the loading toast spinning with no verdict.
+					toast.error(`Could not package ${openedEntry.project}: ${error.message}`, { id: toastId });
 				},
 			},
 		);
@@ -68,8 +118,33 @@ export function DownloadApplicationModal() {
 					<DialogTitle>Download Application</DialogTitle>
 					<DialogDescription>
 						This will package up the contents of <strong>{openedEntry?.project}</strong> into a gzipped file.
+						{measured && (
+							<>
+								{' '}
+								{measured.exact ? 'About' : 'At least'} {humanFileSize(measured.bytes)} across{' '}
+								{new Intl.NumberFormat().format(measured.fileCount)} {measured.fileCount === 1 ? 'file' : 'files'}
+								{includeNodeModules ? ', plus node modules' : ''}.
+							</>
+						)}
 					</DialogDescription>
 				</DialogHeader>
+
+				{isLarge && (
+					<Alert variant="warning">
+						<AlertTriangleIcon />
+						<AlertTitle>This is a large download</AlertTitle>
+						<AlertDescription>
+							<p>
+								Studio has to hold the whole archive in browser memory before it can be saved, so the tab may run out of
+								memory and crash partway through.
+							</p>
+							<p>
+								Copying the application off the host directly —{' '}
+								<code>scp</code>, or the Harper CLI — is more reliable at this size.
+							</p>
+						</AlertDescription>
+					</Alert>
+				)}
 
 				<Label className="flex">
 					<Input
@@ -94,7 +169,7 @@ export function DownloadApplicationModal() {
 						autoFocus={true}
 						onClick={onClickYes}
 					>
-						<DownloadIcon /> {actionStatus}
+						<DownloadIcon /> {isLarge && !isPending && !isSuccess ? 'Download anyway' : actionStatus}
 						{isPending ? '...' : ''}
 					</Button>
 				</div>

--- a/src/features/instance/applications/modals/DownloadApplicationModal.tsx
+++ b/src/features/instance/applications/modals/DownloadApplicationModal.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { useEditorView } from '@/features/instance/applications/hooks/useEditorView';
-import { LARGE_PACKAGE_BYTES, measureProjectPackage } from '@/features/instance/applications/lib/projectPackageSize';
+import { measureProjectPackage, packageCaution } from '@/features/instance/applications/lib/projectPackageSize';
 import { usePackageComponentMutation } from '@/integrations/api/instance/applications/packageComponent';
 import { attemptToRestoreFocus } from '@/lib/attemptToRestoreFocus';
 import { setWatchedValue, useWatchedValue } from '@/lib/events/watcher';
@@ -50,9 +50,7 @@ export function DownloadApplicationModal() {
 		() => measureProjectPackage(rootEntries, openedEntry?.project),
 		[rootEntries, openedEntry?.project],
 	);
-	// node_modules is absent from the tree, so with it included the real package is strictly
-	// larger than what we measured — and usually by a lot. Treat that as large regardless.
-	const isLarge = measured !== undefined && (measured.bytes > LARGE_PACKAGE_BYTES || includeNodeModules);
+	const caution = packageCaution(measured, includeNodeModules);
 
 	const includeNodeModulesChanged = useCallback((e: ChangeEvent<HTMLInputElement>) => {
 		setIncludeNodeModules(e.target.checked);
@@ -121,26 +119,44 @@ export function DownloadApplicationModal() {
 						{measured && (
 							<>
 								{' '}
-								{measured.exact ? 'About' : 'At least'} {humanFileSize(measured.bytes)} across{' '}
+								{
+									/*
+								  A zero total from an instance that reports no sizes is not "0 B" — quoting it
+								  would dress up a complete absence of information as a reassuringly small
+								  number. Give the file count, which is real, and let the alert below carry
+								  the uncertainty.
+								*/
+								}
+								{measured.bytes > 0
+									&& `${measured.exact ? 'About' : 'At least'} ${humanFileSize(measured.bytes)} across `}
 								{new Intl.NumberFormat().format(measured.fileCount)} {measured.fileCount === 1 ? 'file' : 'files'}
+								{measured.bytes > 0 ? '' : ' of unreported size'}
 								{includeNodeModules ? ', plus node modules' : ''}.
 							</>
 						)}
 					</DialogDescription>
 				</DialogHeader>
 
-				{isLarge && (
+				{caution && (
 					<Alert variant="warning">
 						<AlertTriangleIcon />
-						<AlertTitle>This is a large download</AlertTitle>
+						<AlertTitle>
+							{caution === 'large' ? 'This is a large download' : 'This download’s size is unknown'}
+						</AlertTitle>
 						<AlertDescription>
+							{caution === 'unmeasured' && (
+								<p>
+									This instance didn’t report file sizes, so there’s no way to tell up front whether this application is
+									small enough to download.
+								</p>
+							)}
 							<p>
 								Studio has to hold the whole archive in browser memory before it can be saved, so the tab may run out of
 								memory and crash partway through.
 							</p>
 							<p>
-								Copying the application off the host directly —{' '}
-								<code>scp</code>, or the Harper CLI — is more reliable at this size.
+								Copying the application off the host directly — <code>scp</code>, or the Harper CLI — is more reliable
+								{caution === 'large' ? ' at this size' : ' when the size is unknown'}.
 							</p>
 						</AlertDescription>
 					</Alert>
@@ -169,7 +185,7 @@ export function DownloadApplicationModal() {
 						autoFocus={true}
 						onClick={onClickYes}
 					>
-						<DownloadIcon /> {isLarge && !isPending && !isSuccess ? 'Download anyway' : actionStatus}
+						<DownloadIcon /> {caution && !isPending && !isSuccess ? 'Download anyway' : actionStatus}
 						{isPending ? '...' : ''}
 					</Button>
 				</div>

--- a/src/integrations/api/instance/applications/getComponents.ts
+++ b/src/integrations/api/instance/applications/getComponents.ts
@@ -21,6 +21,12 @@ export interface APIDirectoryEntry extends APIFileEntry {
 export interface APIFileEntry {
 	name: string;
 	mtime?: number;
+	/**
+	 * Uncompressed bytes, sent by Harper on every file entry. Note the tree omits `node_modules`
+	 * entirely, so summing it yields the `skip_node_modules: true` package size — see
+	 * `measureProjectPackage`.
+	 */
+	size?: number;
 }
 
 export async function getComponents({ instanceClient }: InstanceClientIdConfig) {


### PR DESCRIPTION
Addresses the Studio half of #1591. The server half is HarperFast/harper#2152 (closes HarperFast/harper#2150).

## Why the tab dies

The bytes arrive fine — the renderer dies decoding them. `package_component` returns the whole archive as base64 in JSON, and the modal then made four more full-size copies:

```ts
const bytes = Uint8Array.from(atob(response.payload), c => c.charCodeAt(0));
const file = new Blob([bytes], { type: 'application/gzip' });
```

axios buffers the response text → `JSON.parse` copies the base64 string → `atob` copies again → `Uint8Array.from(str, callback)` runs a JS callback **per byte** on the main thread → `Blob` copies once more. Roughly 5× the archive inside one renderer, and both strings are subject to V8's 512 MiB cap in the browser too. Hence "Something went wrong while displaying this webpage" with no explanation.

Streaming the archive end to end is harper#2150. **This PR does not consume the stream** — that needs a Harper build with #2152 in it to verify against, so it's deliberately left as the follow-up. What ships here works against every Harper version, today.

## What this does

**Says the size up front.** The modal now reads `About 5 MB across 159 files.` before you commit to anything. It's measured from the `get_components` tree Studio already has cached, so it costs no extra request. That tree omits `node_modules`, which makes the total an exact match for the modal's default (`skip_node_modules: true`) and a floor once the box is ticked.

**Warns past 100 MB** — or whenever node modules are included, where the measured total is only a floor — with the reason and the alternative, and relabels the button to "Download anyway":

> **This is a large download**
> Studio has to hold the whole archive in browser memory before it can be saved, so the tab may run out of memory and crash partway through.
> Copying the application off the host directly — `scp`, or the Harper CLI — is more reliable at this size.

Deliberately one tier, and deliberately not a block. A hard ceiling would have to be guessed from an uncompressed total, and a large tree of compressible source still downloads fine — so the decision stays with the user. This is the warning @jjohnson-hdb asked for in [#1591](https://github.com/HarperFast/studio/issues/1591#issuecomment-5270871335), and "don't do that" really is part of the right answer at 800 MB.

**Reports failures instead of hanging.** Two paths previously left the "Packaging..." toast spinning forever with no verdict: a failed mutation had no `onError` at all, and a decode throw escaped into react-query. Both now resolve the toast into a real error.

## The bug browser verification caught

`calculateRootEntries` rebuilds every node from scratch and was silently dropping the `size` the API sends. Against a real instance the modal first rendered **"At least 0 B across 159 files"** — 159 files found, every size gone. `size` was also undeclared on `APIFileEntry` even though Harper has long sent it. Both fixed; `mtime` is dropped the same way but nothing reads it, so I left it alone.

## Verification

Against the Anvils stage cluster on a real application, serving this worktree on :5173:

| | |
|---|---|
| Default | `About 5 MB across 159 files.` — no warning, button reads "Download" |
| Include Node Modules | `…, plus node modules.` — warning shown, button reads "Download anyway" |
| Unticked again | warning clears |
| Actual download | "Download ready!" — the happy path is intact through the new decode |

Checked in light and dark. Confirmed against the raw operation response that the server really does send per-file `size` (which is what identified the mapping bug rather than blaming the instance).

New tests: `projectPackageSize.test.ts` (9) and `DownloadApplicationModal.test.tsx` (8), covering the size text, the two warning triggers, the button relabel, that the request is never blocked, and both failure paths. Full suite green — 287 files, 2203 passing. (The 4 vitest "errors" in the summary come from `ToolCallGroup.test.tsx` and reproduce on a clean `stage` checkout.)

Decoding now allocates once and fills in a loop rather than the per-byte callback — still O(n) on top of `atob`, but strictly cheaper, and it matches `pemToDer` in `lib/crypto/envSecret.ts`.

## Follow-up

Once #2152 ships, Studio can request `stream: true` and pick the shape off the response `content-type`, so one code path works against both old and new instances. Two things to handle there: axios buffers (this needs `fetch`), and Fabric Connect caps bodies at 2 MB and can't stream at all, so proxy-mode instances need an explicit message — `resolveInstanceConnection` already reports `mode: 'direct' | 'proxy'`. harper#2150 also carries an `estimate` mode that would close the include-node_modules blind spot in the sizing above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
