### PR TITLE
build: drop sourcemaps from the localstudio bundle, strip them from deploys

### DIFF
--- a/.github/workflows/deploy-dev-with-restart.yaml
+++ b/.github/workflows/deploy-dev-with-restart.yaml
@@ -49,6 +49,12 @@ jobs:
             --minified-path-prefix "https://dev.studio.harperfabric.com/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to dev
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -52,6 +52,12 @@ jobs:
             --minified-path-prefix "https://dev.studio.harperfabric.com/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to dev
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-prod-with-restart.yaml
+++ b/.github/workflows/deploy-prod-with-restart.yaml
@@ -49,6 +49,12 @@ jobs:
             --minified-path-prefix "https://fabric.harper.fast/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to prod
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -51,6 +51,12 @@ jobs:
             --minified-path-prefix "https://fabric.harper.fast/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to prod
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-stage-with-restart.yaml
+++ b/.github/workflows/deploy-stage-with-restart.yaml
@@ -53,6 +53,12 @@ jobs:
             --minified-path-prefix "https://stage.studio.harperfabric.com/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to stage
         run: |
           mkdir deploy

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -67,6 +67,13 @@ jobs:
             --minified-path-prefix "https://stage.studio.harperfabric.com/assets"
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      # Datadog now holds the maps and is their only consumer. They are 76% of the build output
+      # (~71 MB, mostly `sourcesContent`), so shipping them too would replicate that to every
+      # node for nothing. See `sourcemapFor` in vite.config.ts, which emits these as `'hidden'`
+      # so no bundle references the files deleted here.
+      - name: Strip sourcemaps from the deployed bundle
+        if: ${{ github.event_name == 'push' }}
+        run: find web/assets -name '*.js.map' -delete
       - name: Deploy to stage
         if: ${{ github.event_name == 'push' }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,39 @@ explicit `sorting: undefined` _replaces_ the default and the first header click 
 `toggleSorting`. Default optional sorting props before handing them over (see
 `SimpleBrowseDataTable`).
 
+## Builds — sourcemaps are per mode, and `localstudio` deliberately has none
+
+`build.sourcemap` in `vite.config.ts` is a function (`sourcemapFor`), not a flag, because the
+three kinds of build want three different things. Sourcemaps dominate this output — they were
+71 MB of a 94 MB build — since each embeds `sourcesContent`, the full original text of every
+module it covers.
+
+| build                                | sourcemap  | why                                              |
+| ------------------------------------ | ---------- | ------------------------------------------------ |
+| `pnpm build:local` (`localstudio`)   | `false`    | ships inside Harper; nothing reads the maps      |
+| `pnpm build --mode dev\|stage\|prod` | `'hidden'` | uploaded to Datadog, then stripped before deploy |
+| bare `pnpm build`                    | `true`     | a developer inspecting a prod build locally      |
+
+**How Studio ships inside Harper.** The `localstudio` mode is the UI bundled into the Harper
+distribution. The **harper** repo drives that build from its own scripts, roughly
+`VITE_STUDIO_VERSION="v$(jq -r '.version' ../package.json)" pnpm run build:local`, and packages
+the resulting `web/` as-is. Nothing on that path uploads maps to Datadog or reads them, so
+emitting them only inflates the published Harper package — which is why the omission is
+configured **here** rather than by post-processing over in harper. Keep it that way: turning
+`localstudio` sourcemaps back on silently adds ~71 MB to the Harper package with no consumer,
+and no failing test will catch it.
+
+**Deploy modes.** Datadog is the only consumer of the deploy maps, and it keeps its own copy, so
+the workflows delete them after the upload and before `mv web deploy/` rather than replicating
+~71 MB to every node for nothing. `'hidden'` is what makes that safe to do: it writes the maps
+but omits the trailing `//# sourceMappingURL=` comment, which under `true` would dangle onto a
+404 once the files are gone. `datadog-ci sourcemaps upload` pairs each `.js.map` with its bundle
+by filename and never needs that comment (verified with `--dry-run`: 173/173 paired). The strip
+step lives in all six `deploy-*.yaml` workflows — add it to any new one.
+
+(The repo is public, so none of this is about keeping `sourcesContent` unreadable — it is purely
+size containment.)
+
 ## pnpm — dependency overrides go in `pnpm-workspace.yaml`, not `package.json`
 
 This repo uses pnpm 11. `overrides` (and other settings like `minimumReleaseAge`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,7 +75,37 @@ function fixMonacoYamlWorkerInit(): Plugin {
 // repo root uncluttered; the developer's own .env.local stays at the root where
 // Vite looks by default. Vite's envDir is global, so we point it at that folder
 // only for these build modes.
-const PUBLIC_ENV_MODES = new Set(['dev', 'stage', 'prod', 'localstudio']);
+const DEPLOY_MODES = new Set(['dev', 'stage', 'prod']);
+const PUBLIC_ENV_MODES = new Set([...DEPLOY_MODES, 'localstudio']);
+
+/**
+ * Sourcemaps are 76% of the build output — 71 MB of the 94 MB `build:local` used to emit —
+ * because each one embeds `sourcesContent`, the full original text of every module it covers.
+ * That is worth paying for where something actually consumes them, and pure weight everywhere
+ * else, so the policy is per mode.
+ *
+ * `localstudio` — the UI bundled into the Harper distribution — gets **none**. The harper repo
+ * builds it with `VITE_STUDIO_VERSION="v$(jq -r '.version' ../package.json)" pnpm run build:local`
+ * and ships `web/` as-is; nothing on that path uploads maps to Datadog or reads them, so they
+ * only inflate the published package. Emitting nothing here keeps the fix on this side of the
+ * repo boundary — harper's build scripts need no change. (See AGENTS.md, "How Studio ships
+ * inside Harper".)
+ *
+ * Deploy modes get `'hidden'`: the maps are written, the deploy workflow uploads them to Datadog
+ * for RUM symbolication, and then deletes them before `mv web deploy/` — Datadog keeps its own
+ * copy, so replicating ~71 MB to every node buys nothing. `'hidden'` — rather than `true` —
+ * omits the trailing `//# sourceMappingURL=` comment, which would otherwise dangle onto a 404
+ * once the maps are gone. `datadog-ci sourcemaps upload` pairs each `.js.map` with its bundle by
+ * filename and never needs that comment.
+ *
+ * Everything else (a bare `vite build`, i.e. a developer inspecting a production build locally)
+ * keeps ordinary linked sourcemaps so DevTools resolves them without extra setup.
+ */
+function sourcemapFor(mode: string): boolean | 'hidden' {
+	if (mode === 'localstudio') { return false; }
+	if (DEPLOY_MODES.has(mode)) { return 'hidden'; }
+	return true;
+}
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -108,7 +138,7 @@ export default defineConfig(({ mode }) => ({
 	build: {
 		outDir: 'web',
 		emptyOutDir: true,
-		sourcemap: true,
+		sourcemap: sourcemapFor(mode),
 		// Every chunk on the initial critical path is now well under 500 kB. The
 		// chunks that exceed it are all loaded on demand — the Monaco editor core
 		// (~2.7 MB, lazy <MonacoEditor>), swagger-ui (API docs route) and mermaid


### PR DESCRIPTION
## Why

`npm run build:local` emitted **94 MB** of assets. 76% of that — **71 MB** — was sourcemaps, because each one embeds `sourcesContent`, the full original text of every module it covers. `build.sourcemap` was an unconditional `true`, so every build mode paid for maps whether or not anything read them.

This is size containment, not source protection — the repo is public.

| | before | after |
| --- | --- | --- |
| `build:local` → bundled into the Harper distribution | 94 MB | **23 MB** |
| deployed `web/`, replicated to every node | 95 MB | **23 MB** |

## What changed

`build.sourcemap` becomes `sourcemapFor(mode)`, because the three kinds of build want three different things:

| build | sourcemap | why |
| --- | --- | --- |
| `pnpm build:local` (`localstudio`) | `false` | ships inside Harper; nothing reads the maps |
| `pnpm build --mode dev\|stage\|prod` | `'hidden'` | uploaded to Datadog, then stripped before deploy |
| bare `pnpm build` | `true` | unchanged — a developer inspecting a prod build locally |

**`localstudio` gets no maps at all.** This is the UI bundled into the Harper distribution: the **harper** repo drives the build from its own scripts (roughly `VITE_STUDIO_VERSION="v$(jq -r '.version' ../package.json)" pnpm run build:local`) and packages the resulting `web/` as-is. Nothing on that path uploads maps to Datadog or reads them, so they only inflated the published Harper package. Configuring the omission **here** rather than post-processing in harper means **harper's build scripts need no change**.

**Deploy modes get `'hidden'`, and the six `deploy-*.yaml` workflows now delete the maps** after the Datadog upload and before `mv web deploy/`. Datadog keeps its own copy and is their only consumer, so replicating ~71 MB to every node bought nothing. `'hidden'` rather than `true` is load-bearing: it omits the trailing `//# sourceMappingURL=` comment that would otherwise dangle onto a 404 once the files are gone.

## Verification

- **`build:local`: 94M → 23M**, 0 maps, no dangling `sourceMappingURL`. (The one grep hit in `ts.worker` is a `sourceMappingURL=${r}` template literal inside the bundled TypeScript compiler, not a build reference.)
- **`--mode prod`**: 173 maps written for the upload, and confirmed **no** `sourceMappingURL` comment in the bundles. Simulating the strip step takes it 95M → 23M with all 191 js / 7 css / 2 html intact.
- **Datadog symbolication still works without the comment** — the one real risk here, so it was dry-run explicitly: `datadog-ci sourcemaps upload --dry-run` handled **173/173** sourcemaps, pairing each `.js.map` to its bundle by filename.
- Bare `vite build` still emits linked maps.
- `dprint`, `oxlint`, `tsc -b` clean; **291 test files / 2255 tests pass**.

No behavioral change to the app — the shipped JS/CSS is byte-identical, only the maps alongside it differ.

## Notes for reviewers

- Monaco was investigated as the other suspect and came out clean: it is already curated in `src/lib/monaco/setup.ts` (8 languages, not all ~90), `editor.api` stays lazy, and the eager critical path is 1.93 MB uncompressed across 25 files. The 13.7 MB of Monaco JS is dominated by `ts.worker` (6.6 MB — the TypeScript compiler) and is genuinely load-on-demand. No change made there.
- `AGENTS.md` gains a *Builds* section recording the per-mode policy and how Studio ships inside Harper, so `localstudio` maps don't get switched back on — that would silently add ~71 MB to the Harper package with no consumer and no failing test to catch it.
- The maps already on prod persist until the next deploy overwrites `web/`; this takes effect going forward rather than retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)