### PR TITLE
feat(permissions): apply the operations allowlist to table read/write gating

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,3 +329,31 @@ Practical consequence for the UI: never describe a restriction the server does n
 never advise "fixing" an `operations` value in place — both mistakes shipped and were caught in
 review. `classifyOperationsValue` needs the instance version because the same shape means different
 things on either side of the 5.0.0-alpha.8 floor (the feature's first tagged build, not 5.0.0).
+
+### Which of those the UI gating turns on
+
+The two facts that decide Studio's permission hooks (`src/hooks/checkOperationPermission.ts`):
+
+- **Gate admin chrome on the allowlist and you hide UI that works.** Because super users never reach
+  the gate, table read/write is the only surface it can actually deny — so
+  `useInstanceManagePermission` and `useInstanceBrowseManagePermission` are deliberately NOT gated.
+- **`isElevatedRole` is the wrong question for a specific operation.** It answers "is the list
+  unenforceable anywhere for this role", which is what the editor warns about. For DML,
+  `structure_user` and `cluster_user` are still gated.
+
+Also two different expansions are correct for two different questions, and sharing one silently broke
+the second once: `expandEffectiveOperations` folds alias spellings together to describe a role's
+effective reach (display); simulating the gate must expand verbatim and canonicalize only the
+operation being checked, or a lone alias grant wrongly reads as working.
+
+### Settling one of these empirically
+
+Reading `verifyPerms` is not enough — the super-user and structure-user verdicts above were confirmed
+by running it. In a Harper checkout, drop a throwaway spec in `unitTests/utility/`,
+`require('#src/utility/operation_authorization')`, build a `hdb_user.role.permission` literal, and call
+`verifyPerms(requestJson, handler.name)`: `null` means allowed, a `PermissionResponseObject` means
+denied. `testUtils.preTestPrep()` + `testUtils.setGlobalSchema(...)` provide the schema globals, and
+`rewire` reaches internals — `requiredPermissions` (to audit which names carry an `api_name`) and
+`verifyPermsAST` (to show SQL skipping the gate). Run with `npx mocha unitTests/utility/<file>`, read
+the verdicts, delete the file. Measured this way: `super_user` + `operations: []` still ALLOWS insert,
+search, restart and get_configuration, while `super_user: false` + `operations: []` DENIES insert.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,8 +335,12 @@ things on either side of the 5.0.0-alpha.8 floor (the feature's first tagged bui
 The two facts that decide Studio's permission hooks (`src/hooks/checkOperationPermission.ts`):
 
 - **Gate admin chrome on the allowlist and you hide UI that works.** Because super users never reach
-  the gate, table read/write is the only surface it can actually deny — so
-  `useInstanceManagePermission` and `useInstanceBrowseManagePermission` are deliberately NOT gated.
+  the gate, `useInstanceManagePermission` and `useInstanceBrowseManagePermission` are deliberately NOT
+  gated. Note browse-manage is only half short-circuited: its DDL half is, but the application-editor
+  operations behind it (`set_component_file`, `drop_component`, `deploy_component`, `set_env_value`,
+  `restart_service`) are not in `STRUCTURE_USER_OPS`, so for a non-super role they do reach the gate —
+  where an allowlist listing them _grants_ them via gate 2. Denying that half on the allowlist would
+  therefore hide UI a scoped role can legitimately use.
 - **`isElevatedRole` is the wrong question for a specific operation.** It answers "is the list
   unenforceable anywhere for this role", which is what the editor warns about. For DML,
   `structure_user` and `cluster_user` are still gated.

--- a/src/features/instance/config/roles/operations/operationsCatalog.test.ts
+++ b/src/features/instance/config/roles/operations/operationsCatalog.test.ts
@@ -1,4 +1,5 @@
 import {
+	canonicalOperationName,
 	expandEffectiveOperations,
 	getAvailableGroups,
 	getGrantableOperations,
@@ -178,6 +179,15 @@ describe('expandEffectiveOperations', () => {
 
 	it('expands an empty allowlist to nothing', () => {
 		expect(expandEffectiveOperations([])).toEqual([]);
+	});
+});
+
+describe('canonicalOperationName', () => {
+	it('collapses aliases onto their authorization entry and leaves everything else alone', () => {
+		expect(canonicalOperationName('create_schema')).toBe('create_database');
+		expect(canonicalOperationName('search_by_id')).toBe('search_by_hash');
+		expect(canonicalOperationName('create_database')).toBe('create_database');
+		expect(canonicalOperationName('my_component_op')).toBe('my_component_op');
 	});
 });
 

--- a/src/features/instance/config/roles/operations/operationsCatalog.ts
+++ b/src/features/instance/config/roles/operations/operationsCatalog.ts
@@ -349,6 +349,11 @@ export function getOperationInfo(name: string): GrantableOperation | undefined {
 	return catalogByName.get(name);
 }
 
+/** The authorization entry a name resolves to; aliases collapse onto their canonical operation. */
+export function canonicalOperationName(name: string): string {
+	return catalogByName.get(name)?.aliasOf ?? name;
+}
+
 export function isOperationGroupName(name: string): boolean {
 	return groupsByName.has(name);
 }

--- a/src/features/instance/databases/components/DatabaseOverview.tsx
+++ b/src/features/instance/databases/components/DatabaseOverview.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdownMenu';
 import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { TableRowContextMenu } from '@/features/instance/databases/components/TableRowContextMenu';
-import { useInstanceBrowseManagePermission } from '@/hooks/usePermissions';
+import { useInstanceBrowseManagePermission, useInstanceImportOperationsPermission } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
 import { getDescribeTableQueryOptions } from '@/integrations/api/instance/database/getDescribeTable';
 import { setWatchedValue } from '@/lib/events/watcher';
@@ -37,6 +37,7 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 	const navigate = useNavigate();
 	const instanceParams = useInstanceClientIdParams();
 	const canManage = useInstanceBrowseManagePermission();
+	const canImport = useInstanceImportOperationsPermission();
 
 	const tables = instanceDatabaseMap?.[databaseName] ?? {};
 	const tableNames = Object.keys(tables).sort();
@@ -91,13 +92,15 @@ export function DatabaseOverview({ instanceDatabaseMap, databaseName }: {
 							<PlusIcon />
 							<span>Create a Table</span>
 						</Button>
-						<Button
-							variant="positiveOutline"
-							onClick={() => setWatchedValue('ShowImportData', { databaseName })}
-						>
-							<CloudUploadIcon />
-							<span>Import Data</span>
-						</Button>
+						{canImport && (
+							<Button
+								variant="positiveOutline"
+								onClick={() => setWatchedValue('ShowImportData', { databaseName })}
+							>
+								<CloudUploadIcon />
+								<span>Import Data</span>
+							</Button>
+						)}
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
 								<Button variant="ghost" size="icon">

--- a/src/features/instance/databases/components/DatabaseTableView.tsx
+++ b/src/features/instance/databases/components/DatabaseTableView.tsx
@@ -13,7 +13,11 @@ import { useExportTableCsv } from '@/features/instance/databases/hooks/useExport
 import { EditTableRowModal } from '@/features/instance/databases/modals/EditTableRowModal';
 import { useStaffPermission } from '@/hooks/useAuth';
 import { useEffectedState } from '@/hooks/useEffectedState';
-import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
+import {
+	useInstanceBrowseManagePermission,
+	useInstanceImportDataPermission,
+	useInstanceSchemaTablePermission,
+} from '@/hooks/usePermissions';
 import { useRefreshClick } from '@/hooks/useRefreshClick';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
 import { useToggler } from '@/hooks/useToggler';
@@ -78,6 +82,7 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 
 	const isStaffInstanceOperator = useStaffPermission('instance:update');
 	const canAddRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'insert');
+	const canImportData = useInstanceImportDataPermission(instanceId ?? clusterId, databaseName, tableName);
 	const canEditRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'update');
 	const canDeleteRecords = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'delete');
 	const canManageBrowseInstance = useInstanceBrowseManagePermission();
@@ -453,7 +458,7 @@ export function DatabaseTableView({ instanceDatabaseMap, databaseName, tableName
 							</span>
 						</Button>
 					)}
-					{canAddRecords && (
+					{canImportData && (
 						<Button
 							variant="positiveOutline"
 							onClick={onImportDataClicked}

--- a/src/features/instance/databases/components/TableContextMenuItems.test.tsx
+++ b/src/features/instance/databases/components/TableContextMenuItems.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ContextMenu, ContextMenuContent } from '@/components/ui/contextMenu';
+import { TableContextMenuItems } from '@/features/instance/databases/components/TableContextMenuItems';
+import { LocalRolePermission } from '@/integrations/api/api.patch';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The permission hooks read the signed-in role from the auth store and the ids from the router; both
+// are mocked so the real allowlist -> hook -> rendered control path is what the assertions exercise.
+const permission = vi.hoisted(() => ({ current: undefined as LocalRolePermission | undefined }));
+
+vi.mock('@tanstack/react-router', () => ({
+	useParams: () => ({ instanceId: 'instance-1' }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+	useInstanceAuth: () => ({ user: { role: { permission: permission.current } } }),
+	isAdminMode: () => false,
+	useCloudAuth: () => ({ user: null }),
+}));
+
+vi.mock('@/features/instance/databases/hooks/useExportTableCsv', () => ({
+	useExportTableCsv: () => ({ exportCsv: () => undefined }),
+}));
+
+function renderMenu(rolePermission: Record<string, unknown>) {
+	permission.current = rolePermission as unknown as LocalRolePermission;
+	return render(
+		<ContextMenu open>
+			<ContextMenuContent forceMount>
+				<TableContextMenuItems
+					databaseName="data"
+					tableName="dog"
+					instanceDatabaseMap={{ data: { dog: {}, cat: {} } } as never}
+				/>
+			</ContextMenuContent>
+		</ContextMenu>,
+	);
+}
+
+const addRecords = () => screen.queryByText('Add New Record(s)');
+const importData = () => screen.queryByText('Import Data');
+
+afterEach(() => {
+	cleanup();
+	permission.current = undefined;
+});
+
+describe('TableContextMenuItems allowlist gating', () => {
+	it('offers both write entries to an unrestricted super_user', () => {
+		renderMenu({ super_user: true });
+		expect(addRecords()).not.toBeNull();
+		expect(importData()).not.toBeNull();
+	});
+
+	it('hides both from a role the allowlist limits to reads', () => {
+		renderMenu({ operations: ['read_only'], data: { tables: { dog: tableGrant() } } });
+		expect(addRecords()).toBeNull();
+		expect(importData()).toBeNull();
+	});
+
+	// The two entries issue different operations, so a CSV grant keeps Import Data while Add Records --
+	// which sends `insert` -- goes away.
+	it('keeps Import Data but drops Add Records for a bulk-load grant', () => {
+		renderMenu({ operations: ['csv_url_load', 'get_job'], data: { tables: { dog: tableGrant() } } });
+		expect(addRecords()).toBeNull();
+		expect(importData()).not.toBeNull();
+	});
+
+	it('hides Import Data when a CSV load has no get_job to poll with', () => {
+		renderMenu({ operations: ['csv_url_load'], data: { tables: { dog: tableGrant() } } });
+		expect(importData()).toBeNull();
+	});
+
+	it('offers both when the allowlist names insert', () => {
+		renderMenu({ operations: ['insert'], data: { tables: { dog: tableGrant() } } });
+		expect(addRecords()).not.toBeNull();
+		expect(importData()).not.toBeNull();
+	});
+
+	it('offers neither while the permission is still loading', () => {
+		renderMenu(undefined as never);
+		expect(addRecords()).toBeNull();
+		expect(importData()).toBeNull();
+	});
+});
+
+function tableGrant() {
+	return { read: true, insert: true, update: false, delete: false, attribute_permissions: null };
+}

--- a/src/features/instance/databases/components/TableContextMenuItems.tsx
+++ b/src/features/instance/databases/components/TableContextMenuItems.tsx
@@ -1,7 +1,11 @@
 import { ContextMenuItem, ContextMenuSeparator } from '@/components/ui/contextMenu';
 import { formatBrowseDataTableHeader } from '@/features/instance/databases/functions/formatBrowseDataTableHeader';
 import { useExportTableCsv } from '@/features/instance/databases/hooks/useExportTableCsv';
-import { useInstanceBrowseManagePermission, useInstanceSchemaTablePermission } from '@/hooks/usePermissions';
+import {
+	useInstanceBrowseManagePermission,
+	useInstanceImportDataPermission,
+	useInstanceSchemaTablePermission,
+} from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
 import { setWatchedValue } from '@/lib/events/watcher';
 import { useParams } from '@tanstack/react-router';
@@ -21,6 +25,7 @@ export function TableContextMenuItems({ databaseName, tableName, instanceDatabas
 	const { clusterId, instanceId }: { clusterId?: string; instanceId?: string } = useParams({ strict: false });
 	const canManage = useInstanceBrowseManagePermission();
 	const canInsert = useInstanceSchemaTablePermission(instanceId ?? clusterId, databaseName, tableName, 'insert');
+	const canImport = useInstanceImportDataPermission(instanceId ?? clusterId, databaseName, tableName);
 	const { exportCsv } = useExportTableCsv();
 
 	const isLastTable = Object.keys(instanceDatabaseMap?.[databaseName] || {}).length <= 1;
@@ -38,7 +43,7 @@ export function TableContextMenuItems({ databaseName, tableName, instanceDatabas
 					Add New Record(s)
 				</ContextMenuItem>
 			)}
-			{canInsert && (
+			{canImport && (
 				<ContextMenuItem onSelect={() => setWatchedValue('ShowImportData', { databaseName, tableName })}>
 					<CloudUploadIcon />
 					Import Data

--- a/src/features/instance/databases/modals/ImportDataModal.permissions.test.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.permissions.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { ImportDataModal } from '@/features/instance/databases/modals/ImportDataModal';
+import { LocalRolePermission } from '@/integrations/api/api.patch';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Only the auth store and the router are stubbed, so these assertions run the real
+// allowlist -> checkImportMethodAllowed -> rendered-radio chain.
+const permission = vi.hoisted(() => ({ current: undefined as LocalRolePermission | undefined }));
+
+vi.mock('@tanstack/react-router', () => ({
+	useParams: () => ({ instanceId: 'instance-1' }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+	useInstanceAuth: () => ({ user: { role: { permission: permission.current } } }),
+	isAdminMode: () => false,
+	useCloudAuth: () => ({ user: null }),
+}));
+
+vi.mock('@/config/useInstanceClient', () => ({
+	useInstanceClientIdParams: () => ({ instanceClient: {}, entityId: 'entity-1', entityType: 'instance' }),
+}));
+
+vi.mock('@/integrations/api/instance/database/importData', () => ({
+	useImportDataMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), loading: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+
+// A 5.x instance; the version gate itself is covered in checkOperationPermission.test.ts.
+vi.mock('@/features/instance/config/roles/operations/useOperationsAllowlistSupported', () => ({
+	useOperationsAllowlistSupported: () => true,
+}));
+
+beforeAll(() => {
+	Element.prototype.hasPointerCapture ??= () => false;
+	Element.prototype.setPointerCapture ??= () => undefined;
+	Element.prototype.releasePointerCapture ??= () => undefined;
+	Element.prototype.scrollIntoView ??= () => undefined;
+	if (typeof window.PointerEvent === 'undefined') {
+		window.PointerEvent = class extends MouseEvent {} as typeof PointerEvent;
+	}
+});
+
+afterEach(() => {
+	cleanup();
+	permission.current = undefined;
+});
+
+function renderModal(rolePermission?: Record<string, unknown>) {
+	permission.current = rolePermission as unknown as LocalRolePermission | undefined;
+	render(
+		<ImportDataModal
+			isModalOpen
+			setIsModalOpen={() => undefined}
+			instanceDatabaseMap={{ data: { dog: {} } } as never}
+			databaseName="data"
+			tableName="dog"
+			onImported={() => undefined}
+		/>,
+	);
+}
+
+const methodNames = () => screen.getAllByRole('radio').map((radio) => radio.getAttribute('id'));
+
+describe('ImportDataModal method gating', () => {
+	it('offers every method to an unrestricted role', () => {
+		renderModal({ super_user: true });
+		expect(methodNames()).toEqual([
+			'import-method-sample',
+			'import-method-file',
+			'import-method-url',
+		]);
+	});
+
+	// An insert-only role can post records (sample/random, .json upload) but cannot run either CSV
+	// load, so the URL method -- which has no non-CSV path -- must not be offered.
+	it('drops the URL method for an insert-only role', () => {
+		renderModal({ operations: ['insert'], data: { tables: { dog: tableGrant() } } });
+		expect(methodNames()).toEqual(['import-method-sample', 'import-method-file']);
+	});
+
+	// The mirror image: a URL-load role cannot insert records, so only the URL method survives.
+	it('keeps only the URL method for a csv_url_load role', () => {
+		renderModal({ operations: ['csv_url_load', 'get_job'], data: { tables: { dog: tableGrant() } } });
+		expect(methodNames()).toEqual(['import-method-url']);
+	});
+
+	it('selects an allowed method by default rather than the contextual preference', () => {
+		// A table is in context, so `file` is preferred -- but this role can only load from a URL.
+		renderModal({ operations: ['csv_url_load', 'get_job'], data: { tables: { dog: tableGrant() } } });
+		expect((screen.getByRole('radio', { checked: true }) as HTMLElement).getAttribute('id')).toBe(
+			'import-method-url',
+		);
+	});
+});
+
+function tableGrant() {
+	return { read: true, insert: true, update: false, delete: false, attribute_permissions: null };
+}

--- a/src/features/instance/databases/modals/ImportDataModal.permissions.test.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.permissions.test.tsx
@@ -6,7 +6,7 @@ import { LocalRolePermission } from '@/integrations/api/api.patch';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-// Only the auth store and the router are stubbed, so these assertions run the real
+// Only the auth store and the router are stubbed, so these run the real
 // allowlist -> checkImportMethodAllowed -> rendered-radio chain.
 const permission = vi.hoisted(() => ({ current: undefined as LocalRolePermission | undefined }));
 
@@ -50,13 +50,17 @@ afterEach(() => {
 	permission.current = undefined;
 });
 
+const withColumn = {
+	data: { dog: { attributes: [{ attribute: 'id', is_primary_key: true }, { attribute: 'name', type: 'String' }] } },
+};
+
 function renderModal(rolePermission?: Record<string, unknown>) {
 	permission.current = rolePermission as unknown as LocalRolePermission | undefined;
 	render(
 		<ImportDataModal
 			isModalOpen
 			setIsModalOpen={() => undefined}
-			instanceDatabaseMap={{ data: { dog: {} } } as never}
+			instanceDatabaseMap={withColumn as never}
 			databaseName="data"
 			tableName="dog"
 			onImported={() => undefined}
@@ -76,14 +80,12 @@ describe('ImportDataModal method gating', () => {
 		]);
 	});
 
-	// An insert-only role can post records (sample/random, .json upload) but cannot run either CSV
-	// load, so the URL method -- which has no non-CSV path -- must not be offered.
+	// The URL method has no non-CSV path, so an insert-only role cannot use it at all.
 	it('drops the URL method for an insert-only role', () => {
 		renderModal({ operations: ['insert'], data: { tables: { dog: tableGrant() } } });
 		expect(methodNames()).toEqual(['import-method-sample', 'import-method-file']);
 	});
 
-	// The mirror image: a URL-load role cannot insert records, so only the URL method survives.
 	it('keeps only the URL method for a csv_url_load role', () => {
 		renderModal({ operations: ['csv_url_load', 'get_job'], data: { tables: { dog: tableGrant() } } });
 		expect(methodNames()).toEqual(['import-method-url']);

--- a/src/features/instance/databases/modals/ImportDataModal.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.tsx
@@ -33,13 +33,15 @@ import {
 } from '@/features/instance/databases/functions/generateRandomRecords';
 import { parseJsonRecords } from '@/features/instance/databases/functions/parseJsonRecords';
 import { sampleDatasets } from '@/features/instance/databases/sampleDatasets';
+import type { ImportMethod } from '@/hooks/checkOperationPermission';
+import { useInstanceImportCapabilities } from '@/hooks/usePermissions';
 import { InstanceDatabaseMap } from '@/integrations/api/api.patch';
 import { databaseNameSchema } from '@/integrations/api/instance/database/databaseNameSchema';
 import { ImportSource, useImportDataMutation } from '@/integrations/api/instance/database/importData';
 import { tableNameSchema } from '@/integrations/api/instance/database/tableNameSchema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { CloudUploadIcon, FileUpIcon, GlobeIcon, InfoIcon, LoaderCircleIcon, PackageIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -131,12 +133,22 @@ export function ImportDataModal({
 	const { mutate: importData, isPending } = useImportDataMutation();
 	const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
 
+	const importCapabilities = useInstanceImportCapabilities();
+	// Offer only methods the role can actually run; a method whose every path is denied would fail at
+	// submit with a 403 the user can do nothing about.
+	const availableMethods = useMemo(
+		() => importMethods.filter(({ value }) => importCapabilities.methods[value]),
+		[importCapabilities],
+	);
+	// With a table already in context (table toolbar) the likely intent is loading your own data;
+	// without one (sidebar, empty database) lead with samples -- then fall back to whatever is allowed.
+	const preferred: ImportMethod = tableName ? 'file' : 'sample';
+	const defaultMethod = importCapabilities.methods[preferred] ? preferred : (availableMethods[0]?.value ?? preferred);
+
 	const form = useForm({
 		resolver: zodResolver(ImportDataFormSchema),
 		defaultValues: {
-			// With a table already in context (table toolbar) the likely intent is loading
-			// your own data; without one (sidebar, empty database) lead with samples.
-			method: tableName ? ('file' as const) : ('sample' as const),
+			method: defaultMethod,
 			database: databaseName || '',
 			table: tableName || '',
 			datasetId: '',
@@ -153,7 +165,7 @@ export function ImportDataModal({
 	useEffect(() => {
 		if (isModalOpen) {
 			reset({
-				method: tableName ? 'file' : 'sample',
+				method: defaultMethod,
 				database: databaseName || '',
 				table: tableName || '',
 				datasetId: '',
@@ -164,7 +176,7 @@ export function ImportDataModal({
 			});
 			setSelectedFileName(null);
 		}
-	}, [isModalOpen, databaseName, tableName, reset]);
+	}, [isModalOpen, databaseName, tableName, defaultMethod, reset]);
 
 	const method = form.watch('method');
 	const datasetId = form.watch('datasetId');
@@ -265,6 +277,18 @@ export function ImportDataModal({
 			source = { kind: 'csv-url', url: values.url };
 		}
 
+		// `sample` and `file` only resolve to a concrete operation here (a bundled dataset bulk-loads,
+		// random records insert; a .json upload inserts, any other extension bulk-loads), so this is the
+		// first point the allowlist can be checked against what will actually be sent.
+		if (!importCapabilities.allowsSource(source.kind)) {
+			form.setError('method', {
+				message: source.kind === 'json-records'
+					? 'This role cannot insert records. Choose a CSV source instead.'
+					: 'This role cannot run CSV loads. Choose a JSON file or random sample data instead.',
+			});
+			return;
+		}
+
 		importData(
 			{
 				database,
@@ -313,7 +337,7 @@ export function ImportDataModal({
 									<FormLabel>Select Import Method</FormLabel>
 									<FormControl>
 										<RadioGroup value={field.value} onValueChange={field.onChange} className="gap-3">
-											{importMethods.map(({ value, title, description, Icon }) => (
+											{availableMethods.map(({ value, title, description, Icon }) => (
 												<FormLabel
 													key={value}
 													htmlFor={`import-method-${value}`}

--- a/src/features/instance/databases/modals/ImportDataModal.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.tsx
@@ -277,6 +277,14 @@ export function ImportDataModal({
 			source = { kind: 'csv-url', url: values.url };
 		}
 
+		// The launcher checked the table it was opened from; the target is editable, so an existing table
+		// chosen here needs its own insert grant. A table that does not exist yet has none to check --
+		// creating it is the browse-manage authority the launcher already required.
+		if (tableExists && !importCapabilities.allowsDestination(database, table)) {
+			form.setError('table', { message: `This role cannot insert into "${table}".` });
+			return;
+		}
+
 		// A file's extension decides its operation, so `file` is the one method whose source is unknown
 		// until here; the sample picker offers only granted sources already.
 		if (!importCapabilities.allowsSource(source.kind)) {

--- a/src/features/instance/databases/modals/ImportDataModal.tsx
+++ b/src/features/instance/databases/modals/ImportDataModal.tsx
@@ -277,9 +277,8 @@ export function ImportDataModal({
 			source = { kind: 'csv-url', url: values.url };
 		}
 
-		// `sample` and `file` only resolve to a concrete operation here (a bundled dataset bulk-loads,
-		// random records insert; a .json upload inserts, any other extension bulk-loads), so this is the
-		// first point the allowlist can be checked against what will actually be sent.
+		// A file's extension decides its operation, so `file` is the one method whose source is unknown
+		// until here; the sample picker offers only granted sources already.
 		if (!importCapabilities.allowsSource(source.kind)) {
 			form.setError('method', {
 				message: source.kind === 'json-records'
@@ -375,14 +374,16 @@ export function ImportDataModal({
 													<SelectValue placeholder="Select a dataset..." />
 												</SelectTrigger>
 												<SelectContent>
-													<SelectGroup>
-														{sampleDatasets.map((dataset) => (
-															<SelectItem key={dataset.id} value={dataset.id}>
-																{dataset.name}
-															</SelectItem>
-														))}
-													</SelectGroup>
-													{canGenerateRandom && (
+													{importCapabilities.allowsSource('csv-data') && (
+														<SelectGroup>
+															{sampleDatasets.map((dataset) => (
+																<SelectItem key={dataset.id} value={dataset.id}>
+																	{dataset.name}
+																</SelectItem>
+															))}
+														</SelectGroup>
+													)}
+													{canGenerateRandom && importCapabilities.allowsSource('json-records') && (
 														<SelectGroup>
 															<SelectLabel>This table</SelectLabel>
 															<SelectItem value={RANDOM_DATASET_ID}>

--- a/src/hooks/checkOperationPermission.test.ts
+++ b/src/hooks/checkOperationPermission.test.ts
@@ -2,7 +2,10 @@ import { getOperationInfo, isOperationGroupName } from '@/features/instance/conf
 import {
 	checkAnyOperationAllowed,
 	checkImportDataOperationsAllowed,
+	checkImportMethodAllowed,
+	checkImportSourceAllowed,
 	checkTableActionAllowed,
+	IMPORT_METHODS,
 	TABLE_ACTION_OPERATIONS,
 } from '@/hooks/checkOperationPermission';
 import { LocalRolePermission } from '@/integrations/api/api.patch';
@@ -168,5 +171,46 @@ describe('checkImportDataOperationsAllowed', () => {
 	it('restricts nothing without an allowlist', () => {
 		expect(checkImportDataOperationsAllowed(undefined)).toBe(true);
 		expect(checkImportDataOperationsAllowed(perm({ structure_user: true }))).toBe(true);
+	});
+});
+
+describe('per-method and per-source import capability', () => {
+	// The launcher being open does not mean every method inside it is: an insert-only role can post
+	// records but cannot run either CSV load, and a URL-load role is the mirror image.
+	it('offers only the methods a role can run', () => {
+		const insertOnly = perm({ operations: ['insert'] });
+		expect(checkImportMethodAllowed(insertOnly, 'sample')).toBe(true);
+		expect(checkImportMethodAllowed(insertOnly, 'file')).toBe(true);
+		expect(checkImportMethodAllowed(insertOnly, 'url')).toBe(false);
+
+		const urlOnly = perm({ operations: ['csv_url_load', 'get_job'] });
+		expect(checkImportMethodAllowed(urlOnly, 'url')).toBe(true);
+		expect(checkImportMethodAllowed(urlOnly, 'sample')).toBe(false);
+		expect(checkImportMethodAllowed(urlOnly, 'file')).toBe(false);
+	});
+
+	// `sample` and `file` each cover two operations, so the method staying open does not settle the
+	// choice the user makes inside it.
+	it('resolves the ambiguous methods per source', () => {
+		const insertOnly = perm({ operations: ['insert'] });
+		expect(checkImportSourceAllowed(insertOnly, 'json-records')).toBe(true);
+		expect(checkImportSourceAllowed(insertOnly, 'csv-data')).toBe(false);
+		expect(checkImportSourceAllowed(insertOnly, 'csv-url')).toBe(false);
+
+		const csvOnly = perm({ operations: ['csv_data_load', 'get_job'] });
+		expect(checkImportSourceAllowed(csvOnly, 'csv-data')).toBe(true);
+		expect(checkImportSourceAllowed(csvOnly, 'json-records')).toBe(false);
+	});
+
+	it('keeps a super_user and an unrestricted role fully capable', () => {
+		expect(checkImportMethodAllowed(perm({ super_user: true, operations: [] }), 'url')).toBe(true);
+		expect(checkImportSourceAllowed(perm({ super_user: true, operations: [] }), 'csv-data')).toBe(true);
+		expect(checkImportSourceAllowed(undefined, 'csv-url')).toBe(true);
+	});
+
+	it('agrees with the launcher gate', () => {
+		const denied = perm({ operations: ['read_only'] });
+		expect(IMPORT_METHODS.every((method) => !checkImportMethodAllowed(denied, method))).toBe(true);
+		expect(checkImportDataOperationsAllowed(denied)).toBe(false);
 	});
 });

--- a/src/hooks/checkOperationPermission.test.ts
+++ b/src/hooks/checkOperationPermission.test.ts
@@ -1,0 +1,172 @@
+import { getOperationInfo, isOperationGroupName } from '@/features/instance/config/roles/operations/operationsCatalog';
+import {
+	checkAnyOperationAllowed,
+	checkImportDataOperationsAllowed,
+	checkTableActionAllowed,
+	TABLE_ACTION_OPERATIONS,
+} from '@/hooks/checkOperationPermission';
+import { LocalRolePermission } from '@/integrations/api/api.patch';
+import { describe, expect, it } from 'vitest';
+
+function perm(value: Record<string, unknown>): LocalRolePermission {
+	return value as unknown as LocalRolePermission;
+}
+
+describe('checkAnyOperationAllowed', () => {
+	it('restricts nothing when the role has no allowlist', () => {
+		expect(checkAnyOperationAllowed(undefined, ['insert'])).toBe(true);
+		expect(checkAnyOperationAllowed(perm({ structure_user: true }), ['insert'])).toBe(true);
+	});
+
+	it('restricts nothing when the allowlist is malformed', () => {
+		expect(checkAnyOperationAllowed(perm({ operations: 'read_only' }), ['insert'])).toBe(true);
+		expect(checkAnyOperationAllowed(perm({ operations: ['sql', 42] }), ['insert'])).toBe(true);
+	});
+
+	// What a pre-5.0 instance puts under this key is a database record, and permissionsTranslator
+	// writes one there for any upgraded v4 role owning a database of that name. Only an array of
+	// strings is an allowlist, so shape alone keeps those roles ungated -- no version lookup needed.
+	it('reads a database record under `operations` as no allowlist at all', () => {
+		const upgradedV4Role = perm({
+			operations: { tables: { dog: { read: true, insert: true, update: true, delete: true } } },
+		});
+		expect(checkAnyOperationAllowed(upgradedV4Role, ['insert'])).toBe(true);
+		expect(checkAnyOperationAllowed(upgradedV4Role, ['deploy_component'])).toBe(true);
+	});
+
+	it('denies everything on an empty allowlist, as the server does', () => {
+		expect(checkAnyOperationAllowed(perm({ operations: [] }), ['insert'])).toBe(false);
+	});
+
+	it('allows a directly listed operation and denies unlisted ones', () => {
+		const permission = perm({ operations: ['insert', 'update'] });
+		expect(checkAnyOperationAllowed(permission, ['insert'])).toBe(true);
+		expect(checkAnyOperationAllowed(permission, ['delete'])).toBe(false);
+		expect(checkAnyOperationAllowed(permission, ['delete', 'update'])).toBe(true);
+	});
+
+	it('expands group names to their members', () => {
+		const permission = perm({ operations: ['standard_user'] });
+		expect(checkAnyOperationAllowed(permission, ['insert'])).toBe(true);
+		expect(checkAnyOperationAllowed(permission, ['create_table'])).toBe(false);
+	});
+
+	it('lets a canonical entry cover operations checked under a legacy alias', () => {
+		expect(checkAnyOperationAllowed(perm({ operations: ['search_by_hash'] }), ['search_by_id'])).toBe(true);
+		expect(checkAnyOperationAllowed(perm({ operations: ['create_database'] }), ['create_schema'])).toBe(
+			true,
+		);
+	});
+
+	// The server stores allowlist entries verbatim but resolves the incoming operation to its
+	// canonical api_name, so granting an alias grants nothing.
+	it('treats a legacy alias inside the allowlist as a dead entry', () => {
+		expect(checkAnyOperationAllowed(perm({ operations: ['search_by_id'] }), ['search_by_hash'])).toBe(
+			false,
+		);
+		expect(checkAnyOperationAllowed(perm({ operations: ['create_schema'] }), ['create_database'])).toBe(
+			false,
+		);
+	});
+
+	it('matches unknown (component-registered) names verbatim', () => {
+		const permission = perm({ operations: ['my_component_op'] });
+		expect(checkAnyOperationAllowed(permission, ['my_component_op'])).toBe(true);
+		expect(checkAnyOperationAllowed(permission, ['insert'])).toBe(false);
+	});
+
+	it('reuses the expansion for a repeated allowlist instance', () => {
+		const operations = ['read_only'];
+		expect(checkAnyOperationAllowed(perm({ operations }), ['sql'])).toBe(true);
+		expect(checkAnyOperationAllowed(perm({ operations }), ['sql'])).toBe(true);
+		expect(checkAnyOperationAllowed(perm({ operations }), ['insert'])).toBe(false);
+	});
+});
+
+describe('operation mappings', () => {
+	// Verbatim matching only works against canonical catalog entries; an alias or group name here
+	// would silently never match.
+	it('name only canonical, non-group catalog operations', () => {
+		for (const name of [...Object.values(TABLE_ACTION_OPERATIONS).flat(), 'csv_data_load', 'csv_url_load', 'get_job']) {
+			const info = getOperationInfo(name);
+			expect(info, name).toBeDefined();
+			expect(info?.aliasOf, name).toBeUndefined();
+			expect(isOperationGroupName(name), name).toBe(false);
+		}
+	});
+
+	it('maps each table action to the operation it issues', () => {
+		expect(TABLE_ACTION_OPERATIONS.insert).toEqual(['insert']);
+		expect(TABLE_ACTION_OPERATIONS.update).toEqual(['update']);
+		expect(TABLE_ACTION_OPERATIONS.delete).toEqual(['delete']);
+	});
+});
+
+describe('checkTableActionAllowed', () => {
+	// verifyPerms clears a super_user before reaching the allowlist, so gating one would hide UI that
+	// works.
+	it('ignores the allowlist for a super_user', () => {
+		expect(checkTableActionAllowed(perm({ super_user: true, operations: [] }), 'insert')).toBe(true);
+		expect(checkTableActionAllowed(perm({ super_user: true, operations: ['read_only'] }), 'delete')).toBe(
+			true,
+		);
+	});
+
+	// isElevatedRole counts these two as well, because it answers a broader question. DML is where
+	// they are still gated.
+	it('still applies the allowlist to structure_user and cluster_user', () => {
+		expect(checkTableActionAllowed(perm({ structure_user: true, operations: ['read_only'] }), 'insert'))
+			.toBe(false);
+		expect(checkTableActionAllowed(perm({ cluster_user: true, operations: ['read_only'] }), 'insert'))
+			.toBe(false);
+	});
+
+	it('applies the allowlist per action', () => {
+		const readOnly = perm({ operations: ['read_only'] });
+		expect(checkTableActionAllowed(readOnly, 'read')).toBe(true);
+		expect(checkTableActionAllowed(readOnly, 'insert')).toBe(false);
+		expect(checkTableActionAllowed(readOnly, 'update')).toBe(false);
+		expect(checkTableActionAllowed(readOnly, 'delete')).toBe(false);
+
+		const standard = perm({ operations: ['standard_user'] });
+		expect(checkTableActionAllowed(standard, 'insert')).toBe(true);
+		expect(checkTableActionAllowed(standard, 'delete')).toBe(true);
+	});
+
+	// A bulk load is Import Data's operation, not Add Records'.
+	it('does not accept a bulk load as an insert', () => {
+		expect(checkTableActionAllowed(perm({ operations: ['csv_url_load'] }), 'insert')).toBe(false);
+	});
+
+	it('leaves roles without an allowlist untouched', () => {
+		expect(checkTableActionAllowed(undefined, 'insert')).toBe(true);
+		expect(checkTableActionAllowed(perm({ structure_user: true }), 'delete')).toBe(true);
+	});
+});
+
+describe('checkImportDataOperationsAllowed', () => {
+	it('accepts an insert grant, which the JSON-records source uses directly', () => {
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['insert'] }))).toBe(true);
+	});
+
+	// A CSV load returns a job id that the client then polls, so the load alone is a trap: the write
+	// commits, the poll 403s, and the reported failure invites a duplicating retry.
+	it('requires get_job alongside a CSV load', () => {
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['csv_url_load'] }))).toBe(false);
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['csv_url_load', 'get_job'] }))).toBe(true);
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['csv_data_load', 'get_job'] }))).toBe(true);
+		// standard_user carries the loads and get_job (via read_only).
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['standard_user'] }))).toBe(true);
+	});
+
+	it('denies a read-only or empty allowlist, and ignores both for a super_user', () => {
+		expect(checkImportDataOperationsAllowed(perm({ operations: ['read_only'] }))).toBe(false);
+		expect(checkImportDataOperationsAllowed(perm({ structure_user: true, operations: [] }))).toBe(false);
+		expect(checkImportDataOperationsAllowed(perm({ super_user: true, operations: [] }))).toBe(true);
+	});
+
+	it('restricts nothing without an allowlist', () => {
+		expect(checkImportDataOperationsAllowed(undefined)).toBe(true);
+		expect(checkImportDataOperationsAllowed(perm({ structure_user: true }))).toBe(true);
+	});
+});

--- a/src/hooks/checkOperationPermission.ts
+++ b/src/hooks/checkOperationPermission.ts
@@ -7,6 +7,7 @@ import {
 	LocalRolePermission,
 	LocalRolePermissionAction,
 } from '@/integrations/api/api.patch';
+import type { ImportSource } from '@/integrations/api/instance/database/importData';
 import { getOperationsAllowlist } from '@/integrations/api/localRolePermission';
 
 /**
@@ -22,7 +23,36 @@ export const TABLE_ACTION_OPERATIONS: Record<LocalRolePermissionAction, readonly
 	delete: ['delete'],
 };
 
-const CSV_LOAD_OPERATIONS = ['csv_data_load', 'csv_url_load'];
+/**
+ * What each import path issues, as an all-of list. A CSV load returns a job id the client then polls,
+ * so `get_job` belongs to those paths: without it a load commits, the poll 403s, and the reported
+ * failure invites a duplicating retry.
+ */
+const RECORDS_PATH = ['insert'];
+const CSV_DATA_PATH = ['csv_data_load', 'get_job'];
+const CSV_URL_PATH = ['csv_url_load', 'get_job'];
+
+const IMPORT_SOURCE_PATHS: Record<ImportSource['kind'], readonly string[]> = {
+	'json-records': RECORDS_PATH,
+	'csv-data': CSV_DATA_PATH,
+	'csv-url': CSV_URL_PATH,
+};
+
+/**
+ * The paths each Import Data method can take. `sample` and `file` stay ambiguous until submit — a
+ * bundled dataset bulk-loads while random records insert, and a `.json` upload inserts while any other
+ * extension bulk-loads — so a method is offered while either path is open, and
+ * {@link checkImportSourceAllowed} settles the actual choice.
+ */
+const IMPORT_METHOD_PATHS = {
+	sample: [RECORDS_PATH, CSV_DATA_PATH],
+	file: [RECORDS_PATH, CSV_DATA_PATH],
+	url: [CSV_URL_PATH],
+} satisfies Record<string, readonly (readonly string[])[]>;
+
+export type ImportMethod = keyof typeof IMPORT_METHOD_PATHS;
+
+export const IMPORT_METHODS = Object.keys(IMPORT_METHOD_PATHS) as ImportMethod[];
 
 // Keyed by the allowlist array, not the permission: a role edit yields a new array, so an entry
 // cannot go stale.
@@ -106,18 +136,28 @@ export function checkTableActionAllowed(
 	return checkTableOperationsAllowed(permission, TABLE_ACTION_OPERATIONS[action] ?? []);
 }
 
-/**
- * Whether any Import Data source is usable. JSON records post straight to `insert`, but both CSV
- * sources start a job and then poll it, so a CSV grant without `get_job` would report failure for a
- * load that actually committed — and a retry would duplicate the rows.
- */
-export function checkImportDataOperationsAllowed(
+function checkPathAllowed(permission: LocalRolePermission | undefined, path: readonly string[]): boolean {
+	return path.every((operation) => checkAnyOperationAllowed(permission, [operation]));
+}
+
+/** Whether the source the user actually chose can run — the check the submit path owes them. */
+export function checkImportSourceAllowed(
 	permission: LocalRolePermission | undefined,
+	kind: ImportSource['kind'],
 ): boolean {
-	if (permission?.super_user === true) {
-		return true;
-	}
-	return checkAnyOperationAllowed(permission, TABLE_ACTION_OPERATIONS.insert)
-		|| (checkAnyOperationAllowed(permission, CSV_LOAD_OPERATIONS)
-			&& checkAnyOperationAllowed(permission, ['get_job']));
+	return permission?.super_user === true || checkPathAllowed(permission, IMPORT_SOURCE_PATHS[kind]);
+}
+
+/** Whether an import method is worth offering: at least one of its paths is open. */
+export function checkImportMethodAllowed(
+	permission: LocalRolePermission | undefined,
+	method: ImportMethod,
+): boolean {
+	return permission?.super_user === true
+		|| IMPORT_METHOD_PATHS[method].some((path) => checkPathAllowed(permission, path));
+}
+
+/** Whether any import method survives — the gate for the launchers. */
+export function checkImportDataOperationsAllowed(permission: LocalRolePermission | undefined): boolean {
+	return IMPORT_METHODS.some((method) => checkImportMethodAllowed(permission, method));
 }

--- a/src/hooks/checkOperationPermission.ts
+++ b/src/hooks/checkOperationPermission.ts
@@ -1,0 +1,123 @@
+import {
+	canonicalOperationName,
+	OPERATION_GROUPS,
+} from '@/features/instance/config/roles/operations/operationsCatalog';
+import {
+	LocalRoleAttributePermissionAction,
+	LocalRolePermission,
+	LocalRolePermissionAction,
+} from '@/integrations/api/api.patch';
+import { getOperationsAllowlist } from '@/integrations/api/localRolePermission';
+
+/**
+ * Harper's `operations` allowlist (5.0+) is reached only by roles verifyPerms has not already cleared:
+ * `isSuperUser && !isSuSystemOperation` returns first, and `structure_user` returns for create/drop
+ * database, table, and attribute. Table reads and writes are the only Studio surface it can deny.
+ */
+
+export const TABLE_ACTION_OPERATIONS: Record<LocalRolePermissionAction, readonly string[]> = {
+	read: ['search', 'search_by_conditions', 'search_by_hash', 'search_by_value', 'sql'],
+	insert: ['insert'],
+	update: ['update'],
+	delete: ['delete'],
+};
+
+const CSV_LOAD_OPERATIONS = ['csv_data_load', 'csv_url_load'];
+
+// Keyed by the allowlist array, not the permission: a role edit yields a new array, so an entry
+// cannot go stale.
+const expandedAllowlists = new WeakMap<readonly string[], ReadonlySet<string>>();
+
+const groupMembers = new Map(OPERATION_GROUPS.map((group) => [group.name, group.members]));
+
+/**
+ * Expands the way `expandOperationsPerms` does — groups to their members, everything else verbatim.
+ * Deliberately not `expandEffectiveOperations`, which folds alias spellings together to describe what
+ * a role can effectively do; the gate does not fold, so a lone alias grant must stay the dead entry it
+ * is server-side. Harper's groups carry both spellings of each pair, so group grants are unaffected.
+ */
+function expandLikeTheGate(allowlist: readonly string[]): ReadonlySet<string> {
+	const allowed = new Set<string>();
+	for (const entry of allowlist) {
+		const members = groupMembers.get(entry);
+		if (members) {
+			for (const member of members) {
+				allowed.add(member);
+			}
+		} else {
+			allowed.add(entry);
+		}
+	}
+	return allowed;
+}
+
+/**
+ * Whether the allowlist leaves any of these operations reachable. Absent or malformed restricts
+ * nothing — a denial that cannot be proven must not hide UI — and an empty array denies everything,
+ * as on the server.
+ *
+ * Version-blind, like the table-grant lookup beside it: `getOperationsAllowlist` only answers yes to
+ * an array of strings, and the shape a pre-5.0 instance puts under that key — a database record from
+ * permissionsTranslator — can never be one. Asking the instance version instead would mean a query
+ * per check, on a hook whose entityId this module does not receive.
+ *
+ * Matching mirrors gate 1: groups expand, entries match verbatim, and the checked operation resolves
+ * to its canonical api_name. Harper registers `search_by_id` under `search_by_hash`, so granting a
+ * legacy alias grants nothing, while a canonical grant covers both spellings.
+ */
+export function checkAnyOperationAllowed(
+	permission: LocalRolePermission | undefined,
+	operations: readonly string[],
+): boolean {
+	const allowlist = getOperationsAllowlist(permission);
+	if (!allowlist) {
+		return true;
+	}
+	let allowed = expandedAllowlists.get(allowlist);
+	if (!allowed) {
+		allowed = expandLikeTheGate(allowlist);
+		expandedAllowlists.set(allowlist, allowed);
+	}
+	return operations.some((operation) => allowed.has(canonicalOperationName(operation)));
+}
+
+/**
+ * Whether these operations survive gate 1 for a table action.
+ *
+ * Not `isElevatedRole`: that answers whether the allowlist is unenforceable anywhere for the role,
+ * which is what the roles editor warns about. DML is where an elevated-but-not-super role is still
+ * gated — `structure_user` short-circuits for DDL alone, and `cluster_user` appears nowhere in
+ * operation_authorization.ts.
+ */
+export function checkTableOperationsAllowed(
+	permission: LocalRolePermission | undefined,
+	operations: readonly string[],
+): boolean {
+	return permission?.super_user === true
+		|| checkAnyOperationAllowed(permission, operations);
+}
+
+export function checkTableActionAllowed(
+	permission: LocalRolePermission | undefined,
+	action: LocalRolePermissionAction | LocalRoleAttributePermissionAction,
+): boolean {
+	// The Record type makes an unmapped action a compile error; the fallback keeps an off-type one from
+	// reaching `.some()` on undefined.
+	return checkTableOperationsAllowed(permission, TABLE_ACTION_OPERATIONS[action] ?? []);
+}
+
+/**
+ * Whether any Import Data source is usable. JSON records post straight to `insert`, but both CSV
+ * sources start a job and then poll it, so a CSV grant without `get_job` would report failure for a
+ * load that actually committed — and a retry would duplicate the rows.
+ */
+export function checkImportDataOperationsAllowed(
+	permission: LocalRolePermission | undefined,
+): boolean {
+	if (permission?.super_user === true) {
+		return true;
+	}
+	return checkAnyOperationAllowed(permission, TABLE_ACTION_OPERATIONS.insert)
+		|| (checkAnyOperationAllowed(permission, CSV_LOAD_OPERATIONS)
+			&& checkAnyOperationAllowed(permission, ['get_job']));
+}

--- a/src/hooks/checkSchemaTablePermission.test.ts
+++ b/src/hooks/checkSchemaTablePermission.test.ts
@@ -111,6 +111,22 @@ describe('checkImportDataPermission', () => {
 		expect(checkSchemaTablePermission(csvOnly, 'data', 'dog', 'insert')).toBe(false);
 	});
 
+	// The Import launcher checks the table it was opened from, but the modal's target is editable, so
+	// the submit path re-asks this for whatever table was finally chosen.
+	it('answers per destination table, not per launcher', () => {
+		const permission = perm({
+			operations: ['insert'],
+			data: {
+				tables: {
+					dog: { read: true, insert: true, update: false, delete: false, attribute_permissions: null },
+					cat: { read: true, insert: false, update: false, delete: false, attribute_permissions: null },
+				},
+			},
+		});
+		expect(checkImportDataPermission(permission, 'data', 'dog')).toBe(true);
+		expect(checkImportDataPermission(permission, 'data', 'cat')).toBe(false);
+	});
+
 	it('denies when the allowlist reaches no import operation', () => {
 		expect(checkImportDataPermission(perm({ operations: ['read_only'], ...tables }), 'data', 'dog')).toBe(false);
 		expect(checkImportDataPermission(perm({ super_user: true, operations: [] }), 'data', 'dog')).toBe(true);

--- a/src/hooks/checkSchemaTablePermission.test.ts
+++ b/src/hooks/checkSchemaTablePermission.test.ts
@@ -1,6 +1,6 @@
 import { LocalRolePermission } from '@/integrations/api/api.patch';
 import { describe, expect, it } from 'vitest';
-import { checkSchemaTablePermission } from './checkSchemaTablePermission';
+import { checkImportDataPermission, checkSchemaTablePermission } from './checkSchemaTablePermission';
 
 // The index-signature/boolean-flag shape of LocalRolePermission is awkward to build as a literal, so
 // cast minimal stand-ins.
@@ -51,5 +51,68 @@ describe('checkSchemaTablePermission', () => {
 	it('never reads a real allowlist as a table grant', () => {
 		const permission: LocalRolePermission = { operations: ['read_only'] };
 		expect(checkSchemaTablePermission(permission, 'operations', 'dog', 'read')).toBe(false);
+	});
+
+	it('lets an operations allowlist override a table CRUD grant', () => {
+		const tables = {
+			data: {
+				tables: { dog: { read: true, insert: true, update: false, delete: false, attribute_permissions: null } },
+			},
+		};
+		expect(checkSchemaTablePermission(perm({ operations: ['read_only'], ...tables }), 'data', 'dog', 'insert'))
+			.toBe(false);
+		expect(checkSchemaTablePermission(perm({ operations: ['read_only'], ...tables }), 'data', 'dog', 'read'))
+			.toBe(true);
+		expect(
+			checkSchemaTablePermission(perm({ operations: ['standard_user'], ...tables }), 'data', 'dog', 'insert'),
+		).toBe(true);
+	});
+
+	it('lets an operations allowlist override structure_user', () => {
+		expect(checkSchemaTablePermission(perm({ structure_user: true, operations: [] }), 'data', 'dog', 'insert'))
+			.toBe(false);
+		expect(
+			checkSchemaTablePermission(
+				perm({ structure_user: true, operations: ['read_only'] }),
+				'data',
+				'dog',
+				'delete',
+			),
+		).toBe(false);
+	});
+
+	// verifyPerms clears a super_user before reaching the allowlist.
+	it('leaves super_user alone, allowlist or not', () => {
+		expect(checkSchemaTablePermission(perm({ super_user: true, operations: [] }), 'data', 'dog', 'insert'))
+			.toBe(true);
+		expect(
+			checkSchemaTablePermission(perm({ super_user: true, operations: ['read_only'] }), 'data', 'dog', 'delete'),
+		).toBe(true);
+	});
+});
+
+describe('checkImportDataPermission', () => {
+	const tables = {
+		data: {
+			tables: { dog: { read: true, insert: true, update: false, delete: false, attribute_permissions: null } },
+		},
+	};
+
+	it('needs the same insert grant Add Records needs', () => {
+		expect(checkImportDataPermission(undefined, 'data', 'dog')).toBe(false);
+		expect(checkImportDataPermission(perm({ data: { tables: {} } }), 'data', 'dog')).toBe(false);
+		expect(checkImportDataPermission(perm(tables), 'data', 'dog')).toBe(true);
+	});
+
+	// Add Records is strictly `insert`; a CSV source needs its load plus the get_job it polls.
+	it('accepts a bulk-load grant that an insert would reject', () => {
+		const csvOnly = perm({ operations: ['csv_url_load', 'get_job'], ...tables });
+		expect(checkImportDataPermission(csvOnly, 'data', 'dog')).toBe(true);
+		expect(checkSchemaTablePermission(csvOnly, 'data', 'dog', 'insert')).toBe(false);
+	});
+
+	it('denies when the allowlist reaches no import operation', () => {
+		expect(checkImportDataPermission(perm({ operations: ['read_only'], ...tables }), 'data', 'dog')).toBe(false);
+		expect(checkImportDataPermission(perm({ super_user: true, operations: [] }), 'data', 'dog')).toBe(true);
 	});
 });

--- a/src/hooks/checkSchemaTablePermission.ts
+++ b/src/hooks/checkSchemaTablePermission.ts
@@ -1,3 +1,4 @@
+import { checkImportDataOperationsAllowed, checkTableActionAllowed } from '@/hooks/checkOperationPermission';
 import { LocalRolePermission, LocalRolePermissionAction } from '@/integrations/api/api.patch';
 import { getDatabasePermissionRecord } from '@/integrations/api/localRolePermission';
 
@@ -8,6 +9,27 @@ import { getDatabasePermissionRecord } from '@/integrations/api/localRolePermiss
  * `[tableName]` is load-bearing (it previously threw for any restricted user opening a table menu).
  */
 export function checkSchemaTablePermission(
+	permission: LocalRolePermission | undefined,
+	databaseName: string,
+	tableName: string,
+	action: LocalRolePermissionAction,
+): boolean {
+	return checkTableActionAllowed(permission, action) && checkTableGrant(permission, databaseName, tableName, action);
+}
+
+/**
+ * Import Data needs the same insert grant Add Records needs, but its sources issue different
+ * operations, so the allowlist half of the question differs.
+ */
+export function checkImportDataPermission(
+	permission: LocalRolePermission | undefined,
+	databaseName: string,
+	tableName: string,
+): boolean {
+	return checkImportDataOperationsAllowed(permission) && checkTableGrant(permission, databaseName, tableName, 'insert');
+}
+
+function checkTableGrant(
 	permission: LocalRolePermission | undefined,
 	databaseName: string,
 	tableName: string,

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -248,6 +248,7 @@ export function useInstanceImportOperationsPermission(entityId?: EntityIds): boo
 export function useInstanceImportCapabilities(entityId?: EntityIds): {
 	methods: Record<ImportMethod, boolean>;
 	allowsSource: (kind: ImportSource['kind']) => boolean;
+	allowsDestination: (databaseName: string, tableName: string) => boolean;
 } {
 	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
 	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
@@ -257,6 +258,9 @@ export function useInstanceImportCapabilities(entityId?: EntityIds): {
 			IMPORT_METHODS.map((method) => [method, checkImportMethodAllowed(permission, method)]),
 		) as Record<ImportMethod, boolean>,
 		allowsSource: (kind: ImportSource['kind']) => checkImportSourceAllowed(permission, kind),
+		// The launcher checked the table it was launched from, but the modal lets the target change.
+		allowsDestination: (databaseName: string, tableName: string) =>
+			checkImportDataPermission(permission, databaseName, tableName),
 	}), [permission]);
 }
 

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,5 +1,12 @@
 import { EntityIds } from '@/features/auth/store/authStore';
-import { checkImportDataOperationsAllowed, checkTableActionAllowed } from '@/hooks/checkOperationPermission';
+import {
+	checkImportDataOperationsAllowed,
+	checkImportMethodAllowed,
+	checkImportSourceAllowed,
+	checkTableActionAllowed,
+	IMPORT_METHODS,
+	type ImportMethod,
+} from '@/hooks/checkOperationPermission';
 import { checkImportDataPermission, checkSchemaTablePermission } from '@/hooks/checkSchemaTablePermission';
 import { hasStaffPermission, useCloudAuth, useInstanceAuth } from '@/hooks/useAuth';
 import {
@@ -9,8 +16,10 @@ import {
 	LocalRolePermissionTable,
 	User,
 } from '@/integrations/api/api.patch';
+import type { ImportSource } from '@/integrations/api/instance/database/importData';
 import { getDatabasePermissionRecord } from '@/integrations/api/localRolePermission';
 import { useParams } from '@tanstack/react-router';
+import { useMemo } from 'react';
 
 interface UR {
 	update: boolean;
@@ -230,6 +239,25 @@ export function useInstanceImportOperationsPermission(entityId?: EntityIds): boo
 	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
 	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
 	return checkImportDataOperationsAllowed(user?.role?.permission);
+}
+
+/**
+ * Per-method and per-source import capability, so the modal offers only what the role can run instead
+ * of failing at submit.
+ */
+export function useInstanceImportCapabilities(entityId?: EntityIds): {
+	methods: Record<ImportMethod, boolean>;
+	allowsSource: (kind: ImportSource['kind']) => boolean;
+} {
+	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
+	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
+	const permission = user?.role?.permission;
+	return useMemo(() => ({
+		methods: Object.fromEntries(
+			IMPORT_METHODS.map((method) => [method, checkImportMethodAllowed(permission, method)]),
+		) as Record<ImportMethod, boolean>,
+		allowsSource: (kind: ImportSource['kind']) => checkImportSourceAllowed(permission, kind),
+	}), [permission]);
 }
 
 export function useInstanceSchemaTableAttributePermission(

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -1,5 +1,6 @@
 import { EntityIds } from '@/features/auth/store/authStore';
-import { checkSchemaTablePermission } from '@/hooks/checkSchemaTablePermission';
+import { checkImportDataOperationsAllowed, checkTableActionAllowed } from '@/hooks/checkOperationPermission';
+import { checkImportDataPermission, checkSchemaTablePermission } from '@/hooks/checkSchemaTablePermission';
 import { hasStaffPermission, useCloudAuth, useInstanceAuth } from '@/hooks/useAuth';
 import {
 	LocalLegacyRolePermissionTable,
@@ -183,6 +184,7 @@ export function useInstanceManagePermission(entityId?: EntityIds): boolean {
 		// (We're probably still loading the user.)
 		return false;
 	}
+	// Not gated on `operations`: verifyPerms clears a super_user before reaching the allowlist.
 	return permission.super_user === true;
 }
 
@@ -195,6 +197,7 @@ export function useInstanceBrowseManagePermission(entityId?: EntityIds): boolean
 		// (We're probably still loading the user.)
 		return false;
 	}
+	// Not gated on `operations` either: structure_user is cleared for every DDL operation this covers.
 	return permission.super_user === true || permission.structure_user === true;
 }
 
@@ -207,6 +210,26 @@ export function useInstanceSchemaTablePermission(
 	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
 	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
 	return checkSchemaTablePermission(user?.role?.permission, databaseName, tableName, action);
+}
+
+export function useInstanceImportDataPermission(
+	entityId: EntityIds | undefined,
+	databaseName: string,
+	tableName: string,
+): boolean {
+	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
+	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
+	return checkImportDataPermission(user?.role?.permission, databaseName, tableName);
+}
+
+/**
+ * The allowlist half of Import Data, for the database-scoped launcher that has no table yet (it
+ * creates one, so there is no per-table grant to consult).
+ */
+export function useInstanceImportOperationsPermission(entityId?: EntityIds): boolean {
+	const { clusterId, instanceId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
+	const { user } = useInstanceAuth(entityId ?? instanceId ?? clusterId);
+	return checkImportDataOperationsAllowed(user?.role?.permission);
 }
 
 export function useInstanceSchemaTableAttributePermission(
@@ -222,6 +245,9 @@ export function useInstanceSchemaTableAttributePermission(
 	if (!permission) {
 		// If we don't yet have record of their permission, deny access.
 		// (We're probably still loading the user.)
+		return false;
+	}
+	if (!checkTableActionAllowed(permission, action)) {
 		return false;
 	}
 	if (permission.super_user === true || permission.structure_user === true) {

--- a/src/integrations/api/instance/database/importData.ts
+++ b/src/integrations/api/instance/database/importData.ts
@@ -61,6 +61,8 @@ export async function importData({
 		}
 	}
 
+	// A new source needs its operation added to checkOperationPermission's import mapping, or the
+	// launcher stays hidden for roles granted only that operation.
 	switch (source.kind) {
 		case 'csv-data': {
 			const { job_id } = await onAddCSVDataSubmit({ database, table, fileData: source.data, instanceClient });


### PR DESCRIPTION
Studio's table permission checks ignored `permission.operations`, so a role whose allowlist excludes a
data operation still saw Add Records, Import Data, and the inline edit/delete affordances — each of
which the server denies at gate 1, before the role's table CRUD grants are consulted.

`checkSchemaTablePermission` and `useInstanceSchemaTableAttributePermission` now consult the allowlist
first, through a new pure `src/hooks/checkOperationPermission.ts`.

Stacks on #1628 (base `role-operations-allowlist`), which added the catalog and the roles-UI editor.

## For the human reviewer

Read [checkOperationPermission.ts](src/hooks/checkOperationPermission.ts) first — its header states the
invariant the whole change rests on — then [checkSchemaTablePermission.ts](src/hooks/checkSchemaTablePermission.ts)
for the gate order, then the call sites.

**The manage and browse-manage hooks are deliberately left alone, which is the opposite of what the
task asked for.** #1627 states the allowlist "denies unlisted operations even for super_user roles," so
the obvious change was to gate `useInstanceManagePermission` (Users, Roles, Config, Logs, Status) and
`useInstanceBrowseManagePermission` (DDL, app editors). I implemented exactly that, then read
`verifyPerms` and reverted it:

```
utility/operation_authorization.ts:553   if (isSuperUser && !isSuSystemOperation) return null;   // "admins can do (almost) anything"
utility/operation_authorization.ts:559   structure_user + create/drop database   → return null
utility/operation_authorization.ts:564   structure_user + STRUCTURE_USER_OPS     → return null
utility/operation_authorization.ts:589   ── the operations allowlist gate lives here ──
```

**Measured, not inferred** (see Verification): a super_user with `operations: []` — the strongest
possible test, since a gate that applied at all would deny everything — is still ALLOWED insert,
search, restart and get_configuration. A restricted-super_user's admin actions do not 403, so gating
that chrome would have hidden UI that works. #1628's `7eff23fc` reached the same conclusion
independently. That leaves table DML as the only surface gate 1 can deny, which is what this gates.

Decisions worth questioning:

- **Add Records and Import Data no longer share a flag, and each import method is gated by the
  operation it issues.** Add Records is strictly `insert`. Import Data's methods are modeled as the
  *paths* they can take, because `sample` and `file` stay ambiguous until submit — a bundled dataset
  bulk-loads while random records insert, and a `.json` upload inserts while any other extension
  bulk-loads. A method is offered while either path is open; the resolved source is re-checked at
  submit, where the choice is finally known. CSV paths require **`get_job`** alongside the load,
  because [importData.ts](src/integrations/api/instance/database/importData.ts) polls the job — a CSV
  grant without it leaves a committed load reporting failure, and the obvious retry duplicates rows.
- **The gate is version-blind, by shape rather than by version.** `getOperationsAllowlist` only says
  yes to an array of strings, and what a pre-5.0 instance puts under that key is a database record
  (`permissionsTranslator` writes one for any upgraded v4 role owning a database named `operations`).
  Asking the instance version instead would mean a query per check on a hook that does not receive
  this module's `entityId` — the bug #1628's `b7c01cf4` just removed.
- **The gate simulation does not reuse `expandEffectiveOperations`.** That helper folds alias spellings
  together to describe a role's effective reach; the server's gate does not fold, so a lone
  `search_by_id` grant must stay the dead entry it is. Simulating the gate is this module's whole job,
  so it expands verbatim and canonicalizes only the operation being checked.
- **Not reusing `isElevatedRole`** (from #1628; counts `structure_user` and `cluster_user`). It answers
  whether the allowlist is unenforceable *anywhere* for the role. For DML both are still gated:
  `STRUCTURE_USER_OPS` is create/drop table and attribute only, and `cluster_user` appears nowhere in
  `operation_authorization.ts`. Measured: `{structure_user: true, operations: ['read_only']}` → insert
  DENIED.
- **Malformed allowlists restrict nothing** (fail-open), because a denial that can't be proven must not
  hide UI. This differs from #1628's editor, which surfaces a malformed value as active — different
  jobs: it warns, this hides.
- **`read` gating is live but inert today** — no production call site passes `'read'`, and the
  attribute hook has no callers. Mapped for symmetry and covered by tests.
- **The database-scoped Import launcher** has no table to check a grant against (it creates one), so it
  is gated on the operations half alone — otherwise a `structure_user` with an empty allowlist could
  start a load denied *after* `create_table` succeeded, leaving an empty table behind.

## Verification

- **End-to-end route: executed `verifyPerms` / `verifyPermsAST` directly** against the Harper checkout
  (`main`, mocha, the same harness as `unitTests/utility/operation_authorization.test.js`), because the
  premise this PR rests on is not covered by any existing test — Harper's allowlist suite sets
  `super_user: false` everywhere. Throwaway probes, since deleted (Harper checkout clean):

  | role + allowlist | operation | verdict |
  |---|---|---|
  | `super_user: true`, `operations: []` | `insert`, `search_by_conditions`, `restart`, `get_configuration` | **ALLOWED** (all four) |
  | `super_user: true`, `operations: ['read_only']` | `insert`, `restart` | **ALLOWED** |
  | `super_user: false`, `operations: []` | `insert` | **DENIED** |
  | `structure_user: true`, `operations: ['read_only']` | `insert` | **DENIED** |

  Two further probes settled @kriszyp's review claims, and both confirmed them — see the PR comment for
  detail. They are Harper-side, not defects in this diff: SQL dispatches through `verifyPermsAST`, which
  has no allowlist gate (`operations: []` still permits SQL writes); and 9 of 23 sampled picker names
  can never match the gate because their authorization entry omits `api_name` (`deploy_component` among
  them, so #1627's own deploy-only CI user is not buildable today). #1628 tracks the second as
  HarperFast/harper#2175 with a `GATE_INERT_OPERATIONS` set; the SQL bypass still wants an issue.
- The Studio-side tests prove an allowlist shows or hides the right control. What remains unproven from
  Studio: a full round-trip against a live 5.x instance carrying such a role.
- `src/hooks/checkOperationPermission.test.ts` (new): absent / malformed / empty / exact / unknown /
  group / both alias directions, a database record under `operations` reading as no allowlist, expansion
  caching, per-action mapping, `structure_user` and `cluster_user`, per-method and per-source import
  capability, and a mapping-integrity test asserting every mapped name is a canonical, non-group catalog
  entry. That last one earned its keep: an earlier draft mapped `list_certificates` and `list_ssh_keys`,
  which harper-pro registers at runtime and the catalog therefore lacks, so they would never have matched.
- `checkSchemaTablePermission.test.ts` extended: allowlist over a CRUD grant, over `structure_user`, the
  super_user pass-through, and the Add-Records-vs-Import divergence.
- `TableContextMenuItems.test.tsx` and `ImportDataModal.permissions.test.tsx` (both new) mock only the
  auth store and the router, so they run the real allowlist → hook → rendered-control chain: entries
  hidden for a read-only allowlist, Import Data surviving a CSV grant while Add Records drops, Import
  Data hidden when a CSV load has no `get_job`, the URL method dropped for an insert-only role, and the
  default selection falling back to an allowed method.
- **Full gate, matching `verify-pr.yaml` exactly** — `tsc -b` ✓, `pnpm test:coverage` ✓ (**301 files /
  2369 passed**, 11 skipped), `pnpm lint` ✓, `pnpm build` ✓; `dprint` no-op. The one uncovered branch in
  the new module is the `?? []` guard TypeScript makes unreachable.
- `test:e2e:docker` is **not** part of CI's PR gate and its specs cover auth/signup/org-users only —
  nothing in the instance browse UI — so it cannot exercise this change.

## Review coverage

Authored by Claude Opus 5. Outside coverage via the bundled pre-push CLI (`--author claude`), plus a
human review; every round changed the design:

| round | lens | outcome |
|---|---|---|
| plan | `gpt-5.6-sol` (codex) | rejected the aggregate manage/browse-manage booleans; the narrowing to DML came from this |
| impl | `gpt-5.6-sol` (codex) | `CHANGES` — the shared insert flag conflated Add Records with Import Data |
| impl `--full` | `gpt-5.6-sol` (codex) | `CHANGES` — CSV imports missing `get_job`; the ungated third Import launcher |
| impl `--full` | gemini via `agy` (default model) | crash risk on an off-type action lookup; no component tests |
| post-push | gemini-code-assist (CI bot) | wanted `csv_file_load`/`import_from_s3` added — declined with rationale, `ImportSource` issues neither |
| post-push | **@kriszyp** (with KrAIs/GPT-5) | the two server findings above, plus per-source import gating — implemented |

`cursor-grok` ✗ (pruned by policy), `cursor-composer` ✗ (`cursor-agent` not installed), Harper domain
adjudication ✗ (exit 1) — so the decision list above is mine, not an adjudicated ledger.

Rebased twice onto a moving #1628 (`b7c01cf4`, `61d068be`), both times with semantic merges rather than
textual ones: the version-blind reversal and the `expandEffectiveOperations` split above both came out of
those. No cross-model round has run against the current head; the changes since the last reviewed SHA are
the import-method gating, the version-blind revert, and tests.

## Docs

No companion PR to HarperFast/documentation: this makes Studio's UI agree with server behavior that
already ships, and adds no API, config, CLI, or default. The allowlist feature's own documentation
belongs with #1628.

<sub>Human-Review-Need: 4 @ eae63ad4f775</sub>
