### PR TITLE
fix(datadog): restore LCP/FCP reporting by keeping the initial_load view alive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,36 @@ Only fields on the SDK's modifiable-field allowlist can be mutated here. `view.n
 `error.fingerprint`; resource events add `resource.url` (plus GraphQL/header/websocket fields).
 Grep the installed bundle for `"view.referrer":"string"` to re-check after an SDK bump.
 
+## Datadog RUM — exactly one `startView` per page load, or Core Web Vitals vanish
+
+[`datadog.ts`](src/integrations/datadog/datadog.ts) sets `trackViewsManually: true`, and the SDK's
+contract for that flag is narrower than it looks. It stays stopped until the **first** `startView`,
+adopts that call's options as its single `initial_load` view, then turns every later call into a
+`route_change` view (`preStartRum.ts` `tryStartRum`, `trackViews.ts` `startView`). Only an
+`initial_load` view runs `trackInitialViewMetrics`, so it is the only view that can ever carry LCP
+or FCP.
+
+A second `startView` on boot therefore ends the one view that collects paint metrics. That is what
+zeroed Studio's vitals for a month (#1570): `useDatadog` and `useOnRouteLoadTracker` both called
+it, 0.3ms apart, and every `initial_load` event shipped with `dom_complete` but no `lcp` and no
+`fcp`. Ownership of that first call now lives in `useOnRouteLoadTracker` alone — it mounts on the
+root route (`rootRoute.ts`), so it runs on every cloud route.
+
+Two traps when reading this from RUM data:
+
+- `view.time_spent` on an `initial_load` view is measured from `clocksOrigin()` — page origin, not
+  SDK start — so a ~1s `time_spent` does **not** mean the view was alive and observing for a
+  second. It says nothing about the observation window.
+- Never name a view from `window.location.pathname`. Studio uses hash routing, so that is
+  permanently `/` — which is why all 880 `initial_load` views in one week were named `/` whatever
+  route actually loaded, and why #1405's "`/` view regression" was really every deep-link entry
+  conflated into one bucket.
+
+Verifying a change here needs a **visible** browser on a production build: a headless or background
+tab reports `visibilityState: 'hidden'`, emits zero paint and LCP entries, and `trackFirstHidden`
+discards them anyway — so vitals always read as absent, and a broken fix looks identical to a
+working one.
+
 ## Never put an address or a credential in a URL
 
 Studio uses **hash routing**, so a query param lives in the fragment: for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,34 @@ and collapses. Fix: make the wrapper `flex flex-col` (or add `block`/`w-full` to
 anchor). The GitHub button (`.github-signin-btn`) sets `display: flex` explicitly and is
 not affected. (Hit while building the "Last used" sign-in badge, #1316.)
 
+## A mocked hook whose value lands in a dependency array must keep a stable identity
+
+If you `vi.mock` a hook and the code under test puts its return value in a `useEffect` dependency
+array, returning a fresh object per call re-fires that effect on **every render** — and any
+assertion counting effect side-effects then passes for the wrong reason. `vi.mock('@tanstack/
+react-router', () => ({ useRouter: () => ({ ... }) }))` did exactly that to
+[`datadog.test.tsx`](src/integrations/datadog/datadog.test.tsx): the test that claimed to prove
+"one view per navigation" would have passed with `location.href` removed from the deps entirely.
+The real `useRouter` returns a stable reference, so the mock was also lying about production.
+
+Instantiate once in the factory and expose changing state through a getter:
+
+```ts
+vi.mock('@tanstack/react-router', () => {
+	const router = {
+		get state() {
+			return { location: { href: routerState.href } };
+		},
+	};
+	return { useRouter: () => router };
+});
+```
+
+The general check, worth running on any effect-counting test: **re-render without changing
+anything and assert nothing happened.** That assertion is what distinguishes "the effect re-ran
+because its input changed" from "the effect re-runs constantly"; it fails immediately against an
+unstable mock.
+
 ## Testing Radix menus in jsdom
 
 This repo has NO `@testing-library/user-event` — only `@testing-library/react` +

--- a/src/integrations/datadog/datadog.test.tsx
+++ b/src/integrations/datadog/datadog.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { rum, routerState } = vi.hoisted(() => ({
+	rum: {
+		init: vi.fn(),
+		startView: vi.fn(),
+		onReady: vi.fn((callback: () => void) => callback()),
+		setUser: vi.fn(),
+		clearUser: vi.fn(),
+		addAction: vi.fn(),
+	},
+	routerState: { href: '/#/org-1/cluster-1/apps', params: [{ organizationId: 'org-1' }] },
+}));
+
+vi.mock('@datadog/browser-rum', () => ({ datadogRum: rum }));
+vi.mock('@datadog/browser-rum-react', () => ({ reactPlugin: () => ({ name: 'react' }) }));
+vi.mock('@/config/constants', () => ({ isLocalStudio: false }));
+vi.mock('@/hooks/useAuth', () => ({ useOverallAuth: () => ({ user: undefined }) }));
+vi.mock('@tanstack/react-router', () => ({
+	useLocation: () => ({ href: routerState.href }),
+	useRouter: () => ({
+		state: { location: { href: routerState.href } },
+		matchRoutes: () => routerState.params.map((params) => ({ params })),
+	}),
+}));
+
+async function loadDatadogModule() {
+	vi.resetModules();
+	// `enabled` is a module-scope const, so DEV has to be false before the import.
+	vi.stubEnv('DEV', false);
+	return import('./datadog');
+}
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllEnvs();
+	vi.clearAllMocks();
+});
+
+describe('useDatadog', () => {
+	it('initializes RUM', async () => {
+		const { useDatadog } = await loadDatadogModule();
+		function Harness() {
+			useDatadog();
+			return null;
+		}
+
+		render(<Harness />);
+
+		expect(rum.init).toHaveBeenCalledTimes(1);
+	});
+
+	// The guard for #1570. Under `trackViewsManually` only the FIRST startView becomes an
+	// `initial_load` view, and only an `initial_load` view collects LCP/FCP — so a startView
+	// here is destroyed by `useOnRouteLoadTracker`'s call in the same effect flush, taking
+	// Studio's Core Web Vitals with it. Ownership of that first call must stay in one place.
+	it("does not start a view — that is useOnRouteLoadTracker's job", async () => {
+		const { useDatadog } = await loadDatadogModule();
+		function Harness() {
+			useDatadog();
+			return null;
+		}
+
+		render(<Harness />);
+
+		expect(rum.startView).not.toHaveBeenCalled();
+	});
+});
+
+describe('useOnRouteLoadTracker', () => {
+	beforeEach(() => {
+		routerState.href = '/#/org-1/cluster-1/apps';
+		routerState.params = [{ organizationId: 'org-1' }];
+	});
+
+	it('starts exactly one view per render pass, named by route', async () => {
+		const { useOnRouteLoadTracker } = await loadDatadogModule();
+		function Harness() {
+			useOnRouteLoadTracker();
+			return null;
+		}
+
+		render(<Harness />);
+
+		expect(rum.startView).toHaveBeenCalledTimes(1);
+		expect(rum.startView.mock.calls[0][0]).toMatchObject({ name: expect.any(String) });
+	});
+});

