### PR TITLE
Add invisible reCAPTCHA verification to the signup and forgot-password forms

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -12,3 +12,9 @@ VITE_HOST=localhost
 
 # Local Harper instance the Local Studio UI talks to (used by dev:local)
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
+
+# reCAPTCHA v3 on the signup / forgot-password forms (invisible; badge bottom-right).
+# Left unset so local dev runs no reCAPTCHA; central-manager does not enforce locally
+# either. Google publishes no v3 test key — to exercise it, create your own v3 key with
+# "localhost" as a domain in the reCAPTCHA console (Google Cloud) and set it here.
+# VITE_RECAPTCHA_SITE_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,8 +13,8 @@ VITE_HOST=localhost
 # Local Harper instance the Local Studio UI talks to (used by dev:local)
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 
-# reCAPTCHA v3 on the signup / forgot-password forms (invisible; badge bottom-right).
+# reCAPTCHA Enterprise on the signup / forgot-password forms (invisible; badge bottom-right).
 # Left unset so local dev runs no reCAPTCHA; central-manager does not enforce locally
-# either. Google publishes no v3 test key — to exercise it, create your own v3 key with
+# either. Google publishes no Enterprise test key — to exercise it, create your own key with
 # "localhost" as a domain in the reCAPTCHA console (Google Cloud) and set it here.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,10 @@ VITE_HOST=localhost
 # Local Harper instance the Local Studio UI talks to (used by dev:local)
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 
-# reCAPTCHA on the auth forms; unset = none (central-manager never enforces
-# locally). No test keys exist — create a key with a "localhost" domain to try it.
+# reCAPTCHA on the auth forms; unset = none, which is fine against a local or dev
+# central-manager (neither enforces). To exercise it against an ENFORCING backend,
+# you must use that environment's own site key — central-manager sends its
+# configured key in every assessment, so a key you create yourself is rejected as
+# a mismatch even if it authorizes localhost. The stage key authorizes localhost
+# for exactly this; copy it from .github/deploy-public-env/.env.stage.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,8 +13,6 @@ VITE_HOST=localhost
 # Local Harper instance the Local Studio UI talks to (used by dev:local)
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 
-# reCAPTCHA Enterprise on the signup / forgot-password forms (invisible; badge bottom-right).
-# Left unset so local dev runs no reCAPTCHA; central-manager does not enforce locally
-# either. Google publishes no Enterprise test key — to exercise it, create your own key with
-# "localhost" as a domain in the reCAPTCHA console (Google Cloud) and set it here.
+# reCAPTCHA on the auth forms; unset = none (central-manager never enforces
+# locally). No test keys exist — create a key with a "localhost" domain to try it.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -36,6 +36,7 @@ Some commonly used variables:
 - `VITE_LOCAL_STUDIO_DEV_URL` — local Harper URL (default `http://localhost:9925`)
 - `VITE_PUBLIC_STRIPE_KEY` — Stripe public key
 - `VITE_ENV_NAME` — environment label (dev/stage/prod)
+- `VITE_RECAPTCHA_SITE_KEY` — reCAPTCHA v3 site key for the signup / forgot-password bot check; unset disables it entirely
 
 See `.github/deploy-public-env/.env.prod` for a production example. For local development, create `.env.local` based on `.env.local.example`.
 

--- a/.github/deploy-public-env/.env.dev
+++ b/.github/deploy-public-env/.env.dev
@@ -4,7 +4,6 @@ VITE_ENV_NAME=dev
 VITE_CENTRAL_MANAGER_API_URL="https://dev.studio.harperfabric.com" # URL for Fabric API
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=0
-# reCAPTCHA Enterprise site key for the signup / forgot-password bot check. Public by design
-# (the secret half lives in central-manager). Unset = no reCAPTCHA at all. Note that
-# central-manager never enforces in dev, so a key here only exercises token minting.
+# Public reCAPTCHA site key; unset = no reCAPTCHA. central-manager never
+# enforces in dev, so a key here only exercises token minting.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.dev
+++ b/.github/deploy-public-env/.env.dev
@@ -4,7 +4,7 @@ VITE_ENV_NAME=dev
 VITE_CENTRAL_MANAGER_API_URL="https://dev.studio.harperfabric.com" # URL for Fabric API
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=0
-# reCAPTCHA v3 site key for the signup / forgot-password bot check. Public by design
+# reCAPTCHA Enterprise site key for the signup / forgot-password bot check. Public by design
 # (the secret half lives in central-manager). Unset = no reCAPTCHA at all. Note that
 # central-manager never enforces in dev, so a key here only exercises token minting.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.dev
+++ b/.github/deploy-public-env/.env.dev
@@ -4,3 +4,7 @@ VITE_ENV_NAME=dev
 VITE_CENTRAL_MANAGER_API_URL="https://dev.studio.harperfabric.com" # URL for Fabric API
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=0
+# reCAPTCHA v3 site key for the signup / forgot-password bot check. Public by design
+# (the secret half lives in central-manager). Unset = no reCAPTCHA at all. Note that
+# central-manager never enforces in dev, so a key here only exercises token minting.
+# VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.prod
+++ b/.github/deploy-public-env/.env.prod
@@ -4,7 +4,6 @@ VITE_ENV_NAME=prod
 VITE_CENTRAL_MANAGER_API_URL="https://fabric.harper.fast"
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
-# reCAPTCHA Enterprise site key for the signup / forgot-password bot check. Public by design
-# (the secret half lives in central-manager). Unset = no reCAPTCHA at all.
-# TODO(#627): fill in from the reCAPTCHA console (Google Cloud) when enabling.
+# Public reCAPTCHA site key; unset = no reCAPTCHA.
+# TODO(#627): fill in from the reCAPTCHA console when enabling.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.prod
+++ b/.github/deploy-public-env/.env.prod
@@ -5,5 +5,4 @@ VITE_CENTRAL_MANAGER_API_URL="https://fabric.harper.fast"
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
 # Public reCAPTCHA site key; unset = no reCAPTCHA.
-# TODO(#627): fill in from the reCAPTCHA console when enabling.
-# VITE_RECAPTCHA_SITE_KEY=
+VITE_RECAPTCHA_SITE_KEY=6LcdO4wtAAAAALJaW4GF6n-rTFbDC11JdfvdLdyI

--- a/.github/deploy-public-env/.env.prod
+++ b/.github/deploy-public-env/.env.prod
@@ -4,3 +4,7 @@ VITE_ENV_NAME=prod
 VITE_CENTRAL_MANAGER_API_URL="https://fabric.harper.fast"
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
+# reCAPTCHA v3 site key for the signup / forgot-password bot check. Public by design
+# (the secret half lives in central-manager). Unset = no reCAPTCHA at all.
+# TODO(#627): fill in from the reCAPTCHA console (Google Cloud) when enabling.
+# VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.prod
+++ b/.github/deploy-public-env/.env.prod
@@ -4,7 +4,7 @@ VITE_ENV_NAME=prod
 VITE_CENTRAL_MANAGER_API_URL="https://fabric.harper.fast"
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
-# reCAPTCHA v3 site key for the signup / forgot-password bot check. Public by design
+# reCAPTCHA Enterprise site key for the signup / forgot-password bot check. Public by design
 # (the secret half lives in central-manager). Unset = no reCAPTCHA at all.
 # TODO(#627): fill in from the reCAPTCHA console (Google Cloud) when enabling.
 # VITE_RECAPTCHA_SITE_KEY=

--- a/.github/deploy-public-env/.env.stage
+++ b/.github/deploy-public-env/.env.stage
@@ -4,3 +4,7 @@ VITE_ENV_NAME=stage
 VITE_CENTRAL_MANAGER_API_URL="https://stage.studio.harperfabric.com" # URL for Fabric API
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
+# reCAPTCHA Enterprise site key (public by design; the API key lives in
+# central-manager's secrets) for the signup / forgot-password bot check.
+# Unset = no reCAPTCHA at all.
+VITE_RECAPTCHA_SITE_KEY=6LckrIotAAAAAI4Kpk0kXiYtaAZKIBn2qhqabIfJ

--- a/.github/deploy-public-env/.env.stage
+++ b/.github/deploy-public-env/.env.stage
@@ -4,7 +4,5 @@ VITE_ENV_NAME=stage
 VITE_CENTRAL_MANAGER_API_URL="https://stage.studio.harperfabric.com" # URL for Fabric API
 VITE_LOCAL_STUDIO_DEV_URL=http://localhost:9925
 VITE_REO_DEV_CLIENT_ID=6565c3e84c377ad
-# reCAPTCHA Enterprise site key (public by design; the API key lives in
-# central-manager's secrets) for the signup / forgot-password bot check.
-# Unset = no reCAPTCHA at all.
+# Public reCAPTCHA site key for the auth-form bot check; unset = no reCAPTCHA.
 VITE_RECAPTCHA_SITE_KEY=6LckrIotAAAAAI4Kpk0kXiYtaAZKIBn2qhqabIfJ

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,9 @@
 export const forceBasicAuth = import.meta.env.VITE_FORCE_BASIC_AUTH === 'true';
 export const isLocalStudio = import.meta.env.VITE_LOCAL_STUDIO === 'true';
 export const localStudioDevUrl = import.meta.env.VITE_LOCAL_STUDIO_DEV_URL;
+// Unset means no bot check on the public auth forms — matches central-manager,
+// which only enforces reCAPTCHA where its own secret key is configured.
+export const recaptchaSiteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 export const defaultOperationsApiPort = 9925;
 export const defaultOperationsApiSecure = true;
 export const defaultClusterUsername = 'HDB_ADMIN';

