### PR TITLE
feat(lint): a comment budget rule, and what calibrating it against our code showed

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,10 +1,20 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"jsPlugins": [
+		"./tools/oxlint-plugins/comment-budget.js"
+	],
 	"ignorePatterns": [
 		"src/integrations/api/*.gen.d.ts",
 		"src/assets/**"
 	],
 	"rules": {
-		"react/exhaustive-deps": "error"
+		"react/exhaustive-deps": "error",
+		"comment-budget/comment-budget": [
+			"warn",
+			{
+				"maxPerFile": 12,
+				"maxPerBlock": 4
+			}
+		]
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,33 @@ at `.husky`. In a fresh clone or worktree that skipped install, `core.hooksPath`
 the hook never fires, and a non-conforming message commits silently — CI is the first thing
 that objects.
 
+## Comments — there is a budget, and it counts sites, not lines
+
+`comment-budget` (`tools/oxlint-plugins/comment-budget.js`, an oxlint JS plugin wired in via
+`jsPlugins`) warns at **12 comments per file** and **4 per block**. It is a `warn`, so it never
+fails `pnpm lint` or the pre-commit hook — the point is to make comment volume visible, not to
+gate on it.
+
+What it counts is **sites**, not comments or lines: a run of own-line comments on consecutive
+lines is one site however long it runs, so a five-line paragraph explaining a race costs the same
+as a lone `// increment i`. Budgeting per line would price the considered explanation above the
+throwaway, which is backwards. Trailing comments never merge with their neighbours (two
+`x = 1; // why` lines in a row are two asides, not a paragraph). Linter/compiler/formatter
+directives (`eslint-*`, `oxlint-*`, `@ts-*`, `dprint-*`, `c8 ignore`, `#region`, …) and JSDoc/TSDoc
+are exempt; a `/*** banner ***/` is not.
+
+**Read a block warning as "this scope does too much", not "these comments are bad."** That is what
+calibrating it against this repo actually showed: the densest scopes here
+(`useResizableDialog.ts`, `DatabaseTableView.tsx`) are commented _well_ — Radix ref-loop hazards,
+why position deliberately isn't persisted, why `describe_all` and `describe_table` race. None of
+that survives being renamed into the code. They trip the budget because the functions are large,
+so the fix is extraction, and deleting the prose to get under the number is the one response that
+makes the file worse. Comments are attributed to their **innermost** block, so splitting a long
+function genuinely clears the warning.
+
+If a file has earned its comments, say so explicitly rather than trimming:
+`// oxlint-disable comment-budget/comment-budget`.
+
 ## Routing — keep `getParentRoute` and `addChildren` in lockstep
 
 In the TanStack Router setup (`src/router/rootRouteTree.ts`), every route's declared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,15 @@ lines is one site however long it runs, so a five-line paragraph explaining a ra
 as a lone `// increment i`. Budgeting per line would price the considered explanation above the
 throwaway, which is backwards. Trailing comments never merge with their neighbours (two
 `x = 1; // why` lines in a row are two asides, not a paragraph). Linter/compiler/formatter
-directives (`eslint-*`, `oxlint-*`, `@ts-*`, `dprint-*`, `c8 ignore`, `#region`, …) and JSDoc/TSDoc
-are exempt; a `/*** banner ***/` is not.
+directives (`eslint-*`, `oxlint-*`, `@ts-*`, `dprint-*`, `c8 ignore`, `#region`, TS triple-slash
+`/// <reference>`) and JSDoc/TSDoc are exempt; a `/*** banner ***/` is not.
+
+**Annotated data literals are charged once, not once per row.** A trailing comment on an element of
+an array, object, tuple, type literal, or enum — `'org-', // empty body` in a table of test cases —
+describes the row it sits on rather than the logic around it, and no renaming can absorb it. The
+whole literal costs one site however many rows carry a note, so a thoroughly documented fixture
+table is cheap. Own-line prose inside a literal is _not_ covered by this and follows the normal
+paragraph rules, so the exemption can't be used to park commentary inside an array.
 
 **Read a block warning as "this scope does too much", not "these comments are bad."** That is what
 calibrating it against this repo actually showed: the densest scopes here

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,3 +12,4 @@ This file collects architecture and design notes for studio that aren't otherwis
 - **Styling stack**: Tailwind 4 + Radix UI + design tokens in `src/index.css`. `cn()` from `src/lib/cn` is the canonical class-merge helper.
 - **Routing**: TanStack Router, file-based, lazy-loaded.
 - **Data fetching**: TanStack React Query 5. Query keys must be instance-scoped when the request targets a specific instance.
+- **Custom lint rules**: oxlint loads repo-local JS plugins from `tools/oxlint-plugins/`, registered in `.oxlintrc.json` under `jsPlugins`. They are written to the ESLint v9 rule API, so they also run under ESLint unchanged, and they are tested by driving the real oxlint binary rather than calling `create()` directly. `comment-budget` is the worked example — see AGENTS.md for what it enforces and why.

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -88,8 +88,8 @@ const commentBudget = {
 
 		/** True when nothing but indentation precedes the comment on its line. */
 		function isOwnLine(comment) {
-			for (let i = comment.range[0] - 1; i >= 0 && text[i] !== '\n'; i--) {
-				if (text[i] !== ' ' && text[i] !== '\t' && text[i] !== '\r') { return false; }
+			for (let i = comment.range[0] - 1; i >= 0 && text[i] !== '\n' && text[i] !== '\r'; i--) {
+				if (text[i] !== ' ' && text[i] !== '\t') { return false; }
 			}
 			return true;
 		}
@@ -119,7 +119,12 @@ const commentBudget = {
 				for (const site of sites) {
 					const block = innermostBlock(site, blocks, program);
 					if (block === program) { continue; }
-					byBlock.set(block, [...(byBlock.get(block) ?? []), site]);
+					const blockSites = byBlock.get(block);
+					if (blockSites) {
+						blockSites.push(site);
+					} else {
+						byBlock.set(block, [site]);
+					}
 				}
 				for (const blockSites of byBlock.values()) {
 					if (blockSites.length > maxPerBlock) {

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -25,22 +25,26 @@
  * leak: `eslint-` also matches `// eslint-based behavior differs here`, and every one of the ten
  * prefixes this replaced had a near-miss like it, each buying a comment a free exemption. `global`,
  * `jshint`, and `jscs` are omitted entirely — their valid forms are indistinguishable from prose.
+ *
+ * Each fixed form ends in `(?=\s|$)` rather than `\b`, because `\b` also succeeds before a hyphen:
+ * `prettier-ignore\b` matches `// prettier-ignore-this explanation`. Every one of the ten `\b`
+ * forms had that leak too.
  */
 const DIRECTIVE = new RegExp(`^\\s*(?:${
 	[
-		String.raw`(?:es|ox)lint-(?:disable|enable)(?:-next-line|-line)?\b`,
-		String.raw`eslint-env\b`,
+		String.raw`(?:es|ox)lint-(?:disable|enable)(?:-next-line|-line)?(?=\s|$)`,
+		String.raw`eslint-env(?=\s|$)`,
 		String.raw`(?:es|ox)lint\s+[\w@/$-]+\s*:`,
-		String.raw`prettier-ignore\b`,
-		String.raw`dprint-ignore(?:-start|-end|-file)?\b`,
-		String.raw`biome-ignore\b`,
-		String.raw`@ts-(?:ignore|expect-error|nocheck|check)\b`,
-		String.raw`@vite-ignore\b`,
-		String.raw`type-coverage:ignore-`,
-		String.raw`[cv]8 ignore\b`,
-		String.raw`istanbul ignore\b`,
+		String.raw`prettier-ignore(?=\s|$)`,
+		String.raw`dprint-ignore(?:-start|-end|-file)?(?=\s|$)`,
+		String.raw`biome-ignore(?=\s|$)`,
+		String.raw`@ts-(?:ignore|expect-error|nocheck|check)(?=\s|$)`,
+		String.raw`@vite-ignore(?=\s|$)`,
+		String.raw`type-coverage:ignore-(?:next-line|line|file)(?=\s|$)`,
+		String.raw`[cv]8 ignore(?=\s|$)`,
+		String.raw`istanbul ignore(?=\s|$)`,
 		String.raw`webpack(?:ChunkName|Mode|Prefetch|Preload|Include|Exclude|Ignore|Exports|FetchPriority)\s*:`,
-		String.raw`[#@]__(?:PURE|NO_SIDE_EFFECTS)__`,
+		String.raw`[#@]__(?:PURE|NO_SIDE_EFFECTS)__(?=\s|$)`,
 		String.raw`#(?:end)?region(?:\s|$)`,
 		String.raw`/\s*<(?:reference|amd-)`,
 	].join('|')

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -28,7 +28,8 @@
  *
  * Each fixed form ends in `(?=\s|$)` rather than `\b`, because `\b` also succeeds before a hyphen:
  * `prettier-ignore\b` matches `// prettier-ignore-this explanation`. Every one of the ten `\b`
- * forms had that leak too.
+ * forms had that leak too. The `@ts-` family additionally accepts `:` as a delimiter, because
+ * `// @ts-expect-error: reason` is the form typescript-eslint's `descriptionFormat` asks for.
  */
 const DIRECTIVE = new RegExp(`^\\s*(?:${
 	[
@@ -38,7 +39,7 @@ const DIRECTIVE = new RegExp(`^\\s*(?:${
 		String.raw`prettier-ignore(?=\s|$)`,
 		String.raw`dprint-ignore(?:-start|-end|-file)?(?=\s|$)`,
 		String.raw`biome-ignore(?=\s|$)`,
-		String.raw`@ts-(?:ignore|expect-error|nocheck|check)(?=\s|$)`,
+		String.raw`@ts-(?:ignore|expect-error|nocheck|check)(?=[:\s]|$)`,
 		String.raw`@vite-ignore(?=\s|$)`,
 		String.raw`type-coverage:ignore-(?:next-line|line|file)(?=\s|$)`,
 		String.raw`[cv]8 ignore(?=\s|$)`,

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -1,0 +1,141 @@
+/**
+ * A comment budget, not a comment ban.
+ *
+ * The rule counts *sites* — one run of adjacent comment lines is one site, however long — so a
+ * single considered explanation costs the same as a single `// increment i`. That is deliberate:
+ * budgeting per line would make the thoughtful six-line note more expensive than six scattered
+ * throwaways, which is backwards. When a block runs out of budget the fix is almost always to
+ * extract a named function, and when a file does it is usually to split it.
+ *
+ * Written to the ESLint v9 rule API so it runs under both oxlint (`jsPlugins`) and ESLint.
+ */
+
+/**
+ * Comments that carry no prose and cannot be replaced by better naming: linter and compiler
+ * directives, formatter pragmas, coverage markers, bundler hints, and editor fold markers.
+ * These never count against a budget — a budget that eats the escape hatches trains people to
+ * disable the budget.
+ */
+const DIRECTIVE =
+	/^\s*(?:eslint|oxlint|globals?\s|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|jshint |@ts-|@vite-|webpack|#__|@__|#?(?:end)?region\b|<\/?reference)/;
+
+/** JSDoc/TSDoc — `/** … *␀/`, but not a `/*** … *␀/` banner or a bare `/* … *␀/`. */
+function isDocComment(comment) {
+	return comment.type === 'Block' && comment.value.startsWith('*') && !comment.value.startsWith('**');
+}
+
+/**
+ * Collapse a comment list into sites. Consecutive lines of *own-line* comments are one wrapped
+ * paragraph and are charged once. A trailing comment (code to its left) never merges, in either
+ * direction: `a = 1; // why` followed by `b = 2; // why` is two separate asides that happen to be
+ * neighbours, not one paragraph.
+ */
+function toSites(comments, isOwnLine) {
+	const sites = [];
+	for (const comment of comments) {
+		const ownLine = isOwnLine(comment);
+		const previous = sites.at(-1);
+		if (ownLine && previous?.ownLine && comment.loc.start.line - previous.endLine <= 1) {
+			previous.endLine = comment.loc.end.line;
+		} else {
+			sites.push({ first: comment, endLine: comment.loc.end.line, ownLine });
+		}
+	}
+	return sites;
+}
+
+/** Of the candidate blocks containing `site`, the one that starts latest is the innermost. */
+function innermostBlock(site, blocks, fallback) {
+	const [start, end] = site.first.range;
+	let innermost = fallback;
+	for (const block of blocks) {
+		if (block.range[0] <= start && end <= block.range[1] && block.range[0] >= innermost.range[0]) {
+			innermost = block;
+		}
+	}
+	return innermost;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const commentBudget = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description: 'Cap how many separate comment sites a file or a single block may carry',
+		},
+		schema: [{
+			type: 'object',
+			properties: {
+				maxPerFile: { type: 'integer', minimum: 0 },
+				maxPerBlock: { type: 'integer', minimum: 0 },
+				allowJSDoc: { type: 'boolean' },
+			},
+			additionalProperties: false,
+		}],
+		messages: {
+			file:
+				'This file has {{count}} comments; the budget is {{max}}. Prefer names that carry the meaning, or split the file.',
+			block:
+				'This block has {{count}} comments; the budget is {{max}}. Extracting a named function usually beats explaining in place.',
+		},
+	},
+
+	create(context) {
+		const { maxPerFile = 10, maxPerBlock = 2, allowJSDoc = true } = context.options[0] ?? {};
+		const sourceCode = context.sourceCode ?? context.getSourceCode();
+		const text = sourceCode.getText();
+		const blocks = [];
+
+		/** True when nothing but indentation precedes the comment on its line. */
+		function isOwnLine(comment) {
+			for (let i = comment.range[0] - 1; i >= 0 && text[i] !== '\n'; i--) {
+				if (text[i] !== ' ' && text[i] !== '\t' && text[i] !== '\r') { return false; }
+			}
+			return true;
+		}
+
+		return {
+			'BlockStatement, StaticBlock, ClassBody, SwitchCase, TSModuleBlock'(node) {
+				blocks.push(node);
+			},
+
+			'Program:exit'(program) {
+				const counted = sourceCode.getAllComments().filter((comment) =>
+					!DIRECTIVE.test(comment.value) && !(allowJSDoc && isDocComment(comment))
+				);
+				const sites = toSites(counted, isOwnLine);
+
+				// One report per scope, on the site that broke the budget, so a file that is far over
+				// gets a single actionable warning instead of a wall of them.
+				if (sites.length > maxPerFile) {
+					context.report({
+						node: sites[maxPerFile].first,
+						messageId: 'file',
+						data: { count: String(sites.length), max: String(maxPerFile) },
+					});
+				}
+
+				const byBlock = new Map();
+				for (const site of sites) {
+					const block = innermostBlock(site, blocks, program);
+					if (block === program) { continue; }
+					byBlock.set(block, [...(byBlock.get(block) ?? []), site]);
+				}
+				for (const blockSites of byBlock.values()) {
+					if (blockSites.length > maxPerBlock) {
+						context.report({
+							node: blockSites[maxPerBlock].first,
+							messageId: 'block',
+							data: { count: String(blockSites.length), max: String(maxPerBlock) },
+						});
+					}
+				}
+			},
+		};
+	},
+};
+
+export default {
+	meta: { name: 'comment-budget' },
+	rules: { 'comment-budget': commentBudget },
+};

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -20,9 +20,13 @@
  * That is why the TypeScript triple-slash forms are written with a leading `\/`: by the time the
  * rule sees `/// <reference types="…" />`, two of the three slashes are gone and the value begins
  * `/ <reference`.
+ *
+ * Every alternative must match real directive syntax rather than a bare tool name, or prose like
+ * `// eslint has different behavior here` buys a free exemption. `global` and `jshint` are omitted
+ * for exactly that reason: their only valid forms are indistinguishable from an English sentence.
  */
 const DIRECTIVE =
-	/^\s*(?:eslint|oxlint|globals?\s|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|jshint |@ts-|@vite-|webpack|#__|@__|#?(?:end)?region\b|\/\s*<(?:reference|amd-))/;
+	/^\s*(?:(?:es|ox)lint(?:-|\s+[\w@/$-]+\s*:)|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|@ts-|@vite-|webpack\w*\s*:|#__|@__|#(?:end)?region\b|\/\s*<(?:reference|amd-))/;
 
 /** JSDoc/TSDoc — `/** … *␀/`, but not a `/*** … *␀/` banner or a bare `/* … *␀/`. */
 function isDocComment(comment) {
@@ -39,8 +43,8 @@ function isDocComment(comment) {
  * The exception is a trailing comment annotating an element of a data literal —
  * `'org-', // empty body` in a table of test cases. That describes the row it sits on rather than
  * the logic around it, and no amount of renaming can absorb it, so the whole annotated literal is
- * charged once however many rows carry a note. Without this, documenting fixture data was the most
- * expensive thing you could write under the rule.
+ * charged once however many rows carry a note; otherwise documenting fixture data would be the most
+ * expensive thing in the codebase.
  */
 function toSites(comments, isOwnLine, annotatedLiteralFor) {
 	const sites = [];
@@ -73,7 +77,6 @@ function toSites(comments, isOwnLine, annotatedLiteralFor) {
 	return sites;
 }
 
-/** Of `nodes`, the innermost one enclosing `[start, end]` — i.e. the enclosing node starting latest. */
 function innermostEnclosing([start, end], nodes) {
 	let innermost;
 	for (const node of nodes) {
@@ -116,7 +119,6 @@ const commentBudget = {
 		const blocks = [];
 		const dataLiterals = [];
 
-		/** True when nothing but indentation precedes the comment on its line. */
 		function isOwnLine(comment) {
 			for (let i = comment.range[0] - 1; i >= 0 && text[i] !== '\n' && text[i] !== '\r'; i--) {
 				if (text[i] !== ' ' && text[i] !== '\t') { return false; }
@@ -124,9 +126,15 @@ const commentBudget = {
 			return true;
 		}
 
-		/** The data literal whose rows this trailing comment annotates, if it sits inside one. */
 		function annotatedLiteralFor(comment) {
-			return innermostEnclosing(comment.range, dataLiterals);
+			const literal = innermostEnclosing(comment.range, dataLiterals);
+			if (!literal) { return undefined; }
+
+			// A comment inside a block that is itself nested in the literal — an object method body —
+			// annotates logic that merely lives in a literal, not a row of data. Without this the
+			// whole method collapses to one site and its block budget stops applying.
+			const block = innermostEnclosing(comment.range, blocks);
+			return block && block.range[0] > literal.range[0] ? undefined : literal;
 		}
 
 		return {

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -30,15 +30,38 @@ function isDocComment(comment) {
 }
 
 /**
- * Collapse a comment list into sites. Consecutive lines of *own-line* comments are one wrapped
- * paragraph and are charged once. A trailing comment (code to its left) never merges, in either
- * direction: `a = 1; // why` followed by `b = 2; // why` is two separate asides that happen to be
- * neighbours, not one paragraph.
+ * Collapse a comment list into sites.
+ *
+ * Consecutive lines of *own-line* comments are one wrapped paragraph and are charged once. A
+ * trailing comment (code to its left) never merges with a neighbour: `a = 1; // why` followed by
+ * `b = 2; // why` is two separate asides, not one paragraph.
+ *
+ * The exception is a trailing comment annotating an element of a data literal —
+ * `'org-', // empty body` in a table of test cases. That describes the row it sits on rather than
+ * the logic around it, and no amount of renaming can absorb it, so the whole annotated literal is
+ * charged once however many rows carry a note. Without this, documenting fixture data was the most
+ * expensive thing you could write under the rule.
  */
-function toSites(comments, isOwnLine) {
+function toSites(comments, isOwnLine, annotatedLiteralFor) {
 	const sites = [];
+	const literalSites = new Map();
+
 	for (const comment of comments) {
 		const ownLine = isOwnLine(comment);
+		const literal = ownLine ? undefined : annotatedLiteralFor(comment);
+
+		if (literal) {
+			const opened = literalSites.get(literal);
+			if (opened) {
+				opened.endLine = comment.loc.end.line;
+			} else {
+				const site = { first: comment, endLine: comment.loc.end.line, ownLine };
+				literalSites.set(literal, site);
+				sites.push(site);
+			}
+			continue;
+		}
+
 		const previous = sites.at(-1);
 		if (ownLine && previous?.ownLine && comment.loc.start.line - previous.endLine <= 1) {
 			previous.endLine = comment.loc.end.line;
@@ -46,16 +69,17 @@ function toSites(comments, isOwnLine) {
 			sites.push({ first: comment, endLine: comment.loc.end.line, ownLine });
 		}
 	}
+
 	return sites;
 }
 
-/** Of the candidate blocks containing `site`, the one that starts latest is the innermost. */
-function innermostBlock(site, blocks, fallback) {
-	const [start, end] = site.first.range;
-	let innermost = fallback;
-	for (const block of blocks) {
-		if (block.range[0] <= start && end <= block.range[1] && block.range[0] >= innermost.range[0]) {
-			innermost = block;
+/** Of `nodes`, the innermost one enclosing `[start, end]` — i.e. the enclosing node starting latest. */
+function innermostEnclosing([start, end], nodes) {
+	let innermost;
+	for (const node of nodes) {
+		const encloses = node.range[0] <= start && end <= node.range[1];
+		if (encloses && (!innermost || node.range[0] >= innermost.range[0])) {
+			innermost = node;
 		}
 	}
 	return innermost;
@@ -90,6 +114,7 @@ const commentBudget = {
 		const sourceCode = context.sourceCode ?? context.getSourceCode();
 		const text = sourceCode.getText();
 		const blocks = [];
+		const dataLiterals = [];
 
 		/** True when nothing but indentation precedes the comment on its line. */
 		function isOwnLine(comment) {
@@ -99,16 +124,25 @@ const commentBudget = {
 			return true;
 		}
 
+		/** The data literal whose rows this trailing comment annotates, if it sits inside one. */
+		function annotatedLiteralFor(comment) {
+			return innermostEnclosing(comment.range, dataLiterals);
+		}
+
 		return {
 			'BlockStatement, StaticBlock, ClassBody, SwitchCase, TSModuleBlock'(node) {
 				blocks.push(node);
+			},
+
+			'ArrayExpression, ObjectExpression, TSTupleType, TSTypeLiteral, TSEnumBody'(node) {
+				dataLiterals.push(node);
 			},
 
 			'Program:exit'(program) {
 				const counted = sourceCode.getAllComments().filter((comment) =>
 					!DIRECTIVE.test(comment.value) && !(allowJSDoc && isDocComment(comment))
 				);
-				const sites = toSites(counted, isOwnLine);
+				const sites = toSites(counted, isOwnLine, annotatedLiteralFor);
 
 				// One report per scope, on the site that broke the budget, so a file that is far over
 				// gets a single actionable warning instead of a wall of them.
@@ -122,7 +156,7 @@ const commentBudget = {
 
 				const byBlock = new Map();
 				for (const site of sites) {
-					const block = innermostBlock(site, blocks, program);
+					const block = innermostEnclosing(site.first.range, blocks) ?? program;
 					if (block === program) { continue; }
 					const blockSites = byBlock.get(block);
 					if (blockSites) {

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -21,12 +21,30 @@
  * rule sees `/// <reference types="…" />`, two of the three slashes are gone and the value begins
  * `/ <reference`.
  *
- * Every alternative must match real directive syntax rather than a bare tool name, or prose like
- * `// eslint has different behavior here` buys a free exemption. `global` and `jshint` are omitted
- * for exactly that reason: their only valid forms are indistinguishable from an English sentence.
+ * This is an allowlist of the exact recognised forms, not a list of tool-name prefixes. Prefixes
+ * leak: `eslint-` also matches `// eslint-based behavior differs here`, and every one of the ten
+ * prefixes this replaced had a near-miss like it, each buying a comment a free exemption. `global`,
+ * `jshint`, and `jscs` are omitted entirely — their valid forms are indistinguishable from prose.
  */
-const DIRECTIVE =
-	/^\s*(?:(?:es|ox)lint(?:-|\s+[\w@/$-]+\s*:)|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|@ts-|@vite-|webpack\w*\s*:|#__|@__|#(?:end)?region\b|\/\s*<(?:reference|amd-))/;
+const DIRECTIVE = new RegExp(`^\\s*(?:${
+	[
+		String.raw`(?:es|ox)lint-(?:disable|enable)(?:-next-line|-line)?\b`,
+		String.raw`eslint-env\b`,
+		String.raw`(?:es|ox)lint\s+[\w@/$-]+\s*:`,
+		String.raw`prettier-ignore\b`,
+		String.raw`dprint-ignore(?:-start|-end|-file)?\b`,
+		String.raw`biome-ignore\b`,
+		String.raw`@ts-(?:ignore|expect-error|nocheck|check)\b`,
+		String.raw`@vite-ignore\b`,
+		String.raw`type-coverage:ignore-`,
+		String.raw`[cv]8 ignore\b`,
+		String.raw`istanbul ignore\b`,
+		String.raw`webpack(?:ChunkName|Mode|Prefetch|Preload|Include|Exclude|Ignore|Exports|FetchPriority)\s*:`,
+		String.raw`[#@]__(?:PURE|NO_SIDE_EFFECTS)__`,
+		String.raw`#(?:end)?region(?:\s|$)`,
+		String.raw`/\s*<(?:reference|amd-)`,
+	].join('|')
+})`);
 
 /** JSDoc/TSDoc — `/** … *␀/`, but not a `/*** … *␀/` banner or a bare `/* … *␀/`. */
 function isDocComment(comment) {

--- a/tools/oxlint-plugins/comment-budget.js
+++ b/tools/oxlint-plugins/comment-budget.js
@@ -15,9 +15,14 @@
  * directives, formatter pragmas, coverage markers, bundler hints, and editor fold markers.
  * These never count against a budget — a budget that eats the escape hatches trains people to
  * disable the budget.
+ *
+ * Matched against `comment.value`, i.e. the text with the opening `//` or `/*` already stripped.
+ * That is why the TypeScript triple-slash forms are written with a leading `\/`: by the time the
+ * rule sees `/// <reference types="…" />`, two of the three slashes are gone and the value begins
+ * `/ <reference`.
  */
 const DIRECTIVE =
-	/^\s*(?:eslint|oxlint|globals?\s|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|jshint |@ts-|@vite-|webpack|#__|@__|#?(?:end)?region\b|<\/?reference)/;
+	/^\s*(?:eslint|oxlint|globals?\s|prettier-|dprint-|biome-|type-coverage:|[cv]8 ignore|istanbul ignore|jscs:|jshint |@ts-|@vite-|webpack|#__|@__|#?(?:end)?region\b|\/\s*<(?:reference|amd-))/;
 
 /** JSDoc/TSDoc — `/** … *␀/`, but not a `/*** … *␀/` banner or a bare `/* … *␀/`. */
 function isDocComment(comment) {

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -270,6 +270,21 @@ describe('comment-budget', () => {
 		expect(lint(handlers, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 4 }]);
 	});
 
+	it('charges a real directive form with prose suffixed onto it', () => {
+		const suffixed = `export function f(n: number) {
+			// prettier-ignore-this explanation
+			let x = n;
+			// eslint-env-specific behavior
+			x += 1;
+			// @vite-ignore-me
+			x *= 2;
+			// istanbul ignore-not-really
+			return x;
+		}`;
+
+		expect(lint(suffixed, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 4 }]);
+	});
+
 	it('charges prose that merely opens with a directive-shaped near-miss', () => {
 		const nearMisses = `export function f(n: number) {
 			// eslint-based behavior differs here

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -1,11 +1,21 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const PLUGIN = resolve(import.meta.dirname, 'comment-budget.js');
-const OXLINT = resolve(import.meta.dirname, '../../node_modules/.bin/oxlint');
+
+/**
+ * oxlint's own `bin` entry, not the `node_modules/.bin` shim: the shim is a POSIX shell script with
+ * a separate `.cmd` twin on Windows, and Node refuses to spawn a `.cmd` without `shell: true`
+ * (CVE-2024-27980 hardening). The declared bin is a plain Node script, so running it through
+ * `process.execPath` works the same everywhere. Read from package.json rather than hardcoded
+ * because pnpm resolves `oxlint` to a store path outside this worktree.
+ */
+const OXLINT_PACKAGE = createRequire(import.meta.url).resolve('oxlint/package.json');
+const OXLINT_CLI = resolve(dirname(OXLINT_PACKAGE), JSON.parse(readFileSync(OXLINT_PACKAGE, 'utf8')).bin.oxlint);
 
 /**
  * Lint `source` by shelling out to the real oxlint. Going through the binary rather than calling
@@ -28,10 +38,11 @@ function lint(source, options = {}) {
 
 		let stdout;
 		try {
-			stdout = execFileSync(OXLINT, ['-c', '.oxlintrc.json', '--format', 'json', 'fixture.ts'], {
-				cwd: dir,
-				encoding: 'utf8',
-			});
+			stdout = execFileSync(
+				process.execPath,
+				[OXLINT_CLI, '-c', '.oxlintrc.json', '--format', 'json', 'fixture.ts'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 		} catch (error) {
 			// oxlint exits non-zero when any *other* default rule errors on the fixture; the report we
 			// care about is still on stdout.
@@ -167,6 +178,15 @@ describe('comment-budget', () => {
 			export const b = 2; // why 2`,
 			{ maxPerFile: 1 },
 		)).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
+	it('treats a bare CR as a line boundary, so the comment after code is still own-line', () => {
+		// Scanning left for indentation has to stop at CR too. It if only stops at LF it runs on into
+		// the previous line, finds the `;`, and calls both of these trailing asides instead of one
+		// paragraph.
+		const crOnly = ['const a = 1;', '// one', '// two', 'export const b = a;'].join('\r');
+
+		expect(lint(crOnly, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 1 }]);
 	});
 
 	it('scopes a switch case separately from the function body around it', () => {

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -184,7 +184,7 @@ describe('comment-budget', () => {
 	});
 
 	it('treats a bare CR as a line boundary, so the comment after code is still own-line', () => {
-		// Scanning left for indentation has to stop at CR too. It if only stops at LF it runs on into
+		// Scanning left for indentation has to stop at CR too. If it only stops at LF it runs on into
 		// the previous line, finds the `;`, and calls both of these trailing asides instead of one
 		// paragraph.
 		const crOnly = ['const a = 1;', '// one', '// two', 'export const b = a;'].join('\r');
@@ -249,6 +249,43 @@ describe('comment-budget', () => {
 		];`;
 
 		expect(lint(prose, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
+	it('does not let a literal absorb comments from a method body nested inside it', () => {
+		const handlers = `export const handlers = {
+			run(n: number) {
+				let x = n; // step one
+				x += 1;    // step two
+				x *= 2;    // step three
+				return x;  // step four
+			},
+		};`;
+
+		expect(lint(handlers, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 4 }]);
+	});
+
+	it('charges prose that merely opens with a tool name', () => {
+		const prose = `export function f(n: number) {
+			// eslint has different behavior here
+			let x = n;
+			// webpack injects this value
+			x += 1;
+			// oxlint used to complain about this
+			x *= 2;
+			// global state is shared across these
+			return x;
+		}`;
+
+		expect(lint(prose, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 4 }]);
+	});
+
+	it('still exempts the inline eslint config form, which is not prose', () => {
+		expect(lint(
+			`/* eslint no-console: "error" */
+			// webpackChunkName: "editor"
+			export const a = 1;`,
+			{ maxPerFile: 0 },
+		)).toEqual([]);
 	});
 
 	it('honours an inline disable directive for the rule itself', () => {

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -121,6 +121,12 @@ describe('comment-budget', () => {
 			/* c8 ignore next */
 			// #region setup
 			// #endregion
+			// prettier-ignore
+			// biome-ignore lint: deliberate
+			// @vite-ignore
+			/* istanbul ignore next */
+			// type-coverage:ignore-next-line
+			/* #__PURE__ */
 			export const a = 1;`,
 			{ maxPerFile: 0 },
 		)).toEqual([]);
@@ -262,6 +268,23 @@ describe('comment-budget', () => {
 		};`;
 
 		expect(lint(handlers, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 4 }]);
+	});
+
+	it('charges prose that merely opens with a directive-shaped near-miss', () => {
+		const nearMisses = `export function f(n: number) {
+			// eslint-based behavior differs here
+			let x = n;
+			// webpack: this build injects the value
+			x += 1;
+			// prettier-style formatting is nicer here
+			x *= 2;
+			// @ts-experts disagree about this
+			x -= 3;
+			// type-coverage: not great in here
+			return x;
+		}`;
+
+		expect(lint(nearMisses, { maxPerFile: 99, maxPerBlock: 2 })).toMatchObject([{ scope: 'block', count: 5 }]);
 	});
 
 	it('charges prose that merely opens with a tool name', () => {

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -208,6 +208,49 @@ describe('comment-budget', () => {
 		)).toEqual([]);
 	});
 
+	it('charges an annotated data literal once, not once per annotated row', () => {
+		const table = `export const CASES = [
+			'org',   // no body
+			'org-',  // empty body
+			'Org-1', // uppercase prefix is a title, not an id
+			'org 1', // space, not a hyphen
+		];`;
+
+		expect(lint(table, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 1 }]);
+	});
+
+	it('does the same for an annotated object literal', () => {
+		const table = `export const LIMITS = {
+			retries: 3,     // matches the gateway's own ceiling
+			backoffMs: 250, // half the observed p50 round trip
+		};`;
+
+		expect(lint(table, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 1 }]);
+	});
+
+	it('charges two sibling literals separately', () => {
+		const tables = `export const A = [
+			1, // one
+		];
+		export const B = [
+			2, // two
+		];`;
+
+		expect(lint(tables, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
+	it('does not exempt own-line prose that merely sits inside a literal', () => {
+		const prose = `export const CASES = [
+			// the parser accepted this until #1199
+			'org-1',
+
+			// and this one only on 4.7
+			'org-2',
+		];`;
+
+		expect(lint(prose, { maxPerFile: 0 })).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
 	it('honours an inline disable directive for the rule itself', () => {
 		expect(lint(
 			`// oxlint-disable comment-budget/comment-budget

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -1,0 +1,198 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PLUGIN = resolve(import.meta.dirname, 'comment-budget.js');
+const OXLINT = resolve(import.meta.dirname, '../../node_modules/.bin/oxlint');
+
+/**
+ * Lint `source` by shelling out to the real oxlint. Going through the binary rather than calling
+ * `create()` directly is the point: it is the only way to prove the rule still works against
+ * oxlint's own AST and SourceCode implementation, which is where breakage would come from.
+ *
+ * @returns {{ scope: 'file' | 'block', line: number, count: number, max: number }[]}
+ */
+function lint(source, options = {}) {
+	const dir = mkdtempSync(join(tmpdir(), 'comment-budget-'));
+	try {
+		writeFileSync(
+			join(dir, '.oxlintrc.json'),
+			JSON.stringify({
+				jsPlugins: [PLUGIN],
+				rules: { 'comment-budget/comment-budget': ['warn', options] },
+			}),
+		);
+		writeFileSync(join(dir, 'fixture.ts'), source);
+
+		let stdout;
+		try {
+			stdout = execFileSync(OXLINT, ['-c', '.oxlintrc.json', '--format', 'json', 'fixture.ts'], {
+				cwd: dir,
+				encoding: 'utf8',
+			});
+		} catch (error) {
+			// oxlint exits non-zero when any *other* default rule errors on the fixture; the report we
+			// care about is still on stdout.
+			stdout = error.stdout;
+			if (!stdout) { throw error; }
+		}
+
+		return JSON.parse(stdout).diagnostics
+			.filter((diagnostic) => diagnostic.code.startsWith('comment-budget'))
+			.map((diagnostic) => ({
+				scope: diagnostic.message.startsWith('This file') ? 'file' : 'block',
+				line: diagnostic.labels[0].span.line,
+				count: Number(diagnostic.message.match(/has (\d+)/)[1]),
+				max: Number(diagnostic.message.match(/budget is (\d+)/)[1]),
+			}));
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe('comment-budget', () => {
+	it('stays quiet while a file is within budget', () => {
+		expect(lint(
+			`// one
+			const a = 1;
+			// two
+			export const b = a;`,
+			{ maxPerFile: 2 },
+		)).toEqual([]);
+	});
+
+	it('reports once per file, on the comment that broke the budget', () => {
+		const [report, ...rest] = lint(
+			`// 1
+			const a = 1;
+			// 2
+			const b = 2;
+			// 3
+			const c = 3;
+			// 4
+			export const d = a + b + c;`,
+			{ maxPerFile: 2 },
+		);
+
+		expect(rest).toEqual([]);
+		expect(report).toEqual({ scope: 'file', line: 5, count: 4, max: 2 });
+	});
+
+	it('charges a run of adjacent comment lines as a single site', () => {
+		const paragraph = `// the exchange rounds half-up, but our ledger rounds half-even, so the two
+			// disagree by a cent on exact halves; reconcile against the ledger, not the feed
+			export const rate = 1;`;
+
+		expect(lint(paragraph, { maxPerFile: 1 })).toEqual([]);
+	});
+
+	it('starts a new site once a blank line breaks the run', () => {
+		expect(lint(
+			`// first
+
+			// second
+			export const a = 1;`,
+			{ maxPerFile: 1 },
+		)).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
+	it('never charges for linter, compiler, or formatter directives', () => {
+		expect(lint(
+			`/* eslint-disable no-console */
+			// oxlint-disable-next-line no-debugger
+			// @ts-expect-error deliberate
+			// dprint-ignore
+			/* c8 ignore next */
+			// #region setup
+			// #endregion
+			export const a = 1;`,
+			{ maxPerFile: 0 },
+		)).toEqual([]);
+	});
+
+	it('exempts doc comments by default and charges them on request', () => {
+		const source = `/** The canonical retry ceiling. */
+			export const MAX_RETRIES = 3;`;
+
+		expect(lint(source, { maxPerFile: 0 })).toEqual([]);
+		expect(lint(source, { maxPerFile: 0, allowJSDoc: false })).toMatchObject([{ scope: 'file', count: 1 }]);
+	});
+
+	it('charges a block banner comment, which only looks like a doc comment', () => {
+		expect(lint(
+			`/*** Section: pricing ***/
+			export const a = 1;`,
+			{ maxPerFile: 0 },
+		)).toMatchObject([{ scope: 'file', count: 1 }]);
+	});
+
+	it('reports a block that is over budget even when the file is not', () => {
+		const [report, ...rest] = lint(
+			`export function f(n: number) {
+				// 1
+				let x = n;
+				// 2
+				x += 1;
+				// 3
+				return x;
+			}`,
+			{ maxPerFile: 99, maxPerBlock: 2 },
+		);
+
+		expect(rest).toEqual([]);
+		expect(report).toEqual({ scope: 'block', line: 6, count: 3, max: 2 });
+	});
+
+	it('charges each comment to its innermost block, not to every enclosing one', () => {
+		expect(lint(
+			`export function f(n: number) {
+				// outer
+				if (n > 0) {
+					// inner 1
+					n += 1;
+					// inner 2
+					n += 2;
+				}
+				return n;
+			}`,
+			{ maxPerFile: 99, maxPerBlock: 2 },
+		)).toEqual([]);
+	});
+
+	it('counts trailing comments, which are the easiest ones to leave behind', () => {
+		expect(lint(
+			`export const a = 1; // why 1
+			export const b = 2; // why 2`,
+			{ maxPerFile: 1 },
+		)).toMatchObject([{ scope: 'file', count: 2 }]);
+	});
+
+	it('scopes a switch case separately from the function body around it', () => {
+		expect(lint(
+			`export function f(kind: string) {
+				// dispatch on the wire tag, not the display name
+				switch (kind) {
+					case 'a':
+						// legacy servers send this lowercased
+						return 1;
+					default:
+						return 0;
+				}
+			}`,
+			{ maxPerFile: 99, maxPerBlock: 1 },
+		)).toEqual([]);
+	});
+
+	it('honours an inline disable directive for the rule itself', () => {
+		expect(lint(
+			`// oxlint-disable comment-budget/comment-budget
+			// 1
+			const a = 1;
+			// 2
+			export const b = a;`,
+			{ maxPerFile: 0 },
+		)).toEqual([]);
+	});
+});

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -111,7 +111,10 @@ describe('comment-budget', () => {
 
 	it('never charges for linter, compiler, or formatter directives', () => {
 		expect(lint(
-			`/* eslint-disable no-console */
+			`/// <reference types="vite/client" />
+			/// <reference lib="dom" />
+			/// <amd-module name="Validator" />
+			/* eslint-disable no-console */
 			// oxlint-disable-next-line no-debugger
 			// @ts-expect-error deliberate
 			// dprint-ignore

--- a/tools/oxlint-plugins/comment-budget.test.js
+++ b/tools/oxlint-plugins/comment-budget.test.js
@@ -122,6 +122,8 @@ describe('comment-budget', () => {
 			// #region setup
 			// #endregion
 			// prettier-ignore
+			// @ts-expect-error: the vendor types are wrong here
+			// @ts-ignore: same story
 			// biome-ignore lint: deliberate
 			// @vite-ignore
 			/* istanbul ignore next */


### PR DESCRIPTION
Adds `comment-budget`, a custom oxlint rule that warns when a file carries more than 12 comment "sites" or a single block more than 4, to push toward code that explains itself rather than prose that drifts from it. It is a `warn` on an experiment footing — CI and the pre-commit hook stay green — and nothing off the shelf does this (the two npm packages that come close are abandoned 2022 stubs, one of which enforces a *minimum* comment density).

Scoped to this repo only; the rule is written to the ESLint v9 API and would need no changes to become a package later, but nothing here depends on that.

## For the human reviewer

1. **Is this worth having at all?** kriszyp's review makes the strongest counter-argument and I largely agree with it: for newly written code the skills updates apply comment discipline at write time, which beats flagging it afterwards. What is left for a lint rule is pre-existing code, human edits made outside the harness, and a trackable number. Sampling my own flagged set (6 of 52 blocks, chosen before reading them) put the precision at 2 clear hits — it flags load-bearing prose about as often as narration. **Reversibility is the argument for merging anyway:** 140 lines and one config entry to delete, and the calibration data is the durable artifact either way. A "no" costs nothing already spent. Approved by kriszyp on the experiment framing; ruling again here is fair game.
2. **Sites, not lines or comments.** A run of adjacent own-line comments is one site however long. Budgeting per line would price a considered six-line explanation above six scattered `// increment i`s, which inverts the incentive. The cost is that verbosity within one comment is unpriced. Reversible in ~10 lines of `toSites`.
3. **12 per file / 4 per block, from measurement not taste.** Across `src`: median 3 sites per file, p90 9, p95 12. At 12/4 that is 78 warnings; 10/2 would be 175. I picked the looser end because the baseline was previously spotless and I did not want to spend that signal. Tightening is a one-line config change.
4. **`warn`, not `error`.** oxlint exits 0 on warnings, so this cannot fail CI or the hook. The cost is 78 permanent warnings eroding a previously clean baseline. Ratcheting later is the intended path, not shipping strict now.
5. **The block signal is really a scope-size signal.** The densest scopes here (`useResizableDialog.ts`, `DatabaseTableView.tsx`) are the *best*-commented code we have — Radix ref-loop hazards, the `describe_all`/`describe_table` race, a `#1199` reference. They trip the budget because the functions are large. `max-lines-per-function` measures that more directly with no custom plugin, and choosing this over that is a real call I could be wrong about. `AGENTS.md` states plainly that answering a warning by deleting prose leaves us worse off.
6. **Test files share the one budget.** Tests hold the extreme tail (220 of 596 commented files; max 40). An oxlint `overrides` block giving them their own budget is a few lines; I left it out because a second knob is easier to add on evidence than to remove. Watch for a few weeks.

## Verification

Route: **new unit tests plus a repo-wide run of the rule against real code** — a lint rule is fully observable at the linter, so there is no integration surface beyond that.

- 20 rule tests, driven through the real oxlint binary rather than by calling `create()` directly, so they exercise oxlint's own AST and `SourceCode` rather than my assumptions about them. Covers budget arithmetic, paragraph grouping, the blank-line break, trailing comments, CR line endings, directive and JSDoc exemption including TS triple-slash, banner comments, annotated array/object literals with both the own-line and nested-block carve-outs, prose that merely opens with a tool name, sibling literals charged separately, innermost-block attribution, switch-case scoping, one-report-per-scope, and the inline disable.
- Every fix was checked against its own counterfactual rather than asserted — reverting the fix must turn its test red. CR: 2 sites instead of 1. Triple-slash: 1 instead of 0. Both exemption holes: `[]` instead of a 4-comment block warning. A regression test that passes either way proves nothing.
- The two exemption holes were reproduced as live defects before being fixed: a five-comment object method body and five prose comments opening with tool names each produced **zero** warnings where five were due.
- Repo-wide: `pnpm lint` reports 78 warnings (29 file, 49 block) and exits 0 — unchanged by the exemption fixes, so neither hole was being exploited here; both were latent. `pnpm test` 292 files / 2,275 tests green, `tsc -b` clean, `dprint check` clean. Studio has no `test:unit:main` / `test:integration:all` scripts; those are the repo's full-gate equivalents.
- Two boundary conditions checked rather than assumed: `jsPlugins` exists in the oxlint config schema back to our declared `^1.32.0` floor, and a broken plugin path fails the whole lint run with exit 1 rather than silently dropping the rule.

## Review coverage

Authored by Opus 5. Cross-model review: **codex (`gpt-5.6-sol`) ✓**, **gemini via `agy` (default model) ✓**. Failed or skipped, named rather than omitted: `cursor-composer` ✗ — `cursor-review` structurally refuses any diff that changes agent instructions, and this one edits `AGENTS.md`; `cursor-grok` ✗ pruned by policy; Harper domain adjudication ✗ (exit 1 twice, then pruned on the narrow deltas). So outside coverage here is two lenses, not four, and no adjudication ran. Receipt @ `6e068c79`.

Five rounds. Rounds 1–4 found five real defects — each reproduced as a live failure before being fixed, each with a counterfactual proving its regression test goes red without the fix. Round 5 returned no findings.

Worth stating plainly: **this review should have run before the first push.** It did not. The four findings that reached this PR from gemini and kriszyp were all the same class the pre-push leg catches in minutes, and running it late turned up five more that no PR reviewer had seen.

<sub>Human-Review-Need: 4 @ 6e068c7954fe</sub>
