### PR TITLE
feat(auth): gate staff features on staffPermissions instead of role names

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,8 +9,9 @@ import { NavigationMenuList } from '@/components/ui/navigation/NavigationMenuLis
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Version } from '@/components/Version';
 import { defaultInstanceRoute, isLocalStudio } from '@/config/constants';
+import { canSeeAdminSection } from '@/features/admin/components/AdminShell';
 import { useLogoutMutation } from '@/features/auth/hooks/useLogout';
-import { isFabricAdmin, useOverallAuth } from '@/hooks/useAuth';
+import { useOverallAuth } from '@/hooks/useAuth';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { getDefaultSignedInCloudRouteForUser } from '@/lib/urls/getDefaultSignedInCloudRouteForUser';
 import { Link, useNavigate, useRouter } from '@tanstack/react-router';
@@ -24,9 +25,9 @@ export function Navbar() {
 	const { mutate: signOut } = useLogoutMutation();
 	const navigate = useNavigate();
 	const { user } = useOverallAuth();
-	// Derived from the existing subscription — useAdminMode() would add a second
-	// authStore listener per Navbar (review feedback on #1533).
-	const isAdmin = isFabricAdmin(user);
+	// Derived from the existing subscription — a permission hook would add a
+	// second authStore listener per Navbar (review feedback on #1533).
+	const isAdmin = canSeeAdminSection(user);
 	const router = useRouter();
 
 	const handleSignOut = useCallback(() => {

--- a/src/features/admin/__tests__/adminShellVisibility.test.ts
+++ b/src/features/admin/__tests__/adminShellVisibility.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+// jsdom: AdminShell imports useAuth, whose authStore touches localStorage at module load.
+import { canSeeAdminSection, visibleAdminItems } from '@/features/admin/components/AdminShell';
+import type { User } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+
+const user = (fabricRole: User['fabricRole'], staffPermissions?: string[]) =>
+	({ fabricRole, staffPermissions }) as User;
+
+const labels = (u: User | null) => visibleAdminItems(u).map((item) => item.label);
+
+describe('admin section visibility', () => {
+	it('shows every page to a holder of all three page permissions', () => {
+		const admin = user('fabric_admin', ['systemStatus:write', 'region:read', 'apiToken:create']);
+		expect(labels(admin)).toEqual(['Notifications', 'Regions', 'API Token']);
+	});
+
+	it('shows only the pages a narrower role holds', () => {
+		expect(labels(user('fabric_support', ['systemStatus:write', 'region:read']))).toEqual([
+			'Notifications',
+			'Regions',
+		]);
+		expect(labels(user('fabric_readonly', ['region:read']))).toEqual(['Regions']);
+	});
+
+	it('hides the section entirely from customers', () => {
+		expect(canSeeAdminSection(user('least_privileged', []))).toBe(false);
+		expect(canSeeAdminSection(null)).toBe(false);
+	});
+
+	// super_user may password-login; without a Google SSO session the token mint
+	// 403s, so the API Token page stays hidden even though it holds the permission.
+	it('never shows the API Token page to super_user', () => {
+		const withField = user('super_user', ['systemStatus:write', 'region:read', 'apiToken:create']);
+		expect(labels(withField)).toEqual(['Notifications', 'Regions']);
+		// Legacy API without staffPermissions: same carve-out via the fallback.
+		expect(labels(user('super_user'))).toEqual(['Notifications', 'Regions']);
+	});
+
+	it('keeps the whole section for a legacy-API fabric_admin', () => {
+		expect(labels(user('fabric_admin'))).toEqual(['Notifications', 'Regions', 'API Token']);
+	});
+});

--- a/src/features/admin/components/AdminShell.tsx
+++ b/src/features/admin/components/AdminShell.tsx
@@ -1,32 +1,60 @@
 import { SubNavItem, SubNavRail } from '@/components/SubNavRail';
-import { isFabricAdmin, useCloudAuth } from '@/hooks/useAuth';
-import { Navigate, Outlet } from '@tanstack/react-router';
+import { hasStaffPermission, useCloudAuth } from '@/hooks/useAuth';
+import { LocalUser, StaffPermission, User } from '@/integrations/api/api.patch';
+import { Navigate, Outlet, useLocation } from '@tanstack/react-router';
 import { BellIcon, GlobeIcon, KeyRoundIcon } from 'lucide-react';
 
 /**
  * Shell for the Admin section: a responsive sub-nav rail (so future admin
- * endpoints slot in as new items) plus the active page. Gated to fabric_admin
- * (matching the token endpoint's SSO-session contract — see isFabricAdmin); the
- * dashboard route guard already handles the unauthenticated redirect.
+ * endpoints slot in as new items) plus the active page. Each item names the
+ * staff permission its page needs; the rail shows only the pages the account
+ * holds, and holding any of them grants entry. The dashboard route guard
+ * already handles the unauthenticated redirect.
  */
-// Order matters: /admin redirects to the first item's route (see adminIndexRoute).
-const items: SubNavItem[] = [
-	{ to: '/admin/notifications', label: 'Notifications', icon: BellIcon },
-	{ to: '/admin/regions', label: 'Regions', icon: GlobeIcon },
-	{ to: '/admin/api-token', label: 'API Token', icon: KeyRoundIcon },
+// Order matters: /admin redirects to the first item's route (see adminIndexRoute);
+// anyone not permitted there is bounced to their first visible page below.
+const items: Array<SubNavItem & { permission: StaffPermission; ssoAccountOnly?: boolean }> = [
+	{ to: '/admin/notifications', label: 'Notifications', icon: BellIcon, permission: 'systemStatus:write' },
+	{ to: '/admin/regions', label: 'Regions', icon: GlobeIcon, permission: 'region:read' },
+	// Minting a token requires the Google SSO session only staff sign-ins have;
+	// super_user may password-login, so the mint would 403 for it.
+	{
+		to: '/admin/api-token',
+		label: 'API Token',
+		icon: KeyRoundIcon,
+		permission: 'apiToken:create',
+		ssoAccountOnly: true,
+	},
 ];
+
+export function visibleAdminItems(user: User | LocalUser | null) {
+	const isSuperUser = user !== null && 'fabricRole' in user && user.fabricRole === 'super_user';
+	return items.filter((item) => hasStaffPermission(user, item.permission) && !(item.ssoAccountOnly && isSuperUser));
+}
+
+/** Whether the account may enter /admin at all — drives the Navbar link too. */
+export function canSeeAdminSection(user: User | LocalUser | null): boolean {
+	return visibleAdminItems(user).length > 0;
+}
 
 export function AdminShell() {
 	const { isLoading, user } = useCloudAuth();
+	const { pathname } = useLocation();
 
 	if (isLoading) { return null; }
-	if (!isFabricAdmin(user)) { return <Navigate to="/" replace />; }
+	const visible = visibleAdminItems(user);
+	if (!visible.length) { return <Navigate to="/" replace />; }
+
+	// Deep links (and the /admin index redirect) may point at a page this account
+	// doesn't hold — send it to its first visible page instead of a broken one.
+	const current = items.find((item) => pathname.startsWith(item.to));
+	if (current && !visible.includes(current)) { return <Navigate to={visible[0].to} replace />; }
 
 	return (
 		<div className="mt-32 px-4 pt-4 md:px-12 min-h-[calc(100vh-(--spacing(32)))]">
 			<div className="md:grid gap-6 md:grid-cols-12">
 				<aside className="md:col-span-3 lg:col-span-2 mb-4 md:mb-0">
-					<SubNavRail items={items} ariaLabel="Admin sections" />
+					<SubNavRail items={visible} ariaLabel="Admin sections" />
 				</aside>
 				<section className="md:col-span-9 lg:col-span-10 min-w-0">
 					<Outlet />

--- a/src/features/admin/notifications/mutations/useNotificationMutations.ts
+++ b/src/features/admin/notifications/mutations/useNotificationMutations.ts
@@ -4,8 +4,8 @@ import { SystemStatusNotification } from '@/integrations/api/api.patch';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 /**
- * Admin CRUD over the central-manager `SystemStatus` table. The resource already gates writes to
- * fabric admins (isFabricAdmin) server-side, so these just need the fabric-admin session. The
+ * Admin CRUD over the central-manager `SystemStatus` table. The resource gates writes on the
+ * systemStatus:write staff permission server-side, so these just need the staff session. The
  * SystemStatus paths aren't in the generated OpenAPI types yet, so URLs are cast (as elsewhere).
  * The global MutationCache.onError surfaces failures as a toast; each write refetches the list.
  */

--- a/src/features/admin/regions/index.tsx
+++ b/src/features/admin/regions/index.tsx
@@ -5,6 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { RegionFormModal } from '@/features/admin/regions/components/RegionFormModal';
 import { formatOrgLabel, getOrganizationsQueryOptions } from '@/features/admin/regions/queries/getOrganizations';
 import { getRegionsQueryOptions } from '@/features/admin/regions/queries/getRegions';
+import { useStaffPermission } from '@/hooks/useAuth';
 import { AdminRegion } from '@/integrations/api/api.patch';
 import { useQuery } from '@tanstack/react-query';
 import { PencilIcon, PlusIcon } from 'lucide-react';
@@ -32,6 +33,9 @@ export function RegionsIndex() {
 	const [modalOpen, setModalOpen] = useState(false);
 	const [editing, setEditing] = useState<AdminRegion | null>(null);
 	const [search, setSearch] = useState('');
+	// The page itself only needs region:read; creating/editing posts to the
+	// region:write-gated endpoints.
+	const canWriteRegions = useStaffPermission('region:write');
 
 	const orgNameById = useMemo(
 		() => new Map((orgResult?.organizations ?? []).map((o) => [o.id, o.name])),
@@ -70,10 +74,12 @@ export function RegionsIndex() {
 						customers; otherwise it's available to everyone.
 					</p>
 				</div>
-				<Button variant="submit" onClick={openCreate} className="shrink-0">
-					<PlusIcon />
-					Create region
-				</Button>
+				{canWriteRegions && (
+					<Button variant="submit" onClick={openCreate} className="shrink-0">
+						<PlusIcon />
+						Create region
+					</Button>
+				)}
 			</div>
 
 			<div className="mt-6">
@@ -124,15 +130,16 @@ export function RegionsIndex() {
 														<RegionScope organizationIds={region.organizationIds} orgNameById={orgNameById} />
 													</TableCell>
 													<TableCell className="text-right">
-														<Button
-															variant="ghost"
-															size="icon"
-															aria-label={`Edit ${region.id}`}
-															onClick={() =>
-																openEdit(region)}
-														>
-															<PencilIcon />
-														</Button>
+														{canWriteRegions && (
+															<Button
+																variant="ghost"
+																size="icon"
+																aria-label={`Edit ${region.id}`}
+																onClick={() => openEdit(region)}
+															>
+																<PencilIcon />
+															</Button>
+														)}
 													</TableCell>
 												</TableRow>
 											))}

--- a/src/features/admin/routes.ts
+++ b/src/features/admin/routes.ts
@@ -11,6 +11,7 @@ export const adminLayoutRoute = createRoute({
 // /admin itself has no page of its own — send it to whatever sits at the top of AdminShell's rail.
 // A redirect rather than a second component mount, so each section keeps exactly one URL (links
 // shared before Regions existed still point at /admin/notifications). Keep in step when reordering.
+// Accounts that can't see the target page are bounced onward by AdminShell's permission filter.
 const adminIndexRoute = createRoute({
 	getParentRoute: () => adminLayoutRoute,
 	path: '/',

--- a/src/features/instance/databases/components/DatabaseTableView.tsx
+++ b/src/features/instance/databases/components/DatabaseTableView.tsx
@@ -11,7 +11,7 @@ import {
 import { getSchemaRelationshipsQueryOptions } from '@/features/instance/databases/functions/schemaRelationships';
 import { useExportTableCsv } from '@/features/instance/databases/hooks/useExportTableCsv';
 import { EditTableRowModal } from '@/features/instance/databases/modals/EditTableRowModal';
-import { useAdminMode } from '@/hooks/useAuth';
+import { useStaffPermission } from '@/hooks/useAuth';
 import { useEffectedState } from '@/hooks/useEffectedState';
 import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
@@ -76,7 +76,7 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 
 	const { toggled: onlyIfCached, toggle: toggleOnlyCached } = useToggler(true);
 
-	const adminMode = useAdminMode();
+	const isStaffInstanceOperator = useStaffPermission('instance:update');
 	const canAddRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'insert');
 	const canEditRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'update');
 	const canDeleteRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'delete');
@@ -545,7 +545,7 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 								</Link>
 							</DropdownMenuItem>
 							{canManageBrowseInstance
-								&& adminMode
+								&& isStaffInstanceOperator
 								&& !!instanceId && (
 								<DropdownMenuItem
 									className="focus:bg-yellow/70 focus:text-white"

--- a/src/features/organizations/components/OrgCard.tsx
+++ b/src/features/organizations/components/OrgCard.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
 import { EntityContextMenu, type EntityMenuItem, renderEntityMenuItems } from '@/components/ui/entityMenu';
 import { AddCouponModal } from '@/features/organization/modals/AddCouponModal';
-import { useAdminMode } from '@/hooks/useAuth';
+import { useStaffPermission } from '@/hooks/useAuth';
 import { useOrganizationPermissions, useOrganizationRolePermissions } from '@/hooks/usePermissions';
 import { excludeFalsy } from '@/lib/arrays/excludeFalsy';
 import { capitalizeWords } from '@/lib/string/capitalizeWords';
@@ -32,7 +32,7 @@ export function OrgCard({
 	const { remove, update: canUpdateOrganization } = useOrganizationPermissions(organizationId);
 	const showBilling = canUpdateOrganization;
 	const { view: showOrgUsersAndRoles } = useOrganizationRolePermissions(organizationId);
-	const isAdminMode = useAdminMode();
+	const canAddCoupon = useStaffPermission('billing:write');
 
 	const [isCouponModalOpen, setIsCouponModalOpen] = useState(false);
 
@@ -73,14 +73,14 @@ export function OrgCard({
 			icon: <KeyRoundIcon className="size-4 mr-2 text-yellow-500" />,
 			label: 'Settings',
 		},
-		isAdminMode && {
+		canAddCoupon && {
 			key: 'add-coupon',
 			onClick: () => setIsCouponModalOpen(true),
 			icon: <TicketIcon className="size-4 mr-2 text-pink-500" />,
 			label: 'Add Coupon',
 		},
-		{ type: 'separator' as const, key: 'sep-bottom' },
-		{
+		remove && { type: 'separator' as const, key: 'sep-bottom' },
+		remove && {
 			key: 'delete',
 			onClick: onDeleteClick,
 			className: 'focus:bg-red/70 focus:text-white',
@@ -89,8 +89,12 @@ export function OrgCard({
 		},
 	].filter(excludeFalsy);
 
+	// The menu carries the destructive/staff actions; without either grant the card
+	// stays a plain link (org members navigate via the org page's own sub-nav).
+	const showMenu = remove || canAddCoupon;
+
 	return (
-		<EntityContextMenu items={remove ? menuItems : []}>
+		<EntityContextMenu items={showMenu ? menuItems : []}>
 			<Card className="relative h-full justify-between transition-[transform,box-shadow] duration-200 hover:scale-[1.02] hover:shadow-lg hover:ring-2 hover:ring-primary/60 dark:hover:ring-violet-400/70">
 				<Link
 					to={organizationId}
@@ -100,7 +104,7 @@ export function OrgCard({
 				<CardHeader>
 					<CardDescription className="flex items-center justify-between">
 						<span className="truncate">{organizationId}</span>
-						{remove && (
+						{showMenu && (
 							<DropdownMenu>
 								<DropdownMenuTrigger
 									aria-label="Options"

--- a/src/features/organizations/index.tsx
+++ b/src/features/organizations/index.tsx
@@ -13,7 +13,7 @@ import {
 	ALL_ORGANIZATIONS_PAGE_SIZE,
 	getAllOrganizationsQueryOptions,
 } from '@/features/organizations/queries/getAllOrganizations';
-import { useAdminMode } from '@/hooks/useAuth';
+import { useStaffPermission } from '@/hooks/useAuth';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
 import { detectEntityId } from '@/lib/string/entityId';
@@ -40,10 +40,12 @@ export function OrganizationsIndex() {
 	const [filterByNameValue, setFilterByNameValue] = useState('');
 	const clearFilterByNameValue = useCallback(() => setFilterByNameValue(''), []);
 
-	const isAdminMode = useAdminMode();
+	// The server-side listing and id lookup read every organization, so the
+	// staff org:read permission is what unlocks them.
+	const canReadAllOrgs = useStaffPermission('org:read');
 	const [showAllOrgs, setShowAllOrgs] = useSessionStorage('ShowAllOrganizations', false);
 	const [pageIndex, setPageIndex] = useState(0);
-	const showAll = isAdminMode && showAllOrgs;
+	const showAll = canReadAllOrgs && showAllOrgs;
 
 	const onShowAllOrgsChanged = useCallback((checked: boolean) => {
 		setShowAllOrgs(checked);
@@ -56,15 +58,15 @@ export function OrganizationsIndex() {
 
 	// A pasted organization/cluster id is resolved by id server-side rather than
 	// matched as a title (see getAllOrganizationsQueryOptions). This works for
-	// any fabric admin regardless of the "All Orgs" toggle, so support can jump
+	// any staff account regardless of the "All Orgs" toggle, so support can jump
 	// straight to an org from an id copied out of a log or ticket.
 	const searchEntityId = useMemo(() => {
-		if (!isAdminMode) {
+		if (!canReadAllOrgs) {
 			return null;
 		}
 		const entity = detectEntityId(debouncedFilterValue);
 		return entity?.kind === 'organization' || entity?.kind === 'cluster' ? entity : null;
-	}, [isAdminMode, debouncedFilterValue]);
+	}, [canReadAllOrgs, debouncedFilterValue]);
 
 	// Both the "All Orgs" listing and an id lookup render from the server query.
 	const isServerSearch = showAll || !!searchEntityId;
@@ -82,12 +84,12 @@ export function OrganizationsIndex() {
 		> = [];
 
 		for (const [organizationId, role] of Object.entries(roles)) {
-			// Fabric admins / super users bypass an org's OAuth requirement, so never
-			// lock their cards — render the org normally even when it requires OAuth.
-			if ('oauthProviders' in role && !isAdminMode) {
+			// Staff access comes from org:read, not membership, so an org's OAuth
+			// requirement doesn't apply — render those cards normally.
+			if ('oauthProviders' in role && !canReadAllOrgs) {
 				locked.push({ organizationId, organizationName: role.organizationName, providers: role.oauthProviders! });
 			} else {
-				normal.push({ organizationId, organizationName: role.organizationName, roleName: role.role ?? 'fabric admin' });
+				normal.push({ organizationId, organizationName: role.organizationName, roleName: role.role ?? 'fabric staff' });
 			}
 		}
 
@@ -96,16 +98,16 @@ export function OrganizationsIndex() {
 			.sort((a, b) => ((a.organizationName || '') > (b.organizationName || '') ? 1 : -1));
 
 		return { organizationRoles: filteredNormal, oauthLockedOrgs: locked };
-	}, [filterByNameValue, user?.roles, isAdminMode]);
+	}, [filterByNameValue, user?.roles, canReadAllOrgs]);
 
-	// Roles for organizations the fabric admin is fetching server-side. Falls
-	// back to "fabric admin" for organizations the user has no role in.
+	// Roles for organizations the staff account is fetching server-side. Falls
+	// back to "fabric staff" for organizations the user has no role in.
 	const allOrganizationRoles = useMemo(() => {
 		const roles = user?.roles || {};
 		return (allOrgsPage?.organizations || []).map((org) => ({
 			organizationId: org.id,
 			organizationName: org.name,
-			roleName: roles[org.id]?.role || 'fabric admin',
+			roleName: roles[org.id]?.role || 'fabric staff',
 		}));
 	}, [allOrgsPage?.organizations, user?.roles]);
 
@@ -160,7 +162,7 @@ export function OrganizationsIndex() {
 		<>
 			<SubNavMenu>
 				<div className="flex w-full items-center justify-end gap-2">
-					{isAdminMode && (
+					{canReadAllOrgs && (
 						<label className="flex shrink-0 cursor-pointer items-center gap-2 text-xs">
 							<Switch
 								checked={showAllOrgs}

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -2,24 +2,51 @@
 // jsdom: importing useAuth pulls in authStore, which touches localStorage at module load.
 import type { LocalUser, User } from '@/integrations/api/api.patch';
 import { describe, expect, it } from 'vitest';
-import { isFabricAdmin } from './useAuth';
+import { hasStaffPermission } from './useAuth';
 
-const cloudUser = (fabricRole: User['fabricRole']) => ({ fabricRole }) as User;
+const cloudUser = (fabricRole: User['fabricRole'], staffPermissions?: string[]) =>
+	({ fabricRole, staffPermissions }) as User;
 // A local-instance user has no fabricRole at all.
 const localUser = { username: 'admin', role: { role: 'super_user' } } as unknown as LocalUser;
 
-describe('isFabricAdmin', () => {
-	// Pins the role boundary the Admin section relies on: only fabric_admin can
-	// satisfy the token endpoint's SSO-session contract. super_user must NOT see
-	// the section (it may password-login and would only get a 403 from the mint).
-	it('is true only for a fabric_admin cloud user', () => {
-		expect(isFabricAdmin(cloudUser('fabric_admin'))).toBe(true);
+describe('hasStaffPermission', () => {
+	it('is true exactly for the permissions the API granted', () => {
+		const support = cloudUser('fabric_support', ['org:read', 'cluster:update', 'systemStatus:write']);
+		expect(hasStaffPermission(support, 'org:read')).toBe(true);
+		expect(hasStaffPermission(support, 'cluster:update')).toBe(true);
+		expect(hasStaffPermission(support, 'org:delete')).toBe(false);
+		expect(hasStaffPermission(support, 'apiToken:create')).toBe(false);
 	});
 
-	it('is false for super_user, least_privileged, a local user, and null', () => {
-		expect(isFabricAdmin(cloudUser('super_user'))).toBe(false);
-		expect(isFabricAdmin(cloudUser('least_privileged'))).toBe(false);
-		expect(isFabricAdmin(localUser)).toBe(false);
-		expect(isFabricAdmin(null)).toBe(false);
+	it('is false for every permission on a customer (empty staffPermissions)', () => {
+		const customer = cloudUser('least_privileged', []);
+		expect(hasStaffPermission(customer, 'org:read')).toBe(false);
+		expect(hasStaffPermission(customer, 'org:update')).toBe(false);
+	});
+
+	// The API withheld these from fabric_admin deliberately; the UI must not
+	// re-grant them by treating the role name as all-powerful.
+	it('does not grant a permission the API withheld from fabric_admin', () => {
+		const admin = cloudUser('fabric_admin', ['org:read', 'org:update', 'cluster:update']);
+		expect(hasStaffPermission(admin, 'org:delete')).toBe(false);
+		expect(hasStaffPermission(admin, 'cluster:delete')).toBe(false);
+	});
+
+	it('is false for a local-instance user and for null', () => {
+		expect(hasStaffPermission(localUser, 'org:read')).toBe(false);
+		expect(hasStaffPermission(null, 'org:read')).toBe(false);
+	});
+
+	describe('API predates staffPermissions (field absent)', () => {
+		it('preserves the legacy behavior: fabric_admin and super_user hold everything', () => {
+			expect(hasStaffPermission(cloudUser('fabric_admin'), 'org:read')).toBe(true);
+			expect(hasStaffPermission(cloudUser('fabric_admin'), 'org:delete')).toBe(true);
+			expect(hasStaffPermission(cloudUser('super_user'), 'systemStatus:write')).toBe(true);
+		});
+
+		it('and everyone else holds nothing', () => {
+			expect(hasStaffPermission(cloudUser('least_privileged'), 'org:read')).toBe(false);
+			expect(hasStaffPermission(cloudUser('fabric_readonly'), 'org:read')).toBe(false);
+		});
 	});
 });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -7,7 +7,7 @@ import {
 	EntityIds,
 	OverallAppSignIn,
 } from '@/features/auth/store/authStore';
-import { LocalUser, User } from '@/integrations/api/api.patch';
+import { LocalUser, StaffPermission, User } from '@/integrations/api/api.patch';
 import { useParams } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 
@@ -37,21 +37,26 @@ export function useCloudAuth(): AuthenticatedCloudConnection {
 	return useOverallAuth() as AuthenticatedCloudConnection;
 }
 
-export function useAdminMode(): boolean {
+/**
+ * Whether the account holds one specific staff permission, per the
+ * `staffPermissions` array on `/User/current`. Accepts the cloud/local union so
+ * callers don't need a type guard; a local-instance user holds nothing.
+ */
+export function hasStaffPermission(user: User | LocalUser | null, permission: StaffPermission): boolean {
+	if (!user || !('fabricRole' in user)) {
+		return false;
+	}
+	if (!user.staffPermissions) {
+		// API predates staffPermissions: preserve the old role-name behavior
+		// (fabric_admin / super_user held everything) until it's redeployed.
+		return user.fabricRole === 'fabric_admin' || user.fabricRole === 'super_user';
+	}
+	return user.staffPermissions.includes(permission);
+}
+
+export function useStaffPermission(permission: StaffPermission): boolean {
 	const { user } = useCloudAuth();
-	return isAdminMode(user);
-}
-
-export function isAdminMode(user: User | null): boolean {
-	return user?.fabricRole === 'fabric_admin' || user?.fabricRole === 'super_user';
-}
-
-// Narrower than isAdminMode: the Fabric Admin section is fabric_admin-only
-// because its API token endpoint requires a Google SSO session, which only
-// fabric_admin accounts have (super_user may password-login and would 403).
-// Accepts the cloud/local union so callers don't need a type guard.
-export function isFabricAdmin(user: User | LocalUser | null): boolean {
-	return user !== null && 'fabricRole' in user && user.fabricRole === 'fabric_admin';
+	return hasStaffPermission(user, permission);
 }
 
 export function useInstanceAuth(entityId?: EntityIds): AuthenticatedInstanceConnection {

--- a/src/hooks/usePermissions.test.ts
+++ b/src/hooks/usePermissions.test.ts
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+// jsdom: usePermissions imports useAuth, whose authStore touches localStorage at module load.
+import type { User } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+import { getOrganizationClusterInstancePermissions, getOrganizationClusterPermissions } from './usePermissions';
+
+const ORG = 'org-1';
+const CLUSTER = 'clu-1';
+
+const staff = (staffPermissions: string[], roles: User['roles'] = {} as User['roles']) =>
+	({ fabricRole: 'fabric_support', staffPermissions, roles }) as User;
+
+const memberRoles = (clusters: object) =>
+	({ [ORG]: { permission: null, organization: { clusters } } }) as unknown as User['roles'];
+
+describe('getOrganizationClusterPermissions', () => {
+	it('maps each verb to its own staff permission instead of granting all four', () => {
+		expect(getOrganizationClusterPermissions(staff(['cluster:read']), ORG, CLUSTER)).toEqual({
+			create: false,
+			remove: false,
+			update: false,
+			view: true,
+		});
+		expect(getOrganizationClusterPermissions(staff(['cluster:update', 'cluster:read']), ORG, CLUSTER)).toEqual({
+			create: false,
+			remove: false,
+			update: true,
+			view: true,
+		});
+	});
+
+	it('unions staff permissions with an org membership rather than shadowing it', () => {
+		// The member role grants delete; the staff grant alone would not.
+		const roles = memberRoles({ create: false, delete: true, update: false, view: true });
+		const result = getOrganizationClusterPermissions(staff(['cluster:read'], roles), ORG, CLUSTER);
+		expect(result).toEqual({ create: false, remove: true, update: false, view: true });
+	});
+
+	it('grants nothing to a customer with no role in the org', () => {
+		const customer = { fabricRole: 'least_privileged', staffPermissions: [], roles: {} } as unknown as User;
+		expect(getOrganizationClusterPermissions(customer, ORG, CLUSTER)).toEqual({
+			create: false,
+			remove: false,
+			update: false,
+			view: false,
+		});
+	});
+});
+
+describe('getOrganizationClusterInstancePermissions', () => {
+	// There are no instance:create / instance:delete permissions — instances are
+	// added and removed through cluster updates, so those verbs follow the
+	// cluster grants.
+	it('drives create/remove from the cluster grants and update/view from the instance ones', () => {
+		expect(getOrganizationClusterInstancePermissions(staff(['instance:read', 'instance:update']), ORG, CLUSTER))
+			.toEqual({ create: false, remove: false, update: true, view: true });
+		expect(getOrganizationClusterInstancePermissions(staff(['cluster:update']), ORG, CLUSTER)).toEqual({
+			create: true,
+			remove: false,
+			update: false,
+			view: false,
+		});
+	});
+});

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,6 +1,6 @@
 import { EntityIds } from '@/features/auth/store/authStore';
 import { checkSchemaTablePermission } from '@/hooks/checkSchemaTablePermission';
-import { isAdminMode, useCloudAuth, useInstanceAuth } from '@/hooks/useAuth';
+import { hasStaffPermission, useCloudAuth, useInstanceAuth } from '@/hooks/useAuth';
 import {
 	LocalLegacyRolePermissionTable,
 	LocalRoleAttributePermissionAction,
@@ -22,15 +22,22 @@ interface CRUV {
 	view: boolean;
 }
 
+// Staff permissions and an org membership are independent grants (a staff account can also be
+// an org member), so every hook below unions the two rather than early-returning on staff.
+
 export function useOrganizationPermissions(orgId?: string): UR {
 	const { user } = useCloudAuth();
 	const { organizationId: orgIdFromRoute }: { organizationId: string } = useParams({ strict: false });
 
-	if (isAdminMode(user)) {
-		return { update: true, remove: true };
-	}
+	const member = memberOrganizationPermissions(user, orgId ?? orgIdFromRoute);
+	return {
+		update: hasStaffPermission(user, 'org:update') || member.update,
+		remove: hasStaffPermission(user, 'org:delete') || member.remove,
+	};
+}
 
-	const role = user?.roles?.[orgId ?? orgIdFromRoute];
+function memberOrganizationPermissions(user: User | null, orgId: string): UR {
+	const role = user?.roles?.[orgId];
 	if (!role || 'oauthProviders' in role) {
 		return { update: false, remove: false };
 	}
@@ -47,11 +54,17 @@ export function useOrganizationRolePermissions(orgId?: string): CRUV {
 	const { user } = useCloudAuth();
 	const { organizationId: orgIdFromRoute }: { organizationId: string } = useParams({ strict: false });
 
-	if (isAdminMode(user)) {
-		return { create: true, remove: true, update: true, view: true };
-	}
+	const member = memberOrganizationRolePermissions(user, orgId ?? orgIdFromRoute);
+	return {
+		create: hasStaffPermission(user, 'role:create') || member.create,
+		remove: hasStaffPermission(user, 'role:delete') || member.remove,
+		update: hasStaffPermission(user, 'role:update') || member.update,
+		view: hasStaffPermission(user, 'role:read') || member.view,
+	};
+}
 
-	const role = user?.roles?.[orgId ?? orgIdFromRoute];
+function memberOrganizationRolePermissions(user: User | null, orgId: string): CRUV {
+	const role = user?.roles?.[orgId];
 	if (!role || 'oauthProviders' in role) {
 		return { create: false, remove: false, update: false, view: false };
 	}
@@ -80,10 +93,16 @@ export function useOrganizationClusterPermissions(orgId?: string, clusterId?: st
 }
 
 export function getOrganizationClusterPermissions(user: User | null, orgId: string, clusterId: string): CRUV {
-	if (isAdminMode(user)) {
-		return { create: true, remove: true, update: true, view: true };
-	}
+	const member = memberClusterPermissions(user, orgId, clusterId);
+	return {
+		create: hasStaffPermission(user, 'cluster:create') || member.create,
+		remove: hasStaffPermission(user, 'cluster:delete') || member.remove,
+		update: hasStaffPermission(user, 'cluster:update') || member.update,
+		view: hasStaffPermission(user, 'cluster:read') || member.view,
+	};
+}
 
+function memberClusterPermissions(user: User | null, orgId: string, clusterId: string): CRUV {
 	const role = user?.roles?.[orgId];
 	if (!role || 'oauthProviders' in role) {
 		return { create: false, remove: false, update: false, view: false };
@@ -119,10 +138,19 @@ export function useOrganizationClusterInstancePermissions(orgId?: string, cluste
 }
 
 export function getOrganizationClusterInstancePermissions(user: User | null, orgId: string, clusterId: string): CRUV {
-	if (isAdminMode(user)) {
-		return { create: true, remove: true, update: true, view: true };
-	}
+	const member = memberClusterInstancePermissions(user, orgId, clusterId);
+	return {
+		// Instances are added/removed through cluster updates (there are no
+		// instance:create / instance:delete permissions), so those verbs follow
+		// the cluster grants.
+		create: hasStaffPermission(user, 'cluster:update') || member.create,
+		remove: hasStaffPermission(user, 'cluster:delete') || member.remove,
+		update: hasStaffPermission(user, 'instance:update') || member.update,
+		view: hasStaffPermission(user, 'instance:read') || member.view,
+	};
+}
 
+function memberClusterInstancePermissions(user: User | null, orgId: string, clusterId: string): CRUV {
 	const role = user?.roles?.[orgId];
 	if (!role || 'oauthProviders' in role) {
 		return { create: false, remove: false, update: false, view: false };

--- a/src/integrations/api/api.patch.d.ts
+++ b/src/integrations/api/api.patch.d.ts
@@ -34,9 +34,44 @@ export interface OAuthLockedRole {
 	oauthProviders?: Array<{ name: string; oauthConfigId: string }>;
 }
 
+/**
+ * The staff permissions the UI gates on, matching the values `/User/current` returns in
+ * `staffPermissions`. A subset — the API defines more, but only these drive UI decisions.
+ */
+export type StaffPermission =
+	| 'org:read'
+	| 'org:update'
+	| 'org:delete'
+	| 'role:read'
+	| 'role:create'
+	| 'role:update'
+	| 'role:delete'
+	| 'cluster:read'
+	| 'cluster:create'
+	| 'cluster:update'
+	| 'cluster:delete'
+	| 'instance:read'
+	| 'instance:update'
+	| 'billing:write'
+	| 'region:read'
+	| 'region:write'
+	| 'systemStatus:write'
+	| 'apiToken:create';
+
 export interface User extends Omit<SchemaUser, 'roles'> {
 	roles: Record<SchemaOrganization['id'], SchemaRole & OAuthLockedRole>;
-	fabricRole: 'fabric_admin' | 'super_user' | 'least_privileged';
+	fabricRole:
+		| 'fabric_admin'
+		| 'fabric_support'
+		| 'fabric_readonly'
+		| 'fabric_staff'
+		| 'super_user'
+		| 'least_privileged';
+	/**
+	 * What this account may do across organizations. Empty for customers; absent when the API
+	 * predates the field (hasStaffPermission then falls back to role names).
+	 */
+	staffPermissions?: string[];
 	/** The oac-… config ID used to authenticate this session, or null if password/global OAuth. */
 	oauthConfigId: string | null;
 }


### PR DESCRIPTION
Closes #1622

## What

`GET /User/current` returns a `staffPermissions` array describing exactly what a staff account may do, but the UI never read it — staff gating was hardcoded to `fabricRole === 'fabric_admin'` (plus `super_user`). That was wrong in both directions: the narrower staff roles saw no staff features at all, and admin mode rendered actions the API has since withheld from `fabric_admin` (org delete, cluster delete), which 403 on click.

This replaces every role-name gate with the specific permission its surface needs, via a new `hasStaffPermission(user, permission)`:

| Surface | Now gated on |
|---|---|
| All Orgs toggle, entity-id jump, OAuth-lock bypass | `org:read` |
| OrgCard "Add Coupon" | `billing:write` |
| OrgCard "Delete" + org permissions hook | `org:delete` / `org:update` (unioned with the member role) |
| Org roles hook | `role:read/create/update/delete` |
| Cluster hook | `cluster:read/create/update/delete` |
| Instance hook | `instance:read/update`; create/remove follow the cluster grants (instances are added/removed through cluster updates) |
| "Cleanup Orphan Blobs" | `instance:update` |
| /admin Notifications | `systemStatus:write` |
| /admin Regions | `region:read` (page), `region:write` (create/edit buttons) |
| /admin API Token | `apiToken:create` |

## Behavior notes

- **`usePermissions` hooks union, not shadow**: a staff account that is also an org member keeps whatever its member role grants, and vice versa — matching the API's own semantics.
- **/admin opens per-page**: the rail shows only the pages the account holds, holding any of them grants entry, and deep links to unheld pages bounce to the first visible one. The `/admin` index redirect is unchanged.
- **super_user never sees the API Token page**, even though it holds the permission: token minting requires the Google SSO session staff sign-ins have, and super_user may password-login — the mint would 403. This preserves the invariant the old `isFabricAdmin` gate encoded, but per-page instead of hiding the whole section.
- **Older backends keep today's behavior**: when `staffPermissions` is absent from the response, `hasStaffPermission` falls back to the legacy role-name check, so deploying this UI ahead of the API changes nothing.
- `isAdminMode` / `useAdminMode` / `isFabricAdmin` are gone — nothing references role names for gating anymore.

## Testing

- New: `hasStaffPermission` unit tests (granted/withheld/customer/local/legacy-fallback), `/admin` visibility per role incl. the super_user carve-out, and cluster/instance hook mapping + union tests.
- Full suite: 293 files, 2268 passed / 11 skipped — same as `stage` baseline plus the new tests. `tsc`, oxlint, and dprint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