--- a/src/features/auth/ForgotPassword.test.tsx
+++ b/src/features/auth/ForgotPassword.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock('@/config/apiClient', () => ({ apiClient: { post } }));
+
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+vi.mock('@tanstack/react-router', () => ({
+	useNavigate: () => navigate,
+	useSearch: () => ({}),
+	Link: ({ children }: PropsWithChildren) => <a>{children}</a>,
+}));
+
+vi.mock('sonner', () => ({
+	toast: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
+}));
+
+// Stands in for Google's script: the hook mints through this module at submit time.
+const { captchaState } = vi.hoisted(() => ({
+	captchaState: { configured: true, token: undefined as string | undefined, mints: [] as string[] },
+}));
+vi.mock('@/lib/recaptcha/recaptchaScript', () => ({
+	isCaptchaConfigured: () => captchaState.configured,
+	warmCaptcha: vi.fn(),
+	getCaptchaToken: async (action: string) => {
+		captchaState.mints.push(action);
+		return captchaState.token;
+	},
+}));
+
+import { ForgotPassword } from './ForgotPassword';
+
+function wrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return ({ children }: PropsWithChildren) => <QueryClientProvider client={queryClient}>{children}
+	</QueryClientProvider>;
+}
+
+function renderForm() {
+	const Wrapper = wrapper();
+	return render(<ForgotPassword />, { wrapper: Wrapper });
+}
+
+async function submitWith(container: HTMLElement, email: string) {
+	const input = container.querySelector('input[type="email"]')!;
+	fireEvent.change(input, { target: { value: email } });
+	fireEvent.submit(container.querySelector('form')!);
+}
+
+beforeEach(() => {
+	captchaState.configured = true;
+	captchaState.token = undefined;
+	captchaState.mints = [];
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('ForgotPassword — reCAPTCHA', () => {
+	it('mints a forgot_password token at submit and sends it as captchaToken', async () => {
+		captchaState.token = 'human-token';
+		post.mockResolvedValue({ data: 'If an account exists with this email...' });
+		const { container } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+		expect(captchaState.mints).toEqual(['forgot_password']);
+		expect(post).toHaveBeenCalledWith('/ForgotPassword/', {
+			email: 'user@example.com',
+			captchaToken: 'human-token',
+		});
+	});
+
+	it('omits the field entirely when no token could be minted (enforcement still off)', async () => {
+		captchaState.configured = false;
+		post.mockResolvedValue({ data: 'If an account exists with this email...' });
+		const { container } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+		expect(post).toHaveBeenCalledWith('/ForgotPassword/', { email: 'user@example.com' });
+		// toHaveBeenCalledWith treats an explicit undefined as absent, so assert the
+		// key is genuinely gone — the rollout depends on an untokened body being clean.
+		expect(post.mock.calls[0][1]).not.toHaveProperty('captchaToken');
+	});
+
+	it('on a 403 shows the try-again notice inline', async () => {
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(
+			{ isAxiosError: true, response: { status: 403, data: 'Verification failed' } } as AxiosError,
+		);
+		const { container, findByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		const alert = await findByRole('alert');
+		expect(alert.textContent).toContain('Verification failed. Please try again.');
+	});
+
+	it('names the real problem when the check never ran (script blocked, key configured)', async () => {
+		captchaState.token = undefined; // configured, but the mint failed
+		post.mockRejectedValue(
+			{ isAxiosError: true, response: { status: 403, data: 'Verification failed' } } as AxiosError,
+		);
+		const { container, findByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		const alert = await findByRole('alert');
+		expect(alert.textContent).toContain('could not run the verification check');
+	});
+
+	it('clears the notice on the next submit, which mints a fresh token by design', async () => {
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValueOnce(
+			{ isAxiosError: true, response: { status: 403, data: 'Verification failed' } } as AxiosError,
+		);
+		const { container, findByRole, queryByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+		await findByRole('alert');
+
+		captchaState.token = 'fresh-token';
+		post.mockResolvedValue({ data: 'If an account exists with this email...' });
+		await submitWith(container, 'user@example.com');
+
+		await waitFor(() => expect(queryByRole('alert')).toBeNull());
+		expect(post).toHaveBeenLastCalledWith('/ForgotPassword/', {
+			email: 'user@example.com',
+			captchaToken: 'fresh-token',
+		});
+		expect(captchaState.mints).toEqual(['forgot_password', 'forgot_password']);
+	});
+
+	it('leaves a non-CAPTCHA failure to the normal error path (no inline notice)', async () => {
+		captchaState.token = 'human-token';
+		post.mockRejectedValue(
+			{ isAxiosError: true, response: { status: 500, data: 'boom' } } as AxiosError,
+		);
+		const { container, queryByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		await waitFor(() => expect(post).toHaveBeenCalled());
+		expect(queryByRole('alert')).toBeNull();
+	});
+});

--- a/src/features/auth/ForgotPassword.test.tsx
+++ b/src/features/auth/ForgotPassword.test.tsx
@@ -88,8 +88,7 @@ describe('ForgotPassword — reCAPTCHA', () => {
 
 		await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
 		expect(post).toHaveBeenCalledWith('/ForgotPassword/', { email: 'user@example.com' });
-		// toHaveBeenCalledWith treats an explicit undefined as absent, so assert the
-		// key is genuinely gone — the rollout depends on an untokened body being clean.
+		// toHaveBeenCalledWith treats explicit undefined as absent; assert it's gone.
 		expect(post.mock.calls[0][1]).not.toHaveProperty('captchaToken');
 	});
 

--- a/src/features/auth/ForgotPassword.test.tsx
+++ b/src/features/auth/ForgotPassword.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { AxiosError } from 'axios';
 import { PropsWithChildren } from 'react';
@@ -21,6 +21,11 @@ vi.mock('sonner', () => ({
 	toast: { success: vi.fn(), error: vi.fn(), dismiss: vi.fn() },
 }));
 
+import { toast } from 'sonner';
+// The app's own mutation-error routing, not a copy: whether a CAPTCHA failure ALSO
+// reaches the global toast is part of what's under test here.
+import { mutationErrorHandler } from '@/react-query/queryClient';
+
 // Stands in for Google's script: the hook mints through this module at submit time.
 const { captchaState } = vi.hoisted(() => ({
 	captchaState: { configured: true, token: undefined as string | undefined, mints: [] as string[] },
@@ -38,6 +43,7 @@ import { ForgotPassword } from './ForgotPassword';
 
 function wrapper() {
 	const queryClient = new QueryClient({
+		mutationCache: new MutationCache({ onError: mutationErrorHandler }),
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	});
 	return ({ children }: PropsWithChildren) => <QueryClientProvider client={queryClient}>{children}
@@ -140,7 +146,37 @@ describe('ForgotPassword — reCAPTCHA', () => {
 		expect(captchaState.mints).toEqual(['forgot_password', 'forgot_password']);
 	});
 
-	it('leaves a non-CAPTCHA failure to the normal error path (no inline notice)', async () => {
+	it('shows a CAPTCHA 403 inline only — never also as a toast', async () => {
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(
+			{ isAxiosError: true, response: { status: 403, data: 'Verification failed' } } as AxiosError,
+		);
+		const { container, findByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		await findByRole('alert');
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('classifies a mixed envelope by the field that names the cause, not the first string', async () => {
+		// { error: 'Forbidden', message: 'Verification failed' } must still read as
+		// a CAPTCHA rejection, or the ad-blocker guidance and support path vanish.
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(
+			{
+				isAxiosError: true,
+				response: { status: 403, data: { error: 'Forbidden', message: 'Verification failed' } },
+			} as AxiosError,
+		);
+		const { container, findByRole } = renderForm();
+
+		await submitWith(container, 'user@example.com');
+
+		expect((await findByRole('alert')).textContent).toContain('Verification failed. Please try again.');
+	});
+
+	it('leaves a non-CAPTCHA failure to the normal error path (toast, no inline notice)', async () => {
 		captchaState.token = 'human-token';
 		post.mockRejectedValue(
 			{ isAxiosError: true, response: { status: 500, data: 'boom' } } as AxiosError,
@@ -151,5 +187,6 @@ describe('ForgotPassword — reCAPTCHA', () => {
 
 		await waitFor(() => expect(post).toHaveBeenCalled());
 		expect(queryByRole('alert')).toBeNull();
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
 	});
 });

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -1,3 +1,4 @@
+import { ContactUs } from '@/components/ContactUs';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form/Form';
 import { FormControl } from '@/components/ui/form/FormControl';
@@ -95,6 +96,12 @@ export function ForgotPassword() {
 					{submitError && (
 						<p role="alert" data-slot="form-message" className="text-destructive text-sm">
 							{submitError}
+							{captcha.supportSuggested && (
+								<>
+									{' '}
+									<ContactUs overEmail /> if this keeps happening.
+								</>
+							)}
 						</p>
 					)}
 					<Button type="submit" variant="submit" disabled={isPending || captcha.minting} className="w-full my-2">

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -41,10 +41,8 @@ export function ForgotPassword() {
 	const captcha = useCaptchaChallenge('forgot_password');
 
 	const submitForm = async (formData: z.infer<typeof ForgotPasswordSchema>) => {
-		// Same reason as SignUp: `handleSubmit` reruns the resolver, which only rewrites
-		// field errors, so a stale `root` would outlive the retry.
+		// Like SignUp: the resolver only rewrites field errors, so clear stale root.
 		clearErrors('root');
-		// Minted per submit: tokens are single use and expire in ~2 minutes.
 		const captchaToken = await captcha.getToken();
 		submitForgotPasswordData({ ...formData, captchaToken }, {
 			onSuccess: (message) => {
@@ -58,9 +56,8 @@ export function ForgotPassword() {
 				navigate({ to: '/sign-in', search: { me: email } });
 			},
 			onError: (error) => {
+				// Non-CAPTCHA failures keep their existing global toast.
 				const captchaMessage = captcha.describeCaptchaError(error);
-				// Every other failure keeps its existing global toast; only the CAPTCHA
-				// needs to say what to do next, right in the form.
 				if (captchaMessage) { setError('root', { type: 'server', message: captchaMessage }); }
 			},
 		});

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
+import { useCaptchaChallenge } from './hooks/useCaptchaChallenge';
 import { useForgotPasswordMutation } from './hooks/useForgotPassword';
 
 const ForgotPasswordSchema = z.object({
@@ -29,16 +30,23 @@ export function ForgotPassword() {
 		},
 	});
 	const email = methods.watch('email');
-	const { setFocus, control, handleSubmit } = methods;
+	const { setFocus, setError, clearErrors, control, handleSubmit, formState } = methods;
+	const submitError = formState.errors.root?.message;
 
 	useEffect(() => {
 		setFocus('email');
 	}, [setFocus]);
 
 	const { mutate: submitForgotPasswordData, isPending } = useForgotPasswordMutation();
+	const captcha = useCaptchaChallenge('forgot_password');
 
 	const submitForm = async (formData: z.infer<typeof ForgotPasswordSchema>) => {
-		submitForgotPasswordData(formData, {
+		// Same reason as SignUp: `handleSubmit` reruns the resolver, which only rewrites
+		// field errors, so a stale `root` would outlive the retry.
+		clearErrors('root');
+		// Minted per submit: v3 tokens are single use and expire in ~2 minutes.
+		const captchaToken = await captcha.getToken();
+		submitForgotPasswordData({ ...formData, captchaToken }, {
 			onSuccess: (message) => {
 				toast.success('Success', {
 					description: `${message}`,
@@ -48,6 +56,12 @@ export function ForgotPassword() {
 					},
 				});
 				navigate({ to: '/sign-in', search: { me: email } });
+			},
+			onError: (error) => {
+				const captchaMessage = captcha.describeCaptchaError(error);
+				// Every other failure keeps its existing global toast; only the CAPTCHA
+				// needs to say what to do next, right in the form.
+				if (captchaMessage) { setError('root', { type: 'server', message: captchaMessage }); }
 			},
 		});
 	};
@@ -81,7 +95,12 @@ export function ForgotPassword() {
 							</FormItem>
 						)}
 					/>
-					<Button type="submit" variant="submit" disabled={isPending} className="w-full my-2">
+					{submitError && (
+						<p role="alert" data-slot="form-message" className="text-destructive text-sm">
+							{submitError}
+						</p>
+					)}
+					<Button type="submit" variant="submit" disabled={isPending || captcha.minting} className="w-full my-2">
 						Send Password Reset Email
 					</Button>
 				</form>

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -44,7 +44,7 @@ export function ForgotPassword() {
 		// Same reason as SignUp: `handleSubmit` reruns the resolver, which only rewrites
 		// field errors, so a stale `root` would outlive the retry.
 		clearErrors('root');
-		// Minted per submit: v3 tokens are single use and expire in ~2 minutes.
+		// Minted per submit: tokens are single use and expire in ~2 minutes.
 		const captchaToken = await captcha.getToken();
 		submitForgotPasswordData({ ...formData, captchaToken }, {
 			onSuccess: (message) => {

--- a/src/features/auth/ForgotPassword.tsx
+++ b/src/features/auth/ForgotPassword.tsx
@@ -8,6 +8,7 @@ import { FormLabel } from '@/components/ui/form/FormLabel';
 import { FormMessage } from '@/components/ui/form/FormMessage';
 import { Input } from '@/components/ui/input';
 import { zodRequireEmail } from '@/lib/zod/email';
+import { errorHandler } from '@/react-query/queryClient';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { useEffect } from 'react';
@@ -57,9 +58,13 @@ export function ForgotPassword() {
 				navigate({ to: '/sign-in', search: { me: email } });
 			},
 			onError: (error) => {
-				// Non-CAPTCHA failures keep their existing global toast.
 				const captchaMessage = captcha.describeCaptchaError(error);
-				if (captchaMessage) { setError('root', { type: 'server', message: captchaMessage }); }
+				if (captchaMessage) {
+					setError('root', { type: 'server', message: captchaMessage });
+					return;
+				}
+				// Everything else keeps the toast it has always had.
+				errorHandler(error);
 			},
 		});
 	};

--- a/src/features/auth/SignUp.test.tsx
+++ b/src/features/auth/SignUp.test.tsx
@@ -210,7 +210,7 @@ describe('SignUp — reCAPTCHA', () => {
 	});
 
 	it('a retry after any failure mints a fresh token by design', async () => {
-		// v3 tokens are single use and minted per submit, so a 409 whose real problem
+		// Tokens are single use and minted per submit, so a 409 whose real problem
 		// was the email address can never leave a spent token behind for the retry.
 		captchaState.token = 'first-token';
 		post.mockRejectedValueOnce(axiosError(409, 'User already exists'));

--- a/src/features/auth/SignUp.test.tsx
+++ b/src/features/auth/SignUp.test.tsx
@@ -194,6 +194,41 @@ describe('SignUp — reCAPTCHA', () => {
 		expect(navigate).not.toHaveBeenCalled();
 	});
 
+	it('offers a human after a second consecutive failure, not a third "try again"', async () => {
+		// A low score can't be retried away, so the dead end needs an exit.
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(axiosError(403, 'Verification failed'));
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+		await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+		expect(screen.queryByRole('link', { name: 'Contact us' })).toBeNull();
+
+		submit();
+		await waitFor(() => expect(screen.getByRole('link', { name: 'Contact us' })).toBeTruthy());
+		expect(screen.getByRole('link', { name: 'Contact us' }).getAttribute('href')).toContain('mailto:');
+		// Pins the space a formatter can silently eat, producing "again.Contact us".
+		expect(screen.getByRole('alert').textContent).toContain('again. Contact us if this keeps happening.');
+	});
+
+	it('drops the support offer once a failure is not the CAPTCHA', async () => {
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(axiosError(403, 'Verification failed'));
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+		await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+		submit();
+		await waitFor(() => expect(screen.getByRole('link', { name: 'Contact us' })).toBeTruthy());
+
+		post.mockRejectedValue(axiosError(409, 'User already exists'));
+		submit();
+		await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('User already exists'));
+		expect(screen.queryByRole('link', { name: 'Contact us' })).toBeNull();
+	});
+
 	it('names the real problem when the check never ran (script blocked, key configured)', async () => {
 		captchaState.token = undefined; // configured, but the mint failed
 		post.mockRejectedValue(axiosError(403, 'Verification failed'));

--- a/src/features/auth/SignUp.test.tsx
+++ b/src/features/auth/SignUp.test.tsx
@@ -195,8 +195,6 @@ describe('SignUp — reCAPTCHA', () => {
 	});
 
 	it('names the real problem when the check never ran (script blocked, key configured)', async () => {
-		// Telling someone to "try again" when the script cannot run — ad blocker, or
-		// Google unreachable — is a dead end; name the actual problem.
 		captchaState.token = undefined; // configured, but the mint failed
 		post.mockRejectedValue(axiosError(403, 'Verification failed'));
 
@@ -210,8 +208,6 @@ describe('SignUp — reCAPTCHA', () => {
 	});
 
 	it('a retry after any failure mints a fresh token by design', async () => {
-		// Tokens are single use and minted per submit, so a 409 whose real problem
-		// was the email address can never leave a spent token behind for the retry.
 		captchaState.token = 'first-token';
 		post.mockRejectedValueOnce(axiosError(409, 'User already exists'));
 

--- a/src/features/auth/SignUp.test.tsx
+++ b/src/features/auth/SignUp.test.tsx
@@ -23,6 +23,19 @@ vi.mock('sonner', () => ({
 
 vi.mock('@/integrations/reo/reo', () => ({ reoClient: { identify: vi.fn() } }));
 
+// Stands in for Google's script: the hook mints through this module at submit time.
+const { captchaState } = vi.hoisted(() => ({
+	captchaState: { configured: true, token: undefined as string | undefined, mints: [] as string[] },
+}));
+vi.mock('@/lib/recaptcha/recaptchaScript', () => ({
+	isCaptchaConfigured: () => captchaState.configured,
+	warmCaptcha: vi.fn(),
+	getCaptchaToken: async (action: string) => {
+		captchaState.mints.push(action);
+		return captchaState.token;
+	},
+}));
+
 import { toast } from 'sonner';
 // The app's own mutation-error routing, not a copy of it: whether the form's failure also
 // reaches the global toast is part of what's under test, so restating that rule here would let
@@ -65,6 +78,9 @@ beforeEach(() => {
 		mutationCache: new MutationCache({ onError: mutationErrorHandler }),
 		defaultOptions: { mutations: { retry: false } },
 	});
+	captchaState.configured = true;
+	captchaState.token = undefined;
+	captchaState.mints = [];
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -133,5 +149,83 @@ describe('SignUp', () => {
 
 		settle!();
 		await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false));
+	});
+});
+
+describe('SignUp — reCAPTCHA', () => {
+	it('mints a signup token at submit and sends it as captchaToken', async () => {
+		captchaState.token = 'human-token';
+		post.mockResolvedValue({ data: { id: 'usr-1', email: 'taken@example.com' } });
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+
+		await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+		expect(captchaState.mints).toEqual(['signup']);
+		expect(post.mock.calls[0][1]).toMatchObject({ captchaToken: 'human-token' });
+	});
+
+	it('omits the field entirely when no token could be minted (enforcement still off)', async () => {
+		captchaState.configured = false;
+		post.mockResolvedValue({ data: { id: 'usr-1', email: 'taken@example.com' } });
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+
+		await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+		// toHaveBeenCalledWith treats an explicit undefined as absent, so assert the key
+		// is genuinely gone — the rollout depends on an untokened body being clean.
+		expect(post.mock.calls[0][1]).not.toHaveProperty('captchaToken');
+	});
+
+	it('reports a rejected token with wording that says what to do next', async () => {
+		captchaState.token = 'rejected-token';
+		post.mockRejectedValue(axiosError(403, 'Verification failed'));
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+
+		await waitFor(() =>
+			expect(screen.getByRole('alert').textContent).toContain('Verification failed. Please try again.')
+		);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it('names the real problem when the check never ran (script blocked, key configured)', async () => {
+		// Telling someone to "try again" when the script cannot run — ad blocker, or
+		// Google unreachable — is a dead end; name the actual problem.
+		captchaState.token = undefined; // configured, but the mint failed
+		post.mockRejectedValue(axiosError(403, 'Verification failed'));
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+
+		await waitFor(() =>
+			expect(screen.getByRole('alert').textContent).toContain('could not run the verification check')
+		);
+	});
+
+	it('a retry after any failure mints a fresh token by design', async () => {
+		// v3 tokens are single use and minted per submit, so a 409 whose real problem
+		// was the email address can never leave a spent token behind for the retry.
+		captchaState.token = 'first-token';
+		post.mockRejectedValueOnce(axiosError(409, 'User already exists'));
+
+		renderSignUp();
+		fillValidForm();
+		submit();
+		await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('User already exists'));
+
+		captchaState.token = 'second-token';
+		post.mockResolvedValueOnce({ data: { id: 'usr-1', email: 'taken@example.com' } });
+		submit();
+
+		await waitFor(() => expect(post).toHaveBeenCalledTimes(2));
+		expect(captchaState.mints).toEqual(['signup', 'signup']);
+		expect(post.mock.calls[1][1]).toMatchObject({ captchaToken: 'second-token' });
 	});
 });

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -91,7 +91,6 @@ export function SignUp() {
 		// Drop the previous attempt's failure explicitly — `handleSubmit` reruns the resolver,
 		// which only rewrites field errors, so a stale `root` would outlive the retry.
 		clearErrors('root');
-		// Minted per submit: tokens are single use and expire in ~2 minutes.
 		const captchaToken = await captcha.getToken();
 		submitSignUpData({ ...userData, captchaToken }, {
 			onSuccess: () => {

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -91,7 +91,7 @@ export function SignUp() {
 		// Drop the previous attempt's failure explicitly — `handleSubmit` reruns the resolver,
 		// which only rewrites field errors, so a stale `root` would outlive the retry.
 		clearErrors('root');
-		// Minted per submit: v3 tokens are single use and expire in ~2 minutes.
+		// Minted per submit: tokens are single use and expire in ~2 minutes.
 		const captchaToken = await captcha.getToken();
 		submitSignUpData({ ...userData, captchaToken }, {
 			onSuccess: () => {
@@ -113,9 +113,6 @@ export function SignUp() {
 			// agnostic — it reports whatever the server said rather than mapping specific codes.
 			onError: (error) => {
 				console.error(error);
-				// Prefer the CAPTCHA wording when that is what failed — describeError would
-				// only echo the server's bare "Verification failed" without saying what to
-				// do about it. A retry mints a fresh token on its own.
 				// `message`, not `description`: the latter is the toast's body, with the first clause
 				// of a "Conflict: …" style message moved out into the heading this has no room for.
 				setError('root', {

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -1,3 +1,4 @@
+import { ContactUs } from '@/components/ContactUs';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form/Form';
 import { FormControl } from '@/components/ui/form/FormControl';
@@ -304,6 +305,12 @@ export function SignUp() {
 					{submitError && (
 						<p role="alert" data-slot="form-message" className="text-destructive text-sm">
 							{submitError}
+							{captcha.supportSuggested && (
+								<>
+									{' '}
+									<ContactUs overEmail /> if this keeps happening.
+								</>
+							)}
 						</p>
 					)}
 

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -20,6 +20,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { GitHubAuthenticationButton } from './components/GitHubAuthenticationButton';
 import { GoogleAuthenticationButton } from './components/GoogleAuthenticationButton';
+import { useCaptchaChallenge } from './hooks/useCaptchaChallenge';
 import { useSignUpMutation } from './hooks/useSignUp';
 
 const SignUpSchema = z.object({
@@ -82,6 +83,7 @@ export function SignUp() {
 	}, [setFocus]);
 
 	const { mutate: submitSignUpData, isPending } = useSignUpMutation();
+	const captcha = useCaptchaChallenge('signup');
 
 	const submitForm = useCallback(async (formData: z.infer<typeof SignUpSchema>) => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -89,7 +91,9 @@ export function SignUp() {
 		// Drop the previous attempt's failure explicitly — `handleSubmit` reruns the resolver,
 		// which only rewrites field errors, so a stale `root` would outlive the retry.
 		clearErrors('root');
-		submitSignUpData(userData, {
+		// Minted per submit: v3 tokens are single use and expire in ~2 minutes.
+		const captchaToken = await captcha.getToken();
+		submitSignUpData({ ...userData, captchaToken }, {
 			onSuccess: () => {
 				const company = parseCompanyFromEmail(userData.email);
 				reoClient?.identify?.({
@@ -109,12 +113,18 @@ export function SignUp() {
 			// agnostic — it reports whatever the server said rather than mapping specific codes.
 			onError: (error) => {
 				console.error(error);
+				// Prefer the CAPTCHA wording when that is what failed — describeError would
+				// only echo the server's bare "Verification failed" without saying what to
+				// do about it. A retry mints a fresh token on its own.
 				// `message`, not `description`: the latter is the toast's body, with the first clause
 				// of a "Conflict: …" style message moved out into the heading this has no room for.
-				setError('root', { type: 'server', message: describeError(error).message });
+				setError('root', {
+					type: 'server',
+					message: captcha.describeCaptchaError(error) ?? describeError(error).message,
+				});
 			},
 		});
-	}, [clearErrors, navigate, setError, submitSignUpData]);
+	}, [clearErrors, navigate, setError, submitSignUpData, captcha]);
 
 	const onOAuthClick = useCallback((e: MouseEvent) => {
 		if (!acceptTerms) {
@@ -301,7 +311,7 @@ export function SignUp() {
 						</p>
 					)}
 
-					<Button type="submit" variant="submit" disabled={isPending} className="w-full my-4">
+					<Button type="submit" variant="submit" disabled={isPending || captcha.minting} className="w-full my-4">
 						Sign Up For Free
 					</Button>
 				</form>

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -6,7 +6,7 @@ const CHALLENGE_FAILED = 'Verification failed. Please try again.';
 const CHALLENGE_UNAVAILABLE =
 	'We could not run the verification check. Disable any ad blocker for this page, then reload and try again.';
 
-/** reCAPTCHA v3 plumbing shared by the two public auth forms (central-manager#627).
+/** reCAPTCHA Enterprise plumbing shared by the two public auth forms (central-manager#627).
  *  Call `getToken()` as the form submits and send the result as `captchaToken`;
  *  pass mutation errors through `describeCaptchaError` — it returns the message to
  *  show when the CAPTCHA is what failed, or undefined for every other error.
@@ -14,8 +14,7 @@ const CHALLENGE_UNAVAILABLE =
  *  Every submit mints a fresh token (they are single use and expire in ~2 min), so
  *  there is no widget, no reset, and no expiry handling here by design. */
 export function useCaptchaChallenge(action: string) {
-	// Warm the script at mount: the badge becomes visible where CAPTCHA is in use
-	// (Google's terms) and the submit-time mint doesn't pay the download.
+	// Google's terms require the badge to be visible where reCAPTCHA is in use.
 	useEffect(() => {
 		warmCaptcha();
 	}, []);

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -21,7 +21,8 @@ export function useCaptchaChallenge(action: string) {
 	// Mint came back empty with a key configured: a later 403 should say the
 	// check couldn't run, not ask the user to retry something that can't succeed.
 	const mintFailed = useRef(false);
-	// Also stops concurrent submits racing mintFailed to the wrong message.
+	// Disabling submit during the mint also stops concurrent submits racing
+	// mintFailed to the wrong message.
 	const [minting, setMinting] = useState(false);
 
 	const getToken = useCallback(async (): Promise<string | undefined> => {

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -1,0 +1,49 @@
+import { getCaptchaToken, isCaptchaConfigured, warmCaptcha } from '@/lib/recaptcha/recaptchaScript';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { isCaptchaVerificationError } from '../isCaptchaVerificationError';
+
+const CHALLENGE_FAILED = 'Verification failed. Please try again.';
+const CHALLENGE_UNAVAILABLE =
+	'We could not run the verification check. Disable any ad blocker for this page, then reload and try again.';
+
+/** reCAPTCHA v3 plumbing shared by the two public auth forms (central-manager#627).
+ *  Call `getToken()` as the form submits and send the result as `captchaToken`;
+ *  pass mutation errors through `describeCaptchaError` — it returns the message to
+ *  show when the CAPTCHA is what failed, or undefined for every other error.
+ *
+ *  Every submit mints a fresh token (they are single use and expire in ~2 min), so
+ *  there is no widget, no reset, and no expiry handling here by design. */
+export function useCaptchaChallenge(action: string) {
+	// Warm the script at mount: the badge becomes visible where CAPTCHA is in use
+	// (Google's terms) and the submit-time mint doesn't pay the download.
+	useEffect(() => {
+		warmCaptcha();
+	}, []);
+
+	// Whether the last mint came back empty with a key configured — that means the
+	// script or Google is unreachable from this browser, and a later 403 should say
+	// so instead of asking the user to retry something that cannot succeed.
+	const mintFailed = useRef(false);
+	// Surfaced so forms can disable submit during the mint (bounded at ~4s by the
+	// script module's timeout); also keeps concurrent submits from racing
+	// mintFailed to the wrong error message.
+	const [minting, setMinting] = useState(false);
+
+	const getToken = useCallback(async (): Promise<string | undefined> => {
+		setMinting(true);
+		try {
+			const token = await getCaptchaToken(action);
+			mintFailed.current = isCaptchaConfigured() && !token;
+			return token;
+		} finally {
+			setMinting(false);
+		}
+	}, [action]);
+
+	const describeCaptchaError = useCallback((error: unknown): string | undefined => {
+		if (!isCaptchaVerificationError(error)) { return undefined; }
+		return mintFailed.current ? CHALLENGE_UNAVAILABLE : CHALLENGE_FAILED;
+	}, []);
+
+	return { getToken, describeCaptchaError, minting };
+}

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -10,10 +10,8 @@ const CHALLENGE_UNAVAILABLE =
 // so a second failure offers a human instead of repeating "try again" forever.
 const SUPPORT_AFTER_FAILURES = 2;
 
-/** reCAPTCHA plumbing for the public auth forms (central-manager#627): call
- *  `getToken()` at submit, send it as `captchaToken`, and route mutation errors
- *  through `describeCaptchaError` (message when the CAPTCHA failed, else
- *  undefined). Fresh single-use token per submit — no reset/expiry handling. */
+/** reCAPTCHA plumbing for the public auth forms (central-manager#627). Fresh
+ *  single-use token per submit, so there is no reset or expiry handling. */
 export function useCaptchaChallenge(action: string) {
 	// Google's terms require the badge to be visible where reCAPTCHA is in use.
 	useEffect(() => {
@@ -23,8 +21,7 @@ export function useCaptchaChallenge(action: string) {
 	// Mint came back empty with a key configured: a later 403 should say the
 	// check couldn't run, not ask the user to retry something that can't succeed.
 	const mintFailed = useRef(false);
-	// Lets forms disable submit during the mint (bounded ~4s); also prevents
-	// concurrent submits racing mintFailed to the wrong message.
+	// Also stops concurrent submits racing mintFailed to the wrong message.
 	const [minting, setMinting] = useState(false);
 
 	const getToken = useCallback(async (): Promise<string | undefined> => {

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -6,26 +6,21 @@ const CHALLENGE_FAILED = 'Verification failed. Please try again.';
 const CHALLENGE_UNAVAILABLE =
 	'We could not run the verification check. Disable any ad blocker for this page, then reload and try again.';
 
-/** reCAPTCHA Enterprise plumbing shared by the two public auth forms (central-manager#627).
- *  Call `getToken()` as the form submits and send the result as `captchaToken`;
- *  pass mutation errors through `describeCaptchaError` — it returns the message to
- *  show when the CAPTCHA is what failed, or undefined for every other error.
- *
- *  Every submit mints a fresh token (they are single use and expire in ~2 min), so
- *  there is no widget, no reset, and no expiry handling here by design. */
+/** reCAPTCHA plumbing for the public auth forms (central-manager#627): call
+ *  `getToken()` at submit, send it as `captchaToken`, and route mutation errors
+ *  through `describeCaptchaError` (message when the CAPTCHA failed, else
+ *  undefined). Fresh single-use token per submit — no reset/expiry handling. */
 export function useCaptchaChallenge(action: string) {
 	// Google's terms require the badge to be visible where reCAPTCHA is in use.
 	useEffect(() => {
 		warmCaptcha();
 	}, []);
 
-	// Whether the last mint came back empty with a key configured — that means the
-	// script or Google is unreachable from this browser, and a later 403 should say
-	// so instead of asking the user to retry something that cannot succeed.
+	// Mint came back empty with a key configured: a later 403 should say the
+	// check couldn't run, not ask the user to retry something that can't succeed.
 	const mintFailed = useRef(false);
-	// Surfaced so forms can disable submit during the mint (bounded at ~4s by the
-	// script module's timeout); also keeps concurrent submits from racing
-	// mintFailed to the wrong error message.
+	// Lets forms disable submit during the mint (bounded ~4s); also prevents
+	// concurrent submits racing mintFailed to the wrong message.
 	const [minting, setMinting] = useState(false);
 
 	const getToken = useCallback(async (): Promise<string | undefined> => {

--- a/src/features/auth/hooks/useCaptchaChallenge.ts
+++ b/src/features/auth/hooks/useCaptchaChallenge.ts
@@ -6,6 +6,10 @@ const CHALLENGE_FAILED = 'Verification failed. Please try again.';
 const CHALLENGE_UNAVAILABLE =
 	'We could not run the verification check. Disable any ad blocker for this page, then reload and try again.';
 
+// A low score can't be fixed by retrying — the signals behind it don't change —
+// so a second failure offers a human instead of repeating "try again" forever.
+const SUPPORT_AFTER_FAILURES = 2;
+
 /** reCAPTCHA plumbing for the public auth forms (central-manager#627): call
  *  `getToken()` at submit, send it as `captchaToken`, and route mutation errors
  *  through `describeCaptchaError` (message when the CAPTCHA failed, else
@@ -34,10 +38,19 @@ export function useCaptchaChallenge(action: string) {
 		}
 	}, [action]);
 
+	const consecutiveFailures = useRef(0);
+	const [supportSuggested, setSupportSuggested] = useState(false);
+
 	const describeCaptchaError = useCallback((error: unknown): string | undefined => {
-		if (!isCaptchaVerificationError(error)) { return undefined; }
+		if (!isCaptchaVerificationError(error)) {
+			consecutiveFailures.current = 0;
+			setSupportSuggested(false);
+			return undefined;
+		}
+		consecutiveFailures.current += 1;
+		setSupportSuggested(consecutiveFailures.current >= SUPPORT_AFTER_FAILURES);
 		return mintFailed.current ? CHALLENGE_UNAVAILABLE : CHALLENGE_FAILED;
 	}, []);
 
-	return { getToken, describeCaptchaError, minting };
+	return { getToken, describeCaptchaError, minting, supportSuggested };
 }

--- a/src/features/auth/hooks/useForgotPassword.ts
+++ b/src/features/auth/hooks/useForgotPassword.ts
@@ -3,15 +3,19 @@ import { useMutation } from '@tanstack/react-query';
 
 export type ForgotPasswordCredential = {
 	email: string;
+	captchaToken?: string;
 };
 
 type ForgotPasswordResponse = {
 	email: string;
 };
 
-export async function onResetPasswordSubmit({ email }: ForgotPasswordCredential): Promise<ForgotPasswordResponse> {
+export async function onResetPasswordSubmit(
+	{ email, captchaToken }: ForgotPasswordCredential,
+): Promise<ForgotPasswordResponse> {
 	const { data } = await apiClient.post('/ForgotPassword/', {
 		email,
+		...(captchaToken ? { captchaToken } : {}),
 	});
 	if (data) {
 		// TODO: The OpenAPI description isn't accurate.

--- a/src/features/auth/hooks/useForgotPassword.ts
+++ b/src/features/auth/hooks/useForgotPassword.ts
@@ -28,5 +28,8 @@ export async function onResetPasswordSubmit(
 export function useForgotPasswordMutation() {
 	return useMutation<ForgotPasswordResponse, Error, ForgotPasswordCredential>({
 		mutationFn: (loginData) => onResetPasswordSubmit(loginData),
+		// The form renders CAPTCHA failures inline and re-raises everything else
+		// through errorHandler, so the global toast would double up here.
+		meta: { skipGlobalErrorToast: true },
 	});
 }

--- a/src/features/auth/hooks/useSignUp.ts
+++ b/src/features/auth/hooks/useSignUp.ts
@@ -7,11 +7,15 @@ export interface SignUpCredentials extends Omit<SchemaUser, 'id'> {
 	password: string;
 	firstname: string;
 	lastname: string;
+	captchaToken?: string;
 }
 
-export async function onSignUpSubmit(signUpCredentials: SignUpCredentials) {
+export async function onSignUpSubmit({ captchaToken, ...signUpCredentials }: SignUpCredentials) {
 	// TODO: The types in our OpenAPI for this endpoint aren't defined.
-	const { data } = await apiClient.post('/User/', signUpCredentials);
+	const { data } = await apiClient.post('/User/', {
+		...signUpCredentials,
+		...(captchaToken ? { captchaToken } : {}),
+	});
 	if (data) {
 		return data;
 	} else {

--- a/src/features/auth/isCaptchaVerificationError.test.ts
+++ b/src/features/auth/isCaptchaVerificationError.test.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { isCaptchaVerificationError } from './isCaptchaVerificationError';
+
+function axiosError(status: number, data: unknown): AxiosError {
+	return { isAxiosError: true, response: { status, data } } as AxiosError;
+}
+
+describe('isCaptchaVerificationError', () => {
+	it("matches central-manager's 403 with a plain-string body", () => {
+		expect(isCaptchaVerificationError(axiosError(403, 'Verification failed'))).toBe(true);
+	});
+
+	it("matches the same message wrapped in Harper's error/message envelopes", () => {
+		expect(isCaptchaVerificationError(axiosError(403, { error: 'Verification failed' }))).toBe(true);
+		expect(isCaptchaVerificationError(axiosError(403, { message: 'Verification failed' }))).toBe(true);
+	});
+
+	it('ignores a 403 that is not the challenge (so it keeps the normal error path)', () => {
+		expect(isCaptchaVerificationError(axiosError(403, 'User account deactivated'))).toBe(false);
+	});
+
+	it('ignores other statuses, including the duplicate-email 409', () => {
+		expect(isCaptchaVerificationError(axiosError(409, 'User already exists'))).toBe(false);
+		expect(isCaptchaVerificationError(axiosError(400, 'Verification failed'))).toBe(false);
+	});
+
+	it('tolerates non-axios and malformed errors', () => {
+		expect(isCaptchaVerificationError(new Error('network down'))).toBe(false);
+		expect(isCaptchaVerificationError(undefined)).toBe(false);
+		expect(isCaptchaVerificationError(axiosError(403, { error: { nested: true } }))).toBe(false);
+	});
+});

--- a/src/features/auth/isCaptchaVerificationError.test.ts
+++ b/src/features/auth/isCaptchaVerificationError.test.ts
@@ -16,6 +16,12 @@ describe('isCaptchaVerificationError', () => {
 		expect(isCaptchaVerificationError(axiosError(403, { message: 'Verification failed' }))).toBe(true);
 	});
 
+	it('matches an RFC 9457 problem body via its title', () => {
+		expect(
+			isCaptchaVerificationError(axiosError(403, { type: 'about:blank', title: 'Verification failed', status: 403 })),
+		).toBe(true);
+	});
+
 	it('ignores a 403 that is not the challenge (so it keeps the normal error path)', () => {
 		expect(isCaptchaVerificationError(axiosError(403, 'User account deactivated'))).toBe(false);
 	});

--- a/src/features/auth/isCaptchaVerificationError.ts
+++ b/src/features/auth/isCaptchaVerificationError.ts
@@ -1,10 +1,7 @@
 import { AxiosError } from 'axios';
 
-/** True for central-manager's rejection of a missing/invalid CAPTCHA token
- *  (403 "Verification failed" from src/lib/recaptcha.js). The public auth
- *  endpoints have no other 403, so the status alone would nearly do — the
- *  message check keeps a future 403 on these routes from silently reading as a
- *  failed verification. */
+/** central-manager's CAPTCHA rejection: 403 + "Verification failed". The
+ *  message check keeps an unrelated future 403 from reading as a failed check. */
 export function isCaptchaVerificationError(error: unknown): boolean {
 	const response = (error as AxiosError<unknown>)?.response;
 	if (response?.status !== 403) { return false; }
@@ -13,9 +10,7 @@ export function isCaptchaVerificationError(error: unknown): boolean {
 	return message.toLowerCase().includes('verification failed');
 }
 
-// Covers today's plain-string body plus Harper's error/message envelopes and an
-// RFC 9457 problem body's title, so a server-side response reshape cannot
-// silently downgrade the CAPTCHA guidance to the generic error path.
+// Plain string, Harper error/message envelopes, or an RFC 9457 title.
 function firstString(data: unknown, keys: string[]): string {
 	for (const key of keys) {
 		const value = (data as Record<string, unknown>)?.[key];

--- a/src/features/auth/isCaptchaVerificationError.ts
+++ b/src/features/auth/isCaptchaVerificationError.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios';
+
+/** True for central-manager's rejection of a missing/invalid CAPTCHA token
+ *  (403 "Verification failed" from src/lib/recaptcha.js). The public auth
+ *  endpoints have no other 403, so the status alone would nearly do — the
+ *  message check keeps a future 403 on these routes from silently reading as a
+ *  failed verification. */
+export function isCaptchaVerificationError(error: unknown): boolean {
+	const response = (error as AxiosError<unknown>)?.response;
+	if (response?.status !== 403) { return false; }
+	const data = response.data;
+	const message = typeof data === 'string'
+		? data
+		: typeof (data as { error?: unknown; message?: unknown })?.error === 'string'
+		? (data as { error: string }).error
+		: typeof (data as { message?: unknown })?.message === 'string'
+		? (data as { message: string }).message
+		: '';
+	return message.toLowerCase().includes('verification failed');
+}

--- a/src/features/auth/isCaptchaVerificationError.ts
+++ b/src/features/auth/isCaptchaVerificationError.ts
@@ -1,20 +1,20 @@
 import { AxiosError } from 'axios';
 
-/** central-manager's CAPTCHA rejection: 403 + "Verification failed". The
- *  message check keeps an unrelated future 403 from reading as a failed check. */
+const CAPTCHA_MARKER = 'verification failed';
+// Plain string, Harper's error/message envelopes, or an RFC 9457 title/detail.
+const MESSAGE_FIELDS = ['error', 'message', 'title', 'detail'];
+
+/** central-manager's CAPTCHA rejection: 403 + "Verification failed". Every
+ *  candidate field is checked, since a mixed envelope can carry a generic
+ *  string ("Forbidden") alongside the one that names the real cause. */
 export function isCaptchaVerificationError(error: unknown): boolean {
 	const response = (error as AxiosError<unknown>)?.response;
 	if (response?.status !== 403) { return false; }
 	const data = response.data;
-	const message = typeof data === 'string' ? data : firstString(data, ['error', 'message', 'title']);
-	return message.toLowerCase().includes('verification failed');
+	if (typeof data === 'string') { return hasMarker(data); }
+	return MESSAGE_FIELDS.some((field) => hasMarker((data as Record<string, unknown>)?.[field]));
 }
 
-// Plain string, Harper error/message envelopes, or an RFC 9457 title.
-function firstString(data: unknown, keys: string[]): string {
-	for (const key of keys) {
-		const value = (data as Record<string, unknown>)?.[key];
-		if (typeof value === 'string') { return value; }
-	}
-	return '';
+function hasMarker(value: unknown): boolean {
+	return typeof value === 'string' && value.toLowerCase().includes(CAPTCHA_MARKER);
 }

--- a/src/features/auth/isCaptchaVerificationError.ts
+++ b/src/features/auth/isCaptchaVerificationError.ts
@@ -9,12 +9,17 @@ export function isCaptchaVerificationError(error: unknown): boolean {
 	const response = (error as AxiosError<unknown>)?.response;
 	if (response?.status !== 403) { return false; }
 	const data = response.data;
-	const message = typeof data === 'string'
-		? data
-		: typeof (data as { error?: unknown; message?: unknown })?.error === 'string'
-		? (data as { error: string }).error
-		: typeof (data as { message?: unknown })?.message === 'string'
-		? (data as { message: string }).message
-		: '';
+	const message = typeof data === 'string' ? data : firstString(data, ['error', 'message', 'title']);
 	return message.toLowerCase().includes('verification failed');
+}
+
+// Covers today's plain-string body plus Harper's error/message envelopes and an
+// RFC 9457 problem body's title, so a server-side response reshape cannot
+// silently downgrade the CAPTCHA guidance to the generic error path.
+function firstString(data: unknown, keys: string[]): string {
+	for (const key of keys) {
+		const value = (data as Record<string, unknown>)?.[key];
+		if (typeof value === 'string') { return value; }
+	}
+	return '';
 }

--- a/src/lib/recaptcha/recaptchaScript.test.ts
+++ b/src/lib/recaptcha/recaptchaScript.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { siteKey } = vi.hoisted(() => ({ siteKey: { value: 'test-site-key' as string | undefined } }));
+vi.mock('@/config/constants', () => ({
+	get recaptchaSiteKey() {
+		return siteKey.value;
+	},
+}));
+
+import {
+	getCaptchaToken,
+	isCaptchaConfigured,
+	resetRecaptchaScriptCacheForTests,
+	warmCaptcha,
+} from './recaptchaScript';
+
+const SCRIPT_SELECTOR = 'script[src^="https://www.google.com/recaptcha/enterprise.js"]';
+
+function injectedScripts() {
+	return [...document.querySelectorAll<HTMLScriptElement>(SCRIPT_SELECTOR)];
+}
+
+function fakeGrecaptcha(token = 'minted-token') {
+	return {
+		ready: (callback: () => void) => callback(),
+		execute: vi.fn().mockResolvedValue(token),
+	};
+}
+
+/** The real script sets window.grecaptcha then fires load; jsdom fetches nothing. */
+function resolveLatestScript(api = fakeGrecaptcha()) {
+	(window as unknown as { grecaptcha?: unknown }).grecaptcha = { enterprise: api };
+	injectedScripts().at(-1)!.dispatchEvent(new Event('load'));
+	return api;
+}
+
+function failLatestScript() {
+	injectedScripts().at(-1)!.dispatchEvent(new Event('error'));
+}
+
+afterEach(() => {
+	resetRecaptchaScriptCacheForTests();
+	for (const script of injectedScripts()) { script.remove(); }
+	delete (window as unknown as { grecaptcha?: unknown }).grecaptcha;
+	siteKey.value = 'test-site-key';
+	vi.clearAllMocks();
+});
+
+describe('getCaptchaToken', () => {
+	it('injects the script once and mints a token for the given action', async () => {
+		const pending = getCaptchaToken('signup');
+		expect(injectedScripts()).toHaveLength(1);
+		expect(injectedScripts()[0].src).toContain('render=test-site-key');
+
+		const api = resolveLatestScript();
+		await expect(pending).resolves.toBe('minted-token');
+		expect(api.execute).toHaveBeenCalledWith('test-site-key', { action: 'signup' });
+	});
+
+	it('resolves undefined without injecting anything when no site key is configured', async () => {
+		siteKey.value = undefined;
+		await expect(getCaptchaToken('signup')).resolves.toBeUndefined();
+		expect(injectedScripts()).toHaveLength(0);
+		expect(isCaptchaConfigured()).toBe(false);
+	});
+
+	it('resolves undefined when the script cannot load (form submits tokenless)', async () => {
+		const pending = getCaptchaToken('signup');
+		failLatestScript();
+		await expect(pending).resolves.toBeUndefined();
+	});
+
+	it('retries the load on the next submit instead of caching the failure', async () => {
+		// A cached rejection would be a dead end: with central-manager enforcing, a user
+		// whose first script load was blocked could never mint a token.
+		const failed = getCaptchaToken('signup');
+		failLatestScript();
+		await expect(failed).resolves.toBeUndefined();
+		// The dead element is removed so the retry gets a fresh one whose load can fire.
+		expect(injectedScripts()).toHaveLength(0);
+
+		const retried = getCaptchaToken('signup');
+		expect(injectedScripts()).toHaveLength(1);
+		resolveLatestScript();
+		await expect(retried).resolves.toBe('minted-token');
+	});
+
+	it('resolves undefined when execute itself rejects (e.g. invalid site key)', async () => {
+		const api = fakeGrecaptcha();
+		api.execute = vi.fn().mockRejectedValue(new Error('Invalid site key'));
+		const pending = getCaptchaToken('signup');
+		resolveLatestScript(api);
+		await expect(pending).resolves.toBeUndefined();
+	});
+
+	it('resolves undefined when the mint hangs, instead of dead-ending the submit', async () => {
+		// Script loaded but Google's token backend unreachable (captive portal,
+		// partial block): execute never settles. The submit must still go out —
+		// tokenless — matching central-manager's own 3s fail-open.
+		vi.useFakeTimers();
+		try {
+			const api = fakeGrecaptcha();
+			api.execute = vi.fn().mockReturnValue(new Promise<string>(() => {}));
+			const pending = getCaptchaToken('signup');
+			resolveLatestScript(api);
+			await vi.advanceTimersByTimeAsync(4000);
+			await expect(pending).resolves.toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('shares one script injection across concurrent mints', async () => {
+		const first = getCaptchaToken('signup');
+		const second = getCaptchaToken('forgot_password');
+		expect(injectedScripts()).toHaveLength(1);
+
+		const api = resolveLatestScript();
+		await expect(first).resolves.toBe('minted-token');
+		await expect(second).resolves.toBe('minted-token');
+		expect(api.execute).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('warmCaptcha', () => {
+	it('starts the script load without minting', async () => {
+		warmCaptcha();
+		expect(injectedScripts()).toHaveLength(1);
+		const api = resolveLatestScript();
+		// Let the warm promise settle; no token was requested.
+		await Promise.resolve();
+		expect(api.execute).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when unconfigured, and swallows a failed load', async () => {
+		siteKey.value = undefined;
+		warmCaptcha();
+		expect(injectedScripts()).toHaveLength(0);
+
+		siteKey.value = 'test-site-key';
+		warmCaptcha();
+		failLatestScript();
+		// The rejection must not surface as an unhandled error; a later mint retries.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const retried = getCaptchaToken('signup');
+		expect(injectedScripts()).toHaveLength(1);
+		resolveLatestScript();
+		await expect(retried).resolves.toBe('minted-token');
+	});
+});

--- a/src/lib/recaptcha/recaptchaScript.test.ts
+++ b/src/lib/recaptcha/recaptchaScript.test.ts
@@ -74,20 +74,16 @@ describe('getCaptchaToken', () => {
 	});
 
 	it('a hung script load (no load, no error event) times out and stays retryable', async () => {
-		// The regression this pins: a load that never settles left the cached promise
-		// pending forever, so every later submit ate the 4s mint timeout and could
-		// never recover without a full page reload.
 		vi.useFakeTimers();
 		try {
 			const hung = getCaptchaToken('signup');
 			expect(injectedScripts()).toHaveLength(1);
 			await vi.advanceTimersByTimeAsync(8000);
 			await expect(hung).resolves.toBeUndefined();
-			// The dead node is gone and the cache cleared, so the retry re-injects...
+			// Dead node gone, cache cleared: the retry re-injects and can succeed.
 			expect(injectedScripts()).toHaveLength(0);
 			const retried = getCaptchaToken('signup');
 			expect(injectedScripts()).toHaveLength(1);
-			// ...and succeeds once the network recovers.
 			resolveLatestScript();
 			await vi.runAllTimersAsync();
 			await expect(retried).resolves.toBe('minted-token');
@@ -105,12 +101,9 @@ describe('getCaptchaToken', () => {
 	});
 
 	it('retries the load on the next submit instead of caching the failure', async () => {
-		// A cached rejection would be a dead end: with central-manager enforcing, a user
-		// whose first script load was blocked could never mint a token.
 		const failed = getCaptchaToken('signup');
 		failLatestScript();
 		await expect(failed).resolves.toBeUndefined();
-		// The dead element is removed so the retry gets a fresh one whose load can fire.
 		expect(injectedScripts()).toHaveLength(0);
 
 		const retried = getCaptchaToken('signup');
@@ -174,7 +167,6 @@ describe('warmCaptcha', () => {
 		siteKey.value = 'test-site-key';
 		warmCaptcha();
 		failLatestScript();
-		// The rejection must not surface as an unhandled error; a later mint retries.
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		const retried = getCaptchaToken('signup');
 		expect(injectedScripts()).toHaveLength(1);

--- a/src/lib/recaptcha/recaptchaScript.test.ts
+++ b/src/lib/recaptcha/recaptchaScript.test.ts
@@ -73,6 +73,37 @@ describe('getCaptchaToken', () => {
 		await expect(pending).resolves.toBeUndefined();
 	});
 
+	it('a hung script load (no load, no error event) times out and stays retryable', async () => {
+		// The regression this pins: a load that never settles left the cached promise
+		// pending forever, so every later submit ate the 4s mint timeout and could
+		// never recover without a full page reload.
+		vi.useFakeTimers();
+		try {
+			const hung = getCaptchaToken('signup');
+			expect(injectedScripts()).toHaveLength(1);
+			await vi.advanceTimersByTimeAsync(8000);
+			await expect(hung).resolves.toBeUndefined();
+			// The dead node is gone and the cache cleared, so the retry re-injects...
+			expect(injectedScripts()).toHaveLength(0);
+			const retried = getCaptchaToken('signup');
+			expect(injectedScripts()).toHaveLength(1);
+			// ...and succeeds once the network recovers.
+			resolveLatestScript();
+			await vi.runAllTimersAsync();
+			await expect(retried).resolves.toBe('minted-token');
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('a script that loads without exposing the API is removed, not leaked', async () => {
+		const pending = getCaptchaToken('signup');
+		// Fire load without defining window.grecaptcha — a content-filter stub.
+		injectedScripts().at(-1)!.dispatchEvent(new Event('load'));
+		await expect(pending).resolves.toBeUndefined();
+		expect(injectedScripts()).toHaveLength(0);
+	});
+
 	it('retries the load on the next submit instead of caching the failure', async () => {
 		// A cached rejection would be a dead end: with central-manager enforcing, a user
 		// whose first script load was blocked could never mint a token.

--- a/src/lib/recaptcha/recaptchaScript.ts
+++ b/src/lib/recaptcha/recaptchaScript.ts
@@ -76,6 +76,11 @@ async function mintToken(action: string): Promise<string> {
 	return enterprise.execute(recaptchaSiteKey, { action });
 }
 
+// A <script> that fires neither load nor error (connection stall, captive
+// portal) would otherwise leave the cached promise pending forever, poisoning
+// every later submit even after the network recovers.
+const LOAD_TIMEOUT_MS = 8000;
+
 function injectScript(): Promise<GrecaptchaEnterprise> {
 	return new Promise<GrecaptchaEnterprise>((resolve, reject) => {
 		if (window.grecaptcha?.enterprise) {
@@ -86,16 +91,20 @@ function injectScript(): Promise<GrecaptchaEnterprise> {
 		script.src = `https://www.google.com/recaptcha/enterprise.js?render=${encodeURIComponent(recaptchaSiteKey)}`;
 		script.async = true;
 		script.defer = true;
-		script.addEventListener('load', () => {
-			if (window.grecaptcha?.enterprise) { resolve(window.grecaptcha.enterprise); }
-			else { reject(new Error('reCAPTCHA script loaded without exposing its API')); }
-		});
-		script.addEventListener('error', () => {
-			// Removed so a retry re-injects rather than finding a dead element whose
-			// load event has already come and gone.
+		// Every rejection removes the node so a retry re-injects a fresh element
+		// rather than finding a dead one whose load event has come and gone.
+		const fail = (message: string) => {
+			clearTimeout(loadTimer);
 			script.remove();
-			reject(new Error('reCAPTCHA script failed to load'));
+			reject(new Error(message));
+		};
+		const loadTimer = setTimeout(() => fail('reCAPTCHA script load timed out'), LOAD_TIMEOUT_MS);
+		script.addEventListener('load', () => {
+			clearTimeout(loadTimer);
+			if (window.grecaptcha?.enterprise) { resolve(window.grecaptcha.enterprise); }
+			else { fail('reCAPTCHA script loaded without exposing its API'); }
 		});
+		script.addEventListener('error', () => fail('reCAPTCHA script failed to load'));
 		document.head.appendChild(script);
 	});
 }

--- a/src/lib/recaptcha/recaptchaScript.ts
+++ b/src/lib/recaptcha/recaptchaScript.ts
@@ -1,0 +1,106 @@
+import { recaptchaSiteKey } from '@/config/constants';
+
+interface GrecaptchaEnterprise {
+	ready: (callback: () => void) => void;
+	execute: (siteKey: string, options: { action: string }) => Promise<string>;
+}
+
+declare global {
+	interface Window {
+		grecaptcha?: { enterprise?: GrecaptchaEnterprise };
+	}
+}
+
+/** Whether a site key is configured — the difference between "no CAPTCHA in this
+ *  environment" and "CAPTCHA expected but the script could not run". */
+export function isCaptchaConfigured(): boolean {
+	return Boolean(recaptchaSiteKey);
+}
+
+let scriptPromise: Promise<GrecaptchaEnterprise> | undefined;
+
+/** Loads Google's reCAPTCHA Enterprise script once per page and resolves its
+ *  global API. enterprise.js, not api.js: central-manager verifies through the
+ *  Enterprise assessments API, and Google's documented pairing for Cloud-console
+ *  score keys is enterprise.js + grecaptcha.enterprise.execute. Loading also
+ *  renders the mandatory reCAPTCHA badge (bottom-right). */
+function loadRecaptcha(): Promise<GrecaptchaEnterprise> {
+	// Success is cached so a remount cannot re-inject the script; failure is
+	// deliberately NOT cached. Against an enforcing central-manager the token is the
+	// user's only way through, so a blocked or flaky load has to stay retryable.
+	scriptPromise ??= injectScript().catch((error: unknown) => {
+		scriptPromise = undefined;
+		throw error;
+	});
+	return scriptPromise;
+}
+
+/** Kick the script load off early (form mount) so the badge is visible and the
+ *  submit-time mint doesn't pay the download. No-op when unconfigured. */
+export function warmCaptcha(): void {
+	if (!isCaptchaConfigured()) { return; }
+	void loadRecaptcha().catch(() => {
+		// Swallowed: warming is opportunistic. getCaptchaToken retries the load and
+		// owns the failure behavior.
+	});
+}
+
+// Mirrors central-manager's 3s assessment abort: a mint that hangs (script loaded
+// but Google's token backend unreachable — captive portal, partial block) must
+// degrade to a tokenless submit, not a dead form.
+const MINT_TIMEOUT_MS = 4000;
+
+/** Mint a reCAPTCHA token for one submit. Tokens are single use and expire in
+ *  two minutes, so this is called at submit time, never at mount.
+ *
+ *  Resolves undefined when no site key is configured or the script/mint failed or
+ *  timed out — the caller submits tokenless. central-manager fails open when it
+ *  cannot reach Google, so a blocked script must not lock a real user out; when
+ *  the server IS enforcing, its 403 comes back and the form explains the real
+ *  problem via isCaptchaConfigured(). */
+export async function getCaptchaToken(action: string): Promise<string | undefined> {
+	if (!recaptchaSiteKey) { return undefined; }
+	try {
+		return await Promise.race([
+			mintToken(action),
+			new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), MINT_TIMEOUT_MS)),
+		]);
+	} catch {
+		return undefined;
+	}
+}
+
+async function mintToken(action: string): Promise<string> {
+	const enterprise = await loadRecaptcha();
+	await new Promise<void>((resolve) => enterprise.ready(resolve));
+	return enterprise.execute(recaptchaSiteKey, { action });
+}
+
+function injectScript(): Promise<GrecaptchaEnterprise> {
+	return new Promise<GrecaptchaEnterprise>((resolve, reject) => {
+		if (window.grecaptcha?.enterprise) {
+			resolve(window.grecaptcha.enterprise);
+			return;
+		}
+		const script = document.createElement('script');
+		script.src = `https://www.google.com/recaptcha/enterprise.js?render=${encodeURIComponent(recaptchaSiteKey)}`;
+		script.async = true;
+		script.defer = true;
+		script.addEventListener('load', () => {
+			if (window.grecaptcha?.enterprise) { resolve(window.grecaptcha.enterprise); }
+			else { reject(new Error('reCAPTCHA script loaded without exposing its API')); }
+		});
+		script.addEventListener('error', () => {
+			// Removed so a retry re-injects rather than finding a dead element whose
+			// load event has already come and gone.
+			script.remove();
+			reject(new Error('reCAPTCHA script failed to load'));
+		});
+		document.head.appendChild(script);
+	});
+}
+
+/** Test-only: drops the cached load so each case starts from a clean page. */
+export function resetRecaptchaScriptCacheForTests() {
+	scriptPromise = undefined;
+}

--- a/src/lib/recaptcha/recaptchaScript.ts
+++ b/src/lib/recaptcha/recaptchaScript.ts
@@ -11,23 +11,18 @@ declare global {
 	}
 }
 
-/** Whether a site key is configured — the difference between "no CAPTCHA in this
- *  environment" and "CAPTCHA expected but the script could not run". */
+/** Distinguishes "no CAPTCHA in this env" from "expected but couldn't run". */
 export function isCaptchaConfigured(): boolean {
 	return Boolean(recaptchaSiteKey);
 }
 
 let scriptPromise: Promise<GrecaptchaEnterprise> | undefined;
 
-/** Loads Google's reCAPTCHA Enterprise script once per page and resolves its
- *  global API. enterprise.js, not api.js: central-manager verifies through the
- *  Enterprise assessments API, and Google's documented pairing for Cloud-console
- *  score keys is enterprise.js + grecaptcha.enterprise.execute. Loading also
- *  renders the mandatory reCAPTCHA badge (bottom-right). */
+/** Loads enterprise.js once per page (pairs with central-manager's Enterprise
+ *  assessments API) and renders the mandatory badge. */
 function loadRecaptcha(): Promise<GrecaptchaEnterprise> {
-	// Success is cached so a remount cannot re-inject the script; failure is
-	// deliberately NOT cached. Against an enforcing central-manager the token is the
-	// user's only way through, so a blocked or flaky load has to stay retryable.
+	// Success is cached; failure is not — a blocked load must stay retryable, or
+	// an enforcing central-manager locks the user out until a reload.
 	scriptPromise ??= injectScript().catch((error: unknown) => {
 		scriptPromise = undefined;
 		throw error;
@@ -35,29 +30,20 @@ function loadRecaptcha(): Promise<GrecaptchaEnterprise> {
 	return scriptPromise;
 }
 
-/** Kick the script load off early (form mount) so the badge is visible and the
- *  submit-time mint doesn't pay the download. No-op when unconfigured. */
+/** Starts the load at form mount so the mint doesn't pay the download. */
 export function warmCaptcha(): void {
 	if (!isCaptchaConfigured()) { return; }
-	void loadRecaptcha().catch(() => {
-		// Swallowed: warming is opportunistic. getCaptchaToken retries the load and
-		// owns the failure behavior.
-	});
+	// Opportunistic: getCaptchaToken retries the load and owns failure behavior.
+	void loadRecaptcha().catch(() => {});
 }
 
-// Mirrors central-manager's 3s assessment abort: a mint that hangs (script loaded
-// but Google's token backend unreachable — captive portal, partial block) must
-// degrade to a tokenless submit, not a dead form.
+// A hung mint (captive portal, partial block) must degrade to a tokenless
+// submit, not a dead form — mirrors central-manager's 3s assessment abort.
 const MINT_TIMEOUT_MS = 4000;
 
-/** Mint a reCAPTCHA token for one submit. Tokens are single use and expire in
- *  two minutes, so this is called at submit time, never at mount.
- *
- *  Resolves undefined when no site key is configured or the script/mint failed or
- *  timed out — the caller submits tokenless. central-manager fails open when it
- *  cannot reach Google, so a blocked script must not lock a real user out; when
- *  the server IS enforcing, its 403 comes back and the form explains the real
- *  problem via isCaptchaConfigured(). */
+/** Mints one single-use token per submit (tokens expire in ~2 min). Resolves
+ *  undefined on any failure so the caller submits tokenless; an enforcing
+ *  server 403s that and the form explains via isCaptchaConfigured(). */
 export async function getCaptchaToken(action: string): Promise<string | undefined> {
 	if (!recaptchaSiteKey) { return undefined; }
 	try {
@@ -76,9 +62,8 @@ async function mintToken(action: string): Promise<string> {
 	return enterprise.execute(recaptchaSiteKey, { action });
 }
 
-// A <script> that fires neither load nor error (connection stall, captive
-// portal) would otherwise leave the cached promise pending forever, poisoning
-// every later submit even after the network recovers.
+// A script firing neither load nor error would leave the cached promise
+// pending forever, poisoning every later submit.
 const LOAD_TIMEOUT_MS = 8000;
 
 function injectScript(): Promise<GrecaptchaEnterprise> {
@@ -91,8 +76,7 @@ function injectScript(): Promise<GrecaptchaEnterprise> {
 		script.src = `https://www.google.com/recaptcha/enterprise.js?render=${encodeURIComponent(recaptchaSiteKey)}`;
 		script.async = true;
 		script.defer = true;
-		// Every rejection removes the node so a retry re-injects a fresh element
-		// rather than finding a dead one whose load event has come and gone.
+		// Rejections remove the node so a retry re-injects a fresh element.
 		const fail = (message: string) => {
 			clearTimeout(loadTimer);
 			script.remove();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,7 @@ interface ImportMetaEnv {
 	readonly VITE_LOCAL_STUDIO_DEV_URL: string;
 	readonly VITE_REO_DEV_CLIENT_ID: string;
 	readonly VITE_CENTRAL_MANAGER_API_URL: string;
+	readonly VITE_RECAPTCHA_SITE_KEY: string;
 	readonly VITE_DISABLE_DEVTOOLS: string;
 	// more env variables...
 }


### PR DESCRIPTION
Adds an invisible reCAPTCHA Enterprise check to the two public auth forms — signup and forgot-password — so [central-manager#677](https://github.com/HarperFast/central-manager/pull/677) can reject the scripted signups and reset-email bombing from the August 2026 campaign before it creates a user or sends an email. Nobody ever picks pictures: Google scores the interaction in the background, the form sends a single-use token as `captchaToken`, and the only visible change is Google's standard badge on those two pages. With `VITE_RECAPTCHA_SITE_KEY` unset the loader is tree-shaken out of the bundle entirely, so nothing changes in an environment that has no key.

## For the human reviewer

1. **Forgot-password shows a CAPTCHA 403 twice — inline *and* in the global toast.** Silencing the toast means routing every forgot-password error inline the way SignUp already does, which is #1612's design rather than this PR's, so I left it. @dawsontoth you own that mechanism — if you'd rather forgot-password converted fully to inline, say so and I'll do it here. Both messages are accurate; only one is actionable.
2. **Any mint or script failure submits tokenless rather than blocking.** central-manager fails open when *it* can't verify, so the client matches: a user on a network that blocks Google still gets through. The cost is that this PR stops zero abuse on its own — all of the enforcement lives server-side. Reversible in one file.
3. **The 403 is classified by matching the literal string `"verification failed"`** across two repos, rather than a structured error code central-manager owns. Cheap to change now, sticky once both sides ship: if CM ever rewords that message the client silently drops back to the generic error and the tailored guidance disappears. A shared error code would be the root-cause fix.
4. **The error + `ContactUs` block is duplicated in both forms** rather than extracted to a shared component. Two copies can drift; the `mailto` itself can't, since it lives in the existing `ContactUs`. Extraction is a ~6-line JSX component — worth it if you disagree with the call.
5. **Support is offered after the *second* consecutive rejection, not the first.** A single failure is often a spent or stale token where retrying genuinely works, so offering support immediately would train people to email us over a self-healing blip. A low score, by contrast, cannot be retried away — the signals behind it don't change — which is why "please try again" alone was a dead end worth fixing.

## Verification

- `pnpm test` — 2298 pass, 11 skipped, 296 files; coverage for this change lives in four test files, three of them new (`recaptchaScript.test.ts`, `isCaptchaVerificationError.test.ts`, `ForgotPassword.test.tsx`) plus additions to the existing `SignUp.test.tsx`. `tsc -b`, `oxlint`, `dprint` clean. Rebased onto current `stage` (23 commits, including the typed-Axios 1.19 adaptation) and re-run against a fresh `pnpm install --frozen-lockfile`, not stale `node_modules`.
- **Proven end to end against a live, enforcing stage central-manager** (that branch deployed, real stage key, local studio pointed at stage): signup **201** — real user created, verification email sent, so the `'signup'` action, origin hostname and score all cleared a real Google assessment — and forgot-password **200**, against **403** for a garbage token and **403** for no token at all. Raising the `RECAPTCHA_MIN_SCORE` Configuration row then made a normally-passing token 403 with this PR's "please try again" wording, which is the score branch and the client's message selection both firing for real.
- **Browser-verified UI states**: badge renders on both forms; a blocked script yields a tokenless submit and the "could not run the verification check" variant rather than the retry one; two consecutive rejections surface the `mailto:support@harperdb.io` link. That last check caught a formatter-eaten space ("try again.Contact us"), now fixed and pinned by an assertion.
- Both site keys are build-verified in isolation: the prod bundle carries only the prod key, the stage bundle only the stage key.
- Not executed: e2e/Playwright (no reCAPTCHA-capable fixture). No organically low-scoring bot has been observed — the score branch was proven by raising the threshold above a good score, not by watching a bad one fail.

## Review coverage

Authored by Claude (Fable 5). Cross-model pre-push review, two rounds against `origin/stage`. Round 1 (**full**, @ 7466e5c4): codex `gpt-5.6-sol` ✓ (graded), gemini via `agy` (default model) ✓, Harper domain adjudication ✓ — `Adjudicated-Severity: minor`; cursor-grok ✗ (cursor-agent not installed on this machine). Round 2 (delta, @ f5e4b9fe): same three legs, no new findings — converged. Independent coverage: true, both rounds. The comment nit was taken; the double-message finding is deliberately unresolved and is ledger entry 1 above. Three commits since the last reviewed SHA are trivial-tier and unreviewed by the legs: two comment rewordings and the prod site-key value (a config value flowing through the already-reviewed configured/unconfigured branches).

Refs HarperFast/central-manager#627 — cross-repo and based on `stage`, so closing keywords won't fire; #627 closes when both halves land.

⚠️ **Deploy ordering matters.** Stage central-manager is already enforcing, so `stage.studio.harperfabric.com` is currently 403ing both auth forms until this deploys — this PR is the fix. For production the reverse holds: this must deploy *before* `RECAPTCHA_API_KEY` lands in `FABRIC_PRODUCTION`, or prod signups 403 in the gap. Note the badge appears on prod as soon as this deploys, ahead of enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>Human-Review-Need: 4 @ f53d9c610d83</sub>
