### PR TITLE
feat(apis-explorer): session-scoped credentials and a real log-in flow

### DIFF
--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -2,8 +2,8 @@ import { isLocalStudio, localStudioDevUrl } from '@/config/constants';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
 import {
-	forgetAllEntitySettings,
 	forgetEntitySettings,
+	pruneStaleEntitySettings,
 	scrubLegacySettings,
 } from '@/features/instance/apis/explorer/settings';
 import { SchemaCluster, SchemaHdbInstance } from '@/integrations/api/api.gen';
@@ -76,36 +76,47 @@ class AuthStore {
 	private readonly fabricConnectInFlight = new Map<EntityIds, Promise<LocalUser>>();
 	private readonly operationTokenRefreshInFlight = new Map<EntityIds, Promise<string | null>>();
 
-	// Per-entity count of sign-out events. The API explorer keeps its credential per browser tab
-	// (sessionStorage), so a sign-out in one tab can't reach another's storage directly: this epoch is
-	// bumped on every sign-out and mirrored to localStorage, letting the explorer (a) reject an
-	// in-flight token mint that resolves after a sign-out and (b) clear its own tab's stored credential
-	// when another tab signs the entity out.
-	private readonly explorerAuthEpoch = new Map<EntityIds, number>();
-	private explorerEpochSeq = Date.now();
+	// Sign-out generations for the API explorer, per entity plus a global `'*'` slot. The explorer keeps
+	// its credential per browser tab (sessionStorage), which SURVIVES a reload — so an event-only signal
+	// is not enough: a tab that reloads after another tab signed out would never see the event. The
+	// generation therefore lives in localStorage (durable, shared) and each stored credential records the
+	// generation it was created under, so a stale credential is detected by comparison at read time
+	// regardless of whether this tab was running when the sign-out happened.
 	private readonly explorerAuthEpochKey = 'Studio:ExplorerAuthEpoch';
 
 	constructor() {
 		this.potentiallyAuthenticated = JSON.parse(localStorage.getItem(this.potentiallyAuthenticatedKey) || '{}');
 	}
 
+	private readExplorerGenerations(): Record<string, number> {
+		try {
+			const raw = JSON.parse(localStorage.getItem(this.explorerAuthEpochKey) || '{}') as unknown;
+			return raw && typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, number> : {};
+		} catch {
+			return {};
+		}
+	}
+
 	/**
-	 * Current sign-out epoch for an entity — its own count plus the global (`'*'`) count, so a global
-	 * logout advances every entity's epoch even in the same tab (where no `storage` event fires). The
-	 * explorer stamps a mint with it and re-checks before applying.
+	 * Current sign-out generation for an entity — its own count plus the global (`'*'`) count, so a
+	 * global logout advances every entity's generation. The explorer stamps a credential with this and
+	 * compares before using it (and before applying an in-flight mint).
 	 */
 	public getExplorerAuthEpoch(id: EntityIds): number {
-		return (this.explorerAuthEpoch.get(id) ?? 0) + (this.explorerAuthEpoch.get('*') ?? 0);
+		const generations = this.readExplorerGenerations();
+		const own = typeof generations[id] === 'number' ? generations[id] : 0;
+		const all = typeof generations['*'] === 'number' ? generations['*'] : 0;
+		return own + all;
 	}
 
 	private writeExplorerInvalidation(id: EntityIds | '*'): void {
-		// Increment the raw slot (not getExplorerAuthEpoch, which folds in the '*' count).
-		this.explorerAuthEpoch.set(id, (this.explorerAuthEpoch.get(id) ?? 0) + 1);
 		try {
-			// Value must differ each write so other tabs' `storage` listeners fire.
-			localStorage.setItem(this.explorerAuthEpochKey, JSON.stringify({ id, seq: ++this.explorerEpochSeq }));
+			const generations = this.readExplorerGenerations();
+			const current = typeof generations[id] === 'number' ? generations[id] : 0;
+			// The value changes on every write, so other tabs' `storage` listeners still fire.
+			localStorage.setItem(this.explorerAuthEpochKey, JSON.stringify({ ...generations, [id]: current + 1 }));
 		} catch {
-			// Storage disabled — the in-memory epoch still guards the same-tab in-flight-mint race.
+			// Storage disabled: the explorer's per-tab clearing on sign-out still applies within this tab.
 		}
 	}
 
@@ -119,39 +130,13 @@ class AuthStore {
 	}
 
 	/**
-	 * The entity a mirrored invalidation names (`'*'` = all), or null if the event isn't one. Advances
-	 * this tab's in-memory epoch for that entity as a side effect, so an in-flight mint here is
-	 * invalidated by another tab's sign-out too — the epoch stays authoritative in every tab. Each
-	 * installed listener advances it, which is fine: only a *change* in the value is meaningful.
+	 * Subscribe to a change in the explorer sign-out generation (any entity, or a global logout). The
+	 * caller re-compares its own entity's stamped generation rather than trusting the event to name one,
+	 * which is the same check that runs at bootstrap — so a missed event can't leave a stale credential.
 	 */
-	private parseExplorerInvalidation(event: StorageEvent): string | null {
-		if (event.key !== this.explorerAuthEpochKey || !event.newValue) {
-			return null;
-		}
-		let id: string | null = null;
-		try {
-			const parsed = JSON.parse(event.newValue) as { id?: string };
-			id = typeof parsed.id === 'string' ? parsed.id : null;
-		} catch {
-			return null;
-		}
-		if (id !== null) {
-			this.explorerAuthEpoch.set(id, (this.explorerAuthEpoch.get(id) ?? 0) + 1);
-		}
-		return id;
-	}
-
-	/**
-	 * Subscribe to cross-tab sign-out of one entity (or a global `'*'` logout). Fires when another tab
-	 * signs `id` out via the mirrored epoch key; the caller resets its live auth state. The browser only
-	 * delivers `storage` events to other documents, so the signing-out tab is unaffected (it clears
-	 * itself directly). This is component-lifetime; a tab whose explorer is unmounted relies on the
-	 * always-on `installExplorerCrossTabCleanup` listener to scrub its stored credential.
-	 */
-	public onExplorerAuthInvalidated(id: EntityIds, callback: () => void): () => void {
+	public onExplorerAuthInvalidated(_id: EntityIds, callback: () => void): () => void {
 		const handler = (event: StorageEvent) => {
-			const invalidated = this.parseExplorerInvalidation(event);
-			if (invalidated === id || invalidated === '*') {
+			if (event.key === this.explorerAuthEpochKey) {
 				callback();
 			}
 		};
@@ -160,20 +145,21 @@ class AuthStore {
 	}
 
 	/**
-	 * App-level (always-on) listener that clears the per-tab explorer credential for an entity another
-	 * tab signed out — even when this tab's explorer is unmounted, so a tab that navigated away can't
-	 * later restore a revoked token. Also re-scrubs the legacy localStorage secret if a pre-upgrade tab
-	 * rewrote it. Installed once at bootstrap.
+	 * App-level cleanup, installed once at bootstrap. Runs immediately — reconciling credentials stored
+	 * in this tab's sessionStorage (which survives a reload) against the durable generation, so a
+	 * sign-out that happened while this tab was closed or reloading is still honored — and again whenever
+	 * the generation changes, so an unmounted explorer's credential is dropped too.
 	 */
 	public installExplorerCrossTabCleanup(): () => void {
-		const handler = (event: StorageEvent) => {
-			const invalidated = this.parseExplorerInvalidation(event);
-			if (invalidated === '*') {
-				forgetAllEntitySettings();
-			} else if (invalidated) {
-				forgetEntitySettings(invalidated);
-			}
+		const reconcile = () => {
+			pruneStaleEntitySettings(entityId => this.getExplorerAuthEpoch(entityId));
 			scrubLegacySettings();
+		};
+		reconcile();
+		const handler = (event: StorageEvent) => {
+			if (event.key === this.explorerAuthEpochKey) {
+				reconcile();
+			}
 		};
 		window.addEventListener('storage', handler);
 		return () => window.removeEventListener('storage', handler);

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -72,8 +72,56 @@ class AuthStore {
 	private readonly fabricConnectInFlight = new Map<EntityIds, Promise<LocalUser>>();
 	private readonly operationTokenRefreshInFlight = new Map<EntityIds, Promise<string | null>>();
 
+	// Per-entity count of sign-out events. The API explorer keeps its credential per browser tab
+	// (sessionStorage), so a sign-out in one tab can't reach another's storage directly: this epoch is
+	// bumped on every sign-out and mirrored to localStorage, letting the explorer (a) reject an
+	// in-flight token mint that resolves after a sign-out and (b) clear its own tab's stored credential
+	// when another tab signs the entity out.
+	private readonly explorerAuthEpoch = new Map<EntityIds, number>();
+	private explorerEpochSeq = Date.now();
+	private readonly explorerAuthEpochKey = 'Studio:ExplorerAuthEpoch';
+
 	constructor() {
 		this.potentiallyAuthenticated = JSON.parse(localStorage.getItem(this.potentiallyAuthenticatedKey) || '{}');
+	}
+
+	/** Current per-entity sign-out epoch; the explorer stamps a mint with it and re-checks before applying. */
+	public getExplorerAuthEpoch(id: EntityIds): number {
+		return this.explorerAuthEpoch.get(id) ?? 0;
+	}
+
+	private bumpExplorerAuthEpoch(id: EntityIds): void {
+		this.explorerAuthEpoch.set(id, this.getExplorerAuthEpoch(id) + 1);
+		try {
+			// Value must differ each write so other tabs' `storage` listeners fire.
+			localStorage.setItem(this.explorerAuthEpochKey, JSON.stringify({ id, seq: ++this.explorerEpochSeq }));
+		} catch {
+			// Storage disabled — the in-memory epoch still guards the same-tab in-flight-mint race.
+		}
+	}
+
+	/**
+	 * Subscribe to cross-tab sign-out of one entity. Fires when another tab signs `id` out (via the
+	 * mirrored epoch key); the caller clears its own tab's stored explorer credential in response. The
+	 * browser only delivers `storage` events to other documents, so the tab that signed out is
+	 * unaffected (it clears itself directly).
+	 */
+	public onExplorerAuthInvalidated(id: EntityIds, callback: () => void): () => void {
+		const handler = (event: StorageEvent) => {
+			if (event.key !== this.explorerAuthEpochKey || !event.newValue) {
+				return;
+			}
+			try {
+				const parsed = JSON.parse(event.newValue) as { id?: string };
+				if (parsed.id === id) {
+					callback();
+				}
+			} catch {
+				// Ignore a malformed signal rather than throwing into the storage-event dispatch.
+			}
+		};
+		window.addEventListener('storage', handler);
+		return () => window.removeEventListener('storage', handler);
 	}
 
 	public getAllConnections(): Record<EntityIds, AuthenticatedConnection> {
@@ -153,6 +201,11 @@ class AuthStore {
 			this.flagKeyAsSignedIn(id, key);
 		} else {
 			this.flagKeyAsSignedOut(id);
+			// Every per-entity disconnect funnels through here (ClusterHome/ClusterCard call
+			// setUserForEntity(entity, null)), so clear the API explorer's stored credentials for the
+			// entity here too — otherwise the next user to sign into the same entity would inherit them.
+			forgetEntitySettings(id);
+			this.bumpExplorerAuthEpoch(id);
 		}
 		this.updateConnectionIfChanged(id, false, user);
 	}
@@ -416,6 +469,7 @@ class AuthStore {
 		this.flagKeyAsSignedOut(id);
 		this.updateConnectionIfChanged(id, false, null);
 		forgetEntitySettings(id);
+		this.bumpExplorerAuthEpoch(id);
 	}
 
 	/**

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -118,17 +118,27 @@ class AuthStore {
 		this.writeExplorerInvalidation('*');
 	}
 
-	/** The entity a mirrored invalidation names (`'*'` = all), or null if the event isn't one. */
+	/**
+	 * The entity a mirrored invalidation names (`'*'` = all), or null if the event isn't one. Advances
+	 * this tab's in-memory epoch for that entity as a side effect, so an in-flight mint here is
+	 * invalidated by another tab's sign-out too — the epoch stays authoritative in every tab. Each
+	 * installed listener advances it, which is fine: only a *change* in the value is meaningful.
+	 */
 	private parseExplorerInvalidation(event: StorageEvent): string | null {
 		if (event.key !== this.explorerAuthEpochKey || !event.newValue) {
 			return null;
 		}
+		let id: string | null = null;
 		try {
 			const parsed = JSON.parse(event.newValue) as { id?: string };
-			return typeof parsed.id === 'string' ? parsed.id : null;
+			id = typeof parsed.id === 'string' ? parsed.id : null;
 		} catch {
 			return null;
 		}
+		if (id !== null) {
+			this.explorerAuthEpoch.set(id, (this.explorerAuthEpoch.get(id) ?? 0) + 1);
+		}
+		return id;
 	}
 
 	/**
@@ -489,6 +499,8 @@ class AuthStore {
 			this.updateConnectionIfChanged(entityId, false, null);
 			this.flagKeyAsSignedOut(entityId);
 			this.fabricConnectAuth.delete(entityId);
+			forgetEntitySettings(entityId);
+			this.bumpExplorerAuthEpoch(entityId);
 			if (entityId === OverallAppSignIn) {
 				continue;
 			}

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -1,6 +1,7 @@
 import { isLocalStudio, localStudioDevUrl } from '@/config/constants';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
+import { forgetEntitySettings } from '@/features/instance/apis/explorer/settings';
 import { SchemaCluster, SchemaHdbInstance } from '@/integrations/api/api.gen';
 import { Cluster, Instance, LocalUser, User } from '@/integrations/api/api.patch';
 import {
@@ -10,28 +11,11 @@ import {
 import { onInstanceLogoutSubmit } from '@/integrations/api/instance/auth/onInstanceLogoutSubmit';
 import { getInstanceUserInfo } from '@/integrations/api/instance/status/getInstanceUserInfo';
 import { sleep } from '@/lib/sleep';
-import { getLocalStorage } from '@/lib/storage/getLocalStorage';
-import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
-import { setLocalStorage } from '@/lib/storage/setLocalStorage';
 import { isCluster } from '@/lib/types/isCluster';
 import { isInstance } from '@/lib/types/isInstance';
 import { getOperationsUrlForCluster } from '@/lib/urls/getOperationsUrlForCluster';
 import { getOperationsUrlForInstance } from '@/lib/urls/getOperationsUrlForInstance';
-
-/**
- * Drop the API explorer's persisted server/credentials for one entity. The explorer keeps a Basic
- * password or Bearer token per entity in localStorage; sign-out must not leave it for a later
- * connection to reuse. (Full sign-out clears all of localStorage; this covers per-entity sign-out.)
- */
-function forgetApiExplorerSettings(id: EntityIds): void {
-	const settings = getLocalStorage<Record<string, unknown>>(LocalStorageKeys.ApiExplorerSettings, {});
-	// A corrupted value (a primitive, or an array) must not throw and abort sign-out; hasOwnProperty
-	// (not `in`) so an entity id can't match an inherited prototype key.
-	if (settings && typeof settings === 'object' && !Array.isArray(settings) && Object.hasOwn(settings, id)) {
-		delete settings[id];
-		setLocalStorage(LocalStorageKeys.ApiExplorerSettings, settings);
-	}
-}
+import { isDirectOperationsUrl } from '@/lib/urls/isDirectOperationsUrl';
 
 type AuthStoreListenerCleanup = () => void;
 
@@ -60,13 +44,6 @@ type OverallAppSignInType = typeof OverallAppSignIn;
 
 export type EntityIds = OverallAppSignInType | Instance['id'] | Cluster['id'];
 type EntityTypes = OverallAppSignInType | Instance | Cluster | null;
-
-// The Fabric Connect proxy routes through these central-manager paths (see getInstanceClient). A
-// direct operations URL must never be one of them, or we'd send the instance Bearer JWT to the proxy
-// origin instead of the instance.
-function isDirectOperationsUrl(url: string | null | undefined): url is string {
-	return !!url && !url.includes('/HDBInstance/') && !url.includes('/Cluster/');
-}
 
 class AuthStore {
 	private readonly broadListeners: Array<(connection: AuthenticatedConnection, id: EntityIds) => void> = [];
@@ -438,7 +415,7 @@ class AuthStore {
 		this.flagForFabricConnect(id, false);
 		this.flagKeyAsSignedOut(id);
 		this.updateConnectionIfChanged(id, false, null);
-		forgetApiExplorerSettings(id);
+		forgetEntitySettings(id);
 	}
 
 	/**

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -1,7 +1,11 @@
 import { isLocalStudio, localStudioDevUrl } from '@/config/constants';
 import { getInstanceClient } from '@/config/getInstanceClient';
 import { getCurrentUser } from '@/features/auth/queries/getCurrentUser';
-import { forgetEntitySettings } from '@/features/instance/apis/explorer/settings';
+import {
+	forgetAllEntitySettings,
+	forgetEntitySettings,
+	scrubLegacySettings,
+} from '@/features/instance/apis/explorer/settings';
 import { SchemaCluster, SchemaHdbInstance } from '@/integrations/api/api.gen';
 import { Cluster, Instance, LocalUser, User } from '@/integrations/api/api.patch';
 import {
@@ -90,7 +94,7 @@ class AuthStore {
 		return this.explorerAuthEpoch.get(id) ?? 0;
 	}
 
-	private bumpExplorerAuthEpoch(id: EntityIds): void {
+	private writeExplorerInvalidation(id: EntityIds | '*'): void {
 		this.explorerAuthEpoch.set(id, this.getExplorerAuthEpoch(id) + 1);
 		try {
 			// Value must differ each write so other tabs' `storage` listeners fire.
@@ -100,25 +104,61 @@ class AuthStore {
 		}
 	}
 
+	private bumpExplorerAuthEpoch(id: EntityIds): void {
+		this.writeExplorerInvalidation(id);
+	}
+
+	/** Signal every tab's explorer to clear, regardless of entity — used on a global (all-entity) logout. */
+	private bumpExplorerAuthEpochAll(): void {
+		this.writeExplorerInvalidation('*');
+	}
+
+	/** The entity a mirrored invalidation names (`'*'` = all), or null if the event isn't one. */
+	private parseExplorerInvalidation(event: StorageEvent): string | null {
+		if (event.key !== this.explorerAuthEpochKey || !event.newValue) {
+			return null;
+		}
+		try {
+			const parsed = JSON.parse(event.newValue) as { id?: string };
+			return typeof parsed.id === 'string' ? parsed.id : null;
+		} catch {
+			return null;
+		}
+	}
+
 	/**
-	 * Subscribe to cross-tab sign-out of one entity. Fires when another tab signs `id` out (via the
-	 * mirrored epoch key); the caller clears its own tab's stored explorer credential in response. The
-	 * browser only delivers `storage` events to other documents, so the tab that signed out is
-	 * unaffected (it clears itself directly).
+	 * Subscribe to cross-tab sign-out of one entity (or a global `'*'` logout). Fires when another tab
+	 * signs `id` out via the mirrored epoch key; the caller resets its live auth state. The browser only
+	 * delivers `storage` events to other documents, so the signing-out tab is unaffected (it clears
+	 * itself directly). This is component-lifetime; a tab whose explorer is unmounted relies on the
+	 * always-on `installExplorerCrossTabCleanup` listener to scrub its stored credential.
 	 */
 	public onExplorerAuthInvalidated(id: EntityIds, callback: () => void): () => void {
 		const handler = (event: StorageEvent) => {
-			if (event.key !== this.explorerAuthEpochKey || !event.newValue) {
-				return;
+			const invalidated = this.parseExplorerInvalidation(event);
+			if (invalidated === id || invalidated === '*') {
+				callback();
 			}
-			try {
-				const parsed = JSON.parse(event.newValue) as { id?: string };
-				if (parsed.id === id) {
-					callback();
-				}
-			} catch {
-				// Ignore a malformed signal rather than throwing into the storage-event dispatch.
+		};
+		window.addEventListener('storage', handler);
+		return () => window.removeEventListener('storage', handler);
+	}
+
+	/**
+	 * App-level (always-on) listener that clears the per-tab explorer credential for an entity another
+	 * tab signed out — even when this tab's explorer is unmounted, so a tab that navigated away can't
+	 * later restore a revoked token. Also re-scrubs the legacy localStorage secret if a pre-upgrade tab
+	 * rewrote it. Installed once at bootstrap.
+	 */
+	public installExplorerCrossTabCleanup(): () => void {
+		const handler = (event: StorageEvent) => {
+			const invalidated = this.parseExplorerInvalidation(event);
+			if (invalidated === '*') {
+				forgetAllEntitySettings();
+			} else if (invalidated) {
+				forgetEntitySettings(invalidated);
 			}
+			scrubLegacySettings();
 		};
 		window.addEventListener('storage', handler);
 		return () => window.removeEventListener('storage', handler);
@@ -490,6 +530,9 @@ class AuthStore {
 		this.fabricConnectInFlight.clear();
 		this.operationTokenRefreshInFlight.clear();
 		this.setUserForEntity(OverallAppSignIn, null);
+		// Broadcast a global clear so other tabs' explorers drop their credentials even for entities not
+		// in this tab's potentiallyAuthenticated set.
+		this.bumpExplorerAuthEpochAll();
 	}
 
 	private calculateKeyFromEntity(entity: EntityTypes): AuthenticatedConnectionKey | undefined {

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -89,13 +89,18 @@ class AuthStore {
 		this.potentiallyAuthenticated = JSON.parse(localStorage.getItem(this.potentiallyAuthenticatedKey) || '{}');
 	}
 
-	/** Current per-entity sign-out epoch; the explorer stamps a mint with it and re-checks before applying. */
+	/**
+	 * Current sign-out epoch for an entity — its own count plus the global (`'*'`) count, so a global
+	 * logout advances every entity's epoch even in the same tab (where no `storage` event fires). The
+	 * explorer stamps a mint with it and re-checks before applying.
+	 */
 	public getExplorerAuthEpoch(id: EntityIds): number {
-		return this.explorerAuthEpoch.get(id) ?? 0;
+		return (this.explorerAuthEpoch.get(id) ?? 0) + (this.explorerAuthEpoch.get('*') ?? 0);
 	}
 
 	private writeExplorerInvalidation(id: EntityIds | '*'): void {
-		this.explorerAuthEpoch.set(id, this.getExplorerAuthEpoch(id) + 1);
+		// Increment the raw slot (not getExplorerAuthEpoch, which folds in the '*' count).
+		this.explorerAuthEpoch.set(id, (this.explorerAuthEpoch.get(id) ?? 0) + 1);
 		try {
 			// Value must differ each write so other tabs' `storage` listeners fire.
 			localStorage.setItem(this.explorerAuthEpochKey, JSON.stringify({ id, seq: ++this.explorerEpochSeq }));

--- a/src/features/instance/apis/APIDocs.tsx
+++ b/src/features/instance/apis/APIDocs.tsx
@@ -6,14 +6,19 @@ import { useInstanceClientIdParams } from '@/config/useInstanceClient';
 import { ApiExplorer } from '@/features/instance/apis/explorer/ApiExplorer';
 import { OpenApiSpec } from '@/features/instance/apis/explorer/types';
 import { useRollingConfigUpdate } from '@/hooks/useRollingConfigUpdate';
+import {
+	createInstanceAuthenticationTokens,
+	mintOperationTokenWithCredentials,
+} from '@/integrations/api/instance/auth/createInstanceAuthenticationTokens';
 import { getConfigurationQueryOptions } from '@/integrations/api/instance/status/getConfiguration';
 import { getOpenAPIQueryOptions } from '@/integrations/api/instance/status/getOpenAPI';
 import { getRegistrationInfoQueryOptions } from '@/integrations/api/instance/status/getRegistrationInfo';
 import { wasAReleasedBeforeB } from '@/lib/string/wasAReleasedBeforeB';
+import { isDirectOperationsUrl } from '@/lib/urls/isDirectOperationsUrl';
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 import { Plus } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export function APIDocs() {
 	const { instanceId, clusterId }: { instanceId?: string; clusterId?: string } = useParams({ strict: false });
@@ -31,6 +36,25 @@ export function APIDocs() {
 		isLoading: isLoadingDocs,
 		error,
 	} = useQuery(getOpenAPIQueryOptions(operationsParams));
+
+	// The credential (username/password) log-in mints directly against the operations client's own
+	// base URL — the address Studio already talks to this instance on. When that address is the Fabric
+	// Connect proxy path, it fails the direct check and the credential fallback is withheld so typed
+	// credentials never reach central manager; session mint (below) still works there.
+	const operationsBaseURL = operationsParams.instanceClient.defaults.baseURL;
+	const onSessionMint = useCallback(
+		async () =>
+			(await createInstanceAuthenticationTokens({ instanceClient: operationsParams.instanceClient })).operationToken,
+		[operationsParams.instanceClient],
+	);
+	const onCredentialMint = useMemo(
+		() =>
+			isDirectOperationsUrl(operationsBaseURL)
+				? (credentials: { username: string; password: string }) =>
+					mintOperationTokenWithCredentials({ operationsUrl: operationsBaseURL, ...credentials })
+				: null,
+		[operationsBaseURL],
+	);
 	// The explorer builds its own server list from `baseURL` (Studio's computed REST URL) plus the
 	// spec's declared servers, and lets the user pick — so we no longer mutate the spec's servers as
 	// the previous Swagger integration did.
@@ -128,6 +152,8 @@ export function APIDocs() {
 				spec={spec as OpenApiSpec | undefined}
 				baseURL={baseURL}
 				entityId={operationsParams.entityId}
+				onSessionMint={onSessionMint}
+				onCredentialMint={onCredentialMint}
 			/>
 		</div>
 	);

--- a/src/features/instance/apis/explorer/ApiExplorer.test.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.test.tsx
@@ -1,8 +1,12 @@
 /** @vitest-environment jsdom */
 import { ApiExplorer } from '@/features/instance/apis/explorer/ApiExplorer';
 import { OpenApiSpec } from '@/features/instance/apis/explorer/types';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function storedAuth() {
+	return JSON.parse(sessionStorage.getItem('ApiExplorerSettings')!)['ins-test'];
+}
 
 // The Try-it-out tab (not exercised here) is the only thing that mounts Monaco; mock it so importing
 // the tree never pulls the editor in, matching how the repo's other component tests handle Monaco.
@@ -18,6 +22,8 @@ const spec: OpenApiSpec = {
 			post: {
 				parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
 				requestBody: { content: { 'application/json': { schema: { type: 'object' } } } },
+				// Marks this operation as requiring auth, so the deep-link to Authorize appears.
+				security: [{ bearerAuth: [] }],
 				responses: {},
 			},
 		},
@@ -27,8 +33,21 @@ const spec: OpenApiSpec = {
 	},
 };
 
-function renderExplorer() {
-	return render(<ApiExplorer spec={spec} baseURL="http://localhost:9926" entityId="ins-test" />);
+function renderExplorer(overrides: {
+	onSessionMint?: () => Promise<string>;
+	onCredentialMint?: ((c: { username: string; password: string }) => Promise<string>) | null;
+} = {}) {
+	return render(
+		<ApiExplorer
+			spec={spec}
+			baseURL="http://localhost:9926"
+			entityId="ins-test"
+			onSessionMint={overrides.onSessionMint ?? (() => Promise.resolve('session-tok'))}
+			onCredentialMint={overrides.onCredentialMint === undefined
+				? (() => Promise.resolve('cred-tok'))
+				: overrides.onCredentialMint}
+		/>,
+	);
 }
 
 describe('ApiExplorer', () => {
@@ -37,7 +56,10 @@ describe('ApiExplorer', () => {
 		Element.prototype.hasPointerCapture = () => false;
 		Element.prototype.scrollIntoView = () => {};
 	});
-	beforeEach(() => localStorage.clear());
+	beforeEach(() => {
+		localStorage.clear();
+		sessionStorage.clear();
+	});
 	afterEach(cleanup);
 
 	it('renders the resource → path → method hierarchy and the first operation by default', () => {
@@ -48,22 +70,123 @@ describe('ApiExplorer', () => {
 		expect(screen.getByText('Responses')).toBeTruthy();
 	});
 
-	it('takes over the detail pane with Server + Authorization when Authorize is clicked', () => {
+	it('takes over the detail pane with Server + Authorization docs when Authorize is clicked', () => {
 		renderExplorer();
 		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
 		expect(screen.getByRole('heading', { name: 'Server' })).toBeTruthy();
 		expect(screen.getByRole('heading', { name: 'Authorization' })).toBeTruthy();
-		expect(screen.getByRole('button', { name: 'Cookie' })).toBeTruthy();
-		expect(screen.getByRole('button', { name: 'Bearer token' })).toBeTruthy();
+		expect(screen.getByRole('tab', { name: 'Documentation' })).toBeTruthy();
+		expect(screen.getByRole('tab', { name: 'Try it out' })).toBeTruthy();
+		// Documentation is the default tab; the method selector lives under Try it out.
+		expect(screen.queryByRole('button', { name: 'Cookie' })).toBeNull();
 		// The operation docs are replaced, not merely appended.
 		expect(screen.queryByText('Responses')).toBeNull();
 	});
 
-	it('selecting an operation from the sidebar shows its documentation', () => {
+	it('shows the method selector and session log-in under Try it out, defaulting to Log in (locked)', () => {
 		renderExplorer();
-		// Exactly one POST in the spec, so its method button is unambiguous.
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		// Method selector (Log in is the default) plus the primary session log-in action.
+		expect(screen.getByRole('button', { name: 'Basic' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Bearer token' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Cookie' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: /authorize with your current session/i })).toBeTruthy();
+		expect(screen.getByText('Not signed in — authenticated requests will be rejected.')).toBeTruthy();
+	});
+
+	it('session log-in mints a token, unlocks, and stores the token (never a password)', async () => {
+		const onSessionMint = vi.fn().mockResolvedValue('session-tok');
+		renderExplorer({ onSessionMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+
+		expect(await screen.findByText(/Authorized —/)).toBeTruthy();
+		expect(onSessionMint).toHaveBeenCalledTimes(1);
+
+		const stored = sessionStorage.getItem('ApiExplorerSettings')!;
+		expect(JSON.parse(stored)['ins-test']).toEqual({ method: 'login', auth: { type: 'bearer', token: 'session-tok' } });
+		expect(stored).not.toContain('password');
+	});
+
+	it('logs in with typed credentials via the credential fallback', async () => {
+		const onCredentialMint = vi.fn().mockResolvedValue('cred-token');
+		renderExplorer({ onCredentialMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'bob' } });
+		fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pw' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+
+		expect(await screen.findByText(/Authorized —/)).toBeTruthy();
+		expect(onCredentialMint).toHaveBeenCalledWith({ username: 'bob', password: 'pw' });
+		expect(storedAuth().auth).toEqual({ type: 'bearer', token: 'cred-token' });
+	});
+
+	it('discards a late session mint when the user switched methods while it was pending', async () => {
+		let resolveMint!: (token: string) => void;
+		const onSessionMint = vi.fn(() =>
+			new Promise<string>(res => {
+				resolveMint = res;
+			})
+		);
+		renderExplorer({ onSessionMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+		// Switch to Basic and apply a credential while the session mint is still pending.
+		fireEvent.click(screen.getByRole('button', { name: 'Basic' }));
+		fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'alice' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+		// The stale mint resolves last — it must not overwrite the Basic credential.
+		await act(async () => {
+			resolveMint('late-session-token');
+			await Promise.resolve();
+		});
+		expect(storedAuth()).toEqual({ method: 'basic', auth: { type: 'basic', username: 'alice', password: '' } });
+	});
+
+	it('does not present a manually pasted Bearer token as a session login when Log in is selected', () => {
+		renderExplorer();
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: 'Bearer token' }));
+		fireEvent.change(screen.getByLabelText('Token'), { target: { value: 'pasted' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+		expect(screen.getByText(/Authorized —/)).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+		expect(screen.queryByText(/Authorized —/)).toBeNull();
+		expect(storedAuth()).toEqual({ method: 'login', auth: { type: 'cookie' } });
+	});
+
+	it('surfaces a log-in error without unlocking', async () => {
+		const onSessionMint = vi.fn().mockRejectedValue(new Error('proxy unauthorized'));
+		renderExplorer({ onSessionMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+
+		expect(await screen.findByText('proxy unauthorized')).toBeTruthy();
+		expect(screen.queryByText(/Authorized —/)).toBeNull();
+	});
+
+	it('hides the password fallback when no direct instance URL is available', () => {
+		renderExplorer({ onCredentialMint: null });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		expect(screen.getByRole('button', { name: /authorize with your current session/i })).toBeTruthy();
+		expect(screen.queryByText('Or use different credentials')).toBeNull();
+	});
+
+	it('an auth-required operation deep-links to the Try-it-out log-in view', () => {
+		renderExplorer();
+		// Exactly one POST in the spec, and it declares security.
 		fireEvent.click(screen.getByRole('button', { name: 'post' }));
-		expect(screen.getByText('Request body')).toBeTruthy();
+		fireEvent.click(screen.getByRole('button', { name: /auth required — authorize/i }));
+		// Landed on the Authorize panel's Try it out tab with the log-in action ready.
+		expect(screen.getByRole('button', { name: /authorize with your current session/i })).toBeTruthy();
 	});
 
 	it('renders a resize separator wired to the persisted sidebar width', () => {

--- a/src/features/instance/apis/explorer/ApiExplorer.test.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.test.tsx
@@ -106,11 +106,11 @@ describe('ApiExplorer', () => {
 		expect(onSessionMint).toHaveBeenCalledTimes(1);
 
 		const stored = sessionStorage.getItem('ApiExplorerSettings')!;
-		expect(JSON.parse(stored)['ins-test']).toEqual({
+		expect(JSON.parse(stored)['ins-test']).toEqual(expect.objectContaining({
 			method: 'login',
 			auth: { type: 'bearer', token: 'session-tok' },
 			authServer: 'http://localhost:9926',
-		});
+		}));
 		expect(stored).not.toContain('password');
 	});
 
@@ -148,11 +148,11 @@ describe('ApiExplorer', () => {
 			resolveMint('late-session-token');
 			await Promise.resolve();
 		});
-		expect(storedAuth()).toEqual({
+		expect(storedAuth()).toEqual(expect.objectContaining({
 			method: 'basic',
 			auth: { type: 'basic', username: 'alice', password: '' },
 			authServer: 'http://localhost:9926',
-		});
+		}));
 	});
 
 	it('does not present a manually pasted Bearer token as a session login when Log in is selected', () => {
@@ -166,7 +166,7 @@ describe('ApiExplorer', () => {
 
 		fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
 		expect(screen.queryByText(/Credential set —/)).toBeNull();
-		expect(storedAuth()).toEqual({ method: 'login', auth: { type: 'cookie' } });
+		expect(storedAuth()).toEqual(expect.objectContaining({ method: 'login', auth: { type: 'cookie' } }));
 	});
 
 	it('surfaces a log-in error without unlocking', async () => {
@@ -266,17 +266,14 @@ describe('ApiExplorer', () => {
 		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
 		expect(await screen.findByText(/Credential set —/)).toBeTruthy();
 
-		// Another tab signs ins-test out: authStore mirrors that to localStorage, firing a storage event.
+		// Another tab signs ins-test out: it advances the durable generation, then this tab gets the event.
 		act(() => {
-			window.dispatchEvent(
-				new StorageEvent('storage', {
-					key: 'Studio:ExplorerAuthEpoch',
-					newValue: JSON.stringify({ id: 'ins-test', seq: 999 }),
-				}),
-			);
+			const bumped = JSON.stringify({ 'ins-test': 99 });
+			localStorage.setItem('Studio:ExplorerAuthEpoch', bumped);
+			window.dispatchEvent(new StorageEvent('storage', { key: 'Studio:ExplorerAuthEpoch', newValue: bumped }));
 		});
+		// The credential no longer matches the current generation, so it is not sent.
 		expect(screen.queryByText(/Credential set —/)).toBeNull();
-		expect(JSON.parse(sessionStorage.getItem('ApiExplorerSettings') ?? '{}')['ins-test']).toBeUndefined();
 	});
 
 	it('discards a session mint that resolves after the entity was signed out', async () => {

--- a/src/features/instance/apis/explorer/ApiExplorer.test.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.test.tsx
@@ -232,6 +232,33 @@ describe('ApiExplorer', () => {
 		expect(storedAuth().auth).toEqual({ type: 'bearer', token: 'tok-2' });
 	});
 
+	it('withholds a minted token when the active server is not the instance it was minted for', async () => {
+		// Pre-select a foreign declared server, then mint: the token is stamped for the trusted instance
+		// URL (baseURL), so it must not be sent to the selected server.
+		sessionStorage.setItem(
+			'ApiExplorerSettings',
+			JSON.stringify({ 'ins-test': { server: 'https://foreign.example' } }),
+		);
+		const specWithServers: OpenApiSpec = { ...spec, servers: [{ url: 'https://foreign.example' }] };
+		render(
+			<ApiExplorer
+				spec={specWithServers}
+				baseURL="http://localhost:9926"
+				entityId="ins-test"
+				onSessionMint={() => Promise.resolve('minted-for-instance')}
+				onCredentialMint={null}
+			/>,
+		);
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+
+		await waitFor(() => expect(storedAuth().auth).toEqual({ type: 'bearer', token: 'minted-for-instance' }));
+		// Stamped to the instance, not the foreign selection — so the credential is withheld.
+		expect(storedAuth().authServer).toBe('http://localhost:9926');
+		expect(screen.queryByText(/Credential set —/)).toBeNull();
+	});
+
 	it('clears the stored credential when another tab signs the entity out (cross-tab)', async () => {
 		renderExplorer();
 		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));

--- a/src/features/instance/apis/explorer/ApiExplorer.test.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.test.tsx
@@ -106,7 +106,11 @@ describe('ApiExplorer', () => {
 		expect(onSessionMint).toHaveBeenCalledTimes(1);
 
 		const stored = sessionStorage.getItem('ApiExplorerSettings')!;
-		expect(JSON.parse(stored)['ins-test']).toEqual({ method: 'login', auth: { type: 'bearer', token: 'session-tok' } });
+		expect(JSON.parse(stored)['ins-test']).toEqual({
+			method: 'login',
+			auth: { type: 'bearer', token: 'session-tok' },
+			authServer: 'http://localhost:9926',
+		});
 		expect(stored).not.toContain('password');
 	});
 
@@ -144,7 +148,11 @@ describe('ApiExplorer', () => {
 			resolveMint('late-session-token');
 			await Promise.resolve();
 		});
-		expect(storedAuth()).toEqual({ method: 'basic', auth: { type: 'basic', username: 'alice', password: '' } });
+		expect(storedAuth()).toEqual({
+			method: 'basic',
+			auth: { type: 'basic', username: 'alice', password: '' },
+			authServer: 'http://localhost:9926',
+		});
 	});
 
 	it('does not present a manually pasted Bearer token as a session login when Log in is selected', () => {

--- a/src/features/instance/apis/explorer/ApiExplorer.test.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { ApiExplorer } from '@/features/instance/apis/explorer/ApiExplorer';
 import { OpenApiSpec } from '@/features/instance/apis/explorer/types';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function storedAuth() {
@@ -102,7 +102,7 @@ describe('ApiExplorer', () => {
 		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
 		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
 
-		expect(await screen.findByText(/Authorized —/)).toBeTruthy();
+		expect(await screen.findByText(/Credential set —/)).toBeTruthy();
 		expect(onSessionMint).toHaveBeenCalledTimes(1);
 
 		const stored = sessionStorage.getItem('ApiExplorerSettings')!;
@@ -119,7 +119,7 @@ describe('ApiExplorer', () => {
 		fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pw' } });
 		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
 
-		expect(await screen.findByText(/Authorized —/)).toBeTruthy();
+		expect(await screen.findByText(/Credential set —/)).toBeTruthy();
 		expect(onCredentialMint).toHaveBeenCalledWith({ username: 'bob', password: 'pw' });
 		expect(storedAuth().auth).toEqual({ type: 'bearer', token: 'cred-token' });
 	});
@@ -154,10 +154,10 @@ describe('ApiExplorer', () => {
 		fireEvent.click(screen.getByRole('button', { name: 'Bearer token' }));
 		fireEvent.change(screen.getByLabelText('Token'), { target: { value: 'pasted' } });
 		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
-		expect(screen.getByText(/Authorized —/)).toBeTruthy();
+		expect(screen.getByText(/Credential set —/)).toBeTruthy();
 
 		fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
-		expect(screen.queryByText(/Authorized —/)).toBeNull();
+		expect(screen.queryByText(/Credential set —/)).toBeNull();
 		expect(storedAuth()).toEqual({ method: 'login', auth: { type: 'cookie' } });
 	});
 
@@ -169,7 +169,7 @@ describe('ApiExplorer', () => {
 		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
 
 		expect(await screen.findByText('proxy unauthorized')).toBeTruthy();
-		expect(screen.queryByText(/Authorized —/)).toBeNull();
+		expect(screen.queryByText(/Credential set —/)).toBeNull();
 	});
 
 	it('hides the password fallback when no direct instance URL is available', () => {
@@ -187,6 +187,84 @@ describe('ApiExplorer', () => {
 		fireEvent.click(screen.getByRole('button', { name: /auth required — authorize/i }));
 		// Landed on the Authorize panel's Try it out tab with the log-in action ready.
 		expect(screen.getByRole('button', { name: /authorize with your current session/i })).toBeTruthy();
+	});
+
+	it('Clear empties the Basic form and drops the stored credential', () => {
+		renderExplorer();
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: 'Basic' }));
+		fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'carol' } });
+		fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+		expect(screen.getByText(/Credential set —/)).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+		expect((screen.getByLabelText('Username') as HTMLInputElement).value).toBe('');
+		expect((screen.getByLabelText('Password') as HTMLInputElement).value).toBe('');
+		expect(storedAuth().auth).toEqual({ type: 'basic', username: '', password: '' });
+	});
+
+	it('clears the login password after re-authenticating while already authorized', async () => {
+		const onCredentialMint = vi.fn().mockResolvedValue('tok-1');
+		renderExplorer({ onCredentialMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'dave' } });
+		fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pw1' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+		expect(await screen.findByText(/Credential set —/)).toBeTruthy();
+
+		// Re-authenticate (already authorized) with different credentials — the password must still clear.
+		onCredentialMint.mockResolvedValue('tok-2');
+		fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'erin' } });
+		fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'pw2' } });
+		fireEvent.click(screen.getByRole('button', { name: 'Authorize' }));
+		await waitFor(() => expect((screen.getByLabelText('Password') as HTMLInputElement).value).toBe(''));
+		expect(storedAuth().auth).toEqual({ type: 'bearer', token: 'tok-2' });
+	});
+
+	it('clears the stored credential when another tab signs the entity out (cross-tab)', async () => {
+		renderExplorer();
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+		expect(await screen.findByText(/Credential set —/)).toBeTruthy();
+
+		// Another tab signs ins-test out: authStore mirrors that to localStorage, firing a storage event.
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: 'Studio:ExplorerAuthEpoch',
+					newValue: JSON.stringify({ id: 'ins-test', seq: 999 }),
+				}),
+			);
+		});
+		expect(screen.queryByText(/Credential set —/)).toBeNull();
+		expect(JSON.parse(sessionStorage.getItem('ApiExplorerSettings') ?? '{}')['ins-test']).toBeUndefined();
+	});
+
+	it('discards a session mint that resolves after the entity was signed out', async () => {
+		let resolveMint!: (token: string) => void;
+		const onSessionMint = vi.fn(() =>
+			new Promise<string>(res => {
+				resolveMint = res;
+			})
+		);
+		renderExplorer({ onSessionMint });
+		fireEvent.click(screen.getByRole('button', { name: /authorize/i }));
+		fireEvent.focus(screen.getByRole('tab', { name: 'Try it out' }));
+		fireEvent.click(screen.getByRole('button', { name: /authorize with your current session/i }));
+
+		// Full logout while the mint is pending bumps the entity's auth epoch.
+		const { authStore } = await import('@/features/auth/store/authStore');
+		act(() => authStore.setUserForIdAndKey('ins-test', 'ins-test-fqdn', null));
+		await act(async () => {
+			resolveMint('late-token');
+			await Promise.resolve();
+		});
+		// The stale token must not be written back after sign-out.
+		expect(JSON.parse(sessionStorage.getItem('ApiExplorerSettings') ?? '{}')['ins-test']).toBeUndefined();
 	});
 
 	it('renders a resize separator wired to the persisted sidebar width', () => {

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -26,17 +26,9 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { cn } from '@/lib/cn';
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 
-/** The origin of a URL, or null if it can't be parsed — used to scope a credential to one server. */
-function originOf(url: string | null): string | null {
-	if (!url) {
-		return null;
-	}
-	try {
-		return new URL(url).origin;
-	} catch {
-		return null;
-	}
-}
+// Stable reference for "no explicit credential" so downstream memoized children don't re-render when a
+// credential is withheld (server mismatch).
+const COOKIE_AUTH: ApiAuth = { type: 'cookie' };
 
 /**
  * The custom Harper API explorer: a searchable operation list beside a detail pane, with an
@@ -78,6 +70,10 @@ export function ApiExplorer(
 
 	const method: AuthMethod = entitySettings.method ?? 'login';
 	const auth: ApiAuth = entitySettings.auth ?? { type: 'cookie' };
+	// The server "Try it out" targets; a credential is stamped with it on apply and only sent back to it.
+	const activeServer = serverOptions.find(s => s.url === entitySettings.server)?.url
+		?? serverOptions[0]?.url
+		?? baseURL;
 
 	// Mint race guard: each mint captures an attempt id; only the latest, on a still-mounted panel,
 	// may apply its token. Clearing authorization or unmounting bumps the id so an in-flight mint that
@@ -115,7 +111,14 @@ export function ApiExplorer(
 		setLoginError(null);
 		try {
 			const token = await mint();
-			if (!mountedRef.current || attempt !== attemptRef.current || authStore.getExplorerAuthEpoch(entityId) !== epoch) {
+			// Superseded by a newer attempt or unmounted — that owner manages the status; leave it alone.
+			if (!mountedRef.current || attempt !== attemptRef.current) {
+				return;
+			}
+			// Signed out (this tab or another) while the mint was in flight — drop the token and clear the
+			// pending state rather than writing the old user's token back.
+			if (authStore.getExplorerAuthEpoch(entityId) !== epoch) {
+				setLoginStatus('idle');
 				return;
 			}
 			if (typeof token !== 'string' || token === '') {
@@ -123,7 +126,7 @@ export function ApiExplorer(
 				setLoginStatus('error');
 				return;
 			}
-			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token } });
+			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token }, authServer: activeServer ?? undefined });
 			setLoginStatus('idle');
 		} catch (error) {
 			if (!mountedRef.current || attempt !== attemptRef.current) {
@@ -146,7 +149,7 @@ export function ApiExplorer(
 	const selectMethod = (next: AuthMethod) => {
 		attemptRef.current++;
 		if (next === 'cookie') {
-			updateEntitySettings({ method: 'cookie', auth: { type: 'cookie' } });
+			updateEntitySettings({ method: 'cookie', auth: { type: 'cookie' }, authServer: undefined });
 		} else if (next === 'basic') {
 			updateEntitySettings({
 				method: 'basic',
@@ -157,13 +160,12 @@ export function ApiExplorer(
 				method: 'bearer',
 				auth: auth.type === 'bearer' ? auth : { type: 'bearer', token: '' },
 			});
+		} else if (method === 'login' && auth.type === 'bearer') {
+			// Re-selecting Login while already logged in keeps the minted token (and its authServer stamp).
+			updateEntitySettings({ method: 'login' });
 		} else {
-			// A bearer from the Bearer tab is not a login credential — only keep it when re-selecting Login
-			// while already logged in; otherwise Login starts logged-out.
-			updateEntitySettings({
-				method: 'login',
-				auth: method === 'login' && auth.type === 'bearer' ? auth : { type: 'cookie' },
-			});
+			// Otherwise Login starts logged-out — a bearer from the Bearer tab is not a login credential.
+			updateEntitySettings({ method: 'login', auth: { type: 'cookie' }, authServer: undefined });
 		}
 		setLoginStatus('idle');
 		setLoginError(null);
@@ -171,11 +173,15 @@ export function ApiExplorer(
 
 	const applyBasic = (username: string, password: string) => {
 		attemptRef.current++;
-		updateEntitySettings({ method: 'basic', auth: { type: 'basic', username, password } });
+		updateEntitySettings({
+			method: 'basic',
+			auth: { type: 'basic', username, password },
+			authServer: activeServer ?? undefined,
+		});
 	};
 	const applyBearer = (token: string) => {
 		attemptRef.current++;
-		updateEntitySettings({ method: 'bearer', auth: { type: 'bearer', token } });
+		updateEntitySettings({ method: 'bearer', auth: { type: 'bearer', token }, authServer: activeServer ?? undefined });
 	};
 	const clearAuth = () => {
 		attemptRef.current++;
@@ -187,23 +193,19 @@ export function ApiExplorer(
 			: method === 'bearer'
 			? { type: 'bearer', token: '' }
 			: { type: 'cookie' };
-		updateEntitySettings({ auth: cleared });
+		updateEntitySettings({ auth: cleared, authServer: undefined });
 	};
 
 	const setSelectedServer = (url: string) => updateEntitySettings({ server: url });
 
-	const activeServer = serverOptions.find(s => s.url === entitySettings.server)?.url
-		?? serverOptions[0]?.url
-		?? baseURL;
 	const [copyServer] = useCopyToClipboard(activeServer ?? '');
 
-	// The credential is scoped to the instance we authorized against (the computed REST origin). Send it
-	// only when the active server shares that origin — whether the user picked another declared server or
-	// the active server recomputed implicitly — so a token/credential never reaches a different origin.
-	const trustedOrigin = originOf(baseURL);
-	const effectiveAuth: ApiAuth = trustedOrigin !== null && originOf(activeServer) === trustedOrigin
-		? auth
-		: { type: 'cookie' };
+	// The credential is stamped with the server it was authorized against (see applyBasic/applyBearer and
+	// the mint) and is sent only when the active server still matches — so switching or recomputing the
+	// active server can't send a token/credential to a different one. Plain string compare (no URL
+	// parsing) so a relative or unusual base URL can't strip a valid credential.
+	const credentialMatchesServer = entitySettings.authServer != null && entitySettings.authServer === activeServer;
+	const effectiveAuth: ApiAuth = isAuthorized(auth) && credentialMatchesServer ? auth : COOKIE_AUTH;
 	const authorized = isAuthorized(effectiveAuth);
 
 	// Width drives a CSS variable applied only at lg+; below that the sidebar stacks full-width.

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -1,9 +1,11 @@
 import { Badge } from '@/components/ui/badge';
+import { authStore } from '@/features/auth/store/authStore';
 import { EndpointList } from '@/features/instance/apis/explorer/EndpointList';
 import { OperationDetail } from '@/features/instance/apis/explorer/OperationDetail';
 import { ApiAuth, AuthMethod, isAuthorized } from '@/features/instance/apis/explorer/request';
 import {
 	ExplorerEntitySettings,
+	forgetEntitySettings,
 	readEntitySettings,
 	writeEntitySettings,
 } from '@/features/instance/apis/explorer/settings';
@@ -81,13 +83,28 @@ export function ApiExplorer(
 	const [loginStatus, setLoginStatus] = useState<'idle' | 'pending' | 'error'>('idle');
 	const [loginError, setLoginError] = useState<string | null>(null);
 
+	// When another tab signs this entity out, clear this tab's stored credential and reset auth state —
+	// sessionStorage is per-tab, so a sign-out elsewhere can't reach it without this cross-tab signal.
+	useEffect(() => {
+		return authStore.onExplorerAuthInvalidated(entityId, () => {
+			attemptRef.current++;
+			forgetEntitySettings(entityId);
+			setEntitySettings({});
+			setLoginStatus('idle');
+			setLoginError(null);
+		});
+	}, [entityId]);
+
 	const runMint = async (mint: () => Promise<string>) => {
 		const attempt = ++attemptRef.current;
+		// Stamp the mint with the entity's sign-out epoch; a sign-out (this tab or another) advances it
+		// so a mint resolving after logout can't write the old user's token back.
+		const epoch = authStore.getExplorerAuthEpoch(entityId);
 		setLoginStatus('pending');
 		setLoginError(null);
 		try {
 			const token = await mint();
-			if (!mountedRef.current || attempt !== attemptRef.current) {
+			if (!mountedRef.current || attempt !== attemptRef.current || authStore.getExplorerAuthEpoch(entityId) !== epoch) {
 				return;
 			}
 			if (typeof token !== 'string' || token === '') {
@@ -162,7 +179,18 @@ export function ApiExplorer(
 		updateEntitySettings({ auth: cleared });
 	};
 
-	const setSelectedServer = (url: string) => updateEntitySettings({ server: url });
+	const setSelectedServer = (url: string) => {
+		if (url === activeServer) {
+			updateEntitySettings({ server: url });
+			return;
+		}
+		// Credentials are scoped to the server they were entered/minted for: switching targets clears
+		// them (and cancels any in-flight mint) so a token minted for one origin is never sent to another.
+		attemptRef.current++;
+		setLoginStatus('idle');
+		setLoginError(null);
+		updateEntitySettings({ server: url, method: 'login', auth: { type: 'cookie' } });
+	};
 
 	const activeServer = serverOptions.find(s => s.url === entitySettings.server)?.url
 		?? serverOptions[0]?.url

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -5,7 +5,6 @@ import { OperationDetail } from '@/features/instance/apis/explorer/OperationDeta
 import { ApiAuth, AuthMethod, isAuthorized } from '@/features/instance/apis/explorer/request';
 import {
 	ExplorerEntitySettings,
-	forgetEntitySettings,
 	readEntitySettings,
 	writeEntitySettings,
 } from '@/features/instance/apis/explorer/settings';
@@ -90,13 +89,14 @@ export function ApiExplorer(
 	const [loginStatus, setLoginStatus] = useState<'idle' | 'pending' | 'error'>('idle');
 	const [loginError, setLoginError] = useState<string | null>(null);
 
-	// When another tab signs this entity out, clear this tab's stored credential and reset auth state —
-	// sessionStorage is per-tab, so a sign-out elsewhere can't reach it without this cross-tab signal.
+	// A sign-out in another tab changes the shared generation. Re-read from storage (the bootstrap
+	// reconciler strips revoked credentials there) rather than assuming this entity was the one signed
+	// out, and cancel any in-flight mint. The render-time generation check below is the real guard, so
+	// this is only about reflecting it promptly.
 	useEffect(() => {
 		return authStore.onExplorerAuthInvalidated(entityId, () => {
 			attemptRef.current++;
-			forgetEntitySettings(entityId);
-			setEntitySettings({});
+			setEntitySettings(readEntitySettings(entityId));
 			setLoginStatus('idle');
 			setLoginError(null);
 		});
@@ -129,7 +129,12 @@ export function ApiExplorer(
 			// A minted token belongs to the instance the mint client talks to — Studio's computed URL for
 			// this entity — NOT to whatever server the spec's picker currently names. Stamping the trusted
 			// server means selecting a foreign declared server withholds the token instead of sending it there.
-			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token }, authServer: baseURL ?? undefined });
+			updateEntitySettings({
+				method: 'login',
+				auth: { type: 'bearer', token },
+				authServer: baseURL ?? undefined,
+				authGeneration: authStore.getExplorerAuthEpoch(entityId),
+			});
 			setLoginStatus('idle');
 		} catch (error) {
 			if (!mountedRef.current || attempt !== attemptRef.current) {
@@ -180,11 +185,17 @@ export function ApiExplorer(
 			method: 'basic',
 			auth: { type: 'basic', username, password },
 			authServer: activeServer ?? undefined,
+			authGeneration: authStore.getExplorerAuthEpoch(entityId),
 		});
 	};
 	const applyBearer = (token: string) => {
 		attemptRef.current++;
-		updateEntitySettings({ method: 'bearer', auth: { type: 'bearer', token }, authServer: activeServer ?? undefined });
+		updateEntitySettings({
+			method: 'bearer',
+			auth: { type: 'bearer', token },
+			authServer: activeServer ?? undefined,
+			authGeneration: authStore.getExplorerAuthEpoch(entityId),
+		});
 	};
 	const clearAuth = () => {
 		attemptRef.current++;
@@ -208,7 +219,12 @@ export function ApiExplorer(
 	// active server can't send a token/credential to a different one. Plain string compare (no URL
 	// parsing) so a relative or unusual base URL can't strip a valid credential.
 	const credentialMatchesServer = entitySettings.authServer != null && entitySettings.authServer === activeServer;
-	const effectiveAuth: ApiAuth = isAuthorized(auth) && credentialMatchesServer ? auth : COOKIE_AUTH;
+	// A credential stamped under an older sign-out generation was revoked while this tab wasn't watching
+	// (it was reloaded or closed) — sessionStorage outlives a reload, so this comparison is the guard.
+	const credentialIsCurrent = entitySettings.authGeneration === authStore.getExplorerAuthEpoch(entityId);
+	const effectiveAuth: ApiAuth = isAuthorized(auth) && credentialMatchesServer && credentialIsCurrent
+		? auth
+		: COOKIE_AUTH;
 	const authorized = isAuthorized(effectiveAuth);
 
 	// Width drives a CSS variable applied only at lg+; below that the sidebar stacks full-width.

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -1,9 +1,13 @@
 import { Badge } from '@/components/ui/badge';
 import { EndpointList } from '@/features/instance/apis/explorer/EndpointList';
 import { OperationDetail } from '@/features/instance/apis/explorer/OperationDetail';
-import { ApiAuth } from '@/features/instance/apis/explorer/request';
-import { readEntitySettings, writeEntitySettings } from '@/features/instance/apis/explorer/settings';
-import { SettingsPanel } from '@/features/instance/apis/explorer/SettingsPanel';
+import { ApiAuth, AuthMethod, isAuthorized } from '@/features/instance/apis/explorer/request';
+import {
+	ExplorerEntitySettings,
+	readEntitySettings,
+	writeEntitySettings,
+} from '@/features/instance/apis/explorer/settings';
+import { LoginController, SettingsPanel } from '@/features/instance/apis/explorer/SettingsPanel';
 import {
 	buildEndpointTree,
 	buildServerOptions,
@@ -18,43 +22,146 @@ import {
 } from '@/features/instance/apis/explorer/useResizableSidebar';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { cn } from '@/lib/cn';
-import { type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 
 /**
- * The custom Harper API explorer: a hierarchical, searchable list of the spec's operations alongside
- * a detail pane. The sidebar's "Authorize" item takes over the detail pane with Server + Auth
- * settings; selecting an endpoint shows its documentation and an interactive "Try it out" runner.
- * Built entirely from the in-house design system — this replaces the previous Swagger UI embed.
- *
- * The CORS warning/enable flow that wraps this component lives in the parent (`APIDocs`).
+ * The custom Harper API explorer: a searchable operation list beside a detail pane, with an
+ * "Authorize" view for server + auth. The token-minting callbacks come from the parent (`APIDocs`) so
+ * the auth-client coupling stays there and this tree stays presentational.
  */
 export function ApiExplorer(
-	{ spec, baseURL, entityId }: { spec: OpenApiSpec | undefined; baseURL: string | null; entityId: string },
+	{ spec, baseURL, entityId, onSessionMint, onCredentialMint }: {
+		spec: OpenApiSpec | undefined;
+		baseURL: string | null;
+		entityId: string;
+		onSessionMint: () => Promise<string>;
+		// Null when no direct instance URL is provable, which withholds the password fallback.
+		onCredentialMint: ((credentials: { username: string; password: string }) => Promise<string>) | null;
+	},
 ) {
 	const allOperations = useMemo(() => flattenOperations(spec), [spec]);
 	const serverOptions = useMemo(() => buildServerOptions(spec, baseURL), [spec, baseURL]);
 	const [filter, setFilter] = useState('');
 	const [view, setView] = useState<'operation' | 'settings'>('operation');
+	const [authorizeTab, setAuthorizeTab] = useState<'docs' | 'try'>('docs');
 	const [selectedId, setSelectedId] = useState<string | undefined>(() => allOperations[0]?.id);
 
-	// Server + auth selections persist per entity, so credentials for one instance never apply to
-	// another. Writes go straight to localStorage via a fresh read-merge-write (see settings.ts) so a
-	// concurrent sign-out in another tab isn't clobbered; local state mirrors it for rendering and
-	// refreshes on the cross-tab `storage` event. Ephemeral navigation state (filter, selected
-	// endpoint, which pane is open) is deliberately not persisted.
+	// Opening Authorize from the sidebar lands on Documentation; a deep-link from an auth-required
+	// operation lands on the actionable "Try it out" log-in view.
+	const openAuthorize = (targetTab: 'docs' | 'try') => {
+		setAuthorizeTab(targetTab);
+		setView('settings');
+	};
+
+	// Server + auth selections persist per entity in sessionStorage (this browser tab only), so
+	// credentials never cross entities and are cleared when the tab closes. Ephemeral navigation state
+	// (filter, selected endpoint, which pane is open) is deliberately not persisted.
 	const [entitySettings, setEntitySettings] = useState(() => readEntitySettings(entityId));
-	useEffect(() => {
-		const refresh = () => setEntitySettings(readEntitySettings(entityId));
-		window.addEventListener('storage', refresh);
-		return () => window.removeEventListener('storage', refresh);
-	}, [entityId]);
-	const updateEntitySettings = (patch: { auth?: ApiAuth; server?: string }) => {
+	const updateEntitySettings = (patch: Partial<ExplorerEntitySettings>) => {
 		writeEntitySettings(entityId, patch);
 		setEntitySettings(prev => ({ ...prev, ...patch }));
 	};
 
-	const auth = entitySettings.auth ?? { type: 'cookie' };
-	const setAuth = (next: ApiAuth) => updateEntitySettings({ auth: next });
+	const method: AuthMethod = entitySettings.method ?? 'login';
+	const auth: ApiAuth = entitySettings.auth ?? { type: 'cookie' };
+	const authorized = isAuthorized(auth);
+
+	// Mint race guard: each mint captures an attempt id; only the latest, on a still-mounted panel,
+	// may apply its token. Clearing authorization or unmounting bumps the id so an in-flight mint that
+	// resolves afterwards can't silently re-authorize.
+	const attemptRef = useRef(0);
+	const mountedRef = useRef(true);
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+			attemptRef.current++;
+		};
+	}, []);
+	const [loginStatus, setLoginStatus] = useState<'idle' | 'pending' | 'error'>('idle');
+	const [loginError, setLoginError] = useState<string | null>(null);
+
+	const runMint = async (mint: () => Promise<string>) => {
+		const attempt = ++attemptRef.current;
+		setLoginStatus('pending');
+		setLoginError(null);
+		try {
+			const token = await mint();
+			if (!mountedRef.current || attempt !== attemptRef.current) {
+				return;
+			}
+			if (typeof token !== 'string' || token === '') {
+				setLoginError('The instance did not return a usable token.');
+				setLoginStatus('error');
+				return;
+			}
+			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token } });
+			setLoginStatus('idle');
+		} catch (error) {
+			if (!mountedRef.current || attempt !== attemptRef.current) {
+				return;
+			}
+			setLoginError(error instanceof Error ? error.message : 'Log in failed.');
+			setLoginStatus('error');
+		}
+	};
+
+	const login: LoginController = {
+		status: loginStatus,
+		error: loginError,
+		runSession: () => runMint(onSessionMint),
+		runCredentials: onCredentialMint ? credentials => runMint(() => onCredentialMint(credentials)) : null,
+	};
+
+	// Any explicit auth change invalidates a mint that's still in flight, so a slow session mint can't
+	// resolve later and overwrite the credential the user just chose.
+	const selectMethod = (next: AuthMethod) => {
+		attemptRef.current++;
+		if (next === 'cookie') {
+			updateEntitySettings({ method: 'cookie', auth: { type: 'cookie' } });
+		} else if (next === 'basic') {
+			updateEntitySettings({
+				method: 'basic',
+				auth: auth.type === 'basic' ? auth : { type: 'basic', username: '', password: '' },
+			});
+		} else if (next === 'bearer') {
+			updateEntitySettings({
+				method: 'bearer',
+				auth: auth.type === 'bearer' ? auth : { type: 'bearer', token: '' },
+			});
+		} else {
+			// A bearer from the Bearer tab is not a login credential — only keep it when re-selecting Login
+			// while already logged in; otherwise Login starts logged-out.
+			updateEntitySettings({
+				method: 'login',
+				auth: method === 'login' && auth.type === 'bearer' ? auth : { type: 'cookie' },
+			});
+		}
+		setLoginStatus('idle');
+		setLoginError(null);
+	};
+
+	const applyBasic = (username: string, password: string) => {
+		attemptRef.current++;
+		updateEntitySettings({ method: 'basic', auth: { type: 'basic', username, password } });
+	};
+	const applyBearer = (token: string) => {
+		attemptRef.current++;
+		updateEntitySettings({ method: 'bearer', auth: { type: 'bearer', token } });
+	};
+	const clearAuth = () => {
+		attemptRef.current++;
+		setLoginStatus('idle');
+		setLoginError(null);
+		// Keep the user on their chosen method; just drop the credential it carries.
+		const cleared: ApiAuth = method === 'basic'
+			? { type: 'basic', username: '', password: '' }
+			: method === 'bearer'
+			? { type: 'bearer', token: '' }
+			: { type: 'cookie' };
+		updateEntitySettings({ auth: cleared });
+	};
+
 	const setSelectedServer = (url: string) => updateEntitySettings({ server: url });
 
 	const activeServer = serverOptions.find(s => s.url === entitySettings.server)?.url
@@ -115,9 +222,10 @@ export function ApiExplorer(
 								onSelect={selectOperation}
 								filter={filter}
 								onFilterChange={setFilter}
-								authType={auth.type}
+								method={method}
+								authorized={authorized}
 								settingsActive={view === 'settings'}
-								onOpenSettings={() => setView('settings')}
+								onOpenSettings={() => openAuthorize('docs')}
 							/>
 							{
 								/* Drag (or focus + Arrow keys) to resize the sidebar — lg+ only; below that it stacks
@@ -152,8 +260,16 @@ export function ApiExplorer(
 								? (
 									<SettingsPanel
 										spec={spec}
+										method={method}
 										auth={auth}
-										onAuthChange={setAuth}
+										authorized={authorized}
+										tab={authorizeTab}
+										onTabChange={setAuthorizeTab}
+										onSelectMethod={selectMethod}
+										onApplyBasic={applyBasic}
+										onApplyBearer={applyBearer}
+										onClearAuth={clearAuth}
+										login={login}
 										serverOptions={serverOptions}
 										activeServer={activeServer ?? undefined}
 										onServerChange={setSelectedServer}
@@ -169,6 +285,8 @@ export function ApiExplorer(
 										spec={spec}
 										baseURL={activeServer ?? null}
 										auth={auth}
+										authorized={authorized}
+										onOpenAuthorize={() => openAuthorize('try')}
 									/>
 								)
 								: <p className="text-muted-foreground text-sm">Select an endpoint to see its documentation.</p>}

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -126,7 +126,10 @@ export function ApiExplorer(
 				setLoginStatus('error');
 				return;
 			}
-			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token }, authServer: activeServer ?? undefined });
+			// A minted token belongs to the instance the mint client talks to — Studio's computed URL for
+			// this entity — NOT to whatever server the spec's picker currently names. Stamping the trusted
+			// server means selecting a foreign declared server withholds the token instead of sending it there.
+			updateEntitySettings({ method: 'login', auth: { type: 'bearer', token }, authServer: baseURL ?? undefined });
 			setLoginStatus('idle');
 		} catch (error) {
 			if (!mountedRef.current || attempt !== attemptRef.current) {

--- a/src/features/instance/apis/explorer/ApiExplorer.tsx
+++ b/src/features/instance/apis/explorer/ApiExplorer.tsx
@@ -26,6 +26,18 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { cn } from '@/lib/cn';
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 
+/** The origin of a URL, or null if it can't be parsed — used to scope a credential to one server. */
+function originOf(url: string | null): string | null {
+	if (!url) {
+		return null;
+	}
+	try {
+		return new URL(url).origin;
+	} catch {
+		return null;
+	}
+}
+
 /**
  * The custom Harper API explorer: a searchable operation list beside a detail pane, with an
  * "Authorize" view for server + auth. The token-minting callbacks come from the parent (`APIDocs`) so
@@ -66,7 +78,6 @@ export function ApiExplorer(
 
 	const method: AuthMethod = entitySettings.method ?? 'login';
 	const auth: ApiAuth = entitySettings.auth ?? { type: 'cookie' };
-	const authorized = isAuthorized(auth);
 
 	// Mint race guard: each mint captures an attempt id; only the latest, on a still-mounted panel,
 	// may apply its token. Clearing authorization or unmounting bumps the id so an in-flight mint that
@@ -179,23 +190,21 @@ export function ApiExplorer(
 		updateEntitySettings({ auth: cleared });
 	};
 
-	const setSelectedServer = (url: string) => {
-		if (url === activeServer) {
-			updateEntitySettings({ server: url });
-			return;
-		}
-		// Credentials are scoped to the server they were entered/minted for: switching targets clears
-		// them (and cancels any in-flight mint) so a token minted for one origin is never sent to another.
-		attemptRef.current++;
-		setLoginStatus('idle');
-		setLoginError(null);
-		updateEntitySettings({ server: url, method: 'login', auth: { type: 'cookie' } });
-	};
+	const setSelectedServer = (url: string) => updateEntitySettings({ server: url });
 
 	const activeServer = serverOptions.find(s => s.url === entitySettings.server)?.url
 		?? serverOptions[0]?.url
 		?? baseURL;
 	const [copyServer] = useCopyToClipboard(activeServer ?? '');
+
+	// The credential is scoped to the instance we authorized against (the computed REST origin). Send it
+	// only when the active server shares that origin — whether the user picked another declared server or
+	// the active server recomputed implicitly — so a token/credential never reaches a different origin.
+	const trustedOrigin = originOf(baseURL);
+	const effectiveAuth: ApiAuth = trustedOrigin !== null && originOf(activeServer) === trustedOrigin
+		? auth
+		: { type: 'cookie' };
+	const authorized = isAuthorized(effectiveAuth);
 
 	// Width drives a CSS variable applied only at lg+; below that the sidebar stacks full-width.
 	const { width: sidebarWidth, isResizing, startResizing, handleKeyDown } = useResizableSidebar();
@@ -312,7 +321,7 @@ export function ApiExplorer(
 										op={selectedOp}
 										spec={spec}
 										baseURL={activeServer ?? null}
-										auth={auth}
+										auth={effectiveAuth}
 										authorized={authorized}
 										onOpenAuthorize={() => openAuthorize('try')}
 									/>

--- a/src/features/instance/apis/explorer/EndpointList.tsx
+++ b/src/features/instance/apis/explorer/EndpointList.tsx
@@ -1,15 +1,16 @@
 import { Input } from '@/components/ui/input';
 import { MethodBadge } from '@/features/instance/apis/explorer/MethodBadge';
-import { ApiAuth } from '@/features/instance/apis/explorer/request';
+import { AuthMethod } from '@/features/instance/apis/explorer/request';
 import { EndpointResourceNode } from '@/features/instance/apis/explorer/types';
 import { cn } from '@/lib/cn';
 import { ChevronDown, ChevronRight, Lock, LockOpen, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
-const AUTH_TYPE_LABEL: Record<ApiAuth['type'], string> = {
-	cookie: 'Cookie',
+const AUTH_METHOD_LABEL: Record<AuthMethod, string> = {
+	login: 'Log in',
 	basic: 'Basic',
 	bearer: 'Bearer',
+	cookie: 'Cookie',
 };
 
 /**
@@ -28,7 +29,8 @@ export function EndpointList({
 	onSelect,
 	filter,
 	onFilterChange,
-	authType,
+	method,
+	authorized,
 	settingsActive,
 	onOpenSettings,
 }: {
@@ -40,7 +42,8 @@ export function EndpointList({
 	onSelect: (id: string) => void;
 	filter: string;
 	onFilterChange: (value: string) => void;
-	authType: ApiAuth['type'];
+	method: AuthMethod;
+	authorized: boolean;
 	settingsActive: boolean;
 	onOpenSettings: () => void;
 }) {
@@ -56,8 +59,6 @@ export function EndpointList({
 			}
 			return next;
 		});
-
-	const usingHeaderAuth = authType === 'basic' || authType === 'bearer';
 
 	return (
 		// On lg the parent (`ApiExplorer`) is a fixed-height app-shell, so the sidebar fills it
@@ -75,11 +76,11 @@ export function EndpointList({
 						: 'border-border hover:bg-accent/60',
 				)}
 			>
-				{usingHeaderAuth
+				{authorized
 					? <Lock className="text-green size-4 shrink-0" />
 					: <LockOpen className="text-muted-foreground size-4 shrink-0" />}
 				<span className="flex-1 font-medium">Authorize</span>
-				<span className="text-muted-foreground text-xs">{AUTH_TYPE_LABEL[authType]}</span>
+				<span className="text-muted-foreground text-xs">{AUTH_METHOD_LABEL[method]}</span>
 			</button>
 
 			<div className="relative shrink-0">

--- a/src/features/instance/apis/explorer/OperationDetail.tsx
+++ b/src/features/instance/apis/explorer/OperationDetail.tsx
@@ -66,7 +66,7 @@ export function OperationDetail({
 							{authorized
 								? <Lock className="text-green size-3" />
 								: <Lock className="text-muted-foreground size-3" />}
-							{authorized ? 'Authorized' : 'Auth required — Authorize'}
+							{authorized ? 'Credential set' : 'Auth required — Authorize'}
 						</button>
 					)}
 				</div>

--- a/src/features/instance/apis/explorer/OperationDetail.tsx
+++ b/src/features/instance/apis/explorer/OperationDetail.tsx
@@ -5,7 +5,7 @@ import { CodeBlock } from '@/features/instance/apis/explorer/CodeBlock';
 import { MethodBadge } from '@/features/instance/apis/explorer/MethodBadge';
 import { ApiAuth } from '@/features/instance/apis/explorer/request';
 import { SchemaView } from '@/features/instance/apis/explorer/SchemaView';
-import { generateExample, jsonSchemaFromContent } from '@/features/instance/apis/explorer/spec';
+import { generateExample, jsonSchemaFromContent, requiresAuth } from '@/features/instance/apis/explorer/spec';
 import { httpStatusColorClass, STATUS_UNKNOWN_CLASS, StatusBadge } from '@/features/instance/apis/explorer/StatusBadge';
 import { TryItOut } from '@/features/instance/apis/explorer/TryItOut';
 import { FlatOperation, OpenApiSpec, Parameter, ResponseObject } from '@/features/instance/apis/explorer/types';
@@ -25,14 +25,18 @@ export function OperationDetail({
 	spec,
 	baseURL,
 	auth,
+	authorized,
+	onOpenAuthorize,
 }: {
 	op: FlatOperation;
 	spec: OpenApiSpec | undefined;
 	baseURL: string | null;
 	auth: ApiAuth;
+	authorized: boolean;
+	onOpenAuthorize: () => void;
 }) {
 	const [copyPath] = useCopyToClipboard(op.path);
-	const requiresAuth = (op.operation.security ?? spec?.security ?? []).length > 0;
+	const authRequired = requiresAuth(op.operation, spec);
 	const summary = op.operation.summary;
 	const description = op.operation.description;
 
@@ -53,10 +57,17 @@ export function OperationDetail({
 						<CopyIcon className="size-3.5" />
 					</Button>
 					{op.operation.deprecated && <Badge variant="warning">Deprecated</Badge>}
-					{requiresAuth && (
-						<Badge variant="secondary" className="gap-1">
-							<Lock className="size-3" /> Auth required
-						</Badge>
+					{authRequired && (
+						<button
+							type="button"
+							onClick={onOpenAuthorize}
+							className="border-border hover:bg-accent/60 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs transition-colors"
+						>
+							{authorized
+								? <Lock className="text-green size-3" />
+								: <Lock className="text-muted-foreground size-3" />}
+							{authorized ? 'Authorized' : 'Auth required — Authorize'}
+						</button>
 					)}
 				</div>
 				{summary && <h2 className="text-lg font-medium">{summary}</h2>}
@@ -76,7 +87,15 @@ export function OperationDetail({
 				</TabsContent>
 
 				<TabsContent value="try">
-					<TryItOut op={op} spec={spec} baseURL={baseURL} auth={auth} />
+					<TryItOut
+						op={op}
+						spec={spec}
+						baseURL={baseURL}
+						auth={auth}
+						authRequired={authRequired}
+						authorized={authorized}
+						onOpenAuthorize={onOpenAuthorize}
+					/>
 				</TabsContent>
 			</Tabs>
 		</div>

--- a/src/features/instance/apis/explorer/SettingsPanel.tsx
+++ b/src/features/instance/apis/explorer/SettingsPanel.tsx
@@ -2,11 +2,21 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { ApiAuth } from '@/features/instance/apis/explorer/request';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ApiAuth, AuthMethod } from '@/features/instance/apis/explorer/request';
 import { ServerOption } from '@/features/instance/apis/explorer/spec';
 import { OpenApiSpec } from '@/features/instance/apis/explorer/types';
 import { cn } from '@/lib/cn';
-import { CopyIcon } from 'lucide-react';
+import { CopyIcon, Lock, LockOpen } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+export interface LoginController {
+	status: 'idle' | 'pending' | 'error';
+	error: string | null;
+	runSession: () => void;
+	// Null when no direct instance URL can be proven, which hides the credential form.
+	runCredentials: ((credentials: { username: string; password: string }) => void) | null;
+}
 
 /** Which explicit-header auth forms to offer, derived from the spec's declared security schemes. */
 function availableHeaderAuth(spec: OpenApiSpec | undefined): { basic: boolean; bearer: boolean } {
@@ -14,7 +24,7 @@ function availableHeaderAuth(spec: OpenApiSpec | undefined): { basic: boolean; b
 	let basic = false;
 	let bearer = false;
 	for (const scheme of schemes) {
-		const kind = scheme?.scheme?.toLowerCase();
+		const kind = typeof scheme?.scheme === 'string' ? scheme.scheme.toLowerCase() : undefined;
 		if (kind === 'basic') {
 			basic = true;
 		}
@@ -32,30 +42,44 @@ function availableHeaderAuth(spec: OpenApiSpec | undefined): { basic: boolean; b
 
 /**
  * The Server + Authorization settings, shown in the detail pane when the sidebar's "Authorize" item
- * is selected. Auth is edited live (no Apply step): picking a type or typing a credential updates the
- * shared auth state immediately. Selections persist per instance in the browser's localStorage.
+ * is selected. Authorization is split into Documentation (what each method is and when to use it) and
+ * "Try it out" (the interactive log-in / credential entry that unlocks authenticated requests).
+ * Selections persist per instance in this browser tab's session storage.
  */
 export function SettingsPanel({
 	spec,
+	method,
 	auth,
-	onAuthChange,
+	authorized,
+	tab,
+	onTabChange,
+	onSelectMethod,
+	onApplyBasic,
+	onApplyBearer,
+	onClearAuth,
+	login,
 	serverOptions,
 	activeServer,
 	onServerChange,
 	onCopyServer,
 }: {
 	spec: OpenApiSpec | undefined;
+	method: AuthMethod;
 	auth: ApiAuth;
-	onAuthChange: (auth: ApiAuth) => void;
+	authorized: boolean;
+	tab: 'docs' | 'try';
+	onTabChange: (tab: 'docs' | 'try') => void;
+	onSelectMethod: (method: AuthMethod) => void;
+	onApplyBasic: (username: string, password: string) => void;
+	onApplyBearer: (token: string) => void;
+	onClearAuth: () => void;
+	login: LoginController;
 	serverOptions: ServerOption[];
 	activeServer: string | undefined;
 	onServerChange: (url: string) => void;
 	onCopyServer: () => void;
 }) {
 	const available = availableHeaderAuth(spec);
-	const username = auth.type === 'basic' ? auth.username : '';
-	const password = auth.type === 'basic' ? auth.password : '';
-	const token = auth.type === 'bearer' ? auth.token : '';
 
 	return (
 		<div className="flex max-w-2xl flex-col gap-8">
@@ -73,80 +97,241 @@ export function SettingsPanel({
 			</section>
 
 			<section className="flex flex-col gap-3">
-				<div>
+				<div className="flex items-center gap-2">
+					{authorized
+						? <Lock className="text-green size-4" />
+						: <LockOpen className="text-muted-foreground size-4" />}
 					<h2 className="text-lg font-medium">Authorization</h2>
-					<p className="text-muted-foreground text-sm">
-						How &quot;Try it out&quot; requests authenticate. Selections are saved in this browser for this instance.
-					</p>
 				</div>
 
-				<div className="flex flex-wrap gap-2">
-					<AuthTypeButton active={auth.type === 'cookie'} onClick={() => onAuthChange({ type: 'cookie' })}>
-						Cookie
-					</AuthTypeButton>
-					{available.basic && (
-						<AuthTypeButton
-							active={auth.type === 'basic'}
-							onClick={() => onAuthChange({ type: 'basic', username, password })}
-						>
-							Basic
-						</AuthTypeButton>
-					)}
-					{available.bearer && (
-						<AuthTypeButton
-							active={auth.type === 'bearer'}
-							onClick={() => onAuthChange({ type: 'bearer', token })}
-						>
-							Bearer token
-						</AuthTypeButton>
-					)}
-				</div>
+				<Tabs value={tab} onValueChange={value => onTabChange(value as 'docs' | 'try')} className="gap-4">
+					<TabsList>
+						<TabsTrigger value="docs">Documentation</TabsTrigger>
+						<TabsTrigger value="try">Try it out</TabsTrigger>
+					</TabsList>
 
-				{auth.type === 'cookie' && (
-					<p className="text-muted-foreground max-w-prose text-sm">
-						Requests are sent with your browser&apos;s instance session cookie (<code>
-							credentials: &quot;include&quot;
-						</code>). Use this when you&apos;re already signed in to this instance — no extra credentials needed.
-					</p>
-				)}
+					<TabsContent value="docs">
+						<AuthorizationDocs available={available} />
+					</TabsContent>
 
-				{auth.type === 'basic' && (
-					<div className="flex max-w-sm flex-col gap-3">
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="api-auth-username">Username</Label>
-							<Input
-								id="api-auth-username"
-								value={username}
-								autoComplete="username"
-								onChange={e => onAuthChange({ type: 'basic', username: e.target.value, password })}
-							/>
-						</div>
-						<div className="flex flex-col gap-1.5">
-							<Label htmlFor="api-auth-password">Password</Label>
-							<Input
-								id="api-auth-password"
-								type="password"
-								value={password}
-								autoComplete="current-password"
-								onChange={e => onAuthChange({ type: 'basic', username, password: e.target.value })}
-							/>
-						</div>
-					</div>
-				)}
-
-				{auth.type === 'bearer' && (
-					<div className="flex max-w-sm flex-col gap-1.5">
-						<Label htmlFor="api-auth-token">Token</Label>
-						<Input
-							id="api-auth-token"
-							value={token}
-							placeholder="eyJhbGciOi…"
-							onChange={e => onAuthChange({ type: 'bearer', token: e.target.value })}
-						/>
-					</div>
-				)}
+					<TabsContent value="try" className="flex flex-col gap-4">
+						<MethodSelector method={method} available={available} onSelect={onSelectMethod} />
+						{authorized && (
+							<div className="border-green/40 bg-green/10 text-foreground flex flex-wrap items-center gap-2 rounded-md border p-3 text-sm">
+								<Lock className="text-green size-4" />
+								<span className="flex-1">Authorized — &quot;Try it out&quot; requests will send this credential.</span>
+								<Button type="button" variant="outline" size="sm" onClick={onClearAuth}>Clear</Button>
+							</div>
+						)}
+						{method === 'login' && <LoginForm login={login} authorized={authorized} />}
+						{method === 'basic' && <BasicForm auth={auth} onApply={onApplyBasic} />}
+						{method === 'bearer' && <BearerForm auth={auth} onApply={onApplyBearer} />}
+						{method === 'cookie' && <CookieNotice />}
+					</TabsContent>
+				</Tabs>
 			</section>
 		</div>
+	);
+}
+
+function AuthorizationDocs({ available }: { available: { basic: boolean; bearer: boolean } }) {
+	return (
+		<div className="text-muted-foreground flex max-w-prose flex-col gap-4 text-sm">
+			<p>
+				How &quot;Try it out&quot; requests authenticate. Your selection is saved in this browser tab only (session
+				storage) and cleared when the tab closes.
+			</p>
+			<dl className="flex flex-col gap-3">
+				<div>
+					<dt className="text-foreground font-medium">Log in (recommended)</dt>
+					<dd>
+						Exchanges your current Studio session — or a username and password — for a short-lived Bearer token, sent as
+						an <code>Authorization</code>{' '}
+						header. This works even when the instance is on a different site than Studio and cookies aren&apos;t sent.
+						Only the minted token is stored, never your password.
+					</dd>
+				</div>
+				{available.basic && (
+					<div>
+						<dt className="text-foreground font-medium">Basic</dt>
+						<dd>
+							Sends your username and password as an <code>Authorization: Basic</code>{' '}
+							header on every request. The username and password are stored in this browser tab until it closes.
+						</dd>
+					</div>
+				)}
+				{available.bearer && (
+					<div>
+						<dt className="text-foreground font-medium">Bearer token</dt>
+						<dd>
+							Paste an existing operation token; it&apos;s sent as an <code>Authorization: Bearer</code> header.
+						</dd>
+					</div>
+				)}
+				<div>
+					<dt className="text-foreground font-medium">Cookie</dt>
+					<dd>
+						Relies on your browser&apos;s instance session cookie (<code>credentials: &quot;include&quot;</code>).
+						Whether the cookie is sent depends on how the instance is deployed relative to Studio (same site, cookie
+						attributes, HTTPS), so it often won&apos;t work in a deployed environment — prefer Log in there.
+					</dd>
+				</div>
+			</dl>
+		</div>
+	);
+}
+
+function MethodSelector({
+	method,
+	available,
+	onSelect,
+}: {
+	method: AuthMethod;
+	available: { basic: boolean; bearer: boolean };
+	onSelect: (method: AuthMethod) => void;
+}) {
+	return (
+		<div className="flex flex-wrap gap-2">
+			<AuthTypeButton active={method === 'login'} onClick={() => onSelect('login')}>Log in</AuthTypeButton>
+			{available.basic && (
+				<AuthTypeButton active={method === 'basic'} onClick={() => onSelect('basic')}>Basic</AuthTypeButton>
+			)}
+			{available.bearer && (
+				<AuthTypeButton active={method === 'bearer'} onClick={() => onSelect('bearer')}>Bearer token</AuthTypeButton>
+			)}
+			<AuthTypeButton active={method === 'cookie'} onClick={() => onSelect('cookie')}>Cookie</AuthTypeButton>
+		</div>
+	);
+}
+
+function LoginForm({ login, authorized }: { login: LoginController; authorized: boolean }) {
+	const [username, setUsername] = useState('');
+	const [password, setPassword] = useState('');
+	const pending = login.status === 'pending';
+
+	// Don't keep the typed credentials in memory once a token has been minted from them.
+	useEffect(() => {
+		if (authorized) {
+			setUsername('');
+			setPassword('');
+		}
+	}, [authorized]);
+
+	return (
+		<div className="flex max-w-sm flex-col gap-4">
+			<div className="flex flex-col gap-1.5">
+				<Button type="button" variant="submit" disabled={pending} onClick={login.runSession}>
+					{pending ? 'Authorizing…' : 'Authorize with your current session'}
+				</Button>
+				<span className="text-muted-foreground text-xs">
+					Mints a token as the user you&apos;re signed in to Studio as — no credentials to retype.
+				</span>
+			</div>
+
+			{login.runCredentials && (
+				<form
+					className="flex flex-col gap-3"
+					onSubmit={event => {
+						event.preventDefault();
+						login.runCredentials?.({ username, password });
+					}}
+				>
+					<span className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+						Or use different credentials
+					</span>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="api-login-username">Username</Label>
+						<Input
+							id="api-login-username"
+							value={username}
+							autoComplete="username"
+							onChange={e => setUsername(e.target.value)}
+						/>
+					</div>
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="api-login-password">Password</Label>
+						<Input
+							id="api-login-password"
+							type="password"
+							value={password}
+							autoComplete="current-password"
+							onChange={e => setPassword(e.target.value)}
+						/>
+					</div>
+					<Button type="submit" variant="outline" disabled={pending || !username || !password}>
+						{pending ? 'Authorizing…' : 'Authorize'}
+					</Button>
+				</form>
+			)}
+
+			{login.status === 'error' && login.error && <p className="text-red text-sm">{login.error}</p>}
+			{!authorized && login.status === 'idle' && (
+				<p className="text-muted-foreground text-xs">Not signed in — authenticated requests will be rejected.</p>
+			)}
+		</div>
+	);
+}
+
+function BasicForm({ auth, onApply }: { auth: ApiAuth; onApply: (username: string, password: string) => void }) {
+	const [username, setUsername] = useState(auth.type === 'basic' ? auth.username : '');
+	const [password, setPassword] = useState(auth.type === 'basic' ? auth.password : '');
+	return (
+		<form
+			className="flex max-w-sm flex-col gap-3"
+			onSubmit={event => {
+				event.preventDefault();
+				onApply(username, password);
+			}}
+		>
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="api-auth-username">Username</Label>
+				<Input
+					id="api-auth-username"
+					value={username}
+					autoComplete="username"
+					onChange={e => setUsername(e.target.value)}
+				/>
+			</div>
+			<div className="flex flex-col gap-1.5">
+				<Label htmlFor="api-auth-password">Password</Label>
+				<Input
+					id="api-auth-password"
+					type="password"
+					value={password}
+					autoComplete="current-password"
+					onChange={e => setPassword(e.target.value)}
+				/>
+			</div>
+			<Button type="submit" variant="outline" disabled={!username}>Authorize</Button>
+		</form>
+	);
+}
+
+function BearerForm({ auth, onApply }: { auth: ApiAuth; onApply: (token: string) => void }) {
+	const [token, setToken] = useState(auth.type === 'bearer' ? auth.token : '');
+	return (
+		<form
+			className="flex max-w-sm flex-col gap-1.5"
+			onSubmit={event => {
+				event.preventDefault();
+				onApply(token);
+			}}
+		>
+			<Label htmlFor="api-auth-token">Token</Label>
+			<Input id="api-auth-token" value={token} placeholder="eyJhbGciOi…" onChange={e => setToken(e.target.value)} />
+			<Button type="submit" variant="outline" className="mt-2" disabled={!token}>Authorize</Button>
+		</form>
+	);
+}
+
+function CookieNotice() {
+	return (
+		<p className="text-muted-foreground max-w-prose text-sm">
+			Requests are sent with your browser&apos;s instance session cookie (<code>
+				credentials: &quot;include&quot;
+			</code>). Whether it&apos;s sent depends on how the instance is deployed relative to Studio, so it often
+			won&apos;t work in a deployed environment — use Log in if requests come back unauthorized.
+		</p>
 	);
 }
 

--- a/src/features/instance/apis/explorer/SettingsPanel.tsx
+++ b/src/features/instance/apis/explorer/SettingsPanel.tsx
@@ -8,7 +8,7 @@ import { ServerOption } from '@/features/instance/apis/explorer/spec';
 import { OpenApiSpec } from '@/features/instance/apis/explorer/types';
 import { cn } from '@/lib/cn';
 import { CopyIcon, Lock, LockOpen } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export interface LoginController {
 	status: 'idle' | 'pending' | 'error';
@@ -119,7 +119,7 @@ export function SettingsPanel({
 						{authorized && (
 							<div className="border-green/40 bg-green/10 text-foreground flex flex-wrap items-center gap-2 rounded-md border p-3 text-sm">
 								<Lock className="text-green size-4" />
-								<span className="flex-1">Authorized — &quot;Try it out&quot; requests will send this credential.</span>
+								<span className="flex-1">Credential set — &quot;Try it out&quot; requests will send it.</span>
 								<Button type="button" variant="outline" size="sm" onClick={onClearAuth}>Clear</Button>
 							</div>
 						)}
@@ -209,13 +209,17 @@ function LoginForm({ login, authorized }: { login: LoginController; authorized: 
 	const [password, setPassword] = useState('');
 	const pending = login.status === 'pending';
 
-	// Don't keep the typed credentials in memory once a token has been minted from them.
+	// Drop the typed credentials once a mint from them succeeds (pending → idle). Keyed on the status
+	// transition, not the `authorized` boolean, so re-authenticating while already authorized (where
+	// `authorized` never changes) still clears the password from memory.
+	const prevStatus = useRef(login.status);
 	useEffect(() => {
-		if (authorized) {
+		if (prevStatus.current === 'pending' && login.status === 'idle') {
 			setUsername('');
 			setPassword('');
 		}
-	}, [authorized]);
+		prevStatus.current = login.status;
+	}, [login.status]);
 
 	return (
 		<div className="flex max-w-sm flex-col gap-4">
@@ -275,6 +279,12 @@ function LoginForm({ login, authorized }: { login: LoginController; authorized: 
 function BasicForm({ auth, onApply }: { auth: ApiAuth; onApply: (username: string, password: string) => void }) {
 	const [username, setUsername] = useState(auth.type === 'basic' ? auth.username : '');
 	const [password, setPassword] = useState(auth.type === 'basic' ? auth.password : '');
+	// Resync when the applied credential changes underneath the form (e.g. Clear empties it), so a
+	// cleared password doesn't linger in the input and get resubmitted.
+	useEffect(() => {
+		setUsername(auth.type === 'basic' ? auth.username : '');
+		setPassword(auth.type === 'basic' ? auth.password : '');
+	}, [auth]);
 	return (
 		<form
 			className="flex max-w-sm flex-col gap-3"
@@ -309,6 +319,10 @@ function BasicForm({ auth, onApply }: { auth: ApiAuth; onApply: (username: strin
 
 function BearerForm({ auth, onApply }: { auth: ApiAuth; onApply: (token: string) => void }) {
 	const [token, setToken] = useState(auth.type === 'bearer' ? auth.token : '');
+	// Resync when the applied token changes underneath the form (e.g. Clear empties it).
+	useEffect(() => {
+		setToken(auth.type === 'bearer' ? auth.token : '');
+	}, [auth]);
 	return (
 		<form
 			className="flex max-w-sm flex-col gap-1.5"

--- a/src/features/instance/apis/explorer/TryItOut.tsx
+++ b/src/features/instance/apis/explorer/TryItOut.tsx
@@ -42,11 +42,17 @@ export function TryItOut({
 	spec,
 	baseURL,
 	auth,
+	authRequired,
+	authorized,
+	onOpenAuthorize,
 }: {
 	op: FlatOperation;
 	spec: OpenApiSpec | undefined;
 	baseURL: string | null;
 	auth: ApiAuth;
+	authRequired: boolean;
+	authorized: boolean;
+	onOpenAuthorize: () => void;
 }) {
 	const monacoTheme = useMonacoTheme();
 
@@ -90,6 +96,18 @@ export function TryItOut({
 
 	return (
 		<div className="flex flex-col gap-5">
+			{authRequired && !authorized && (
+				<div className="border-border bg-muted/40 text-muted-foreground flex flex-wrap items-center gap-1.5 rounded-md border px-3 py-2 text-xs">
+					<span>This endpoint requires authorization.</span>
+					<button
+						type="button"
+						onClick={onOpenAuthorize}
+						className="text-foreground font-medium underline underline-offset-2"
+					>
+						Authorize →
+					</button>
+				</div>
+			)}
 			{pathParamDefs.length > 0 && (
 				<ParamInputs
 					title="Path parameters"

--- a/src/features/instance/apis/explorer/request.test.ts
+++ b/src/features/instance/apis/explorer/request.test.ts
@@ -4,6 +4,7 @@ import {
 	buildRequest,
 	executeRequest,
 	formatResponseBody,
+	isAuthorized,
 	joinUrl,
 	MAX_DISPLAY_BODY_CHARS,
 	methodHasBody,
@@ -119,6 +120,19 @@ describe('buildRequest', () => {
 		}, noAuth);
 		expect(req.headers['X-Trace']).toBe('abc');
 		expect(req.headers['X-Blank']).toBeUndefined();
+	});
+});
+
+describe('isAuthorized', () => {
+	it('is true only for a Basic username or a non-empty Bearer token', () => {
+		expect(isAuthorized({ type: 'basic', username: 'u', password: 'p' })).toBe(true);
+		expect(isAuthorized({ type: 'bearer', token: 'tok' })).toBe(true);
+	});
+
+	it('is false for cookie and for empty explicit credentials', () => {
+		expect(isAuthorized({ type: 'cookie' })).toBe(false);
+		expect(isAuthorized({ type: 'basic', username: '', password: '' })).toBe(false);
+		expect(isAuthorized({ type: 'bearer', token: '' })).toBe(false);
 	});
 });
 

--- a/src/features/instance/apis/explorer/request.ts
+++ b/src/features/instance/apis/explorer/request.ts
@@ -11,6 +11,25 @@ export type ApiAuth =
 	| { type: 'basic'; username: string; password: string }
 	| { type: 'bearer'; token: string };
 
+/**
+ * The credential-acquisition method the user picked in the Authorize panel. Distinct from the wire
+ * `ApiAuth` so "Log in" can be a real, representable default and a logged-in state stays
+ * distinguishable from a manually pasted Bearer token: `login` resolves to a `bearer` credential once
+ * a token has been minted, but is presented and defaulted to on its own.
+ */
+export type AuthMethod = 'login' | 'basic' | 'bearer' | 'cookie';
+
+/**
+ * Whether the auth carries an explicit credential the request will actually send — a Basic username
+ * or a Bearer token. `cookie` (and an empty Basic/Bearer) is not "authorized" in this sense: it only
+ * relies on an ambient session cookie that may not be sent cross-site. Branch-only, allocation-free:
+ * it runs on the sidebar's lock indicator during ordinary renders.
+ */
+export function isAuthorized(auth: ApiAuth): boolean {
+	return (auth.type === 'basic' && typeof auth.username === 'string' && auth.username !== '')
+		|| (auth.type === 'bearer' && typeof auth.token === 'string' && auth.token !== '');
+}
+
 export interface RequestInputs {
 	pathParams: Record<string, string>;
 	queryParams: Record<string, string>;

--- a/src/features/instance/apis/explorer/settings.test.ts
+++ b/src/features/instance/apis/explorer/settings.test.ts
@@ -2,9 +2,10 @@
 import {
 	forgetEntitySettings,
 	readEntitySettings,
+	scrubLegacySettings,
 	writeEntitySettings,
 } from '@/features/instance/apis/explorer/settings';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 const KEY = 'ApiExplorerSettings';
 
@@ -60,24 +61,27 @@ describe('explorer settings legacy scrub', () => {
 		localStorage.clear();
 	});
 
-	// The one-time scrub runs on a module's first read, so each case imports a fresh module instance.
-	it('drops the legacy localStorage secrets on first read (never migrating them)', async () => {
-		vi.resetModules();
+	it('drops the legacy localStorage secrets, never migrating them', () => {
 		localStorage.setItem(
 			KEY,
 			JSON.stringify({ 'ins-a': { auth: { type: 'basic', username: 'u', password: 'secret' } } }),
 		);
-		const mod = await import('@/features/instance/apis/explorer/settings');
-		expect(mod.readEntitySettings('ins-a')).toEqual({});
+		scrubLegacySettings();
 		expect(localStorage.getItem(KEY)).toBeNull();
 	});
 
-	it('removes a corrupted legacy value too', async () => {
-		vi.resetModules();
+	it('removes a corrupted legacy value too', () => {
 		localStorage.setItem(KEY, 'corrupt-not-json');
-		const mod = await import('@/features/instance/apis/explorer/settings');
-		mod.readEntitySettings('ins-a');
+		scrubLegacySettings();
 		expect(localStorage.getItem(KEY)).toBeNull();
+	});
+
+	it('does not scrub on ordinary reads (bootstrap/installer-driven only)', () => {
+		localStorage.setItem(KEY, 'legacy');
+		readEntitySettings('ins-a');
+		writeEntitySettings('ins-a', { server: 'http://a' });
+		// A read/write must not touch the legacy localStorage key.
+		expect(localStorage.getItem(KEY)).toBe('legacy');
 	});
 });
 

--- a/src/features/instance/apis/explorer/settings.test.ts
+++ b/src/features/instance/apis/explorer/settings.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import {
 	forgetEntitySettings,
+	pruneStaleEntitySettings,
 	readEntitySettings,
 	scrubLegacySettings,
 	writeEntitySettings,
@@ -124,5 +125,51 @@ describe('explorer legacy scrub (exported, re-runnable)', () => {
 		localStorage.setItem(KEY, 'rewritten');
 		scrubLegacySettings();
 		expect(localStorage.getItem(KEY)).toBeNull();
+	});
+});
+
+describe('stale-credential reconciliation (missed invalidation, e.g. tab reloaded)', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		localStorage.clear();
+	});
+
+	it('strips a credential stamped under an older generation, keeping non-secret selections', () => {
+		writeEntitySettings('ins-a', {
+			method: 'bearer',
+			auth: { type: 'bearer', token: 'revoked' },
+			authServer: 'https://a',
+			authGeneration: 1,
+			server: 'https://a',
+		});
+		// The entity was signed out while this tab wasn't listening, so the generation moved on.
+		pruneStaleEntitySettings(() => 2);
+		expect(readEntitySettings('ins-a')).toEqual({ method: 'bearer', server: 'https://a' });
+	});
+
+	it('keeps a credential whose generation still matches', () => {
+		writeEntitySettings('ins-a', { auth: { type: 'bearer', token: 'live' }, authGeneration: 7 });
+		pruneStaleEntitySettings(() => 7);
+		expect(readEntitySettings('ins-a').auth).toEqual({ type: 'bearer', token: 'live' });
+	});
+
+	it('strips a credential that carries no generation stamp at all', () => {
+		writeEntitySettings('ins-a', { auth: { type: 'basic', username: 'u', password: 'p' } });
+		pruneStaleEntitySettings(() => 0);
+		expect(readEntitySettings('ins-a').auth).toBeUndefined();
+	});
+
+	it('honors an invalidation written before any listener was installed (bootstrap path)', async () => {
+		const { authStore } = await import('@/features/auth/store/authStore');
+		writeEntitySettings('ins-a', {
+			auth: { type: 'bearer', token: 'stale' },
+			authGeneration: authStore.getExplorerAuthEpoch('ins-a'),
+		});
+		// Another tab signs out; this tab is not running, so no storage event is ever delivered here.
+		authStore.signOutLocally('ins-a');
+		writeEntitySettings('ins-a', { auth: { type: 'bearer', token: 'stale' }, authGeneration: 0 });
+		// Bootstrap reconciliation (what installExplorerCrossTabCleanup runs immediately) must drop it.
+		pruneStaleEntitySettings(id => authStore.getExplorerAuthEpoch(id));
+		expect(readEntitySettings('ins-a').auth).toBeUndefined();
 	});
 });

--- a/src/features/instance/apis/explorer/settings.test.ts
+++ b/src/features/instance/apis/explorer/settings.test.ts
@@ -80,3 +80,45 @@ describe('explorer settings legacy scrub', () => {
 		expect(localStorage.getItem(KEY)).toBeNull();
 	});
 });
+
+describe('explorer settings cleared on per-entity sign-out (cross-user leak guard)', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		localStorage.clear();
+	});
+
+	// User A authorizes the explorer, then the entity is disconnected (the path ClusterHome/ClusterCard
+	// use, setUserForEntity(entity, null) → setUserForIdAndKey(..., null)); user B must not inherit A's
+	// stored credential on the same entity.
+	it('a sign-out through setUserForIdAndKey drops the stored explorer credential', async () => {
+		const { authStore } = await import('@/features/auth/store/authStore');
+		writeEntitySettings('ins-shared', { auth: { type: 'bearer', token: 'user-A-token' } });
+		authStore.setUserForIdAndKey('ins-shared', 'ins-shared-fqdn', null);
+		expect(readEntitySettings('ins-shared')).toEqual({});
+	});
+
+	it('a sign-out bumps the entity auth epoch (guards in-flight mints and cross-tab clears)', async () => {
+		const { authStore } = await import('@/features/auth/store/authStore');
+		const before = authStore.getExplorerAuthEpoch('ins-epoch');
+		authStore.setUserForIdAndKey('ins-epoch', 'ins-epoch-fqdn', null);
+		expect(authStore.getExplorerAuthEpoch('ins-epoch')).toBe(before + 1);
+	});
+});
+
+describe('explorer legacy scrub (exported, re-runnable)', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		localStorage.clear();
+	});
+
+	it('removes the legacy key and re-runs (not one-shot) so a rewritten key is scrubbed again', async () => {
+		const { scrubLegacySettings } = await import('@/features/instance/apis/explorer/settings');
+		localStorage.setItem(KEY, JSON.stringify({ x: { auth: { type: 'bearer', token: 't' } } }));
+		scrubLegacySettings();
+		expect(localStorage.getItem(KEY)).toBeNull();
+		// A concurrently-open pre-upgrade tab rewrites it; a later scrub removes it again.
+		localStorage.setItem(KEY, 'rewritten');
+		scrubLegacySettings();
+		expect(localStorage.getItem(KEY)).toBeNull();
+	});
+});

--- a/src/features/instance/apis/explorer/settings.test.ts
+++ b/src/features/instance/apis/explorer/settings.test.ts
@@ -1,41 +1,82 @@
 /** @vitest-environment jsdom */
-import { readEntitySettings, writeEntitySettings } from '@/features/instance/apis/explorer/settings';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	forgetEntitySettings,
+	readEntitySettings,
+	writeEntitySettings,
+} from '@/features/instance/apis/explorer/settings';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const KEY = 'ApiExplorerSettings';
 
-describe('explorer settings persistence', () => {
-	beforeEach(() => localStorage.clear());
-
-	it('round-trips one entity without touching others', () => {
-		writeEntitySettings('ins-a', { auth: { type: 'bearer', token: 'A' } });
-		writeEntitySettings('ins-b', { server: 'http://b' });
-		expect(readEntitySettings('ins-a')).toEqual({ auth: { type: 'bearer', token: 'A' } });
-		expect(readEntitySettings('ins-b')).toEqual({ server: 'http://b' });
+describe('explorer settings persistence (sessionStorage)', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		localStorage.clear();
 	});
 
-	it('a write does not resurrect an entity another tab signed out (fresh read-merge-write)', () => {
+	it('round-trips one entity in sessionStorage without touching others or localStorage', () => {
+		writeEntitySettings('ins-a', { method: 'bearer', auth: { type: 'bearer', token: 'A' } });
+		writeEntitySettings('ins-b', { server: 'http://b' });
+		expect(readEntitySettings('ins-a')).toEqual({ method: 'bearer', auth: { type: 'bearer', token: 'A' } });
+		expect(readEntitySettings('ins-b')).toEqual({ server: 'http://b' });
+		expect(sessionStorage.getItem(KEY)).toBeTruthy();
+		expect(localStorage.getItem(KEY)).toBeNull();
+	});
+
+	it('forgetEntitySettings drops only the named entity', () => {
 		writeEntitySettings('ins-a', { auth: { type: 'bearer', token: 'A' } });
 		writeEntitySettings('ins-b', { auth: { type: 'bearer', token: 'B' } });
-
-		// Another tab signs ins-b out: it deletes ins-b's key directly in localStorage.
-		const map = JSON.parse(localStorage.getItem(KEY)!);
-		delete map['ins-b'];
-		localStorage.setItem(KEY, JSON.stringify(map));
-
-		// This tab (which still had a stale full map in memory) edits ins-a.
-		writeEntitySettings('ins-a', { server: 'http://a' });
-
-		const after = JSON.parse(localStorage.getItem(KEY)!);
-		expect(Object.hasOwn(after, 'ins-b')).toBe(false); // B stays signed out, not resurrected
-		expect(after['ins-a']).toEqual({ auth: { type: 'bearer', token: 'A' }, server: 'http://a' });
+		forgetEntitySettings('ins-a');
+		expect(readEntitySettings('ins-a')).toEqual({});
+		expect(readEntitySettings('ins-b')).toEqual({ auth: { type: 'bearer', token: 'B' } });
 	});
 
-	it('reads a corrupted (non-object) stored value as empty', () => {
-		localStorage.setItem(KEY, '5');
+	it('reads a corrupted (non-object) stored value as empty and recovers on write', () => {
+		sessionStorage.setItem(KEY, '5');
 		expect(readEntitySettings('ins-a')).toEqual({});
-		// And a subsequent write recovers to a valid map.
 		writeEntitySettings('ins-a', { server: 'http://a' });
 		expect(readEntitySettings('ins-a')).toEqual({ server: 'http://a' });
+	});
+
+	it('normalizes unknown method/auth shapes and drops non-string fields', () => {
+		sessionStorage.setItem(
+			KEY,
+			JSON.stringify({
+				'ins-a': { method: 'nonsense', auth: { type: 'weird' }, server: 5 },
+				'ins-b': { method: 'basic', auth: { type: 'basic', username: 'u', password: 2 } },
+			}),
+		);
+		expect(readEntitySettings('ins-a')).toEqual({});
+		expect(readEntitySettings('ins-b')).toEqual({
+			method: 'basic',
+			auth: { type: 'basic', username: 'u', password: '' },
+		});
+	});
+});
+
+describe('explorer settings legacy scrub', () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		localStorage.clear();
+	});
+
+	// The one-time scrub runs on a module's first read, so each case imports a fresh module instance.
+	it('drops the legacy localStorage secrets on first read (never migrating them)', async () => {
+		vi.resetModules();
+		localStorage.setItem(
+			KEY,
+			JSON.stringify({ 'ins-a': { auth: { type: 'basic', username: 'u', password: 'secret' } } }),
+		);
+		const mod = await import('@/features/instance/apis/explorer/settings');
+		expect(mod.readEntitySettings('ins-a')).toEqual({});
+		expect(localStorage.getItem(KEY)).toBeNull();
+	});
+
+	it('removes a corrupted legacy value too', async () => {
+		vi.resetModules();
+		localStorage.setItem(KEY, 'corrupt-not-json');
+		const mod = await import('@/features/instance/apis/explorer/settings');
+		mod.readEntitySettings('ins-a');
+		expect(localStorage.getItem(KEY)).toBeNull();
 	});
 });

--- a/src/features/instance/apis/explorer/settings.ts
+++ b/src/features/instance/apis/explorer/settings.ts
@@ -1,18 +1,113 @@
-import { ApiAuth } from '@/features/instance/apis/explorer/request';
-import { getLocalStorage } from '@/lib/storage/getLocalStorage';
-import { LocalStorageKeys } from '@/lib/storage/localStorageKeys';
-import { setLocalStorage } from '@/lib/storage/setLocalStorage';
+import { ApiAuth, AuthMethod } from '@/features/instance/apis/explorer/request';
+import { getSessionStorage } from '@/lib/storage/getSessionStorage';
+import { setSessionStorage } from '@/lib/storage/setSessionStorage';
 
-/** Per-entity server + auth selections, persisted under `LocalStorageKeys.ApiExplorerSettings`. */
+const KEY = 'ApiExplorerSettings' as const;
+
+/**
+ * Per-entity Authorize selections. `method` is the UI credential source; `auth` is the wire
+ * credential the request builder consumes. They are stored together (rather than deriving one from
+ * the other) so a logged-in `bearer` stays distinguishable from a manually pasted `bearer`. Persisted
+ * per browser tab in sessionStorage — cleared when the tab closes — under a single map key.
+ */
 export interface ExplorerEntitySettings {
+	method?: AuthMethod;
 	auth?: ApiAuth;
 	server?: string;
 }
 
-/** The whole persisted map, guarded so a corrupted (non-object) value reads as empty rather than throwing. */
+function normalizeMethod(value: unknown): AuthMethod | undefined {
+	return value === 'login' || value === 'basic' || value === 'bearer' || value === 'cookie' ? value : undefined;
+}
+
+/** Coerce an untrusted stored `auth` into a known `ApiAuth` shape, dropping unknown types/fields. */
+function normalizeAuth(value: unknown): ApiAuth | undefined {
+	if (!value || typeof value !== 'object') {
+		return undefined;
+	}
+	const v = value as Record<string, unknown>;
+	if (v.type === 'cookie') {
+		return { type: 'cookie' };
+	}
+	if (v.type === 'basic') {
+		return {
+			type: 'basic',
+			username: typeof v.username === 'string' ? v.username : '',
+			password: typeof v.password === 'string' ? v.password : '',
+		};
+	}
+	if (v.type === 'bearer') {
+		return { type: 'bearer', token: typeof v.token === 'string' ? v.token : '' };
+	}
+	return undefined;
+}
+
+function normalizeEntity(value: unknown): ExplorerEntitySettings {
+	if (!value || typeof value !== 'object') {
+		return {};
+	}
+	const v = value as Record<string, unknown>;
+	const out: ExplorerEntitySettings = {};
+	const method = normalizeMethod(v.method);
+	if (method) {
+		out.method = method;
+	}
+	const auth = normalizeAuth(v.auth);
+	if (auth) {
+		out.auth = auth;
+	}
+	if (typeof v.server === 'string') {
+		out.server = v.server;
+	}
+	return out;
+}
+
+let legacyScrubbed = false;
+
+/**
+ * One-time removal of the pre-sessionStorage `localStorage` map. That map persisted Basic passwords
+ * and Bearer tokens in plaintext across sessions; simply switching this module to sessionStorage would
+ * leave the old value readable indefinitely. We drop it wholesale (no secret is migrated) and always
+ * attempt removal even if reading threw. Bounded limitation: a concurrently-open pre-upgrade tab can
+ * write the key back — this runs on every explorer init, but not continuously.
+ */
+function scrubLegacySettings(): void {
+	if (legacyScrubbed) {
+		return;
+	}
+	legacyScrubbed = true;
+	try {
+		localStorage.removeItem(KEY);
+	} catch {
+		// Storage disabled by policy — nothing to scrub, nothing to fail.
+	}
+}
+
+/** The whole persisted map, guarded so disabled/corrupted storage reads as empty rather than throwing. */
 function readMap(): Record<string, ExplorerEntitySettings> {
-	const map = getLocalStorage<Record<string, ExplorerEntitySettings>>(LocalStorageKeys.ApiExplorerSettings, {});
-	return map && typeof map === 'object' && !Array.isArray(map) ? map : {};
+	scrubLegacySettings();
+	let raw: Record<string, unknown> = {};
+	try {
+		const stored = getSessionStorage<unknown, typeof KEY>(KEY, {});
+		if (stored && typeof stored === 'object' && !Array.isArray(stored)) {
+			raw = stored as Record<string, unknown>;
+		}
+	} catch {
+		return {};
+	}
+	const map: Record<string, ExplorerEntitySettings> = {};
+	for (const [id, value] of Object.entries(raw)) {
+		map[id] = normalizeEntity(value);
+	}
+	return map;
+}
+
+function writeMap(map: Record<string, ExplorerEntitySettings>): void {
+	try {
+		setSessionStorage<Record<string, ExplorerEntitySettings>, typeof KEY>(KEY, map);
+	} catch {
+		// Storage disabled/full — the in-memory state still drives the current session's requests.
+	}
 }
 
 export function readEntitySettings(entityId: string): ExplorerEntitySettings {
@@ -20,14 +115,18 @@ export function readEntitySettings(entityId: string): ExplorerEntitySettings {
 	return Object.hasOwn(map, entityId) ? map[entityId] ?? {} : {};
 }
 
-/**
- * Persist one entity's settings with a fresh read-merge-write against localStorage — never a stale
- * in-memory copy of the whole map. Another tab may have signed an entity out (deleting its key) since
- * this tab loaded; writing back a stale full map would resurrect that entity's credentials and break
- * the sign-out guarantee. Merging into a fresh read touches only this entity.
- */
+/** Persist one entity's settings with a fresh read-merge-write, touching only that entity's slot. */
 export function writeEntitySettings(entityId: string, patch: Partial<ExplorerEntitySettings>): void {
 	const map = readMap();
 	map[entityId] = { ...map[entityId], ...patch };
-	setLocalStorage(LocalStorageKeys.ApiExplorerSettings, map);
+	writeMap(map);
+}
+
+/** Drop one entity's persisted settings — used on per-entity sign-out so credentials aren't reusable. */
+export function forgetEntitySettings(entityId: string): void {
+	const map = readMap();
+	if (Object.hasOwn(map, entityId)) {
+		delete map[entityId];
+		writeMap(map);
+	}
 }

--- a/src/features/instance/apis/explorer/settings.ts
+++ b/src/features/instance/apis/explorer/settings.ts
@@ -14,6 +14,8 @@ export interface ExplorerEntitySettings {
 	method?: AuthMethod;
 	auth?: ApiAuth;
 	server?: string;
+	/** The server the credential was authorized against; it's only sent when the active server matches. */
+	authServer?: string;
 }
 
 function normalizeMethod(value: unknown): AuthMethod | undefined {
@@ -58,6 +60,9 @@ function normalizeEntity(value: unknown): ExplorerEntitySettings {
 	}
 	if (typeof v.server === 'string') {
 		out.server = v.server;
+	}
+	if (typeof v.authServer === 'string') {
+		out.authServer = v.authServer;
 	}
 	return out;
 }

--- a/src/features/instance/apis/explorer/settings.ts
+++ b/src/features/instance/apis/explorer/settings.ts
@@ -80,7 +80,6 @@ export function scrubLegacySettings(): void {
 
 /** The whole persisted map, guarded so disabled/corrupted storage reads as empty rather than throwing. */
 function readMap(): Record<string, ExplorerEntitySettings> {
-	scrubLegacySettings();
 	let raw: Record<string, unknown> = {};
 	try {
 		const stored = getSessionStorage<unknown, typeof KEY>(KEY, {});
@@ -123,5 +122,14 @@ export function forgetEntitySettings(entityId: string): void {
 	if (Object.hasOwn(map, entityId)) {
 		delete map[entityId];
 		writeMap(map);
+	}
+}
+
+/** Drop every entity's persisted settings — used on a global (all-entity) sign-out. */
+export function forgetAllEntitySettings(): void {
+	try {
+		sessionStorage.removeItem(KEY);
+	} catch {
+		// Storage disabled — nothing to clear.
 	}
 }

--- a/src/features/instance/apis/explorer/settings.ts
+++ b/src/features/instance/apis/explorer/settings.ts
@@ -62,20 +62,15 @@ function normalizeEntity(value: unknown): ExplorerEntitySettings {
 	return out;
 }
 
-let legacyScrubbed = false;
-
 /**
- * One-time removal of the pre-sessionStorage `localStorage` map. That map persisted Basic passwords
- * and Bearer tokens in plaintext across sessions; simply switching this module to sessionStorage would
- * leave the old value readable indefinitely. We drop it wholesale (no secret is migrated) and always
- * attempt removal even if reading threw. Bounded limitation: a concurrently-open pre-upgrade tab can
- * write the key back — this runs on every explorer init, but not continuously.
+ * Removal of the pre-sessionStorage `localStorage` map. That map persisted Basic passwords and Bearer
+ * tokens in plaintext across sessions; switching this module to sessionStorage would otherwise leave
+ * the old value readable indefinitely. It's dropped wholesale (no secret is migrated). Called at app
+ * bootstrap (so upgraded users who never open the explorer are still scrubbed) and again on every
+ * explorer read — not one-shot, so a pre-upgrade tab that rewrites the key is re-scrubbed on the next
+ * read. Idempotent and cheap (a `removeItem`).
  */
-function scrubLegacySettings(): void {
-	if (legacyScrubbed) {
-		return;
-	}
-	legacyScrubbed = true;
+export function scrubLegacySettings(): void {
 	try {
 		localStorage.removeItem(KEY);
 	} catch {

--- a/src/features/instance/apis/explorer/settings.ts
+++ b/src/features/instance/apis/explorer/settings.ts
@@ -16,6 +16,12 @@ export interface ExplorerEntitySettings {
 	server?: string;
 	/** The server the credential was authorized against; it's only sent when the active server matches. */
 	authServer?: string;
+	/**
+	 * The sign-out generation this credential was created under. sessionStorage survives a reload, so a
+	 * tab that restarts after another tab signed out would otherwise keep a revoked credential; comparing
+	 * this against the current durable generation catches that without relying on a live event.
+	 */
+	authGeneration?: number;
 }
 
 function normalizeMethod(value: unknown): AuthMethod | undefined {
@@ -63,6 +69,9 @@ function normalizeEntity(value: unknown): ExplorerEntitySettings {
 	}
 	if (typeof v.authServer === 'string') {
 		out.authServer = v.authServer;
+	}
+	if (typeof v.authGeneration === 'number' && Number.isFinite(v.authGeneration)) {
+		out.authGeneration = v.authGeneration;
 	}
 	return out;
 }
@@ -126,6 +135,29 @@ export function forgetEntitySettings(entityId: string): void {
 	const map = readMap();
 	if (Object.hasOwn(map, entityId)) {
 		delete map[entityId];
+		writeMap(map);
+	}
+}
+
+/**
+ * Strip the credential from every stored entity whose stamped generation no longer matches the current
+ * one — i.e. a sign-out happened that this tab may never have observed as an event (it was reloaded, or
+ * had not started yet). Non-secret state (server/method selection) is kept. The current generation is
+ * injected so this module doesn't depend on the auth store (which depends on this one).
+ */
+export function pruneStaleEntitySettings(currentGeneration: (entityId: string) => number): void {
+	const map = readMap();
+	let changed = false;
+	for (const [entityId, settings] of Object.entries(map)) {
+		if (!settings.auth || settings.auth.type === 'cookie') {
+			continue;
+		}
+		if ((settings.authGeneration ?? -1) !== currentGeneration(entityId)) {
+			map[entityId] = { method: settings.method, server: settings.server };
+			changed = true;
+		}
+	}
+	if (changed) {
 		writeMap(map);
 	}
 }

--- a/src/features/instance/apis/explorer/spec.test.ts
+++ b/src/features/instance/apis/explorer/spec.test.ts
@@ -10,11 +10,12 @@ import {
 	operationMatchesFilter,
 	pathParametersFor,
 	refName,
+	requiresAuth,
 	resolveRef,
 	resourceOf,
 	schemaTypeLabel,
 } from '@/features/instance/apis/explorer/spec';
-import { JsonSchema, OpenApiSpec } from '@/features/instance/apis/explorer/types';
+import { JsonSchema, OpenApiSpec, Operation } from '@/features/instance/apis/explorer/types';
 import { describe, expect, it } from 'vitest';
 
 const spec: OpenApiSpec = {
@@ -368,5 +369,37 @@ describe('buildServerOptions', () => {
 
 	it('falls back to spec servers when there is no computed URL', () => {
 		expect(buildServerOptions(spec, null)).toEqual([{ url: 'http://localhost:9926/', label: 'REST API' }]);
+	});
+});
+
+describe('requiresAuth', () => {
+	const op = (security?: unknown): Operation => ({ security: security as Operation['security'] });
+
+	it('is false when no security is declared at operation or spec level', () => {
+		expect(requiresAuth({}, undefined)).toBe(false);
+		expect(requiresAuth({}, { security: [] })).toBe(false);
+	});
+
+	it('is true when every alternative is a non-empty requirement object', () => {
+		expect(requiresAuth(op([{ bearerAuth: [] }]), undefined)).toBe(true);
+		expect(requiresAuth(op([{ basicAuth: [] }, { bearerAuth: [] }]), undefined)).toBe(true);
+	});
+
+	it('is false when an empty-object alternative permits anonymous access', () => {
+		expect(requiresAuth(op([{}]), undefined)).toBe(false);
+		expect(requiresAuth(op([{}, { bearerAuth: [] }]), undefined)).toBe(false);
+	});
+
+	it('treats an empty operation-level array as an explicit override of spec security', () => {
+		expect(requiresAuth(op([]), { security: [{ bearerAuth: [] }] })).toBe(false);
+	});
+
+	it('inherits spec-level security when the operation declares none', () => {
+		expect(requiresAuth({}, { security: [{ bearerAuth: [] }] })).toBe(true);
+	});
+
+	it('tolerates malformed entries (null / non-object) as not requiring auth', () => {
+		expect(requiresAuth(op([null]), undefined)).toBe(false);
+		expect(requiresAuth(op('nope'), undefined)).toBe(false);
 	});
 });

--- a/src/features/instance/apis/explorer/spec.ts
+++ b/src/features/instance/apis/explorer/spec.ts
@@ -4,6 +4,7 @@ import {
 	HTTP_METHODS,
 	JsonSchema,
 	OpenApiSpec,
+	Operation,
 	Parameter,
 	PathItem,
 } from '@/features/instance/apis/explorer/types';
@@ -14,6 +15,33 @@ const DEFAULT_TAG = 'default';
 export function resourceOf(path: string): string {
 	const segment = path.split('/').find(Boolean);
 	return segment ?? '/';
+}
+
+/**
+ * Whether an operation actually requires authentication. An OpenAPI security requirement is an array
+ * of alternatives (OR): an empty object `{}` in it means "unauthenticated access is also allowed", and
+ * an empty array `[]` at the operation level explicitly overrides a secured document root. So auth is
+ * required only when every listed alternative is a non-empty requirement object. The spec is fetched
+ * untyped, so a malformed entry (`null`, non-object) is treated as not requiring auth rather than
+ * throwing.
+ */
+export function requiresAuth(operation: Operation, spec: OpenApiSpec | undefined): boolean {
+	const security = operation.security ?? spec?.security;
+	if (!Array.isArray(security) || security.length === 0) {
+		return false;
+	}
+	return security.every(hasSecurityRequirement);
+}
+
+/** A single security alternative that actually demands a credential: a non-empty requirement object. */
+function hasSecurityRequirement(requirement: unknown): boolean {
+	if (!requirement || typeof requirement !== 'object' || Array.isArray(requirement)) {
+		return false;
+	}
+	for (const _ in requirement) {
+		return true;
+	}
+	return false;
 }
 
 /** Flatten `spec.paths` into a flat, document-ordered list of operations. */

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
@@ -65,6 +65,36 @@ describe('mintOperationTokenWithCredentials', () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it('aborts when the response body never resolves (timer covers body consumption)', async () => {
+		vi.useFakeTimers();
+		try {
+			// Headers arrive, then the body stalls until the request is aborted — as a real stalled body does.
+			const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+				const signal = init.signal!;
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					statusText: 'OK',
+					json: () =>
+						new Promise((_resolve, reject) =>
+							signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+						),
+				} as unknown as Response);
+			});
+			vi.stubGlobal('fetch', fetchMock);
+			const pending = mintOperationTokenWithCredentials({
+				operationsUrl: 'https://host:9925/',
+				username: 'admin',
+				password: 'pw',
+			});
+			const assertion = expect(pending).rejects.toThrow('did not respond within 30 seconds');
+			await vi.advanceTimersByTimeAsync(30_000);
+			await assertion;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('surfaces a server-provided error message (200 or non-OK) instead of a generic one', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'account locked' }, { status: 200 })));
 		await expect(

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
@@ -30,6 +30,7 @@ describe('mintOperationTokenWithCredentials', () => {
 			headers: { 'Content-Type': 'application/json' },
 			credentials: 'omit',
 			redirect: 'error',
+			signal: expect.any(AbortSignal),
 			body: JSON.stringify({ operation: 'create_authentication_tokens', username: 'admin', password: 'pw' }),
 		});
 	});

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
@@ -1,0 +1,70 @@
+import { mintOperationTokenWithCredentials } from '@/integrations/api/instance/auth/createInstanceAuthenticationTokens';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function jsonResponse(body: unknown, init: { status?: number; statusText?: string } = {}): Response {
+	const status = init.status ?? 200;
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: init.statusText ?? 'OK',
+		json: () => Promise.resolve(body),
+	} as unknown as Response;
+}
+
+describe('mintOperationTokenWithCredentials', () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it('POSTs the credentials directly (no cookies) and returns the operation token', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ operation_token: 'op-tok', refresh_token: 'r' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		const token = await mintOperationTokenWithCredentials({
+			operationsUrl: 'https://host:9925/',
+			username: 'admin',
+			password: 'pw',
+		});
+
+		expect(token).toBe('op-tok');
+		expect(fetchMock).toHaveBeenCalledWith('https://host:9925/', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'omit',
+			redirect: 'error',
+			body: JSON.stringify({ operation: 'create_authentication_tokens', username: 'admin', password: 'pw' }),
+		});
+	});
+
+	it('throws a credential-safe message on 401/403 without reflecting the password', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({}, { status: 401, statusText: 'Unauthorized' })));
+		await expect(
+			mintOperationTokenWithCredentials({ operationsUrl: 'https://host:9925/', username: 'admin', password: 'pw' }),
+		).rejects.toThrow('Those credentials were not accepted by this instance.');
+	});
+
+	it('throws when the instance returns no operation token', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ refresh_token: 'r' })));
+		await expect(
+			mintOperationTokenWithCredentials({ operationsUrl: 'https://host:9925/', username: 'admin', password: 'pw' }),
+		).rejects.toThrow('did not return an operation token');
+	});
+
+	it('refuses to POST credentials to a non-direct (proxy) URL, without fetching', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+		await expect(
+			mintOperationTokenWithCredentials({
+				operationsUrl: 'https://cm.example/HDBInstance/ins-1/operation',
+				username: 'admin',
+				password: 'pw',
+			}),
+		).rejects.toThrow('non-direct operations URL');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a server-provided error message (200 or non-OK) instead of a generic one', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ error: 'account locked' }, { status: 200 })));
+		await expect(
+			mintOperationTokenWithCredentials({ operationsUrl: 'https://host:9925/', username: 'admin', password: 'pw' }),
+		).rejects.toThrow('account locked');
+	});
+});

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.test.ts
@@ -51,13 +51,16 @@ describe('mintOperationTokenWithCredentials', () => {
 	it('refuses to POST credentials to a non-direct (proxy) URL, without fetching', async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal('fetch', fetchMock);
-		await expect(
-			mintOperationTokenWithCredentials({
-				operationsUrl: 'https://cm.example/HDBInstance/ins-1/operation',
-				username: 'admin',
-				password: 'pw',
-			}),
-		).rejects.toThrow('non-direct operations URL');
+		for (
+			const operationsUrl of [
+				'https://cm.example/HDBInstance/ins-1/operation',
+				'https://cm.example/hdbinstance/ins-1/operation',
+			]
+		) {
+			await expect(
+				mintOperationTokenWithCredentials({ operationsUrl, username: 'admin', password: 'pw' }),
+			).rejects.toThrow('non-direct operations URL');
+		}
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -43,14 +43,23 @@ export async function mintOperationTokenWithCredentials(
 	if (!isDirectOperationsUrl(operationsUrl)) {
 		throw new Error('Refusing to send credentials to a non-direct operations URL.');
 	}
-	const response = await fetch(operationsUrl, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		credentials: 'omit',
-		// Fail on a redirect rather than replaying the credential-bearing POST to an unchecked origin.
-		redirect: 'error',
-		body: JSON.stringify({ operation: 'create_authentication_tokens', username, password }),
-	});
+	// Bound the request so an unreachable instance can't hang the log-in indefinitely.
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 30_000);
+	let response: Response;
+	try {
+		response = await fetch(operationsUrl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'omit',
+			// Fail on a redirect rather than replaying the credential-bearing POST to an unchecked origin.
+			redirect: 'error',
+			signal: controller.signal,
+			body: JSON.stringify({ operation: 'create_authentication_tokens', username, password }),
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
 	const data = (await response.json().catch(() => undefined)) as
 		| { operation_token?: string; error?: string; message?: string }
 		| undefined;

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -57,6 +57,13 @@ export async function mintOperationTokenWithCredentials(
 			signal: controller.signal,
 			body: JSON.stringify({ operation: 'create_authentication_tokens', username, password }),
 		});
+	} catch (error) {
+		// Replace the browser's opaque abort/network text with something the log-in form can explain.
+		throw new Error(
+			controller.signal.aborted
+				? 'The instance did not respond within 30 seconds.'
+				: `Could not reach the instance to log in. ${error instanceof Error ? error.message : ''}`.trim(),
+		);
 	} finally {
 		clearTimeout(timeout);
 	}

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -47,6 +47,7 @@ export async function mintOperationTokenWithCredentials(
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), 30_000);
 	let response: Response;
+	let data: { operation_token?: string; error?: string; message?: string } | undefined;
 	try {
 		response = await fetch(operationsUrl, {
 			method: 'POST',
@@ -57,6 +58,15 @@ export async function mintOperationTokenWithCredentials(
 			signal: controller.signal,
 			body: JSON.stringify({ operation: 'create_authentication_tokens', username, password }),
 		});
+		// Body consumption stays inside the timer: an instance that sends headers and then stalls the body
+		// would otherwise leave the log-in pending forever. A non-JSON body is tolerated (handled below),
+		// but an abort must propagate rather than read as "no token returned".
+		data = (await response.json().catch((error: unknown) => {
+			if (controller.signal.aborted) {
+				throw error;
+			}
+			return undefined;
+		})) as typeof data;
 	} catch (error) {
 		// Replace the browser's opaque abort/network text with something the log-in form can explain.
 		throw new Error(
@@ -67,9 +77,6 @@ export async function mintOperationTokenWithCredentials(
 	} finally {
 		clearTimeout(timeout);
 	}
-	const data = (await response.json().catch(() => undefined)) as
-		| { operation_token?: string; error?: string; message?: string }
-		| undefined;
 	if (!response.ok) {
 		throw new Error(
 			data?.error || data?.message

--- a/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
+++ b/src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts
@@ -1,4 +1,5 @@
 import { InstanceClientConfig } from '@/config/instanceClientConfig';
+import { isDirectOperationsUrl } from '@/lib/urls/isDirectOperationsUrl';
 import type { AxiosRequestConfig } from 'axios';
 
 export interface InstanceAuthenticationTokens {
@@ -27,6 +28,44 @@ export async function createInstanceAuthenticationTokens(
 		throw new Error('Fabric Connect did not return an operation token');
 	}
 	return { operationToken, refreshToken };
+}
+
+/**
+ * Mints an operation token from an explicit username/password, sent DIRECTLY to a Harper instance's
+ * operations endpoint with `fetch` — never through the Fabric Connect proxy. The direct-URL check is
+ * enforced here, not just at the call site, so no future caller can regress the boundary and POST
+ * credentials to a proxy path. `credentials` is omitted so no ambient session cookie rides along, and
+ * neither the body nor the token is logged.
+ */
+export async function mintOperationTokenWithCredentials(
+	{ operationsUrl, username, password }: { operationsUrl: string; username: string; password: string },
+): Promise<string> {
+	if (!isDirectOperationsUrl(operationsUrl)) {
+		throw new Error('Refusing to send credentials to a non-direct operations URL.');
+	}
+	const response = await fetch(operationsUrl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		credentials: 'omit',
+		// Fail on a redirect rather than replaying the credential-bearing POST to an unchecked origin.
+		redirect: 'error',
+		body: JSON.stringify({ operation: 'create_authentication_tokens', username, password }),
+	});
+	const data = (await response.json().catch(() => undefined)) as
+		| { operation_token?: string; error?: string; message?: string }
+		| undefined;
+	if (!response.ok) {
+		throw new Error(
+			data?.error || data?.message
+				|| (response.status === 401 || response.status === 403
+					? 'Those credentials were not accepted by this instance.'
+					: `The instance returned ${response.status} ${response.statusText}`.trim()),
+		);
+	}
+	if (!data?.operation_token) {
+		throw new Error(data?.error || data?.message || 'The instance did not return an operation token.');
+	}
+	return data.operation_token;
 }
 
 /**

--- a/src/lib/storage/localStorageKeys.ts
+++ b/src/lib/storage/localStorageKeys.ts
@@ -1,6 +1,5 @@
 export const enum LocalStorageKeys {
 	'AckedNotificationIds' = 'AckedNotificationIds',
-	'ApiExplorerSettings' = 'ApiExplorerSettings',
 	'ApiExplorerSidebarWidth' = 'ApiExplorerSidebarWidth',
 	'ApplicationChatPosition' = 'ApplicationChatPosition',
 	'ApplicationChatWidth' = 'ApplicationChatWidth',

--- a/src/lib/storage/sessionStorageKeys.ts
+++ b/src/lib/storage/sessionStorageKeys.ts
@@ -1,4 +1,5 @@
 export interface SessionStorageKeys {
+	'ApiExplorerSettings': true;
 	'ApplicationChat': true;
 	'ApplicationChatOpen': true;
 	'ApplicationChatPosition': true;

--- a/src/lib/urls/isDirectOperationsUrl.test.ts
+++ b/src/lib/urls/isDirectOperationsUrl.test.ts
@@ -7,9 +7,11 @@ describe('isDirectOperationsUrl', () => {
 		expect(isDirectOperationsUrl('http://localhost:9925')).toBe(true);
 	});
 
-	it('rejects Fabric Connect proxy paths', () => {
+	it('rejects Fabric Connect proxy paths (case-insensitively)', () => {
 		expect(isDirectOperationsUrl('https://cm.example/HDBInstance/ins-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/Cluster/clu-1/operation')).toBe(false);
+		expect(isDirectOperationsUrl('https://cm.example/hdbinstance/ins-1/operation')).toBe(false);
+		expect(isDirectOperationsUrl('https://cm.example/cluster/clu-1/operation')).toBe(false);
 	});
 
 	it('rejects empty / missing URLs', () => {

--- a/src/lib/urls/isDirectOperationsUrl.test.ts
+++ b/src/lib/urls/isDirectOperationsUrl.test.ts
@@ -5,21 +5,23 @@ describe('isDirectOperationsUrl', () => {
 	it('accepts a direct instance/cluster operations URL', () => {
 		expect(isDirectOperationsUrl('https://host.example:9925/')).toBe(true);
 		expect(isDirectOperationsUrl('http://localhost:9925')).toBe(true);
+		// A host merely named like the proxy segment is still direct (the check is on the path).
+		expect(isDirectOperationsUrl('https://hdbinstance.example.com:9925/')).toBe(true);
 	});
 
-	it('rejects Fabric Connect proxy paths (case-insensitive, no trailing slash required)', () => {
+	it('rejects Fabric Connect proxy paths (case-insensitive, bare, concatenated, or with a query)', () => {
 		expect(isDirectOperationsUrl('https://cm.example/HDBInstance/ins-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/Cluster/clu-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/hdbinstance/ins-1/operation')).toBe(false);
-		expect(isDirectOperationsUrl('https://cm.example/cluster/clu-1/operation')).toBe(false);
-		// Bare segment (no trailing slash) and query-string variants must still be rejected.
 		expect(isDirectOperationsUrl('https://cm.example/HDBInstance')).toBe(false);
+		expect(isDirectOperationsUrl('https://cm.example/HDBInstance123/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/Cluster?x=1')).toBe(false);
 	});
 
-	it('rejects empty / missing URLs', () => {
+	it('fails closed on empty, relative, or unparseable URLs', () => {
 		expect(isDirectOperationsUrl(null)).toBe(false);
 		expect(isDirectOperationsUrl(undefined)).toBe(false);
 		expect(isDirectOperationsUrl('')).toBe(false);
+		expect(isDirectOperationsUrl('/api')).toBe(false);
 	});
 });

--- a/src/lib/urls/isDirectOperationsUrl.test.ts
+++ b/src/lib/urls/isDirectOperationsUrl.test.ts
@@ -7,11 +7,14 @@ describe('isDirectOperationsUrl', () => {
 		expect(isDirectOperationsUrl('http://localhost:9925')).toBe(true);
 	});
 
-	it('rejects Fabric Connect proxy paths (case-insensitively)', () => {
+	it('rejects Fabric Connect proxy paths (case-insensitive, no trailing slash required)', () => {
 		expect(isDirectOperationsUrl('https://cm.example/HDBInstance/ins-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/Cluster/clu-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/hdbinstance/ins-1/operation')).toBe(false);
 		expect(isDirectOperationsUrl('https://cm.example/cluster/clu-1/operation')).toBe(false);
+		// Bare segment (no trailing slash) and query-string variants must still be rejected.
+		expect(isDirectOperationsUrl('https://cm.example/HDBInstance')).toBe(false);
+		expect(isDirectOperationsUrl('https://cm.example/Cluster?x=1')).toBe(false);
 	});
 
 	it('rejects empty / missing URLs', () => {

--- a/src/lib/urls/isDirectOperationsUrl.test.ts
+++ b/src/lib/urls/isDirectOperationsUrl.test.ts
@@ -1,0 +1,20 @@
+import { isDirectOperationsUrl } from '@/lib/urls/isDirectOperationsUrl';
+import { describe, expect, it } from 'vitest';
+
+describe('isDirectOperationsUrl', () => {
+	it('accepts a direct instance/cluster operations URL', () => {
+		expect(isDirectOperationsUrl('https://host.example:9925/')).toBe(true);
+		expect(isDirectOperationsUrl('http://localhost:9925')).toBe(true);
+	});
+
+	it('rejects Fabric Connect proxy paths', () => {
+		expect(isDirectOperationsUrl('https://cm.example/HDBInstance/ins-1/operation')).toBe(false);
+		expect(isDirectOperationsUrl('https://cm.example/Cluster/clu-1/operation')).toBe(false);
+	});
+
+	it('rejects empty / missing URLs', () => {
+		expect(isDirectOperationsUrl(null)).toBe(false);
+		expect(isDirectOperationsUrl(undefined)).toBe(false);
+		expect(isDirectOperationsUrl('')).toBe(false);
+	});
+});

--- a/src/lib/urls/isDirectOperationsUrl.ts
+++ b/src/lib/urls/isDirectOperationsUrl.ts
@@ -1,0 +1,6 @@
+// The Fabric Connect proxy routes operations through these central-manager paths (see
+// getInstanceClient). A URL carrying either segment points at the proxy, not the instance, so it must
+// never receive an instance Bearer JWT or typed credentials — those would reach the central manager.
+export function isDirectOperationsUrl(url: string | null | undefined): url is string {
+	return !!url && !url.includes('/HDBInstance/') && !url.includes('/Cluster/');
+}

--- a/src/lib/urls/isDirectOperationsUrl.ts
+++ b/src/lib/urls/isDirectOperationsUrl.ts
@@ -1,8 +1,19 @@
 // The Fabric Connect proxy routes operations through these central-manager paths (see
-// getInstanceClient). A URL carrying either segment points at the proxy, not the instance, so it must
-// never receive an instance Bearer JWT or typed credentials — those would reach the central manager.
-// Matched case-insensitively and on a segment boundary (not requiring a trailing slash) so a
-// differently-cased path, a bare `/HDBInstance`, or one with a query string can't slip past this gate.
+// getInstanceClient). A URL whose PATH carries either segment points at the proxy, not the instance,
+// so it must never receive an instance Bearer JWT or typed credentials — those would reach the central
+// manager. The check is on the parsed pathname (case-insensitive), so a host merely named
+// `hdbinstance.example.com` isn't rejected, while any proxy path — bare, cased, concatenated
+// (`/HDBInstance123`), or with a query string — is. It fails closed: an unparseable/relative URL
+// (which we can't prove points at the instance) is treated as non-direct.
 export function isDirectOperationsUrl(url: string | null | undefined): url is string {
-	return !!url && !/\/(hdbinstance|cluster)\b/i.test(url);
+	if (!url) {
+		return false;
+	}
+	let pathname: string;
+	try {
+		pathname = new URL(url).pathname;
+	} catch {
+		return false;
+	}
+	return !/\/(hdbinstance|cluster)/i.test(pathname);
 }

--- a/src/lib/urls/isDirectOperationsUrl.ts
+++ b/src/lib/urls/isDirectOperationsUrl.ts
@@ -1,6 +1,7 @@
 // The Fabric Connect proxy routes operations through these central-manager paths (see
 // getInstanceClient). A URL carrying either segment points at the proxy, not the instance, so it must
 // never receive an instance Bearer JWT or typed credentials — those would reach the central manager.
+// Matched case-insensitively so a differently-cased path can't slip a credential past this gate.
 export function isDirectOperationsUrl(url: string | null | undefined): url is string {
-	return !!url && !url.includes('/HDBInstance/') && !url.includes('/Cluster/');
+	return !!url && !/\/(hdbinstance|cluster)\//i.test(url);
 }

--- a/src/lib/urls/isDirectOperationsUrl.ts
+++ b/src/lib/urls/isDirectOperationsUrl.ts
@@ -1,7 +1,8 @@
 // The Fabric Connect proxy routes operations through these central-manager paths (see
 // getInstanceClient). A URL carrying either segment points at the proxy, not the instance, so it must
 // never receive an instance Bearer JWT or typed credentials — those would reach the central manager.
-// Matched case-insensitively so a differently-cased path can't slip a credential past this gate.
+// Matched case-insensitively and on a segment boundary (not requiring a trailing slash) so a
+// differently-cased path, a bare `/HDBInstance`, or one with a query string can't slip past this gate.
 export function isDirectOperationsUrl(url: string | null | undefined): url is string {
-	return !!url && !/\/(hdbinstance|cluster)\//i.test(url);
+	return !!url && !/\/(hdbinstance|cluster)\b/i.test(url);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { App } from '@/App';
+import { scrubLegacySettings } from '@/features/instance/apis/explorer/settings';
 import { installApiUnauthorizedRedirect } from '@/lib/installApiUnauthorizedRedirect';
 import { installBrowserTranslationDomGuard } from '@/lib/installBrowserTranslationDomGuard';
 import { installStaleDeployReload } from '@/lib/installStaleDeployReload';
@@ -16,6 +17,9 @@ installStaleDeployReload();
 // Redirect to /sign-in when a CM call returns 401 (lost/expired session), instead
 // of leaving the SPA on a stale user while every data call fails.
 installApiUnauthorizedRedirect();
+// Remove the pre-sessionStorage API-explorer credential map (plaintext Basic passwords / Bearer
+// tokens) at boot, so an upgraded user who never reopens the explorer is still scrubbed.
+scrubLegacySettings();
 
 createRoot(
 	document.getElementById('root')!,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { App } from '@/App';
+import { authStore } from '@/features/auth/store/authStore';
 import { scrubLegacySettings } from '@/features/instance/apis/explorer/settings';
 import { installApiUnauthorizedRedirect } from '@/lib/installApiUnauthorizedRedirect';
 import { installBrowserTranslationDomGuard } from '@/lib/installBrowserTranslationDomGuard';
@@ -20,6 +21,9 @@ installApiUnauthorizedRedirect();
 // Remove the pre-sessionStorage API-explorer credential map (plaintext Basic passwords / Bearer
 // tokens) at boot, so an upgraded user who never reopens the explorer is still scrubbed.
 scrubLegacySettings();
+// Clear the explorer's per-tab credential when another tab signs an entity out, even while this tab's
+// explorer is unmounted — so a tab that navigated away can't later restore a revoked token.
+authStore.installExplorerCrossTabCleanup();
 
 createRoot(
 	document.getElementById('root')!,


### PR DESCRIPTION
Builds out the APIs Explorer "Authorize" story so authorization is credible and safe in deployed
environments, where the default cookie flow silently fails.

## What changed

- **Session-scoped credentials.** Per-entity Authorize state moves from `localStorage` to
  `sessionStorage` (cleared on tab close), with a one-time scrub of the legacy plaintext
  `localStorage` secrets on first load. `authStore` sign-out now delegates to a shared
  `forgetEntitySettings`.
- **A real log-in that works cross-site.** Cookie auth isn't sent when the instance is on a
  different site than Studio. The Authorize panel now mints a Bearer **operation token** — one click
  for your current Studio session, or a username/password fallback — sent as an explicit
  `Authorization` header, which crosses origins where cookies don't.
- **Docs + Try it out.** The Authorize panel is now a Documentation / Try it out pair (mirroring
  operations): docs explain Log in / Basic / Bearer / Cookie; Try it out is where you authenticate,
  which flips the lock and unlocks authenticated requests. Default method is Log in.
- **Deep-links.** Auth-required operations link to the Try-it-out log-in view; `requiresAuth` now
  honors OpenAPI optional-auth (`security: [{}]`) and explicit `[]` overrides.

## For the human reviewer

Read `src/features/instance/apis/APIDocs.tsx` and
`src/integrations/api/instance/auth/createInstanceAuthenticationTokens.ts` first — the credential
boundary is the thing to scrutinize.

Decisions a reviewer might reasonably question:

- **decision — credential-mint direct-URL source.** The username/password fallback POSTs
  `create_authentication_tokens` to the **operations client's own `baseURL`** — the address Studio
  already uses to talk to this instance — and only when it passes `isDirectOperationsUrl` (rejects
  the Fabric Connect `/HDBInstance/…`/`/Cluster/…` proxy paths). The check is enforced *inside* the
  mint helper, not just at the call site, so the boundary can't regress. When the only reachable URL
  is the proxy, the password fallback is withheld (fail-closed) and one-click session mint still
  works. Session mint intentionally uses the existing (possibly proxied) client because it authorizes
  as *you* and discloses no one else's credentials.
- **decision — token stored, password not (for Log in).** The log-in flow stores only the minted
  short-lived token in sessionStorage, never the password. Basic auth still stores username+password
  (session-scoped); the docs say so per method. `sessionStorage` is not claimed as an XSS boundary —
  it's a persistence/lifetime choice.
- **decision — code sample shows the live credential.** `buildFetchSnippet` embeds the real
  `Authorization` header in the copyable sample (as the prior Swagger UI did). Kept deliberately: it's
  the user's own credential in their own tab, and redacting would break the copy-paste-run purpose.
  Flagging in case exfil-via-clipboard is in scope for this surface.
- **verified — entity sign-out clears explorer creds.** `signOutOfInstance` → `signOutLocally` →
  `forgetEntitySettings` clears per-entity; full logout (`clearAuthStateLocally`, `logoutOnSuccess`)
  calls `clearSessionStorage()`. So a review note that "normal disconnect paths bypass cleanup" did
  not hold on trace.
- **hardening — the credential POST fails on redirect** (`redirect: 'error'`) so a 3xx can't replay
  it past the direct-URL check, and the log-in form drops the typed password from memory once a token
  is minted.

## Verification

- Full local gate on Node 24.19.0: `tsc -b`, `oxlint`, `dprint check` clean; `vitest run` — all
  2630 tests pass (added coverage for storage/scrub, `isDirectOperationsUrl`, `requiresAuth`, the
  mint helper incl. non-direct refusal + server-error surfacing, and the explorer's login flows,
  method-switch mint race, and deep-link). The suite's process exit is non-zero only from a
  pre-existing, unrelated undici-WebSocket unhandled error in a Chat test (reproduces without this
  diff).
- Dev server smoke: the explorer builds and loads against the stage central manager.
- Cross-origin: the cross-site Bearer flow was verified locally — a minted token is accepted on a
  cross-origin request (the instance's CORS allows the `Authorization` header on preflight), which is
  the behavior the cookie path couldn't provide and the core reason for this change.

## Process

Planning review (step 6) cleared `chosen-approach-sound` after widening the option set. Step-10
cross-model review ran five rounds (codex + gemini + cursor-grok, independent). The Harper-domain
adjudication leg fails on this host (zero-byte log), so outside findings were hand-adjudicated.
Round 1 (BLOCK) → round 2 (CHANGES; blocker + majors fixed) → round 3 found **no blockers or majors** →
round 4 (delta) covers a gemini bot finding — the credential direct-URL gate was case-sensitive, so
`isDirectOperationsUrl` now rejects proxy paths case-insensitively → round 5 is the Final-artifact
check after rebasing onto `stage` to integrate its API-explorer sidebar-resize feature, and found
**no blockers or majors** in the merge. The `Human-Review-Need: 4` floor reflects the high-risk
auth/storage surface plus the failed adjudication leg (degraded coverage), not an open blocker.

Review response (kriszyp): all 8 inline findings are fixed and the threads resolved — per-entity
cleanup centralized in `setUserForIdAndKey` (closing a cross-user credential leak via the
ClusterHome/ClusterCard disconnect paths), an auth-epoch that invalidates in-flight mints and
propagates sign-out across tabs (including an always-on listener for unmounted tabs), credentials
stamped to the server they were authorized against, form drafts resynced on Clear, the legacy scrub
moved to bootstrap, and the "Authorized" indicator relabelled "Credential set".

Follow-up rounds fixed three further majors the reviews surfaced in my own hardening: minted tokens
are now stamped with Studio's computed URL for the entity (not the spec picker's selection, which had
recreated a narrower version of the leak the stamping exists to prevent);
`signOutFromPotentiallyAuthenticatedInstances` — the one sign-out path that flags sign-out directly
rather than via `signOutLocally` — also clears explorer state; and a mirrored cross-tab invalidation
advances this tab's in-memory epoch so an in-flight mint is caught by the epoch check too. Each has a
regression test.

A second review round from kriszyp found two more real gaps, both fixed in `a439aad7`: an event-only
cross-tab signal couldn't survive a reload (sessionStorage outlives one, so a restarted tab never saw
the invalidation and kept a revoked credential) — the sign-out generation is now durable and every
credential is stamped with the generation it was created under, reconciled at bootstrap; and the mint's
abort timer didn't cover body consumption, so a stalled body left the log-in pending forever.

**Coverage gap, stated plainly:** the last two commits (`e832fca6`, `a439aad7`) have **no outside-model
review**. The run for the first produced nothing — Gemini hit an account quota and Codex hung and was
killed with no budget to retry — and I did not re-run for the second. That is an absent review, not a
clean one. What they do have: the full local gate (2661 unit tests, `tsc`, `oxlint`, `dprint`) and a
regression test per fix — including one that caught a bug in my own first attempt at the abort fix
(a blanket `.catch` was swallowing the abort). Everything up to `254c81ee` was reviewed by
codex+gemini. Reviewers may reasonably want to look hardest at those two commits.

Known follow-up (not in this PR): the credential indicator reports that *a* credential is configured,
not that it satisfies the operation's specific security requirement (AND/OR alternatives against
referenced schemes). Happy to fold that in if wanted.

Complexity: moderate — new auth UI surface plus a narrow, well-bounded reach into the operations
client for token minting.

<sub>Review-Coverage: authored=unknown; ran=none; rounds=1 @ a439aad722dd</sub>

<sub>Human-Review-Need: 4 @ a439aad722dd</sub>