--- a/src/integrations/datadog/datadog.test.tsx
+++ b/src/integrations/datadog/datadog.test.tsx
@@ -20,13 +20,21 @@ vi.mock('@datadog/browser-rum', () => ({ datadogRum: rum }));
 vi.mock('@datadog/browser-rum-react', () => ({ reactPlugin: () => ({ name: 'react' }) }));
 vi.mock('@/config/constants', () => ({ isLocalStudio: false }));
 vi.mock('@/hooks/useAuth', () => ({ useOverallAuth: () => ({ user: undefined }) }));
-vi.mock('@tanstack/react-router', () => ({
-	useLocation: () => ({ href: routerState.href }),
-	useRouter: () => ({
-		state: { location: { href: routerState.href } },
+// One stable `router` identity, as the real `useRouter` returns — the tracker's effect lists
+// `router` in its deps, so a fresh object per render would re-fire it on every render and the
+// navigation assertions below would hold even if `location.href` were not a dependency.
+vi.mock('@tanstack/react-router', () => {
+	const router = {
+		get state() {
+			return { location: { href: routerState.href } };
+		},
 		matchRoutes: () => routerState.params.map((params) => ({ params })),
-	}),
-}));
+	};
+	return {
+		useLocation: () => ({ href: routerState.href }),
+		useRouter: () => router,
+	};
+});
 
 async function loadDatadogModule() {
 	vi.resetModules();
@@ -102,9 +110,11 @@ describe('Datadog view tracking', () => {
 		}
 
 		const { rerender } = render(<CloudRoot />);
+		rerender(<CloudRoot />);
 		routerState.href = '/org-1/clu-2/config';
 		rerender(<CloudRoot />);
 
+		// The middle re-render changed nothing, so it must not have produced a view.
 		expect(rum.startView.mock.calls.map(([options]) => options.name)).toEqual([
 			'/$organizationId/$clusterId/apps/',
 			'/$organizationId/$clusterId/config/',

--- a/src/integrations/datadog/datadog.test.tsx
+++ b/src/integrations/datadog/datadog.test.tsx
@@ -47,7 +47,6 @@ afterEach(() => {
 });
 
 describe('Datadog view tracking', () => {
-	// The nesting mirrors production: App calls useDatadog, StudioCloud calls the tracker.
 	it('starts exactly one view when the whole tree boots', async () => {
 		const { useDatadog, useOnRouteLoadTracker } = await loadDatadogModule();
 		function CloudRoot() {

--- a/src/integrations/datadog/datadog.test.tsx
+++ b/src/integrations/datadog/datadog.test.tsx
@@ -13,7 +13,7 @@ const { rum, routerState } = vi.hoisted(() => ({
 		clearUser: vi.fn(),
 		addAction: vi.fn(),
 	},
-	routerState: { href: '/#/org-1/cluster-1/apps', params: [{ organizationId: 'org-1' }] },
+	routerState: { href: '/org-1/clu-2/apps', params: [{ organizationId: 'org-1', clusterId: 'clu-2' }] },
 }));
 
 vi.mock('@datadog/browser-rum', () => ({ datadogRum: rum }));
@@ -35,30 +35,59 @@ async function loadDatadogModule() {
 	return import('./datadog');
 }
 
+beforeEach(() => {
+	routerState.href = '/org-1/clu-2/apps';
+	routerState.params = [{ organizationId: 'org-1', clusterId: 'clu-2' }];
+});
+
 afterEach(() => {
 	cleanup();
 	vi.unstubAllEnvs();
 	vi.clearAllMocks();
 });
 
-describe('useDatadog', () => {
-	it('initializes RUM', async () => {
-		const { useDatadog } = await loadDatadogModule();
-		function Harness() {
-			useDatadog();
+describe('Datadog view tracking', () => {
+	// Only the first `startView` of a page load becomes an `initial_load` view, and only an
+	// `initial_load` view collects LCP/FCP — so a second one on boot zeroes Core Web Vitals
+	// (#1570). This mirrors the production tree: App calls useDatadog, then StudioCloud (the
+	// root route component) calls useOnRouteLoadTracker.
+	it('starts exactly one view when the whole tree boots', async () => {
+		const { useDatadog, useOnRouteLoadTracker } = await loadDatadogModule();
+		function CloudRoot() {
+			useOnRouteLoadTracker();
 			return null;
 		}
+		function App() {
+			useDatadog();
+			return <CloudRoot />;
+		}
 
-		render(<Harness />);
+		render(<App />);
 
 		expect(rum.init).toHaveBeenCalledTimes(1);
+		expect(rum.startView).toHaveBeenCalledTimes(1);
 	});
 
-	// The guard for #1570. Under `trackViewsManually` only the FIRST startView becomes an
-	// `initial_load` view, and only an `initial_load` view collects LCP/FCP — so a startView
-	// here is destroyed by `useOnRouteLoadTracker`'s call in the same effect flush, taking
-	// Studio's Core Web Vitals with it. Ownership of that first call must stay in one place.
-	it("does not start a view — that is useOnRouteLoadTracker's job", async () => {
+	it("names that view by route, not by the hash router's pathname", async () => {
+		const { useDatadog, useOnRouteLoadTracker } = await loadDatadogModule();
+		function CloudRoot() {
+			useOnRouteLoadTracker();
+			return null;
+		}
+		function App() {
+			useDatadog();
+			return <CloudRoot />;
+		}
+
+		render(<App />);
+
+		expect(rum.startView).toHaveBeenCalledWith(
+			expect.objectContaining({ name: '/$organizationId/$clusterId/apps/' }),
+		);
+	});
+
+	// Narrows a failure of the tree-level assertion above to the hook that regressed.
+	it('does not start a view from useDatadog', async () => {
 		const { useDatadog } = await loadDatadogModule();
 		function Harness() {
 			useDatadog();
@@ -68,25 +97,5 @@ describe('useDatadog', () => {
 		render(<Harness />);
 
 		expect(rum.startView).not.toHaveBeenCalled();
-	});
-});
-
-describe('useOnRouteLoadTracker', () => {
-	beforeEach(() => {
-		routerState.href = '/#/org-1/cluster-1/apps';
-		routerState.params = [{ organizationId: 'org-1' }];
-	});
-
-	it('starts exactly one view per render pass, named by route', async () => {
-		const { useOnRouteLoadTracker } = await loadDatadogModule();
-		function Harness() {
-			useOnRouteLoadTracker();
-			return null;
-		}
-
-		render(<Harness />);
-
-		expect(rum.startView).toHaveBeenCalledTimes(1);
-		expect(rum.startView.mock.calls[0][0]).toMatchObject({ name: expect.any(String) });
 	});
 });

--- a/src/integrations/datadog/datadog.test.tsx
+++ b/src/integrations/datadog/datadog.test.tsx
@@ -47,10 +47,7 @@ afterEach(() => {
 });
 
 describe('Datadog view tracking', () => {
-	// Only the first `startView` of a page load becomes an `initial_load` view, and only an
-	// `initial_load` view collects LCP/FCP — so a second one on boot zeroes Core Web Vitals
-	// (#1570). This mirrors the production tree: App calls useDatadog, then StudioCloud (the
-	// root route component) calls useOnRouteLoadTracker.
+	// The nesting mirrors production: App calls useDatadog, StudioCloud calls the tracker.
 	it('starts exactly one view when the whole tree boots', async () => {
 		const { useDatadog, useOnRouteLoadTracker } = await loadDatadogModule();
 		function CloudRoot() {
@@ -86,7 +83,6 @@ describe('Datadog view tracking', () => {
 		);
 	});
 
-	// Narrows a failure of the tree-level assertion above to the hook that regressed.
 	it('does not start a view from useDatadog', async () => {
 		const { useDatadog } = await loadDatadogModule();
 		function Harness() {
@@ -97,5 +93,22 @@ describe('Datadog view tracking', () => {
 		render(<Harness />);
 
 		expect(rum.startView).not.toHaveBeenCalled();
+	});
+
+	it('starts a further view on each subsequent navigation', async () => {
+		const { useOnRouteLoadTracker } = await loadDatadogModule();
+		function CloudRoot() {
+			useOnRouteLoadTracker();
+			return null;
+		}
+
+		const { rerender } = render(<CloudRoot />);
+		routerState.href = '/org-1/clu-2/config';
+		rerender(<CloudRoot />);
+
+		expect(rum.startView.mock.calls.map(([options]) => options.name)).toEqual([
+			'/$organizationId/$clusterId/apps/',
+			'/$organizationId/$clusterId/config/',
+		]);
 	});
 });

--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -42,13 +42,13 @@ export function useDatadog() {
 				plugins: [reactPlugin()],
 			});
 
-			datadogRum.onReady(() => {
-				datadogRum.startView({
-					service: 'studio',
-					version: import.meta.env.VITE_STUDIO_VERSION,
-					name: window.location.pathname || 'initial',
-				});
-			});
+			// Deliberately no `startView` here. Under `trackViewsManually` the SDK stays stopped
+			// until the FIRST `startView`, adopts that call's options as its one `initial_load`
+			// view, and downgrades every later call to `route_change` — and only an `initial_load`
+			// view ever collects LCP/FCP. A second call therefore destroys the vitals (#1570). That
+			// one call belongs to `useOnRouteLoadTracker`, which mounts on the root route (so it
+			// runs on every cloud route) and names the view by route rather than by the hash
+			// router's permanently-`/` pathname.
 		}
 	}, []);
 }

--- a/src/integrations/datadog/datadog.ts
+++ b/src/integrations/datadog/datadog.ts
@@ -42,13 +42,8 @@ export function useDatadog() {
 				plugins: [reactPlugin()],
 			});
 
-			// Deliberately no `startView` here. Under `trackViewsManually` the SDK stays stopped
-			// until the FIRST `startView`, adopts that call's options as its one `initial_load`
-			// view, and downgrades every later call to `route_change` — and only an `initial_load`
-			// view ever collects LCP/FCP. A second call therefore destroys the vitals (#1570). That
-			// one call belongs to `useOnRouteLoadTracker`, which mounts on the root route (so it
-			// runs on every cloud route) and names the view by route rather than by the hash
-			// router's permanently-`/` pathname.
+			// No `startView` here: `useOnRouteLoadTracker` must own the sole boot view, because
+			// only the first one is an `initial_load` view and only that view collects LCP/FCP.
 		}
 	}, []);
 }


### PR DESCRIPTION
Studio has reported no LCP or FCP since 2026-07-04 ([#1570](https://github.com/HarperFast/studio/issues/1570)) because it called `datadogRum.startView` twice on boot, and the second call destroyed the only view that can carry paint metrics. This removes the redundant call, which also fixes every initial page load being attributed to the view name `/`.

Under `trackViewsManually: true` the RUM SDK stays stopped until the **first** `startView`, adopts that call's options as its single `initial_load` view, and turns every later call into a `route_change` view (`preStartRum.ts` `tryStartRum`, `trackViews.ts` `startView`). Only an `initial_load` view runs `trackInitialViewMetrics`, so it is the only view that can ever carry LCP or FCP. `useDatadog` and `useOnRouteLoadTracker` both called `startView`, so the initial view was ended microseconds after it began.

## For the human reviewer

1. **Which of the two `startView` calls to delete.** Kept `useOnRouteLoadTracker`'s, deleted `useDatadog`'s. The alternative — keep `useDatadog`'s and gate the tracker to fire only on *subsequent* routes — restores vitals equally well but leaves every `initial_load` view named `/`, because `useDatadog` named views from `window.location.pathname` and Studio uses hash routing. Deleting `useDatadog`'s call fixes both defects with one edit. Fully reversible; a change of mind costs one commit.

2. **A boot-time redirect can still fire two views, and I deliberately did not fix it.** The one finding most worth your judgment. `dashboardLayout.beforeLoad` throws `redirect({ to: '/sign-in' })` for a logged-out deep link (`src/router/dashboardRoute.ts:11-19`), so `location.href` changes twice during that boot and the tracker's effect — keyed `[location.href, router]` — can fire twice, downgrading the `initial_load` view again for those sessions. I confirmed the redirect exists but **not** that `StudioCloud` mounts before the redirect resolves; if the router holds the root component until the initial navigation settles, the second view never happens. I left it alone because suppressing that second `startView` risks losing genuine `route_change` tracking, and because this change is a strict improvement regardless — it removes the double-fire that hit *every* load, which is why LCP is 0-for-200 today rather than merely low. Say the word and I'll extend this PR; otherwise I'll file it as a follow-up. Cost of a "no": logged-out deep-link sessions may keep reporting no vitals.

3. **RUM now starts on first route render rather than on `App` mount — and there is a narrow telemetry consequence.** This follows from (1): the first `startView` is what starts the SDK, and the tracker lives in `StudioCloud`, the root route component. Gemini flagged this as a data-loss major on the theory that some routes render outside the cloud root; that is **refuted** — `rootRouteTree` is `rootRoute.addChildren([...])`, so every route renders inside `StudioCloud`, including `defaultNotFoundComponent` and `defaultErrorComponent`. What remains is genuinely narrow: if the root component or the router itself fails catastrophically before rendering, no view ever starts and that session reports nothing, where previously `useDatadog` would already have started RUM from outside the router. If you want that closed, the clean way is `useDatadog` keeping a `startView` and the tracker calling `setViewName()` on its first run instead of `startView` — the SDK exposes it (`rumPublicApi.ts:118`) and it renames the initial view without ending it. I did not do it because it adds first-run state for a failure mode I cannot reproduce, but it is the strictly-better design if you judge the boot-error window worth it.

4. **`StudioLocal` does not call the tracker, so local Studio never starts a view.** Pre-existing and correct — `enabled` is `!import.meta.env.DEV && !isLocalStudio`, so RUM is fully disabled there and no view would have been sent anyway. Flagged only because the asymmetry reads like an oversight in the diff.

Addressed from PR review: gemini-code-assist found the mocked `useRouter` returned a fresh object per render. That was not cosmetic — because the tracker's effect lists `router` in its deps, the effect re-fired on every render and the subsequent-navigation assertion was vacuous, holding even without `location.href` as a dependency. Fixed in `ff3635b0` with a single stable router identity, plus an assertion that a no-op re-render produces no view; that assertion fails against the old mock, so it stays guarded. Note it is the test-side mirror of the `router`-dep finding declined below — the production deps are sound only because the real `useRouter` is stable.

Declined: a repeated nit asking to remove the comment above the router mock. It explains why the mock uses a single instance with a getter, which is the one thing a future reader would otherwise "simplify" back into a literal — silently making the navigation tests vacuous again. That is a constraint the code cannot express, so it stays.

Verified and closed, recorded here so you don't re-derive them: gemini's child-before-parent effect-ordering concern (the tracker in a child firing `startView` before `useDatadog`'s `init`) is **safe** — `onReady` invokes its callback synchronously in the bundled build, and a `startView` arriving before `init` is buffered as `firstStartViewCall` and adopted as `initialViewOptions` (`preStartRum.ts:106-118, 295-296`), which is exactly the SDK's designed path. Not taken: narrowing the tracker's effect deps from `router` to `location.href` — a pre-existing line this PR doesn't touch, with a hypothetical trigger, so it stayed out under YAGNI.

## Verification

**Route: live reproduction against the real SDK, recorded — the change is not observable through the e2e suite** (RUM is disabled in dev and test builds, and no e2e spec touches it).

Served the shipped `@datadog/browser-rum@7.8.0` bundle over HTTP and replicated Studio's boot sequence (`init` in a deferred callback, `startView` inside `onReady`, then a second `startView` in the same flush), with a `beforeSend` that captured each assembled event and returned `false` so nothing reached Datadog:

- **Two calls (current `stage` behaviour):** the calls land at `t=78.2ms` and `t=78.5ms` — 0.3ms apart. The `initial_load` event ships with `dom_complete: 79ms` and **no `lcp`, no `fcp`**, then a `route_change` view takes over.
- **Production agrees:** of 200 raw `initial_load` views over 7 days, `dom_complete` 17, `fcp` 2, **`lcp` 0**. All 880 `initial_load` views that week are named `/` — one facet bucket — while `route_change` views carry proper route names.

**Regression tests** (`datadog.test.tsx`, 4 cases): mounts both hooks in the production nesting and asserts exactly one `startView`; pins its name to the translated route; keeps an isolated `useDatadog` case to localise a failure; and asserts a further named view per subsequent navigation. Mutation-verified — re-adding the deleted block turns the tree-level and isolated tests red.

**Gates** (Node 24.19.0, all exit 0, re-run after every review round): `vitest run` 322 files / 2625 passed, `tsc -b`, `oxlint`, `dprint check`, and `pnpm test:e2e:docker` (4 passed, 4 skipped — the skipped specs need roundtrip credentials). Script mapping: Studio has no `test:unit:main`/`test:unit:resources`/`test:integration:all`; the equivalents are `test` (vitest) and `test:e2e:docker` (Playwright).

**Not proven, and the thing to watch post-merge:** that the fix *restores* LCP/FCP end-to-end. Every browser surface available locally reports `visibilityState: 'hidden'`, which emits zero paint and LCP entries, and `trackFirstHidden` would discard them anyway — so vitals read as absent whether the fix works or not. The cheap confirmation is `@view.largest_contentful_paint` coverage on `initial_load` views after this deploys: it should go from 0% to a non-trivial share. Note #1405's baseline predates this and needs re-framing rather than just fresh data — its "`/` view" was every deep-link entry conflated into one bucket.

**Coverage caveat:** across six pre-push review rounds the Harper `domain` adjudicator failed every time (exit-1, zero-byte log — a known failure on this machine), so the outside findings above were **never machine-adjudicated**; I triaged them myself against the SDK source and the route tree, which is why two are recorded as refuted/verified rather than fixed. `gemini` ran in rounds 2–4 and failed in rounds 1 and 5 (a sandbox denial, then a leg failure), so the final round is codex-only. That is a coverage gap, not an open blocker.

Complexity: medium

<sub>Review-Coverage: authored=claude; ran=codex; blocked=gemini(quota); declined=cursor-grok,cursor-composer,domain; rounds=6 @ b6d33ae8bc46</sub>

<sub>Human-Review-Need: 4 @ b6d33ae8bc46</sub>
